### PR TITLE
feat: enable mcp by default for collocation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,13 +492,23 @@ See the full docs for more detail:
 
 ## Built-in MCP Server
 
-`mcp` exposes your docs as a built-in MCP server for local agents and remote HTTP clients.
+MCP is enabled by default, so your docs can be exposed as a built-in MCP server for local agents
+and remote HTTP clients without extra config.
+
+```ts
+export default defineDocs({
+  entry: "docs",
+  theme: fumadocs(),
+});
+```
+
+Opt out explicitly when you do not want the MCP surface:
 
 ```ts
 export default defineDocs({
   entry: "docs",
   mcp: {
-    enabled: true,
+    enabled: false,
   },
   theme: fumadocs(),
 });

--- a/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
@@ -132,12 +132,12 @@ access and parity checks, but the HTTP `.md` route is the simple public contract
 
 ## Docs Config
 
-The example app keeps MCP enabled so the markdown route and MCP can both be exercised:
+The example app does not need any MCP flag. `withDocs()` picks up the default MCP surface
+automatically, so the markdown route and MCP can both be exercised without extra config:
 
 ```tsx title="examples/next/docs.config.tsx"
 export default defineDocs({
   entry: "docs",
-  mcp: { enabled: true },
   ordering: "numeric",
   pageActions: {
     copyMarkdown: { enabled: true },

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -45,7 +45,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
-| `mcp`         | `boolean \| DocsMcpConfig`                      | `false`          | Built-in MCP server over stdio and `/api/docs/mcp`                                   |
+| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio and `/api/docs/mcp`                                   |
 | `apiReference` | `boolean \| ApiReferenceConfig`               | `false`          | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON |
 | `changelog`   | `boolean \| ChangelogConfig`                    | `false`          | Generated changelog feed and entry pages from dated MDX entries                      |
 | `ordering`    | `"alphabetical" \| "numeric" \| OrderingItem[]` | `"alphabetical"` | Sidebar page ordering strategy                                                       |
@@ -155,7 +155,7 @@ Built-in MCP server configuration for AI clients, IDE agents, and local MCP tool
 
 | Property   | Type                  | Default           | Description |
 | ---------- | --------------------- | ----------------- | ----------- |
-| `enabled`  | `boolean`             | `true` in object config | Enable the MCP server when the object is present |
+| `enabled`  | `boolean`             | `true`                | Enable the MCP server. MCP is on by default; set `false` to opt out. |
 | `route`    | `string`              | `"/api/docs/mcp"` | Streamable HTTP route used by the MCP endpoint |
 | `name`     | `string`              | `nav.title` or `@farming-labs/docs` | MCP server name reported to clients |
 | `version`  | `string`              | `"0.0.0"`         | Version string reported to clients |
@@ -165,7 +165,6 @@ Built-in MCP server configuration for AI clients, IDE agents, and local MCP tool
 export default defineDocs({
   entry: "docs",
   mcp: {
-    enabled: true,
     route: "/api/docs/mcp",
     name: "My Docs MCP",
     tools: {

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -209,7 +209,6 @@ export default defineDocs({
       ],
     },
   },
-  mcp: { enabled: true },
   ordering: "numeric",
   metadata: {
     titleTemplate: "%s – Docs",

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -33,6 +33,21 @@ async function parseMcpPayload<T>(response: Response): Promise<T> {
 }
 
 describe("resolveDocsMcpConfig", () => {
+  it("enables MCP by default when config is omitted", () => {
+    expect(resolveDocsMcpConfig()).toEqual({
+      enabled: true,
+      route: "/api/docs/mcp",
+      name: "@farming-labs/docs",
+      version: "0.0.0",
+      tools: {
+        listPages: true,
+        readPage: true,
+        searchDocs: true,
+        getNavigation: true,
+      },
+    });
+  });
+
   it("normalizes defaults for enabled object configs", () => {
     expect(
       resolveDocsMcpConfig({
@@ -526,7 +541,7 @@ No frontmatter title here.
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toMatchObject({
-      error: expect.stringContaining("MCP is not enabled"),
+      error: expect.stringContaining("MCP is disabled"),
     });
   });
 

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -48,6 +48,21 @@ describe("resolveDocsMcpConfig", () => {
     });
   });
 
+  it("treats null config like an omitted config", () => {
+    expect(resolveDocsMcpConfig(null as never)).toEqual({
+      enabled: true,
+      route: "/api/docs/mcp",
+      name: "@farming-labs/docs",
+      version: "0.0.0",
+      tools: {
+        listPages: true,
+        readPage: true,
+        searchDocs: true,
+        getNavigation: true,
+      },
+    });
+  });
+
   it("normalizes defaults for enabled object configs", () => {
     expect(
       resolveDocsMcpConfig({

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -135,7 +135,7 @@ export function resolveDocsMcpConfig(
     defaultRoute?: string;
   } = {},
 ): DocsMcpResolvedConfig {
-  if (!mcp) {
+  if (mcp === false) {
     return {
       enabled: false,
       route: normalizeDocsMcpRoute(defaults.defaultRoute),
@@ -396,17 +396,17 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
       GET: async () =>
         createJsonErrorResponse(
           404,
-          "MCP is not enabled. Set `mcp: { enabled: true }` in docs.config to enable it.",
+          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
         ),
       POST: async () =>
         createJsonErrorResponse(
           404,
-          "MCP is not enabled. Set `mcp: { enabled: true }` in docs.config to enable it.",
+          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
         ),
       DELETE: async () =>
         createJsonErrorResponse(
           404,
-          "MCP is not enabled. Set `mcp: { enabled: true }` in docs.config to enable it.",
+          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
         ),
     };
   }

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -150,7 +150,7 @@ export function resolveDocsMcpConfig(
     };
   }
 
-  const config = typeof mcp === "object" ? mcp : {};
+  const config = mcp && typeof mcp === "object" ? mcp : {};
 
   return {
     enabled: typeof mcp === "boolean" ? mcp : (config.enabled ?? true),

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1617,9 +1617,10 @@ export interface DocsConfig {
   /**
    * Built-in MCP server for agent/assistant access to your docs content.
    *
+   * - omitted → enable the default MCP surface at `/api/docs/mcp`
    * - `true` → enable the default MCP surface at `/api/docs/mcp`
    * - `{ route: "/api/docs/mcp" }` → enable with explicit route/config
-   * - `false` or omitted → MCP stays disabled
+   * - `false` or `{ enabled: false }` → disable MCP explicitly
    */
   mcp?: boolean | DocsMcpConfig;
   /**

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -62,7 +62,6 @@ Welcome to the docs.
       rootDir,
       entry: "docs",
       nav: { title: "Example Docs" },
-      mcp: { enabled: true },
     });
 
     const response = await POST(

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -169,6 +169,16 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(route).toContain("search: docsConfig.search");
   });
 
+  it("generates the default MCP route when mcp config is omitted", () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG, "utf-8");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    withDocs({});
+
+    expect(existsSync(join(tmpDir, "app/api/docs/mcp/route.ts"))).toBe(true);
+  });
+
   it("generates the markdown bridge route and rewrites", async () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -902,11 +902,11 @@ function readMcpConfig(root: string): {
         route: normalizeRoutePath(routeMatch?.[1] ?? "/api/docs/mcp"),
       };
     } catch {
-      return { enabled: false, route: "/api/docs/mcp" };
+      return { enabled: true, route: "/api/docs/mcp" };
     }
   }
 
-  return { enabled: false, route: "/api/docs/mcp" };
+  return { enabled: true, route: "/api/docs/mcp" };
 }
 
 function normalizeRoutePath(route: string): string {

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -46,7 +46,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `ai` | `AIConfig` | — | RAG-powered AI chat (see `ask-ai` skill) |
 | `search` | `boolean \| DocsSearchConfig` | `true` | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `changelog` | `boolean \| ChangelogConfig` | `false` | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
-| `mcp` | `boolean \| DocsMcpConfig` | `false` | Built-in MCP server over stdio and `/api/docs/mcp` |
+| `mcp` | `boolean \| DocsMcpConfig` | enabled | Built-in MCP server over stdio and `/api/docs/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false` | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON document |
 | `metadata` | `DocsMetadata` | — | SEO: titleTemplate, description, etc. |
 | `og` | `OGConfig` | — | Dynamic Open Graph images |
@@ -278,12 +278,20 @@ feedback: {
 
 ## MCP Server
 
-Use `mcp` to expose your docs as a built-in MCP server for local agents and remote HTTP clients.
+MCP is enabled by default. Use `mcp` when you want to customize the built-in MCP server for local
+agents and remote HTTP clients, or set `enabled: false` to opt out.
 
 ```ts
 mcp: {
-  enabled: true,
   route: "/api/docs/mcp",
+}
+```
+
+Opt out explicitly:
+
+```ts
+mcp: {
+  enabled: false,
 }
 ```
 

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -43,7 +43,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
-- **Built-in MCP server** — enable `mcp: { enabled: true }` to expose `/api/docs/mcp` and local stdio tools.
+- **Built-in MCP server** — enabled by default at `/api/docs/mcp` and for local stdio tools. Opt out with `mcp: false` or `mcp: { enabled: false }`.
 - **Machine-readable markdown routes** — Next.js serves `/docs/<slug>.md` automatically with `withDocs()`. Add a sibling `agent.md` to override agent-facing markdown; otherwise the route falls back to the normal page markdown. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`.
 
 ### MCP quick test

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -132,7 +132,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
-| `mcp`         | `boolean \| DocsMcpConfig`     | `false`         | Built-in MCP server over stdio and `/api/docs/mcp` |
+| `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio and `/api/docs/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |
 | `i18n`        | `DocsI18nConfig`               | —               | Query-param locale support and locale switcher     |
 | `metadata`    | `DocsMetadata`                 | —               | SEO metadata template                              |
@@ -320,13 +320,26 @@ Notes:
 
 ## MCP Server
 
-Use `mcp` to expose your docs as a built-in MCP server for AI tools and IDE agents.
+MCP is enabled by default. Use `mcp` to customize the built-in MCP server for AI tools and IDE
+agents, or set `enabled: false` to opt out.
 
 ```ts title="docs.config.ts"
 export default defineDocs({
   entry: "docs",
   mcp: {
-    enabled: true,
+    route: "/api/docs/mcp",
+  },
+  theme: fumadocs(),
+});
+```
+
+Opt out explicitly:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  mcp: {
+    enabled: false,
   },
   theme: fumadocs(),
 });

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -21,7 +21,9 @@ It also exposes resources for:
 - `docs://navigation`
 - one `docs://…` resource per page
 
-## Enable it
+## Default behavior
+
+MCP is enabled by default.
 
 ```ts title="docs.config.ts"
 import { defineDocs } from "@farming-labs/docs";
@@ -30,13 +32,10 @@ import { pixelBorder } from "@farming-labs/theme/pixel-border";
 export default defineDocs({
   entry: "docs",
   theme: pixelBorder(),
-  mcp: {
-    enabled: true,
-  },
 });
 ```
 
-That enables the built-in MCP surface with the default Streamable HTTP route:
+That gives you the built-in MCP surface with the default Streamable HTTP route:
 
 ```txt title="/api/docs/mcp"
 /api/docs/mcp
@@ -47,13 +46,24 @@ That enables the built-in MCP surface with the default Streamable HTTP route:
   `https://docs.farming-labs.dev/api/docs/mcp`.
 </Callout>
 
+Opt out explicitly:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  mcp: {
+    enabled: false,
+  },
+});
+```
+
 ## Default HTTP route
 
 `/api/docs/mcp` is the default MCP endpoint across the framework adapters.
 
 <Callout type="info" title="Minimal route behavior">
-  **Next.js** auto-generates the default `/api/docs/mcp` route when `mcp` is enabled and you use
-  `withDocs()`.
+  **Next.js** auto-generates the default `/api/docs/mcp` route when you use `withDocs()`, unless
+  you explicitly disable MCP.
 
   **TanStack Start**, **SvelteKit**, **Astro**, and **Nuxt** still need the framework route file,
   but they all reuse the built-in MCP handler from the docs server helper.

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -48,7 +48,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
-| `mcp`         | `boolean \| DocsMcpConfig`                      | `false`          | Built-in MCP server over stdio and `/api/docs/mcp`                                   |
+| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio and `/api/docs/mcp`                                   |
 | `apiReference` | `boolean \| ApiReferenceConfig`               | `false`          | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON |
 | `changelog`   | `boolean \| ChangelogConfig`                    | `false`          | Generated changelog feed and entry pages from dated MDX entries                      |
 | `ordering`    | `"alphabetical" \| "numeric" \| OrderingItem[]` | `"alphabetical"` | Sidebar page ordering strategy                                                       |
@@ -158,7 +158,7 @@ Built-in MCP server configuration for AI clients, IDE agents, and local MCP tool
 
 | Property   | Type                  | Default           | Description |
 | ---------- | --------------------- | ----------------- | ----------- |
-| `enabled`  | `boolean`             | `true` in object config | Enable the MCP server when the object is present |
+| `enabled`  | `boolean`             | `true`                | Enable the MCP server. MCP is on by default; set `false` to opt out. |
 | `route`    | `string`              | `"/api/docs/mcp"` | Streamable HTTP route used by the MCP endpoint |
 | `name`     | `string`              | `nav.title` or `@farming-labs/docs` | MCP server name reported to clients |
 | `version`  | `string`              | `"0.0.0"`         | Version string reported to clients |
@@ -168,7 +168,6 @@ Built-in MCP server configuration for AI clients, IDE agents, and local MCP tool
 export default defineDocs({
   entry: "docs",
   mcp: {
-    enabled: true,
     route: "/api/docs/mcp",
     name: "My Docs MCP",
     tools: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable MCP by default across docs and the Next.js adapter, with a simple opt-out via `mcp: false`. This auto-exposes `/api/docs/mcp` and removes extra config in examples.

- **New Features**
  - MCP is on by default when `mcp` is omitted or `null` in `defineDocs()` (normalized defaults for route, tools, name, version).
  - `withDocs()` auto-generates `app/api/docs/mcp/route.ts` for Next.js by default and assumes MCP is enabled if `docs.config.ts` can’t be read.
  - Clearer disabled state: 404 now says “MCP is disabled” with guidance to remove `mcp: false` or set `mcp: { enabled: true }`.

- **Migration**
  - To disable MCP, set `mcp: false` or `mcp: { enabled: false }`.
  - Confirm `/api/docs/mcp` doesn’t conflict with custom routes.
  - No changes needed if you already had `mcp: { enabled: true }`.

<sup>Written for commit 9294f55abe2e92bf757eb03c9446af09b6f5e0fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

