### PR TITLE
chore: readme and skill sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ If you enable **API reference** during init, the CLI writes the `apiReference` b
 If your backend is hosted somewhere else, you can switch the generated `apiReference` block to
 remote mode later by setting `specUrl` to a hosted `openapi.json`.
 
+If you are testing unpublished changes inside this monorepo or another local workspace, keep
+`@farming-labs/*` app dependencies linked locally (for example `workspace:*`). This matters most
+for TanStack Start on Node 22 / Vercel, where the app should resolve the built
+`@farming-labs/tanstack-start/vite` entry instead of raw TypeScript from `node_modules`.
+
 You can also run the built-in MCP server locally:
 
 ```bash

--- a/packages/astro-theme/package.json
+++ b/packages/astro-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro-theme",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Astro UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "astro",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Astro adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "astro",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/docs",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Modern, flexible MDX-based docs framework — core types, config, and CLI",
   "keywords": [
     "docs",

--- a/packages/fumadocs/package.json
+++ b/packages/fumadocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/theme",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Theme package for @farming-labs/docs — layout, provider, MDX components, and styles",
   "keywords": [
     "docs",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/next",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Next.js adapter for @farming-labs/docs — MDX config wrapper",
   "keywords": [
     "docs",

--- a/packages/nuxt-theme/package.json
+++ b/packages/nuxt-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt-theme",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Nuxt/Vue UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Nuxt adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/svelte-theme/package.json
+++ b/packages/svelte-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte-theme",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Svelte UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "SvelteKit adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/tanstack-start",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "TanStack Start adapter for @farming-labs/docs — content loading, search, and AI utilities",
   "keywords": [
     "docs",

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -244,6 +244,7 @@ When the user chooses **Existing project**, the CLI detects (or prompts for) fra
 1. **Monorepo** — Run `init` from the app package root (where `package.json` with the framework dependency lives). For `upgrade`, use `--framework` if auto-detect picks the wrong one.
 2. **No package.json / wrong directory** — Init and upgrade must run in a directory that has (or will have) a `package.json` with the framework dependency.
 3. **Beta** — Use `upgrade --beta` to get beta versions of the docs packages.
+4. **TanStack Start local package development** — In this repo's examples and other monorepos, prefer local links such as `workspace:*` for `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/tanstack-start` while testing unpublished changes. On Node 22 / Vercel, this prevents the adapter Vite entry from resolving to raw TypeScript inside `node_modules`.
 
 ---
 

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -203,6 +203,7 @@ For fully static builds (e.g. Cloudflare Pages, no server), set `staticExport: t
 4. **Existing project** — Run `init` in the project root; the CLI detects the framework and scaffolds files.
 5. **Static hosting** — Set `staticExport: true`; search and AI are then hidden.
 6. **API reference on non-Next frameworks** — `apiReference` in `docs.config` is not enough by itself on TanStack Start, SvelteKit, Astro, or Nuxt; add the `/{path}` handler manually or let `init --api-reference` scaffold it, even when you use a remote `specUrl`.
+7. **TanStack Start in a monorepo** — If the app and docs packages live in the same workspace, keep `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/tanstack-start` linked locally (for example `workspace:*`). This avoids Node 22 / Vercel loading raw adapter TypeScript from `node_modules`.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -533,6 +533,8 @@ When you choose **Existing project**, the CLI does the following (framework-spec
     7. **Updates existing app files when needed** — Injects `RootProvider` into `src/routes/__root.tsx` and adds `docsMdx()` / Tailwind plugins to `vite.config.ts`
     8. **Installs dependencies** — `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/tanstack-start`
     9. **Starts the dev server** — Opens your docs at `http://localhost:5173/docs`
+
+    > In this repo's examples and in other monorepos, keep those `@farming-labs/*` dependencies linked locally while testing unpublished changes. CI and Vercel on Node 22 should consume the built adapter entrypoints, not raw `src/*.ts` files from `node_modules`.
   </Tab>
   <Tab value="SvelteKit">
     1. **Detects SvelteKit** via `@sveltejs/kit` in your `package.json` (or asks you to pick a framework)

--- a/website/app/docs/contributing/page.mdx
+++ b/website/app/docs/contributing/page.mdx
@@ -76,6 +76,7 @@ Please be respectful and constructive. We aim to keep the community welcoming an
 - **`packages/`** — Core packages: `docs`, `fumadocs` (theme), `next`, `svelte`, `svelte-theme`, `astro`, `astro-theme`, `nuxt`, `nuxt-theme`.
 - **`website/`** — This docs site (Next.js); content under `app/docs/`.
 - **`examples/`** — Example apps (Next.js, TanStack Start, and others) for testing.
+  When you work on this monorepo, keep local `@farming-labs/*` example dependencies linked with `workspace:*` so CI and Vercel on Node 22 resolve the built workspace adapters instead of an older published package from `node_modules`.
 
 Doc content lives in `website/app/docs/` as MDX. Config and sidebar are driven by [docs.config.tsx](/docs/configuration) in `website/`.
 

--- a/website/app/docs/installation/page.mdx
+++ b/website/app/docs/installation/page.mdx
@@ -129,6 +129,8 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
       </Tab>
     </Tabs>
 
+    > **Monorepo note**: If you are developing `@farming-labs/docs` and a TanStack Start app in the same workspace, keep `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/tanstack-start` linked locally (for example `workspace:*`). This avoids Node 22 / Vercel trying to load raw adapter TypeScript from `node_modules`.
+
     ### 2. Create `docs.config.tsx`
 
     ```tsx title="docs.config.tsx"
@@ -241,6 +243,8 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
         ```
       </Tab>
     </Tabs>
+
+    > **Monorepo note**: If you are developing `@farming-labs/docs` and a TanStack Start app in the same workspace, keep `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/tanstack-start` linked locally (for example `workspace:*`). This avoids Node 22 / Vercel trying to load raw adapter TypeScript from `node_modules`.
 
     ### 2. Create `docs.config.tsx`
 


### PR DESCRIPTION
- **chore: release v0.1.11**
- **chore: readme and skill sync**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds monorepo guidance to README/docs for TanStack Start on Node 22/Vercel and syncs SKILL docs. Bumps all `@farming-labs/*` packages to v0.1.11.

- **Dependencies**
  - Version bump to v0.1.11 for: `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/next`, `@farming-labs/nuxt`, `@farming-labs/nuxt-theme`, `@farming-labs/astro`, `@farming-labs/astro-theme`, `@farming-labs/svelte`, `@farming-labs/svelte-theme`, `@farming-labs/tanstack-start`.

- **Migration**
  - In monorepos, link `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/tanstack-start` locally (e.g., `workspace:*`) so Node 22/Vercel uses built adapter entrypoints (e.g., `@farming-labs/tanstack-start/vite`) instead of raw TypeScript from `node_modules`.

<sup>Written for commit 068aa46a0a8b46606d8c472289498a1ffd575974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

