### PR TITLE
chore: collocation agent and human optimized docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modern, flexible MDX-based documentation framework. Write markdown, get a poli
 - 💬 **Built-in docs actions** — page feedback, copy/open page actions, and code-block copy callbacks
 - 🔎 **Search adapters** — zero-config built-in search, plus Typesense, Algolia, and custom adapters
 - 🤖 **Built-in MCP server** — expose docs over stdio or `/api/docs/mcp` for MCP clients and IDE agents
+- 📝 **Machine-readable markdown routes** — serve docs as markdown with optional page-local `agent.md` overrides
 
 **Get started:**
 
@@ -533,6 +534,46 @@ See:
 - [Configuration](https://docs.farming-labs.dev/docs/configuration#mcp-server)
 - [API Reference](https://docs.farming-labs.dev/docs/reference#docsmcpconfig)
 
+## Machine-readable Markdown Routes
+
+The shared docs API can return page markdown through the existing docs handler:
+
+```txt
+/api/docs?format=markdown&path=getting-started/quickstart
+```
+
+In **Next.js**, `withDocs()` also exposes public page-level markdown routes automatically:
+
+```txt
+/docs/getting-started/quickstart.md
+```
+
+Add a sibling `agent.md` only when a page needs a machine-specific override:
+
+```txt
+app/docs/getting-started/quickstart/
+  page.mdx
+
+app/docs/getting-started/agent-ready-docs/
+  page.mdx
+  agent.md
+```
+
+Behavior:
+
+- `/docs/<slug>` stays the normal HTML page
+- if `agent.md` exists, `/docs/<slug>.md` returns that file
+- if `agent.md` does not exist, the markdown route falls back to the normal page markdown
+- MCP `read_page("/docs/<slug>")` uses the same page source and sees the same override
+
+This does **not** require a separate `docs.config` flag.
+
+See:
+
+- [Markdown Routes](https://docs.farming-labs.dev/docs/customization/markdown-routes)
+- [MCP Server](https://docs.farming-labs.dev/docs/customization/mcp)
+- [llms.txt](https://docs.farming-labs.dev/docs/customization/llms-txt)
+
 Each page uses frontmatter for metadata:
 
 ```md
@@ -812,6 +853,7 @@ This matters because:
 - **One config file** means an AI can understand your entire docs setup by reading a single file, rather than tracing through multiple interconnected files.
 - **Declarative config** is hard to break — an AI can change `theme: darksharp()` or add `ai: { enabled: true }` without worrying about import paths or component hierarchies.
 - **llms.txt** is built in — your docs are automatically served in LLM-optimized format with zero extra config.
+- **Page-level markdown routes** let agents fetch a single docs page over plain HTTP instead of parsing HTML, and `agent.md` gives you a focused page-local override when needed.
 
 ### The CLI does the heavy lifting
 

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, API reference, and MCP).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, API reference, MCP, and machine-readable markdown routes).
 
 The repo also includes a runnable Next example for testing MCP plus external search providers:
 
@@ -14,6 +14,9 @@ Useful routes:
 
 - MCP: `http://127.0.0.1:3000/api/docs/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
+- Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=getting-started/quickstart`
+- Public markdown page (Next.js): `http://127.0.0.1:3000/docs/getting-started/quickstart.md`
+- Agent override example (Next.js): `http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md`
 
 ---
 
@@ -21,12 +24,12 @@ Useful routes:
 
 | Skill | Path | When to use |
 | ----- | ---- | ----------- |
-| **Getting started** | [getting-started](./getting-started/SKILL.md) | Setting up docs, init, manual install, theme CSS, docs.config, packages by framework, generated changelog pages in Next.js, and API reference wiring from local routes or a hosted OpenAPI JSON. |
+| **Getting started** | [getting-started](./getting-started/SKILL.md) | Setting up docs, init, manual install, theme CSS, docs.config, packages by framework, generated changelog pages in Next.js, machine-readable markdown routes, and API reference wiring from local routes or a hosted OpenAPI JSON. |
 | **CLI** | [cli](./cli/SKILL.md) | Scaffolding and commands: init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), `init` / `upgrade` / `mcp`, `--template`, `--name`, `--theme`, `--entry`, `--api-reference`, `--framework`, `--config`, package manager commands. |
 | **Creating themes** | [creating-themes](./creating-themes/SKILL.md) | Building a custom theme with `createTheme()`, `extendTheme()`, `ui.components` defaults like `HoverLink`, publishing as npm, CSS overrides. |
 | **Ask AI** | [ask-ai](./ask-ai/SKILL.md) | Enabling and configuring the RAG-powered AI chat: mode, floatingStyle, providers, models, suggestedQuestions, apiKey. |
-| **Page actions** | [page-actions](./page-actions/SKILL.md) | Copy Markdown and Open in LLM buttons: copyMarkdown, openDocs, providers, urlTemplate, position, alignment, and provider defaults. |
-| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, feedback, metadata, og, `mcp`, and `apiReference` including remote `specUrl` support. |
+| **Page actions** | [page-actions](./page-actions/SKILL.md) | Copy Markdown and Open in LLM buttons: copyMarkdown, openDocs, providers, urlTemplate, `{url}.md` markdown route patterns, position, alignment, and provider defaults. |
+| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, feedback, metadata, og, `mcp`, built-in markdown routes, and `apiReference` including remote `specUrl` support. |
 
 ---
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -71,6 +71,39 @@ export default defineDocs({
 
 ---
 
+## Machine-readable markdown routes
+
+No separate `docs.config` flag is required for page-level markdown delivery.
+
+Default behavior:
+
+- the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
+- **Next.js:** `withDocs()` also serves `/docs/<slug>.md`
+- if a page folder has `agent.md`, that file becomes the markdown response for that page
+- if `agent.md` is missing, the markdown response falls back to the normal page markdown
+- MCP `read_page("/docs/<slug>")` uses the same page source and sees the same override
+
+Folder example:
+
+```txt
+app/docs/getting-started/quickstart/
+  page.mdx
+
+app/docs/getting-started/agent-ready-docs/
+  page.mdx
+  agent.md
+```
+
+Useful checks:
+
+```bash
+curl "http://127.0.0.1:3000/api/docs?format=markdown&path=getting-started/quickstart"
+curl "http://127.0.0.1:3000/docs/getting-started/quickstart.md"
+curl "http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md"
+```
+
+---
+
 ## GitHub (Edit on GitHub and openDocs)
 
 ```ts

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -44,6 +44,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
 - **Built-in MCP server** — enable `mcp: { enabled: true }` to expose `/api/docs/mcp` and local stdio tools.
+- **Machine-readable markdown routes** — Next.js serves `/docs/<slug>.md` automatically with `withDocs()`. Add a sibling `agent.md` to override agent-facing markdown; otherwise the route falls back to the normal page markdown. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`.
 
 ### MCP quick test
 

--- a/skills/farming-labs/page-actions/SKILL.md
+++ b/skills/farming-labs/page-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: page-actions
-description: Configure page actions in @farming-labs/docs — Copy Markdown and Open in LLM buttons. Use when enabling copyMarkdown, openDocs, custom providers, urlTemplate placeholders ({url}, {mdxUrl}, {githubUrl}), alignment, or position (above-title, below-title).
+description: Configure page actions in @farming-labs/docs — Copy Markdown and Open in LLM buttons. Use when enabling copyMarkdown, openDocs, custom providers, urlTemplate placeholders ({url}, {mdxUrl}, {githubUrl}), `{url}.md` markdown route patterns, alignment, or position (above-title, below-title).
 ---
 
 # @farming-labs/docs — Page Actions
@@ -121,8 +121,12 @@ interface OpenDocsProvider {
 | Placeholder | Replaced with |
 | ----------- | -------------- |
 | `{url}` | Current page URL (e.g. `https://docs.example.com/docs/installation`) |
-| `{mdxUrl}` | `.mdx` variant of the page URL (for raw source) |
+| `{mdxUrl}` | Raw `.mdx` source URL for the page |
 | `{githubUrl}` | GitHub **edit** URL for the current page. Requires `github` in config. Use `urlTemplate: "{githubUrl}"` for "Open in GitHub". |
+
+If the project exposes machine-readable markdown routes, use `{url}.md` when you want the public
+page markdown instead of the raw source file. In Next.js, that route can return a sibling
+`agent.md` when the page has one.
 
 ### Custom providers example
 
@@ -155,6 +159,22 @@ pageActions: {
 For `{githubUrl}` to work, the top-level `github` config must be set (e.g. `github: { url: "https://github.com/owner/repo", directory: "website" }`).
 
 **Cursor deeplink:** The web example uses `https://cursor.com/link/prompt?text=...`. To open the Cursor app directly instead, use `cursor://anysphere.cursor-deeplink/prompt?text=...`.
+
+Example using the public markdown route:
+
+```ts
+pageActions: {
+  openDocs: {
+    enabled: true,
+    providers: [
+      {
+        name: "ChatGPT",
+        urlTemplate: "https://chatgpt.com/?q=Read+this+page:+{url}.md",
+      },
+    ],
+  },
+}
+```
 
 ---
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -140,6 +140,17 @@ All configuration lives in a single `docs.config.ts` file.
 
 The default MDX map already includes built-ins like `Callout`, `Tabs`, and `HoverLink`. Use `components` when you want to add your own components or override any of those defaults. If you only want to change the default props of a built-in like `HoverLink`, use `theme.ui.components` instead. See [Components](/docs/customization/components) for examples and a live `HoverLink` demo.
 
+## Machine-readable markdown routes
+
+No separate config flag is required for machine-readable page markdown.
+
+- The shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
+- In Next.js, `withDocs()` also serves `/docs/<slug>.md`
+- When a page folder has `agent.md`, that file is returned instead of the normal page markdown
+
+See [Markdown Routes](/docs/customization/markdown-routes) for the routing behavior and folder
+convention.
+
 ## Static export
 
 For fully static builds (e.g. **Cloudflare Pages**, static hosting with no server), set `staticExport: true` in your config. This:

--- a/website/app/docs/customization/markdown-routes/page.mdx
+++ b/website/app/docs/customization/markdown-routes/page.mdx
@@ -1,0 +1,100 @@
+---
+title: "Markdown Routes"
+description: "Serve machine-readable markdown for docs pages, with optional agent.md overrides."
+icon: "fileText"
+order: 5.7
+---
+
+# Markdown Routes
+
+`@farming-labs/docs` can expose each docs page as machine-readable markdown for HTTP clients and
+agents.
+
+The shared docs API supports markdown reads through:
+
+```txt title="/api/docs?format=markdown&path=<slug>"
+/api/docs?format=markdown&path=getting-started/quickstart
+```
+
+In **Next.js**, `withDocs()` also generates public page-level markdown routes automatically:
+
+```txt title="/docs/<slug>.md"
+/docs/getting-started/quickstart.md
+```
+
+## Why use this
+
+- give agents and tools a plain markdown URL for one page
+- keep the human page at `/docs/<slug>` and the machine page at `/docs/<slug>.md`
+- add page-local agent instructions without rewriting the human docs page
+
+## Folder Convention
+
+Use a normal `page.mdx` for people and add a sibling `agent.md` only when the page needs a focused
+agent override.
+
+```txt
+app/docs/getting-started/quickstart/
+  page.mdx
+
+app/docs/getting-started/agent-ready-docs/
+  page.mdx
+  agent.md
+```
+
+## Behavior
+
+- `page.mdx` stays the human page at `/docs/<slug>`
+- if `agent.md` exists, the markdown endpoint returns that file
+- if `agent.md` does not exist, the markdown endpoint falls back to the normal page markdown
+- MCP `read_page("/docs/<slug>")` uses the same page source and sees the same `agent.md` override
+
+<Callout type="info" title="No extra config flag">
+  There is no separate `docs.config` option to turn this on. The shared docs API already supports
+  markdown mode, and the Next.js adapter exposes the public `.md` routes automatically when you use
+  `withDocs()`.
+</Callout>
+
+## Next.js
+
+With `withDocs()`, no extra route file is needed for the default behavior.
+
+```ts title="next.config.ts"
+import { withDocs } from "@farming-labs/next/config";
+
+export default withDocs();
+```
+
+That gives you:
+
+- `/docs/<slug>` for the normal HTML page
+- `/docs/<slug>.md` for the machine-readable page markdown
+
+## Other Frameworks and Custom Routes
+
+The existing docs API handler can already return page markdown through `format=markdown`.
+
+```txt
+/api/docs?format=markdown&path=getting-started/quickstart
+```
+
+That means TanStack Start, SvelteKit, Astro, and Nuxt can use the same shared markdown mode through
+their existing docs API route. If you want a public `/docs/<slug>.md` URL outside Next.js, add a
+framework-specific route that forwards into the same docs API handler.
+
+## Testing
+
+```bash title="terminal"
+curl http://localhost:3000/docs/getting-started/agent-ready-docs.md
+curl http://localhost:3000/docs/getting-started/quickstart.md
+curl "http://localhost:3000/api/docs?format=markdown&path=getting-started/quickstart"
+```
+
+## When To Use This vs MCP and `llms.txt`
+
+- Use **markdown routes** when you want one page over plain HTTP
+- Use **MCP** when you want a structured, queryable interface with tools like `search_docs` and `read_page`
+- Use **`llms.txt`** when you want a static, crawler-friendly summary or full-site dump
+
+They work well together. Markdown routes are the simplest page-level HTTP contract, MCP is the
+interactive tool surface, and `llms.txt` is the lightweight public export.

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -320,9 +320,11 @@ The built-in resources mirror that same data:
 - `docs://docs/installation`
 - `docs://docs/guides/quickstart`
 
-## When to use this vs `llms.txt`
+## When to use this vs markdown routes and `llms.txt`
 
+- Use **markdown routes** when you want a plain HTTP URL for one page
 - Use **`llms.txt`** when you want a static, crawler-friendly docs summary
 - Use **MCP** when you want a structured, queryable docs interface for agents and IDE tools
 
-They complement each other well. `llms.txt` is lightweight and public; MCP is interactive and tool-based.
+They complement each other well. Markdown routes are the simplest page-level HTTP surface,
+`llms.txt` is lightweight and public, and MCP is interactive and tool-based.

--- a/website/app/docs/customization/page-actions/page.mdx
+++ b/website/app/docs/customization/page-actions/page.mdx
@@ -141,8 +141,14 @@ The `urlTemplate` string supports these placeholders:
 | Placeholder   | Replaced with                                                                 |
 | ------------- | ----------------------------------------------------------------------------- |
 | `{url}`       | The current page URL (e.g. `https://docs.example.com/docs/installation`)      |
-| `{mdxUrl}`    | The `.mdx` variant of the page URL (useful for raw source)                    |
+| `{mdxUrl}`    | The raw `.mdx` source URL for the page (useful when you want the source file) |
 | `{githubUrl}` | GitHub **edit** URL for the current page (same as "Edit on GitHub"). Requires `github` in config. Use `urlTemplate: "{githubUrl}"` so "Open in GitHub" opens the file on GitHub. |
+
+<Callout type="info" title="Use `{url}.md` for agent-ready page markdown">
+  `{mdxUrl}` points at the raw source file. If you want the built-in machine-readable docs page
+  instead, use `{url}.md`. In Next.js, that route can return a sibling `agent.md` when the page
+  has one. See [Markdown Routes](/docs/customization/markdown-routes).
+</Callout>
 
 ### Custom Providers Example
 
@@ -162,6 +168,22 @@ pageActions: {
       {
         name: "Cursor",
         urlTemplate: "https://cursor.com/link/prompt?text=Read+this+documentation:+{url}",
+      },
+    ],
+  },
+}
+```
+
+Example using the public markdown route instead of raw source:
+
+```ts title="docs.config.ts"
+pageActions: {
+  openDocs: {
+    enabled: true,
+    providers: [
+      {
+        name: "ChatGPT",
+        urlTemplate: "https://chatgpt.com/?q=Read+this+page:+{url}.md",
       },
     ],
   },

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customization"
-description: "Colors, typography, sidebar, components, OG images, AI chat, and page actions"
+description: "Colors, typography, sidebar, components, markdown routes, OG images, AI chat, and page actions"
 icon: "settings"
 order: 5
 ---
@@ -18,6 +18,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[OG Images](/docs/customization/og-images)** — Dynamic or static Open Graph images; what context your image generator receives; how the docs website does it
 - **[Ask AI](/docs/customization/ai-chat)** — RAG-powered AI chat with configurable LLM, floating/search modes, and more
 - **[Page Actions](/docs/customization/page-actions)** — "Copy Markdown" and "Open in LLM" buttons on doc pages
+- **[Markdown Routes](/docs/customization/markdown-routes)** — machine-readable page markdown with optional `agent.md` overrides
 - **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio and `/api/docs/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1052,7 +1052,7 @@ Action buttons shown on each docs page. See [Page Actions](/docs/customization/p
 | ------------- | ----------- | --------------------------------------------------------------------------------- |
 | `name`        | `string`    | Display name (e.g. `"ChatGPT"`, `"Claude"`)                                       |
 | `icon`        | `ReactNode` | Icon rendered next to the name                                                    |
-| `urlTemplate` | `string`    | URL template. `{url}` is replaced with the page URL, `{mdxUrl}` with the MDX URL, and `{githubUrl}` with the GitHub edit URL when `github` is configured. |
+| `urlTemplate` | `string`    | URL template. `{url}` is replaced with the page URL, `{mdxUrl}` with the raw MDX source URL, and `{githubUrl}` with the GitHub edit URL when `github` is configured. Use `{url}.md` when you want the public machine-readable page route. |
 
 ```ts
 pageActions: {
@@ -1243,7 +1243,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | Property | Type                                                       | Description |
 | -------- | ---------------------------------------------------------- | ----------- |
 | `load`   | `({ pathname, locale? }) => Promise<DocsServerLoadResult>` | Loads docs page data and the sidebar tree for a pathname |
-| `GET`    | `({ request }) => Response`                                | Search / `llms.txt` endpoint handler |
+| `GET`    | `({ request }) => Response`                                | Search / markdown / `llms.txt` endpoint handler |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
 
 ```ts title="src/lib/docs.server.ts"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds machine-readable markdown routes and optional `agent.md` overrides so agents can fetch a single page as markdown via the shared API or `/docs/<slug>.md` in Next.js. Also clarifies page action URL templates and updates skills and reference docs across `@farming-labs/docs`.

- New Features
  - New “Markdown Routes” doc detailing behavior, folder convention (`page.mdx` + optional `agent.md`), and curl tests
  - README and Configuration: document `/api/docs?format=markdown&path=<slug>` and Next.js `withDocs()` exposing `/docs/<slug>.md`; MCP reads the same source/override
  - Page Actions: recommend `{url}.md` for machine-readable page content; clarify `{mdxUrl}` is raw source; add example provider
  - Skills: update getting-started, configuration, page-actions, and skills README with markdown route usage and examples
  - Reference: refine `pageActions.urlTemplate` notes and mark server `GET` as search/markdown/llms handler

<sup>Written for commit f308a6fd916ead550a61e2cbee00f3ba99382b83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

