### PR TITLE
feat: common grid theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ docs/
 
 ## Themes
 
-Nine built-in theme entrypoints (`fumadocs`, `darksharp`, `pixel-border`, `colorful`, `greentree`, `darkbold`, `shiny`, `concrete`, `hardline`) are available across Next.js, TanStack Start, SvelteKit, Astro, and Nuxt. `hardline` is the original hard-edge preset, and `concrete` is the louder brutalist poster-style variant.
+Ten built-in theme entrypoints (`fumadocs`, `darksharp`, `pixel-border`, `colorful`, `greentree`, `darkbold`, `shiny`, `concrete`, `command-grid`, `hardline`) are available across Next.js, TanStack Start, SvelteKit, Astro, and Nuxt. `hardline` is the original hard-edge preset, `concrete` is the louder brutalist poster-style variant, and `command-grid` is the mono-first paper-grid preset inspired by the better-cmdk landing page.
 
 ### Next.js
 
@@ -696,11 +696,12 @@ import { pixelBorder } from "@farming-labs/theme/pixel-border";
 import { colorful } from "@farming-labs/theme/colorful";
 import { greentree } from "@farming-labs/theme/greentree";
 import { concrete } from "@farming-labs/theme/concrete";
+import { commandGrid } from "@farming-labs/theme/command-grid";
 ```
 
 ```css
 @import "@farming-labs/theme/default/css";
-/* or darksharp, pixel-border, colorful, greentree, concrete, hardline, etc. */
+/* or darksharp, pixel-border, colorful, greentree, concrete, command-grid, hardline, etc. */
 ```
 
 ### SvelteKit
@@ -708,11 +709,12 @@ import { concrete } from "@farming-labs/theme/concrete";
 ```ts
 import { fumadocs } from "@farming-labs/svelte-theme";
 import { concrete } from "@farming-labs/svelte-theme/concrete";
+import { commandGrid } from "@farming-labs/svelte-theme/command-grid";
 ```
 
 ```css
 @import "@farming-labs/svelte-theme/fumadocs/css";
-/* or darksharp, pixel-border, colorful, greentree, concrete, hardline, etc. */
+/* or darksharp, pixel-border, colorful, greentree, concrete, command-grid, hardline, etc. */
 ```
 
 ### Astro
@@ -720,11 +722,12 @@ import { concrete } from "@farming-labs/svelte-theme/concrete";
 ```ts
 import { fumadocs } from "@farming-labs/astro-theme";
 import { concrete } from "@farming-labs/astro-theme/concrete";
+import { commandGrid } from "@farming-labs/astro-theme/command-grid";
 ```
 
 ```css
 @import "@farming-labs/astro-theme/css";
-/* or pixel-border, darksharp, colorful, greentree, concrete, hardline, etc. */
+/* or pixel-border, darksharp, colorful, greentree, concrete, command-grid, hardline, etc. */
 ```
 
 ### Nuxt
@@ -732,11 +735,12 @@ import { concrete } from "@farming-labs/astro-theme/concrete";
 ```ts
 import { fumadocs } from "@farming-labs/nuxt-theme";
 import { concrete } from "@farming-labs/nuxt-theme/concrete";
+import { commandGrid } from "@farming-labs/nuxt-theme/command-grid";
 ```
 
 ```css
 @import "@farming-labs/nuxt-theme/fumadocs/css";
-/* or darksharp, pixel-border, colorful, greentree, concrete, hardline, etc. */
+/* or darksharp, pixel-border, colorful, greentree, concrete, command-grid, hardline, etc. */
 ```
 
 ## Token Efficiency — Why This Matters for AI
@@ -768,7 +772,7 @@ Already have a project? Run `init` inside it — the CLI auto-detects your frame
 npx @farming-labs/docs init
 ```
 
-Pick from `next`, `tanstack-start`, `nuxt`, `sveltekit`, or `astro`. Choose any of the 8 built-in themes. Your existing code is untouched.
+Pick from `next`, `tanstack-start`, `nuxt`, `sveltekit`, or `astro`. Choose any of the 10 built-in themes. Your existing code is untouched.
 
 ## Configuration
 

--- a/examples/next/app/global.css
+++ b/examples/next/app/global.css
@@ -1,2 +1,2 @@
 @import "tailwindcss";
-@import "@farming-labs/theme/pixel-border/css";
+@import "@farming-labs/theme/command-grid/css";

--- a/examples/next/app/layout.tsx
+++ b/examples/next/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Bebas_Neue, Geist, Geist_Mono, IBM_Plex_Mono } from "next/font/google";
 import { RootProvider } from "@farming-labs/theme";
 import docsConfig from "@/docs.config";
 import "./global.css";
@@ -22,6 +22,18 @@ const geistMonoDocs = Geist_Mono({
   subsets: ["latin"],
 });
 
+const betterCmdkDisplay = Bebas_Neue({
+  variable: "--font-bebas",
+  weight: "400",
+  subsets: ["latin"],
+});
+
+const betterCmdkMono = IBM_Plex_Mono({
+  variable: "--font-ibm-plex-mono",
+  weight: ["400", "500", "600", "700"],
+  subsets: ["latin"],
+});
+
 export const metadata: Metadata = {
   title: {
     default: "Docs",
@@ -34,7 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistSansDocs.variable} ${geistMono.variable} ${geistMonoDocs.variable}`}
+        className={`${geistSans.variable} ${geistSansDocs.variable} ${geistMono.variable} ${geistMonoDocs.variable} ${betterCmdkDisplay.variable} ${betterCmdkMono.variable}`}
       >
         <RootProvider>{children}</RootProvider>
       </body>

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -17,7 +17,7 @@ import {
   Users,
   Mail,
 } from "lucide-react";
-import { pixelBorder } from "@farming-labs/theme/pixel-border";
+import { commandGrid } from "@farming-labs/theme/command-grid";
 
 const typesenseBaseUrl = process.env.TYPESENSE_URL ?? process.env.TYPESENSE_BASE_URL;
 const typesenseCollection = process.env.TYPESENSE_COLLECTION ?? "docs";
@@ -81,15 +81,7 @@ export default defineDocs({
     branch: "main",
     directory: "examples/next",
   },
-  theme: pixelBorder({
-    ui: {
-      layout: {
-        toc: { enabled: true, depth: 3, style: "default" },
-        sidebarWidth: 308,
-      },
-      components: { Callout: { variant: "outline" } },
-    },
-  }),
+  theme: commandGrid(),
   ai: {
     enabled: true,
     // mode: "sidebar-icon",

--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-build/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/astro-theme/package.json
+++ b/packages/astro-theme/package.json
@@ -35,6 +35,9 @@
       "concrete": [
         "./src/themes/concrete.d.ts"
       ],
+      "command-grid": [
+        "./src/themes/command-grid.d.ts"
+      ],
       "hardline": [
         "./src/themes/hardline.d.ts"
       ]
@@ -77,6 +80,11 @@
       "import": "./src/themes/concrete.js",
       "default": "./src/themes/concrete.js"
     },
+    "./command-grid": {
+      "types": "./src/themes/command-grid.d.ts",
+      "import": "./src/themes/command-grid.js",
+      "default": "./src/themes/command-grid.js"
+    },
     "./css": "./styles/docs.css",
     "./fumadocs/css": "./styles/docs.css",
     "./styles/pixel-border.css": "./styles/pixel-border.css",
@@ -95,7 +103,9 @@
     "./styles/hardline.css": "./styles/hardline.css",
     "./hardline/css": "./styles/hardline-bundle.css",
     "./styles/concrete.css": "./styles/concrete.css",
-    "./concrete/css": "./styles/concrete-bundle.css"
+    "./concrete/css": "./styles/concrete-bundle.css",
+    "./styles/command-grid.css": "./styles/command-grid.css",
+    "./command-grid/css": "./styles/command-grid-bundle.css"
   },
   "scripts": {
     "build": "echo 'Astro components are shipped as source'",

--- a/packages/astro-theme/src/lib/renderMarkdown.js
+++ b/packages/astro-theme/src/lib/renderMarkdown.js
@@ -53,7 +53,7 @@ function renderTable(rows) {
     })
     .join("");
 
-  return `<table>${thead}<tbody>${bodyRows}</tbody></table>`;
+  return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table>${thead}<tbody>${bodyRows}</tbody></table></div>`;
 }
 
 export function renderMarkdown(text) {

--- a/packages/astro-theme/src/themes/command-grid.d.ts
+++ b/packages/astro-theme/src/themes/command-grid.d.ts
@@ -1,0 +1,4 @@
+export declare const commandGrid: (overrides?: {
+  ui?: Record<string, unknown>;
+}) => import("@farming-labs/docs").DocsTheme;
+export declare const CommandGridUIDefaults: Record<string, unknown>;

--- a/packages/astro-theme/src/themes/command-grid.js
+++ b/packages/astro-theme/src/themes/command-grid.js
@@ -1,0 +1,45 @@
+import { createTheme } from "@farming-labs/docs";
+
+const CommandGridUIDefaults = {
+  colors: {
+    primary: "#141414",
+    background: "#f8f6ed",
+    muted: "#3d3d3d",
+    border: "#141210",
+  },
+  typography: {
+    font: {
+      style: {
+        sans: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+        mono: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+      },
+      h1: { size: "3.3rem", weight: 400, lineHeight: "0.86", letterSpacing: "0.01em" },
+      h2: { size: "2.4rem", weight: 400, lineHeight: "0.92", letterSpacing: "0.012em" },
+      h3: { size: "1.42rem", weight: 600, lineHeight: "1.18", letterSpacing: "-0.01em" },
+      h4: { size: "1.05rem", weight: 600, lineHeight: "1.34", letterSpacing: "0em" },
+      body: { size: "0.98rem", weight: 400, lineHeight: "1.7" },
+      small: { size: "0.8rem", weight: 500, lineHeight: "1.45", letterSpacing: "0.02em" },
+    },
+  },
+  radius: "0px",
+  layout: {
+    contentWidth: 900,
+    sidebarWidth: 304,
+    toc: { enabled: true, depth: 3, style: "directional" },
+    header: { height: 64, sticky: true },
+  },
+  sidebar: { style: "bordered" },
+  components: {
+    Callout: { variant: "soft", icon: true },
+    CodeBlock: { showCopyButton: true },
+    HoverLink: { linkLabel: "Open page", showIndicator: false },
+    Tabs: { style: "default" },
+  },
+};
+
+export const commandGrid = createTheme({
+  name: "command-grid",
+  ui: CommandGridUIDefaults,
+});
+
+export { CommandGridUIDefaults };

--- a/packages/astro-theme/styles/command-grid-bundle.css
+++ b/packages/astro-theme/styles/command-grid-bundle.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/astro-theme/styles/command-grid-bundle.css
+++ b/packages/astro-theme/styles/command-grid-bundle.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/astro-theme/styles/command-grid-bundle.css
+++ b/packages/astro-theme/styles/command-grid-bundle.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/astro-theme/styles/command-grid.css
+++ b/packages/astro-theme/styles/command-grid.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/astro-theme/styles/command-grid.css
+++ b/packages/astro-theme/styles/command-grid.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/astro-theme/styles/command-grid.css
+++ b/packages/astro-theme/styles/command-grid.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -429,7 +429,7 @@ export async function renderMarkdown(
       const rowsHtml = rows
         .map((row: string[]) => `<tr>${row.map((c: string) => `<td>${c}</td>`).join("")}</tr>`)
         .join("");
-      return `<div class="fd-table-wrapper"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
+      return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
     },
   );
 

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -142,7 +142,7 @@ ${pc.dim("Supported frameworks:")}
 ${pc.dim("Options for init:")}
   ${pc.cyan("--template <name>")}  Bootstrap a project (${pc.dim("next")}, ${pc.dim("nuxt")}, ${pc.dim("sveltekit")}, ${pc.dim("astro")}, ${pc.dim("tanstack-start")}); use with ${pc.cyan("--name")}
   ${pc.cyan("--name <project>")}  Project folder name when using ${pc.cyan("--template")}; prompt if omitted (e.g. ${pc.dim("my-docs")})
-  ${pc.cyan("--theme <name>")}     Skip theme prompt (e.g. ${pc.dim("darksharp")}, ${pc.dim("concrete")})
+  ${pc.cyan("--theme <name>")}     Skip theme prompt (e.g. ${pc.dim("darksharp")}, ${pc.dim("command-grid")})
   ${pc.cyan("--entry <path>")}     Skip entry path prompt (e.g. ${pc.dim("docs")})
   ${pc.cyan("--api-reference")}    Scaffold API reference support during ${pc.cyan("init")}
   ${pc.cyan("--no-api-reference")} Skip API reference scaffold during ${pc.cyan("init")}

--- a/packages/docs/src/cli/init.ts
+++ b/packages/docs/src/cli/init.ts
@@ -559,6 +559,11 @@ export async function init(options: InitOptions = {}) {
       hint: "Brutalist poster-style theme with offset shadows and loud contrast",
     },
     {
+      value: "command-grid",
+      label: "Command Grid",
+      hint: "Paper-grid docs shell inspired by better-cmdk",
+    },
+    {
       value: "hardline",
       label: "Hardline",
       hint: "Hard-edge theme with square corners and bold borders",
@@ -1517,6 +1522,7 @@ function scaffoldSvelteKit(
     shiny: "shiny",
     greentree: "greentree",
     concrete: "concrete",
+    "command-grid": "command-grid",
     hardline: "hardline",
     default: "fumadocs",
   };
@@ -1598,6 +1604,7 @@ function scaffoldAstro(
     shiny: "shiny",
     greentree: "greentree",
     concrete: "concrete",
+    "command-grid": "command-grid",
     hardline: "hardline",
     default: "fumadocs",
   };
@@ -1682,6 +1689,7 @@ function scaffoldNuxt(
     shiny: "shiny",
     greentree: "greentree",
     concrete: "concrete",
+    "command-grid": "command-grid",
     hardline: "hardline",
     default: "fumadocs",
   };

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -214,6 +214,11 @@ describe("globalCssTemplate", () => {
     expect(out).toContain("@farming-labs/theme/concrete/css");
   });
 
+  it("uses correct theme path for command-grid", () => {
+    const out = globalCssTemplate("command-grid");
+    expect(out).toContain("@farming-labs/theme/command-grid/css");
+  });
+
   it("uses correct theme path for hardline", () => {
     const out = globalCssTemplate("hardline");
     expect(out).toContain("@farming-labs/theme/hardline/css");
@@ -265,6 +270,12 @@ describe("docsConfigTemplate", () => {
     const out = docsConfigTemplate({ ...baseConfig, theme: "concrete" });
     expect(out).toContain("concrete");
     expect(out).toContain("@farming-labs/theme/concrete");
+  });
+
+  it("uses correct theme factory for command-grid", () => {
+    const out = docsConfigTemplate({ ...baseConfig, theme: "command-grid" });
+    expect(out).toContain("commandGrid");
+    expect(out).toContain("@farming-labs/theme/command-grid");
   });
 
   it("uses correct theme factory for hardline", () => {

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -139,6 +139,17 @@ const THEME_INFO: Record<string, ThemeInfo> = {
     astroCssTheme: "concrete",
     nuxtCssTheme: "concrete",
   },
+  "command-grid": {
+    factory: "commandGrid",
+    nextImport: "@farming-labs/theme/command-grid",
+    svelteImport: "@farming-labs/svelte-theme/command-grid",
+    astroImport: "@farming-labs/astro-theme/command-grid",
+    nuxtImport: "@farming-labs/nuxt-theme/command-grid",
+    nextCssImport: "command-grid",
+    svelteCssTheme: "command-grid",
+    astroCssTheme: "command-grid",
+    nuxtCssTheme: "command-grid",
+  },
   hardline: {
     factory: "hardline",
     nextImport: "@farming-labs/theme/hardline",

--- a/packages/fumadocs/package.json
+++ b/packages/fumadocs/package.json
@@ -78,6 +78,11 @@
       "import": "./dist/concrete/index.mjs",
       "default": "./dist/concrete/index.mjs"
     },
+    "./command-grid": {
+      "types": "./dist/command-grid/index.d.mts",
+      "import": "./dist/command-grid/index.mjs",
+      "default": "./dist/command-grid/index.mjs"
+    },
     "./search": {
       "types": "./dist/search.d.mts",
       "import": "./dist/search.mjs",
@@ -109,6 +114,7 @@
     "./greentree/css": "./styles/greentree.css",
     "./hardline/css": "./styles/hardline.css",
     "./concrete/css": "./styles/concrete.css",
+    "./command-grid/css": "./styles/command-grid.css",
     "./presets/neutral": "./styles/presets/neutral.css",
     "./presets/black": "./styles/presets/black.css",
     "./presets/base": "./styles/presets/base.css"

--- a/packages/fumadocs/src/command-grid/index.ts
+++ b/packages/fumadocs/src/command-grid/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Command Grid theme preset.
+ * Better-cmdk-inspired light theme over the concrete base, without offset shadows.
+ *
+ * CSS: `@import "@farming-labs/theme/command-grid/css";`
+ */
+import { createTheme } from "@farming-labs/docs";
+
+const CommandGridUIDefaults = {
+  colors: {
+    primary: "#141414",
+    background: "#f8f6ed",
+    muted: "#3d3d3d",
+    border: "#141210",
+  },
+  typography: {
+    font: {
+      style: {
+        sans: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+        mono: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+      },
+      h1: { size: "3.3rem", weight: 400, lineHeight: "0.86", letterSpacing: "0.01em" },
+      h2: { size: "2.4rem", weight: 400, lineHeight: "0.92", letterSpacing: "0.012em" },
+      h3: { size: "1.42rem", weight: 600, lineHeight: "1.18", letterSpacing: "-0.01em" },
+      h4: { size: "1.05rem", weight: 600, lineHeight: "1.34", letterSpacing: "0em" },
+      body: { size: "0.98rem", weight: 400, lineHeight: "1.7" },
+      small: { size: "0.8rem", weight: 500, lineHeight: "1.45", letterSpacing: "0.02em" },
+    },
+  },
+  radius: "0px",
+  layout: {
+    contentWidth: 900,
+    sidebarWidth: 304,
+    toc: { enabled: true, depth: 3, style: "directional" as const },
+    header: { height: 64, sticky: true },
+  },
+  sidebar: {
+    style: "bordered" as const,
+  },
+  components: {
+    Callout: { variant: "soft", icon: true },
+    CodeBlock: { showCopyButton: true },
+    HoverLink: { linkLabel: "Open page", showIndicator: false },
+    Tabs: { style: "default" as const },
+  },
+};
+
+export const commandGrid = createTheme({
+  name: "command-grid",
+  ui: CommandGridUIDefaults,
+});
+
+export { CommandGridUIDefaults };

--- a/packages/fumadocs/src/index.ts
+++ b/packages/fumadocs/src/index.ts
@@ -5,6 +5,7 @@
  *   - `@farming-labs/theme/default`      → default neutral theme
  *   - `@farming-labs/theme/darksharp`    → sharp all-black theme
  *   - `@farming-labs/theme/pixel-border` → better-auth inspired rounded borders
+ *   - `@farming-labs/theme/command-grid` → better-cmdk inspired paper-grid docs shell
  *   - `@farming-labs/theme/concrete`     → brutalist poster-style hard-edge theme
  *   - `@farming-labs/theme/hardline`     → high-contrast hard-edge theme
  *
@@ -68,6 +69,7 @@ export { RootProvider } from "./provider.js";
 
 // ─── Default theme preset (backward compat) ───────────────────────────
 export { fumadocs, DefaultUIDefaults as FumadocsUIDefaults } from "./default/index.js";
+export { commandGrid, CommandGridUIDefaults } from "./command-grid/index.js";
 export { concrete, ConcreteUIDefaults } from "./concrete/index.js";
 export { hardline, HardlineUIDefaults } from "./hardline/index.js";
 

--- a/packages/fumadocs/src/mdx.ts
+++ b/packages/fumadocs/src/mdx.ts
@@ -25,9 +25,20 @@ import { createPreWithCopyCallback } from "./code-block-copy-wrapper.js";
 import { HoverLink, type HoverLinkProps } from "./hover-link.js";
 import type { CodeBlockCopyData, DocsTheme } from "@farming-labs/docs";
 
+function Table(props: React.ComponentPropsWithoutRef<"table">) {
+  return React.createElement(
+    "div",
+    {
+      className: "fd-table-wrapper relative overflow-auto prose-no-margin my-6",
+    },
+    React.createElement("table", props),
+  );
+}
+
 const extendedMdxComponents = {
   ...defaultMdxComponents,
   img: MDXImg,
+  table: Table,
   HoverLink,
   Tab,
   Tabs,

--- a/packages/fumadocs/styles/command-grid.css
+++ b/packages/fumadocs/styles/command-grid.css
@@ -1,0 +1,627 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/fumadocs/styles/command-grid.css
+++ b/packages/fumadocs/styles/command-grid.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -581,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -598,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -609,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/fumadocs/styles/command-grid.css
+++ b/packages/fumadocs/styles/command-grid.css
@@ -557,6 +557,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +569,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }

--- a/packages/fumadocs/tsdown.config.ts
+++ b/packages/fumadocs/tsdown.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     "src/darkbold/index.ts",
     "src/greentree/index.ts",
     "src/concrete/index.ts",
+    "src/command-grid/index.ts",
     "src/hardline/index.ts",
   ],
   format: "esm",

--- a/packages/nuxt-theme/package.json
+++ b/packages/nuxt-theme/package.json
@@ -52,6 +52,11 @@
       "import": "./src/themes/concrete.js",
       "default": "./src/themes/concrete.js"
     },
+    "./command-grid": {
+      "types": "./src/themes/command-grid.d.ts",
+      "import": "./src/themes/command-grid.js",
+      "default": "./src/themes/command-grid.js"
+    },
     "./css": "./styles/docs.css",
     "./fumadocs/css": "./styles/docs.css",
     "./styles/pixel-border.css": "./styles/pixel-border.css",
@@ -70,7 +75,9 @@
     "./styles/hardline.css": "./styles/hardline.css",
     "./hardline/css": "./styles/hardline-bundle.css",
     "./styles/concrete.css": "./styles/concrete.css",
-    "./concrete/css": "./styles/concrete-bundle.css"
+    "./concrete/css": "./styles/concrete-bundle.css",
+    "./styles/command-grid.css": "./styles/command-grid.css",
+    "./command-grid/css": "./styles/command-grid-bundle.css"
   },
   "scripts": {
     "build": "echo 'Nuxt theme components are shipped as source'",

--- a/packages/nuxt-theme/src/lib/renderMarkdown.js
+++ b/packages/nuxt-theme/src/lib/renderMarkdown.js
@@ -53,7 +53,7 @@ function renderTable(rows) {
     })
     .join("");
 
-  return `<table>${thead}<tbody>${bodyRows}</tbody></table>`;
+  return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table>${thead}<tbody>${bodyRows}</tbody></table></div>`;
 }
 
 export function renderMarkdown(text) {

--- a/packages/nuxt-theme/src/themes/command-grid.d.ts
+++ b/packages/nuxt-theme/src/themes/command-grid.d.ts
@@ -1,0 +1,4 @@
+export declare const commandGrid: (overrides?: {
+  ui?: Record<string, unknown>;
+}) => import("@farming-labs/docs").DocsTheme;
+export declare const CommandGridUIDefaults: Record<string, unknown>;

--- a/packages/nuxt-theme/src/themes/command-grid.js
+++ b/packages/nuxt-theme/src/themes/command-grid.js
@@ -1,0 +1,45 @@
+import { createTheme } from "@farming-labs/docs";
+
+const CommandGridUIDefaults = {
+  colors: {
+    primary: "#141414",
+    background: "#f8f6ed",
+    muted: "#3d3d3d",
+    border: "#141210",
+  },
+  typography: {
+    font: {
+      style: {
+        sans: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+        mono: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+      },
+      h1: { size: "3.3rem", weight: 400, lineHeight: "0.86", letterSpacing: "0.01em" },
+      h2: { size: "2.4rem", weight: 400, lineHeight: "0.92", letterSpacing: "0.012em" },
+      h3: { size: "1.42rem", weight: 600, lineHeight: "1.18", letterSpacing: "-0.01em" },
+      h4: { size: "1.05rem", weight: 600, lineHeight: "1.34", letterSpacing: "0em" },
+      body: { size: "0.98rem", weight: 400, lineHeight: "1.7" },
+      small: { size: "0.8rem", weight: 500, lineHeight: "1.45", letterSpacing: "0.02em" },
+    },
+  },
+  radius: "0px",
+  layout: {
+    contentWidth: 900,
+    sidebarWidth: 304,
+    toc: { enabled: true, depth: 3, style: "directional" },
+    header: { height: 64, sticky: true },
+  },
+  sidebar: { style: "bordered" },
+  components: {
+    Callout: { variant: "soft", icon: true },
+    CodeBlock: { showCopyButton: true },
+    HoverLink: { linkLabel: "Open page", showIndicator: false },
+    Tabs: { style: "default" },
+  },
+};
+
+export const commandGrid = createTheme({
+  name: "command-grid",
+  ui: CommandGridUIDefaults,
+});
+
+export { CommandGridUIDefaults };

--- a/packages/nuxt-theme/styles/command-grid-bundle.css
+++ b/packages/nuxt-theme/styles/command-grid-bundle.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/nuxt-theme/styles/command-grid-bundle.css
+++ b/packages/nuxt-theme/styles/command-grid-bundle.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/nuxt-theme/styles/command-grid-bundle.css
+++ b/packages/nuxt-theme/styles/command-grid-bundle.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/nuxt-theme/styles/command-grid.css
+++ b/packages/nuxt-theme/styles/command-grid.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/nuxt-theme/styles/command-grid.css
+++ b/packages/nuxt-theme/styles/command-grid.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/nuxt-theme/styles/command-grid.css
+++ b/packages/nuxt-theme/styles/command-grid.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -423,7 +423,7 @@ export async function renderMarkdown(
       const rowsHtml = rows
         .map((row: string[]) => `<tr>${row.map((c: string) => `<td>${c}</td>`).join("")}</tr>`)
         .join("");
-      return `<div class="fd-table-wrapper"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
+      return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
     },
   );
 

--- a/packages/svelte-theme/package.json
+++ b/packages/svelte-theme/package.json
@@ -36,6 +36,9 @@
       "concrete": [
         "./src/themes/concrete.d.ts"
       ],
+      "command-grid": [
+        "./src/themes/command-grid.d.ts"
+      ],
       "hardline": [
         "./src/themes/hardline.d.ts"
       ]
@@ -79,6 +82,11 @@
       "import": "./src/themes/concrete.js",
       "default": "./src/themes/concrete.js"
     },
+    "./command-grid": {
+      "types": "./src/themes/command-grid.d.ts",
+      "import": "./src/themes/command-grid.js",
+      "default": "./src/themes/command-grid.js"
+    },
     "./css": "./styles/docs.css",
     "./fumadocs/css": "./styles/docs.css",
     "./styles/pixel-border.css": "./styles/pixel-border.css",
@@ -97,7 +105,9 @@
     "./styles/hardline.css": "./styles/hardline.css",
     "./hardline/css": "./styles/hardline-bundle.css",
     "./styles/concrete.css": "./styles/concrete.css",
-    "./concrete/css": "./styles/concrete-bundle.css"
+    "./concrete/css": "./styles/concrete-bundle.css",
+    "./styles/command-grid.css": "./styles/command-grid.css",
+    "./command-grid/css": "./styles/command-grid-bundle.css"
   },
   "scripts": {
     "build": "echo 'Svelte components are shipped as source'",

--- a/packages/svelte-theme/src/lib/renderMarkdown.js
+++ b/packages/svelte-theme/src/lib/renderMarkdown.js
@@ -53,7 +53,7 @@ function renderTable(rows) {
     })
     .join("");
 
-  return `<table>${thead}<tbody>${bodyRows}</tbody></table>`;
+  return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table>${thead}<tbody>${bodyRows}</tbody></table></div>`;
 }
 
 export function renderMarkdown(text) {

--- a/packages/svelte-theme/src/themes/command-grid.d.ts
+++ b/packages/svelte-theme/src/themes/command-grid.d.ts
@@ -1,0 +1,4 @@
+export declare const commandGrid: (overrides?: {
+  ui?: Record<string, unknown>;
+}) => import("@farming-labs/docs").DocsTheme;
+export declare const CommandGridUIDefaults: Record<string, unknown>;

--- a/packages/svelte-theme/src/themes/command-grid.js
+++ b/packages/svelte-theme/src/themes/command-grid.js
@@ -1,0 +1,45 @@
+import { createTheme } from "@farming-labs/docs";
+
+const CommandGridUIDefaults = {
+  colors: {
+    primary: "#141414",
+    background: "#f8f6ed",
+    muted: "#3d3d3d",
+    border: "#141210",
+  },
+  typography: {
+    font: {
+      style: {
+        sans: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+        mono: "var(--font-ibm-plex-mono), 'IBM Plex Mono', 'Geist Mono', ui-monospace, monospace",
+      },
+      h1: { size: "3.3rem", weight: 400, lineHeight: "0.86", letterSpacing: "0.01em" },
+      h2: { size: "2.4rem", weight: 400, lineHeight: "0.92", letterSpacing: "0.012em" },
+      h3: { size: "1.42rem", weight: 600, lineHeight: "1.18", letterSpacing: "-0.01em" },
+      h4: { size: "1.05rem", weight: 600, lineHeight: "1.34", letterSpacing: "0em" },
+      body: { size: "0.98rem", weight: 400, lineHeight: "1.7" },
+      small: { size: "0.8rem", weight: 500, lineHeight: "1.45", letterSpacing: "0.02em" },
+    },
+  },
+  radius: "0px",
+  layout: {
+    contentWidth: 900,
+    sidebarWidth: 304,
+    toc: { enabled: true, depth: 3, style: "directional" },
+    header: { height: 64, sticky: true },
+  },
+  sidebar: { style: "bordered" },
+  components: {
+    Callout: { variant: "soft", icon: true },
+    CodeBlock: { showCopyButton: true },
+    HoverLink: { linkLabel: "Open page", showIndicator: false },
+    Tabs: { style: "default" },
+  },
+};
+
+export const commandGrid = createTheme({
+  name: "command-grid",
+  ui: CommandGridUIDefaults,
+});
+
+export { CommandGridUIDefaults };

--- a/packages/svelte-theme/styles/command-grid-bundle.css
+++ b/packages/svelte-theme/styles/command-grid-bundle.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/svelte-theme/styles/command-grid-bundle.css
+++ b/packages/svelte-theme/styles/command-grid-bundle.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/svelte-theme/styles/command-grid-bundle.css
+++ b/packages/svelte-theme/styles/command-grid-bundle.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/svelte-theme/styles/command-grid.css
+++ b/packages/svelte-theme/styles/command-grid.css
@@ -475,19 +475,108 @@ figure.shiki:has(figcaption) > div:first-child,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-docs-content table,
-.fd-page-body .fd-table-wrapper {
+.fd-table-wrapper,
+.fd-table-wrapper table,
+.prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
+  border-radius: 0 !important;
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a {
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+.fd-page-nav-card:hover,
+[class*="page-nav"] a:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.fd-page-nav-card:hover *,
+[class*="page-nav"] a:hover * {
+  color: inherit !important;
+}
+
+.fd-table-wrapper {
+  overflow: hidden;
+}
+
+.fd-table-wrapper table,
+.prose .fd-table-wrapper table {
+  border: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+}
+
+.prose table,
+.prose thead,
+.prose tbody,
+.prose tr,
+.prose th,
+.prose td,
+.prose table *,
+.fd-table-wrapper,
+.fd-table-wrapper *,
+.fd-table-wrapper table,
+.fd-table-wrapper thead,
+.fd-table-wrapper tbody,
+.fd-table-wrapper tr,
+.fd-table-wrapper th,
+.fd-table-wrapper td {
+  border-radius: 0 !important;
+}
+
+.prose thead tr:first-child th:first-child,
+.prose thead tr:first-child th:last-child,
+.prose tbody tr:last-child td:first-child,
+.prose tbody tr:last-child td:last-child,
+.fd-table-wrapper thead tr:first-child th:first-child,
+.fd-table-wrapper thead tr:first-child th:last-child,
+.fd-table-wrapper tbody tr:last-child td:first-child,
+.fd-table-wrapper tbody tr:last-child td:last-child {
+  border-radius: 0 !important;
+}
+
+.prose th,
+.fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-callout,
+[class*="fd-callout"] {
+  border: 2px solid var(--color-fd-border) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-fd-card) 88%,
+    var(--color-fd-secondary) 12%
+  ) !important;
+  border-radius: 0 !important;
+}
+
+.fd-callout-indicator {
+  width: 8px;
+  background: var(--color-fd-accent) !important;
+}
+
+.fd-callout-title {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
 }
 
 .fd-docs-content :not(pre) > code {
@@ -557,6 +646,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-input-wrap,
 .fd-ai-results,
 .fd-ai-messages {
@@ -568,6 +658,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-tab-bar,
 .fd-ai-search-wrap,
 .fd-ai-chat-footer,
+.fd-ai-fm-topbar,
 .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
@@ -579,6 +670,7 @@ figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-result-empty,
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
 .fd-ai-model-dropdown-label,
@@ -596,6 +688,7 @@ figure.shiki:has(figcaption) > div:first-child,
 
 .fd-ai-esc,
 .fd-ai-close-btn,
+.fd-ai-fm-close-btn,
 .fd-ai-tab,
 .fd-ai-model-dropdown-btn,
 .fd-ai-model-dropdown-item,
@@ -607,8 +700,14 @@ figure.shiki:has(figcaption) > div:first-child,
   box-shadow: none !important;
 }
 
+.fd-ai-fm-close-btn {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
 .fd-ai-tab[data-active="true"],
 .fd-ai-close-btn:hover,
+.fd-ai-fm-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,

--- a/packages/svelte-theme/styles/command-grid.css
+++ b/packages/svelte-theme/styles/command-grid.css
@@ -1,0 +1,624 @@
+/* @farming-labs/theme - command-grid theme CSS */
+@import "./concrete.css";
+
+:root {
+  --color-fd-primary: #141414;
+  --color-fd-primary-foreground: #f8f6ed;
+  --color-fd-ring: #141414;
+
+  --color-fd-background: #f8f6ed;
+  --color-fd-foreground: #141414;
+  --color-fd-card: #fdfcf8;
+  --color-fd-card-foreground: #141414;
+  --color-fd-popover: #fdfcf8;
+  --color-fd-popover-foreground: #141414;
+  --color-fd-secondary: #e6dfca;
+  --color-fd-secondary-foreground: #141414;
+  --color-fd-muted: #e6dfca;
+  --color-fd-muted-foreground: #3d3d3d;
+  --color-fd-accent: #d1c0a9;
+  --color-fd-accent-foreground: #141414;
+  --color-fd-border: #141414;
+
+  --radius: 0px;
+  --fd-nav-height: 64px;
+}
+
+:is(html.dark, body.dark) {
+  --color-fd-primary: #f8f6ed;
+  --color-fd-primary-foreground: #121212;
+  --color-fd-ring: #f8f6ed;
+
+  --color-fd-background: #121212;
+  --color-fd-foreground: #f8f6ed;
+  --color-fd-card: #1a1a1a;
+  --color-fd-card-foreground: #f8f6ed;
+  --color-fd-popover: #1a1a1a;
+  --color-fd-popover-foreground: #f8f6ed;
+  --color-fd-secondary: #292929;
+  --color-fd-secondary-foreground: #f8f6ed;
+  --color-fd-muted: #292929;
+  --color-fd-muted-foreground: #c5c0b5;
+  --color-fd-accent: #b6a791;
+  --color-fd-accent-foreground: #121212;
+  --color-fd-border: #f8f6ed;
+}
+
+body:has(#nd-docs-layout) {
+  background: var(--color-fd-background);
+  background-image:
+    linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(20 20 20 / 6%) 1px, transparent 1px);
+  background-size: 48px 48px;
+  background-attachment: fixed;
+}
+
+:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+  background-image:
+    linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
+}
+
+#nd-docs-layout > header,
+[role="banner"] {
+  border-bottom: 4px solid var(--color-fd-border) !important;
+  background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
+  backdrop-filter: blur(8px);
+  box-shadow: none !important;
+}
+
+aside#nd-sidebar {
+  border-right: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-background) !important;
+}
+
+aside#nd-sidebar,
+.fd-sidebar {
+  color: var(--color-fd-foreground);
+}
+
+aside#nd-sidebar [data-radix-scroll-area-viewport],
+aside#nd-sidebar [data-radix-scroll-area-content],
+aside#nd-sidebar .fd-sidebar {
+  background: transparent !important;
+}
+
+aside#nd-sidebar > *,
+.fd-sidebar > * {
+  background: transparent;
+}
+
+aside a[data-active],
+aside button[data-active],
+.fd-sidebar a,
+.fd-sidebar button {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.77rem;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+  border: 2px solid transparent;
+  border-radius: 0 !important;
+  min-height: 2.9rem;
+}
+
+aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+  background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
+  color: var(--color-fd-foreground) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside#nd-sidebar a.inline-flex,
+.fd-sidebar a.inline-flex {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+aside [data-active="false"] {
+  color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
+}
+
+aside a[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+aside div.overflow-hidden.relative[data-state]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active] {
+  padding-inline-start: 1.75rem !important;
+}
+
+aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+  inset-inline-start: 1.125rem !important;
+}
+
+#nd-toc {
+  border-left: 2px solid var(--color-fd-border) !important;
+  padding-left: 1rem;
+  background: transparent !important;
+}
+
+#toc-title,
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+}
+
+#toc-title {
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.fd-toc-link,
+.fd-toc-clerk .fd-toc-link {
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  border-left: 2px solid transparent;
+  padding-left: 0.8rem;
+  color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
+}
+
+.fd-toc-link:hover,
+.fd-toc-clerk .fd-toc-link:hover {
+  border-left-color: var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.fd-toc-link-active,
+.fd-toc-clerk .fd-toc-link[data-active="true"] {
+  border-left-color: var(--color-fd-foreground);
+  color: var(--color-fd-foreground);
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1,
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  max-width: none;
+  font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
+  font-weight: 400 !important;
+  text-transform: uppercase !important;
+  line-height: 0.9 !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-page-title,
+#nd-page > h1,
+.fd-docs-content article h1,
+#nd-page h1,
+.fd-docs-content h1 {
+  font-size: clamp(3.1rem, 7vw, 5.75rem);
+  letter-spacing: 0.04em;
+  text-wrap: balance;
+  margin-bottom: 0.9rem;
+}
+
+.fd-docs-content article h2,
+#nd-page h2,
+.fd-docs-content h2 {
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  letter-spacing: 0.045em;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+}
+
+.fd-page-title > a,
+#nd-page > h1 > a,
+.fd-docs-content article h1 > a,
+#nd-page h1 > a,
+.fd-docs-content h1 > a,
+.fd-docs-content article h2 > a,
+#nd-page h2 > a,
+.fd-docs-content h2 > a {
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  line-height: inherit !important;
+}
+
+.fd-docs-content article h3,
+#nd-page h3,
+.fd-docs-content h3,
+.fd-docs-content article h4,
+#nd-page h4,
+.fd-docs-content h4 {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
+}
+
+.fd-docs-content h3 {
+  font-size: 0.96rem;
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+}
+
+.fd-docs-content h4 {
+  font-size: 0.82rem;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.fd-page-description,
+.fd-docs-content p,
+.fd-docs-content li,
+.fd-docs-content td,
+.fd-docs-content blockquote {
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-page-description {
+  color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  line-height: 1.75;
+  max-width: 72ch;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-page-body .fd-table-wrapper,
+.fd-docs-content table,
+.fd-tabs,
+.fd-tabs-list,
+.fd-tabs-trigger,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
+.fd-card,
+[data-card],
+[class*="fd-callout"],
+.fd-page-action-menu,
+.fd-page-action-btn,
+.fd-page-nav,
+.fd-page-nav-card,
+[class*="page-nav"] a,
+.fd-hover-link-card,
+.fd-feedback-input,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-dialog,
+.fd-ai-fm-input-container,
+.fd-ai-fm-suggestion,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-menu,
+.fd-ai-model-dropdown-item,
+.fd-ai-floating-btn,
+.omni-content,
+.omni-item,
+.omni-item-ext,
+.fd-copy-btn,
+.fd-ai-code-copy {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-page-action-btn,
+.fd-feedback-submit,
+.fd-feedback-choice,
+.fd-ai-tab,
+.fd-copy-btn,
+.fd-ai-code-copy,
+.fd-ai-floating-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease !important;
+}
+
+aside a[data-active="true"],
+aside a[data-active="true"]:hover,
+.fd-page-action-btn:hover,
+.fd-page-action-btn[data-selected="true"],
+.fd-page-action-btn[data-copied="true"],
+.fd-feedback-choice:hover,
+.fd-feedback-choice[data-selected="true"],
+.fd-ai-tab[data-active="true"],
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover,
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover,
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover {
+  box-shadow: none !important;
+  transform: translateY(-2px);
+}
+
+.dark aside a[data-active="true"],
+.dark .fd-page-action-btn:hover,
+.dark .fd-page-action-btn[data-selected="true"],
+.dark .fd-page-action-btn[data-copied="true"],
+.dark .fd-feedback-choice:hover,
+.dark .fd-feedback-choice[data-selected="true"],
+.dark .fd-ai-tab[data-active="true"] {
+  box-shadow: none !important;
+}
+
+.fd-sidebar-search-btn,
+.fd-sidebar-ai-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-sidebar-search-btn:hover,
+.fd-sidebar-ai-btn:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-sidebar-search-kbd,
+.fd-sidebar-search-kbd kbd {
+  color: inherit !important;
+  border-color: currentColor !important;
+}
+
+button[data-search-full],
+[data-search-full] {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-secondary) !important;
+  color: var(--color-fd-foreground) !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-size: 0.76rem !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: none !important;
+}
+
+button[data-search-full]:hover,
+[data-search-full]:hover {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+button[data-search-full] kbd,
+[data-search-full] kbd {
+  border: 1px solid currentColor !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  color: inherit !important;
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-docs-content pre,
+.fd-docs-content .shiki,
+.fd-docs-content [data-codeblock],
+.fd-ai-code-block {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+  background-image: none !important;
+}
+
+.fd-codeblock-title,
+figure.shiki:has(figcaption) > div:first-child,
+.fd-ai-code-header {
+  background: var(--color-fd-secondary) !important;
+  border-bottom: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn,
+.fd-ai-code-copy {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border: 2px solid var(--color-fd-border) !important;
+}
+
+.fd-copy-btn:hover,
+.fd-ai-code-copy:hover {
+  background: var(--color-fd-card) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
+.fd-docs-content table,
+.fd-page-body .fd-table-wrapper {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-docs-content th,
+.fd-page-body th {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.fd-docs-content :not(pre) > code {
+  background: var(--color-fd-secondary);
+}
+
+.omni-content {
+  border: 2px solid var(--color-fd-border) !important;
+  background: var(--color-fd-card) !important;
+}
+
+.omni-header,
+.omni-footer {
+  border-color: var(--color-fd-border) !important;
+  background: var(--color-fd-secondary) !important;
+}
+
+.omni-search-input,
+.omni-item-label,
+.omni-item-subtitle,
+.omni-group-label,
+.omni-footer-inner,
+.omni-kbd,
+.omni-close-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
+}
+
+.omni-item {
+  border: 1px solid transparent !important;
+}
+
+.omni-item:hover {
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-kbd,
+.omni-close-btn,
+.omni-item-ext {
+  border: 1px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.omni-item-active {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.omni-item-active .omni-item-icon,
+.omni-item-active .omni-item-badge,
+.omni-item-active .omni-item-ext,
+.omni-item-active .omni-item-chevron,
+.omni-item-active .omni-item-subtitle,
+.omni-item-active .omni-item-shortcuts {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+
+.fd-ai-dialog,
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-input-wrap,
+.fd-ai-results,
+.fd-ai-messages {
+  border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
+}
+
+.fd-ai-header,
+.fd-ai-tab-bar,
+.fd-ai-search-wrap,
+.fd-ai-chat-footer,
+.fd-ai-fm-input-container {
+  background: var(--color-fd-secondary) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-input,
+.fd-ai-result,
+.fd-ai-result-empty,
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-model-dropdown-label,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.fd-ai-header-title,
+.fd-ai-tab,
+.fd-ai-floating-btn {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.fd-ai-esc,
+.fd-ai-close-btn,
+.fd-ai-tab,
+.fd-ai-model-dropdown-btn,
+.fd-ai-model-dropdown-item,
+.fd-ai-fm-suggestion,
+.fd-ai-floating-btn {
+  border: 2px solid var(--color-fd-border) !important;
+  border-radius: 0 !important;
+  background: var(--color-fd-card) !important;
+}
+
+.fd-ai-tab[data-active="true"],
+.fd-ai-model-dropdown-item[data-active="true"],
+.fd-ai-floating-btn:hover,
+.fd-ai-model-dropdown-btn:hover,
+.fd-ai-model-dropdown-item:hover,
+.fd-ai-fm-suggestion:hover,
+.fd-ai-result[data-active="true"] {
+  background: var(--color-fd-foreground) !important;
+  color: var(--color-fd-background) !important;
+  border-color: var(--color-fd-border) !important;
+}
+
+.fd-ai-input,
+.fd-ai-input::placeholder {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}

--- a/packages/svelte-theme/styles/command-grid.css
+++ b/packages/svelte-theme/styles/command-grid.css
@@ -604,9 +604,11 @@ figure.shiki:has(figcaption) > div:first-child,
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-tab[data-active="true"],
+.fd-ai-close-btn:hover,
 .fd-ai-model-dropdown-item[data-active="true"],
 .fd-ai-floating-btn:hover,
 .fd-ai-model-dropdown-btn:hover,
@@ -616,6 +618,7 @@ figure.shiki:has(figcaption) > div:first-child,
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
+  box-shadow: none !important;
 }
 
 .fd-ai-input,

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -423,7 +423,7 @@ export async function renderMarkdown(
       const rowsHtml = rows
         .map((row: string[]) => `<tr>${row.map((c: string) => `<td>${c}</td>`).join("")}</tr>`)
         .join("");
-      return `<div class="fd-table-wrapper"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
+      return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
     },
   );
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -52,7 +52,7 @@ Replace `my-docs` with the desired folder name. Same pattern with `pnpm dlx`, `y
 | ---- | ----------- |
 | `--template <name>` | Bootstrap a project: `next`, `tanstack-start`, `nuxt`, `sveltekit`, `astro`. Use with `--name`. Skips the existing-vs-fresh prompt. |
 | `--name <project>` | Project folder name when using `--template` (e.g. `my-docs`). If omitted with `--template`, CLI prompts (default `my-docs`). |
-| `--theme <name>` | Skip theme prompt. Values: e.g. `fumadocs`, `greentree`, `pixel-border`, `darksharp`, `colorful`, `darkbold`, `shiny`, `hardline`, `concrete`. |
+| `--theme <name>` | Skip theme prompt. Values: e.g. `fumadocs`, `greentree`, `pixel-border`, `darksharp`, `colorful`, `darkbold`, `shiny`, `concrete`, `command-grid`, `hardline`. |
 | `--entry <path>` | Skip entry path prompt. Default is `docs`. |
 | `--api-reference` | Enable API reference scaffold during `init`. |
 | `--no-api-reference` | Explicitly skip the API reference scaffold. |

--- a/skills/farming-labs/creating-themes/SKILL.md
+++ b/skills/farming-labs/creating-themes/SKILL.md
@@ -64,7 +64,7 @@ export const myTheme = extendTheme(fumadocs(), {
 });
 ```
 
-For other frameworks use the same framework's theme package (e.g. `@farming-labs/svelte-theme`, `@farming-labs/astro-theme`, `@farming-labs/nuxt-theme`). You can extend any built-in: `fumadocs`, `darksharp`, `pixelBorder`, `colorful`, `greentree`, `darkbold`, `shiny`, `hardline`, and `concrete`.
+For other frameworks use the same framework's theme package (e.g. `@farming-labs/svelte-theme`, `@farming-labs/astro-theme`, `@farming-labs/nuxt-theme`). You can extend any built-in: `fumadocs`, `darksharp`, `pixelBorder`, `colorful`, `greentree`, `darkbold`, `shiny`, `concrete`, `commandGrid`, and `hardline`.
 
 **Important:** `extendTheme()` returns a theme **instance** (not a factory). Use `createTheme()` when you want a reusable preset that others call as `myTheme()`.
 

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -35,7 +35,7 @@ description: Get started with @farming-labs/docs — MDX-based documentation for
 
 ### Built-in themes
 
-Nine built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border`, `colorful`, `greentree`, `darkbold`, `shiny`, `hardline`, and `concrete`. `hardline` is the existing hard-edge preset, and `concrete` is the louder brutalist poster-style variant. The init CLI offers **Create your own theme** — it prompts for a theme name (default `my-theme`) and scaffolds `themes/<name>.ts` and `themes/<name>.css`. The theme name in config must match the theme's CSS import path (e.g. `greentree` → `@farming-labs/theme/greentree/css` for Next.js).
+Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border`, `colorful`, `greentree`, `darkbold`, `shiny`, `concrete`, `command-grid`, and `hardline`. `hardline` is the existing hard-edge preset, `concrete` is the louder brutalist poster-style variant, and `command-grid` is the mono-first paper-grid preset inspired by the better-cmdk landing page. The init CLI offers **Create your own theme** — it prompts for a theme name (default `my-theme`) and scaffolds `themes/<name>.ts` and `themes/<name>.css`. The theme name in config must match the theme's CSS import path (e.g. `greentree` → `@farming-labs/theme/greentree/css` for Next.js).
 
 ### Built-in UI features
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -483,8 +483,9 @@ The init CLI offers several built-in themes plus an option to create your own:
 | `pixel-border` | Refined dark UI inspired by better-auth.com                |
 | `colorful`     | Fumadocs-style neutral theme with description support      |
 | `greentree`    | Emerald green accent, Inter font, Mintlify-inspired        |
-| `hardline`     | Hard-edge theme with square corners and bold borders        |
+| `command-grid` | Mono-first paper-grid preset inspired by the better-cmdk landing page |
 | `concrete`     | Brutalist poster-style theme with offset shadows            |
+| `hardline`     | Hard-edge theme with square corners and bold borders        |
 | `darkbold`     | Pure monochrome, Geist typography, clean minimalism        |
 | `shiny`        | Glossy, modern look with subtle shimmer effects            |
 | **Create your own theme** | Scaffolds `themes/<name>.ts` and `themes/<name>.css`; you’re prompted for the theme name (default `my-theme`). See [Creating your own theme](/docs/themes/creating-themes). |
@@ -616,8 +617,9 @@ When you choose **Existing project**, the CLI does the following (framework-spec
       │ ○ pixel-border
       │ ○ colorful
       │ ○ greentree
-      │ ○ hardline
       │ ○ concrete
+      │ ○ command-grid
+      │ ○ hardline
       │ ○ darkbold
       │ ○ shiny
       │ ○ Create your own theme
@@ -688,8 +690,9 @@ When you choose **Existing project**, the CLI does the following (framework-spec
       │ ○ pixel-border
       │ ○ colorful
       │ ○ greentree
-      │ ○ hardline
       │ ○ concrete
+      │ ○ command-grid
+      │ ○ hardline
       │ ○ darkbold
       │ ○ shiny
       │ ○ Create your own theme
@@ -737,11 +740,12 @@ When you choose **Existing project**, the CLI does the following (framework-spec
       │ ○ darksharp
       │ ○ pixel-border
       │ ○ colorful
-      │ ○ greentree
-      │ ○ hardline
-      │ ○ concrete
       │ ○ darkbold
       │ ○ shiny
+      │ ○ greentree
+      │ ○ concrete
+      │ ○ command-grid
+      │ ○ hardline
       │
       ◆ Entry path for docs:
       │ docs
@@ -804,11 +808,12 @@ When you choose **Existing project**, the CLI does the following (framework-spec
       │ ○ darksharp
       │ ○ pixel-border
       │ ○ colorful
-      │ ○ greentree
-      │ ○ hardline
-      │ ○ concrete
       │ ○ darkbold
       │ ○ shiny
+      │ ○ greentree
+      │ ○ concrete
+      │ ○ command-grid
+      │ ○ hardline
       │
       ◆ Entry path for docs:
       │ docs
@@ -873,11 +878,12 @@ When you choose **Existing project**, the CLI does the following (framework-spec
       │ ○ darksharp
       │ ○ pixel-border
       │ ○ colorful
-      │ ○ greentree
-      │ ○ hardline
-      │ ○ concrete
       │ ○ darkbold
       │ ○ shiny
+      │ ○ greentree
+      │ ○ concrete
+      │ ○ command-grid
+      │ ○ hardline
       │
       ◆ Entry path for docs:
       │ docs
@@ -928,7 +934,7 @@ When you choose **Existing project**, the CLI does the following (framework-spec
 | ----------------------- | --------------------------------------------------------------------------- |
 | `--template <name>`     | Bootstrap a project: `next`, `tanstack-start`, `nuxt`, `sveltekit`, or `astro`. Use with `--name`. |
 | `--name <project>`      | Project folder name when using `--template`; prompt if omitted (e.g. `my-docs`) |
-| `--theme <name>`        | Skip theme prompt: `fumadocs`, `darksharp`, `pixel-border`, `colorful`, `darkbold`, `shiny`, `greentree`, `hardline`, `concrete` |
+| `--theme <name>`        | Skip theme prompt: `fumadocs`, `darksharp`, `pixel-border`, `colorful`, `darkbold`, `shiny`, `greentree`, `concrete`, `command-grid`, `hardline` |
 | `--entry <path>`        | Skip entry path prompt (e.g. `--entry docs`)                                |
 
 **Starting from scratch?** Use `--template` with `--name <project>`. The CLI bootstraps a project with the given name, installs dependencies, and then you run `cd <project> && pnpm run dev` to start.

--- a/website/app/docs/themes/command-grid/page.mdx
+++ b/website/app/docs/themes/command-grid/page.mdx
@@ -1,0 +1,55 @@
+---
+title: "Command Grid"
+description: "Mono-first paper-grid theme inspired by the better-cmdk landing page"
+icon: "grid2x2"
+order: 4.8
+---
+
+# Command Grid Theme
+
+A mono-first preset with a paper-grid light mode, lead-toned dark mode, sharper borders, and calmer surfaces inspired by the better-cmdk landing page.
+
+## Usage
+
+```tsx title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+import { commandGrid } from "@farming-labs/theme/command-grid";
+
+export default defineDocs({
+  entry: "docs",
+  theme: commandGrid(),
+});
+```
+
+```css title="app/global.css"
+@import "tailwindcss";
+@import "@farming-labs/theme/command-grid/css";
+```
+
+## Defaults
+
+| Property      | Value                               |
+| ------------- | ----------------------------------- |
+| Primary       | `#141414`                           |
+| Background    | `#f8f6ed` (light), `#121212` (dark) |
+| Border radius | `0px`                               |
+| Content width | 900px                               |
+| Sidebar width | 304px                               |
+
+## Style Notes
+
+- Mono-first typography across the sidebar, TOC, and command surfaces
+- Paper-grid background in light mode with a quieter dark-mode grid
+- Sharper tables, callouts, search UI, and Ask AI surfaces
+- Better-cmdk-inspired light/dark palette without the heavier concrete shadow treatment
+
+## Customizing
+
+```tsx title="customizing.tsx"
+theme: commandGrid({
+  ui: {
+    colors: { accent: "#d9c9b4" },
+    layout: { sidebarWidth: 320 },
+  },
+}),
+```

--- a/website/app/docs/themes/page.mdx
+++ b/website/app/docs/themes/page.mdx
@@ -7,7 +7,7 @@ order: 4
 
 # Themes
 
-@farming-labs/docs ships with nine built-in theme entrypoints. Each is a preset factory function that you pass to `defineDocs()`. `hardline` stays as the original hard-edge preset, and `concrete` is the second, louder brutalist variant.
+@farming-labs/docs ships with ten built-in theme entrypoints. Each is a preset factory function that you pass to `defineDocs()`. `hardline` stays as the original hard-edge preset, `concrete` is the louder brutalist variant, and `command-grid` is the mono-first paper-grid preset inspired by the better-cmdk landing page.
 
 <Callout type="tip" title="Create your own theme">
   Want to build a custom theme or publish one as a package? See **[Creating your own theme](/docs/themes/creating-themes)** for the full guide.
@@ -25,6 +25,7 @@ order: 4
 | [DarkBold](/docs/themes/darkbold)         | `@farming-labs/theme/darkbold`     | Pure monochrome, Geist typography       |
 | [GreenTree](/docs/themes/greentree)       | `@farming-labs/theme/greentree`    | Mintlify-inspired, emerald green accent |
 | [Concrete](/docs/themes/concrete)         | `@farming-labs/theme/concrete`     | Brutalist poster-style hard-edge theme  |
+| [Command Grid](/docs/themes/command-grid) | `@farming-labs/theme/command-grid` | Mono-first paper-grid preset inspired by better-cmdk |
 | [Hardline](/docs/themes/hardline)         | `@farming-labs/theme/hardline`     | Original hard-edge theme with strong borders |
 
 ## Using a Theme

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -772,6 +772,12 @@ function ThemesSection() {
       import: '@import "@farming-labs/theme/concrete/css";',
       colors: ["#ff5b31", "#f6ead9", "#5b4e42", "#141210"],
     },
+    {
+      name: "Command Grid",
+      description: "Mono-first paper-grid preset inspired by the better-cmdk landing page",
+      import: '@import "@farming-labs/theme/command-grid/css";',
+      colors: ["#141414", "#f8f6ed", "#d1c0a9", "#3d3d3d"],
+    },
   ];
 
   return (

--- a/website/app/themes/page.tsx
+++ b/website/app/themes/page.tsx
@@ -172,6 +172,25 @@ export default defineDocs({
     globalCss: `@import "tailwindcss";
 @import "@farming-labs/theme/concrete/css";`,
   },
+  {
+    key: "command-grid",
+    name: "Command Grid",
+    description:
+      "Mono-first paper-grid preset inspired by the better-cmdk landing page, with sharper docs chrome and calmer surfaces.",
+    cssImport: '@import "@farming-labs/theme/command-grid/css";',
+    colors: ["#141414", "#f8f6ed", "#d1c0a9", "#3d3d3d"],
+    accent: "#141414",
+    previewEnabled: false,
+    configSnippet: `import { defineDocs } from "@farming-labs/docs";
+import { commandGrid } from "@farming-labs/theme/command-grid";
+
+export default defineDocs({
+  entry: "docs",
+  theme: commandGrid(),
+});`,
+    globalCss: `@import "tailwindcss";
+@import "@farming-labs/theme/command-grid/css";`,
+  },
 ];
 
 type Theme = (typeof themes)[number];


### PR DESCRIPTION
- **feat: common grid theme**
- **chore: update**
- **chore: lint**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the Command Grid theme across Next, Svelte, Nuxt, and Astro with a new theme factory, CSS bundles, CLI support, and a Next example update. Also revamps MDX table rendering for consistent overflow handling and spacing.

- **New Features**
  - Added `commandGrid` preset with `CommandGridUIDefaults` in `@farming-labs/fumadocs` and framework themes (`@farming-labs/astro-theme`, `@farming-labs/nuxt-theme`, `@farming-labs/svelte-theme`).
  - Published CSS bundles/exports: `@farming-labs/theme/command-grid/css` and framework equivalents.
  - CLI `init`: added theme option, template mappings, help text, and tests for CSS/config templates.
  - Next example switched to `command-grid`; added `Bebas Neue` and `IBM Plex Mono` via `next/font/google`; fixed types path to `./.next/dev/types/routes.d.ts`.

- **Bug Fixes**
  - MDX/Markdown tables now render inside a scrollable `.fd-table-wrapper` with proper spacing across packages (Astro, Nuxt, Svelte, and `@farming-labs/fumadocs` MDX).

<sup>Written for commit c5c18c6a3c5149c1537f02ebc5d40a199c3cfcaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

