### PR TITLE
chore: agent feedback loop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An AI-native documentation framework for Next.js, TanStack Start, SvelteKit, Ast
 - 🧾 **Generated API reference from framework route handlers or a hosted OpenAPI JSON**
 - 📣 **Built-in changelog pages for Next.js** — release feed + detail pages from dated MDX entries
 - 🧩 **Built-in MDX UI** — `Callout`, `Tabs`, `HoverLink`, and overridable built-ins via `components` and `theme.ui.components`
-- 💬 **Built-in docs actions** — page feedback, copy/open page actions, and code-block copy callbacks
+- 💬 **Built-in docs actions** — human page feedback, agent feedback endpoints, copy/open page actions, and code-block copy callbacks
 - 🔎 **Search adapters** — zero-config built-in search, plus Typesense, Algolia, and custom adapters
 - 🤖 **Built-in MCP server** — expose docs over stdio or `/api/docs/mcp` for MCP clients and IDE agents
 - 📝 **Machine-readable markdown routes** — serve docs as markdown with embedded `Agent` blocks and optional page-local `agent.md` overrides
@@ -607,6 +607,50 @@ See:
 - [Agent Primitive](https://docs.farming-labs.dev/docs/customization/agent-primitive)
 - [MCP Server](https://docs.farming-labs.dev/docs/customization/mcp)
 - [llms.txt](https://docs.farming-labs.dev/docs/customization/llms-txt)
+
+## Agent Feedback Endpoints
+
+The shared docs API can also expose machine-readable feedback endpoints for agents:
+
+```ts
+feedback: {
+  agent: {
+    enabled: true,
+    async onFeedback(data) {
+      console.log(data.context?.source, data.payload);
+    },
+  },
+},
+```
+
+Default routes:
+
+```txt
+GET  /api/docs/agent/feedback/schema
+POST /api/docs/agent/feedback
+```
+
+The request body always uses a stable envelope:
+
+```json
+{
+  "context": {
+    "page": "/docs/installation",
+    "source": "md-route"
+  },
+  "payload": {
+    "task": "install docs in an existing Next.js app",
+    "outcome": "implemented"
+  }
+}
+```
+
+Notes:
+
+- `feedback.agent` does not turn on the human footer UI by itself
+- the shared `/api/docs` handler remains the source of truth
+- in Next.js, `withDocs()` wires the public `/api/docs/agent/feedback` routes automatically
+- customize `route`, `schemaRoute`, or `schema` in `docs.config` when needed
 
 Each page uses frontmatter for metadata:
 

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, API reference, MCP, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent feedback endpoints, API reference, MCP, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
 
 The repo also includes a runnable Next example for testing MCP plus external search providers:
 
@@ -15,6 +15,7 @@ Useful routes:
 - MCP: `http://127.0.0.1:3000/api/docs/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`
+- Agent feedback schema: `http://127.0.0.1:3000/api/docs/agent/feedback/schema`
 - Public markdown page with embedded `Agent` block (Next.js): `http://127.0.0.1:3000/docs/quickstart.md`
 - Agent override example (Next.js): `http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md`
 
@@ -29,7 +30,7 @@ Useful routes:
 | **Creating themes** | [creating-themes](./creating-themes/SKILL.md) | Building a custom theme with `createTheme()`, `extendTheme()`, `ui.components` defaults like `HoverLink`, publishing as npm, CSS overrides. |
 | **Ask AI** | [ask-ai](./ask-ai/SKILL.md) | Enabling and configuring the RAG-powered AI chat: mode, floatingStyle, providers, models, suggestedQuestions, apiKey. |
 | **Page actions** | [page-actions](./page-actions/SKILL.md) | Copy Markdown and Open in LLM buttons: copyMarkdown, openDocs, providers, urlTemplate, `{url}.md` markdown route patterns, position, alignment, and provider defaults. |
-| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, feedback, metadata, og, `mcp`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
+| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, human page feedback, agent feedback endpoints, metadata, og, `mcp`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
 
 ---
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -41,7 +41,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `icons` | `Record<string, Component>` | — | Icon registry for frontmatter `icon` fields |
 | `components` | `Record<string, Component>` | — | Custom MDX components and built-in overrides like `HoverLink` |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | — | Callback when user copies a code block (title, content, url, language) |
-| `feedback` | `boolean \| FeedbackConfig` | `false` | End-of-page feedback prompt and callback |
+| `feedback` | `boolean \| FeedbackConfig` | `false` | Human page feedback UI plus optional agent feedback endpoints |
 | `pageActions` | `PageActionsConfig` | — | Copy Markdown, Open in LLM (see `page-actions` skill) |
 | `ai` | `AIConfig` | — | RAG-powered AI chat (see `ask-ai` skill) |
 | `search` | `boolean \| DocsSearchConfig` | `true` | Built-in simple search, Typesense, Algolia, or a custom adapter |
@@ -290,6 +290,71 @@ feedback: {
 - Use `feedback: true` to show the UI with no callback.
 - **Next.js / TanStack Start / SvelteKit / Nuxt:** `feedback.onFeedback` runs from the built-in UI with no extra client bridge file.
 - **Astro:** the built-in UI still works with `feedback: true`; optional analytics hooks can listen to `window.__fdOnFeedback__` or the `fd:feedback` event.
+
+## Agent feedback endpoints
+
+Use `feedback.agent` when agents or automation should be able to report docs understanding or
+implementation outcomes back through the shared docs API.
+
+```ts
+feedback: {
+  agent: {
+    enabled: true,
+    async onFeedback(data) {
+      console.log(data.context?.page, data.payload);
+    },
+  },
+}
+```
+
+Default behavior:
+
+- `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
+- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
+- the shared `/api/docs` handler remains the source of truth
+- **Next.js:** `withDocs()` adds the public rewrites automatically
+- `feedback.agent` alone does not enable the human footer UI
+
+Default payload shape:
+
+```json
+{
+  "context": {
+    "page": "/docs/installation",
+    "source": "md-route"
+  },
+  "payload": {
+    "task": "install docs in an existing Next.js app",
+    "understanding": "partial",
+    "outcome": "implemented",
+    "confidence": 0.78,
+    "neededCodeReading": true,
+    "missingContext": ["how the markdown route is resolved"],
+    "docIssues": ["command example was unclear"],
+    "suggestedImprovement": "Add one sentence about rewrite behavior."
+  }
+}
+```
+
+Customize the route or payload schema when needed:
+
+```ts
+feedback: {
+  agent: {
+    route: "/internal/docs/agent-feedback",
+    schemaRoute: "/internal/docs/agent-feedback/schema",
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        task: { type: "string" },
+        outcome: { type: "string" },
+      },
+      required: ["task", "outcome"],
+    },
+  },
+}
+```
 
 ---
 

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,6 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
+- **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
 - **Built-in MCP server** — enabled by default at `/api/docs/mcp` and for local stdio tools. Opt out with `mcp: false` or `mcp: { enabled: false }`.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -127,7 +127,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `icons`       | `Record<string, Component>`    | —               | Icon registry for frontmatter `icon` fields        |
 | `components`  | `Record<string, Component>`    | —               | Custom MDX components and built-in overrides like `HoverLink` |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | —         | Callback when the user clicks the copy button on a code block |
-| `feedback`    | `boolean \| FeedbackConfig`    | `false`         | End-of-page feedback prompt and callback                     |
+| `feedback`    | `boolean \| FeedbackConfig`    | `false`         | Human page feedback UI plus optional agent feedback endpoints |
 | `pageActions` | `PageActionsConfig`            | —               | Copy Markdown, Open in LLM buttons                 |
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
@@ -976,6 +976,91 @@ export async function POST(request: Request) {
 
   return NextResponse.json({ ok: true }, { status: 201 });
 }
+```
+
+## Agent Feedback Endpoints
+
+Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware
+automation. This is separate from the built-in page footer UI.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  feedback: {
+    agent: {
+      enabled: true,
+      async onFeedback(data) {
+        console.log(data.context?.source, data.payload);
+      },
+    },
+  },
+});
+```
+
+Default behavior:
+
+- `GET /api/docs/agent/feedback/schema` returns the feedback schema
+- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
+- the shared `/api/docs` handler is still the source of truth
+- in Next.js, `withDocs()` adds the public rewrites automatically
+- `feedback.agent` alone does not enable the human footer UI
+
+Default request shape:
+
+```json title="POST body"
+{
+  "context": {
+    "page": "/docs/installation",
+    "url": "https://docs.example.com/docs/installation.md",
+    "slug": "installation",
+    "locale": "en",
+    "source": "md-route"
+  },
+  "payload": {
+    "task": "install docs in an existing Next.js app",
+    "understanding": "partial",
+    "outcome": "implemented",
+    "confidence": 0.78,
+    "neededCodeReading": true,
+    "missingContext": ["how the markdown route is resolved"],
+    "docIssues": ["command example was unclear"],
+    "suggestedImprovement": "Add one sentence about the rewrite behavior."
+  }
+}
+```
+
+Customize the public route or the payload schema when needed:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  feedback: {
+    agent: {
+      route: "/internal/docs/agent-feedback",
+      schemaRoute: "/internal/docs/agent-feedback/schema",
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          task: { type: "string" },
+          outcome: { type: "string" },
+          confidence: { type: "number", minimum: 0, maximum: 1 }
+        },
+        required: ["task", "outcome"]
+      }
+    }
+  }
+});
+```
+
+Quick test:
+
+```bash title="terminal"
+curl "http://127.0.0.1:3000/api/docs/agent/feedback/schema"
+
+curl -X POST "http://127.0.0.1:3000/api/docs/agent/feedback" \
+  -H "content-type: application/json" \
+  -d '{"payload":{"task":"demo","outcome":"implemented"}}'
 ```
 
 ## Page Actions

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -41,7 +41,11 @@ The shared docs API also accepts the same feature through query parameters:
 - schema: `/api/docs?feedback=agent&schema=1`
 - submit: `/api/docs?feedback=agent`
 
-Read the schema first, then submit a body shaped like:
+Fetch the schema endpoint first and use the returned schema as the source of truth for the body you
+submit. Do not assume the payload fields are fixed, because the site can customize
+`feedback.agent.schema`.
+
+For the default schema, the body looks like:
 
 ```json
 {

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -29,6 +29,36 @@ Use this page when you need the page-level authoring contract for agent-facing d
 - API route: `/api/docs?format=markdown&path=customization/agent-primitive`
 - MCP read target: `/docs/customization/agent-primitive`
 
+## Feedback Contract
+
+If agent feedback is enabled for the site, use these default endpoints:
+
+- schema: `/api/docs/agent/feedback/schema`
+- submit: `/api/docs/agent/feedback`
+
+The shared docs API also accepts the same feature through query parameters:
+
+- schema: `/api/docs?feedback=agent&schema=1`
+- submit: `/api/docs?feedback=agent`
+
+Read the schema first, then submit a body shaped like:
+
+```json
+{
+  "context": {
+    "page": "/docs/customization/agent-primitive",
+    "source": "md-route"
+  },
+  "payload": {
+    "task": "understand page-level agent docs",
+    "outcome": "implemented"
+  }
+}
+```
+
+If the project customizes `feedback.agent.route` or `feedback.agent.schemaRoute`, use those
+configured paths instead of the defaults.
+
 ## Skills
 
 This repo also ships reusable Agent Skills for broader workflows that are larger than one page.

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -72,6 +72,43 @@ This is the stronger option. Use it when agents need:
 - testing or validation steps
 - a shorter, more targeted page than the human docs should show
 
+## Point Agents At Feedback Endpoints
+
+Page primitives are also a good place to tell agents how to report whether the docs were enough to
+complete a task.
+
+If `feedback.agent` is enabled in `docs.config`, agents can read the schema first and then post
+structured feedback back into the shared docs API:
+
+- schema: `/api/docs/agent/feedback/schema`
+- submit: `/api/docs/agent/feedback`
+
+Example additive block:
+
+```mdx title="app/docs/installation/page.mdx"
+# Installation
+
+Human-facing setup instructions.
+
+<Agent>
+If this page was enough to complete the task, or if something was missing, fetch the feedback
+schema from `/api/docs/agent/feedback/schema` and submit structured feedback to
+`/api/docs/agent/feedback`.
+
+Use a body shaped like:
+{
+  "context": { "page": "/docs/installation", "source": "md-route" },
+  "payload": { "task": "install docs", "outcome": "implemented" }
+}
+</Agent>
+```
+
+That works especially well when:
+
+- the feedback instruction belongs to one page or workflow
+- you want the agent-facing `.md` route to carry the reporting contract
+- the human page should stay uncluttered
+
 ## Choosing Between Them
 
 - Use `Agent` when the normal page should stay the source of truth and you only need extra machine context

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -92,10 +92,10 @@ Human-facing setup instructions.
 
 <Agent>
 If this page was enough to complete the task, or if something was missing, fetch the feedback
-schema from `/api/docs/agent/feedback/schema` and submit structured feedback to
-`/api/docs/agent/feedback`.
+schema from `/api/docs/agent/feedback/schema` first. Use the returned schema as the source of truth
+for the request body, then submit structured feedback to `/api/docs/agent/feedback`.
 
-Use a body shaped like:
+For the default schema, the body looks like:
 {
   "context": { "page": "/docs/installation", "source": "md-route" },
   "payload": { "task": "install docs", "outcome": "implemented" }

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -44,7 +44,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `icons`       | `Record<string, unknown>`                       | —                | Icon registry for frontmatter `icon` fields                                          |
 | `components`  | `Record<string, unknown>`                       | —                | Custom MDX component overrides, including built-ins like `HoverLink`                |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void`              | —                | Callback when the user clicks the copy button on a code block (runs in addition to copy) |
-| `feedback`    | `boolean \| FeedbackConfig`                     | `false`          | End-of-page feedback prompt and feedback callback                                    |
+| `feedback`    | `boolean \| FeedbackConfig`                     | `false`          | Human page feedback UI plus optional agent feedback endpoints                        |
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
@@ -653,7 +653,7 @@ export default defineDocs({
 
 ---
 
-## `feedback`, `FeedbackConfig`, and `DocsFeedbackData`
+## `feedback`, `FeedbackConfig`, `AgentFeedbackConfig`, and feedback payloads`
 
 Optional docs page feedback UI. When enabled, a built-in "Good / Bad" prompt is rendered at the end of the page and emits a feedback payload when the user clicks one of the buttons.
 
@@ -666,6 +666,7 @@ Optional docs page feedback UI. When enabled, a built-in "Good / Bad" prompt is 
 | `positiveLabel` | `string`                                 | `"Good"`          | Label for the positive button                |
 | `negativeLabel` | `string`                                 | `"Bad"`           | Label for the negative button                |
 | `onFeedback`    | `(data: DocsFeedbackData) => void`       | —                 | Callback fired when the user clicks a button |
+| `agent`         | `boolean \| AgentFeedbackConfig`         | —                 | Agent feedback routes served through `/api/docs` |
 
 ### `DocsFeedbackData`
 
@@ -702,6 +703,84 @@ This docs site persists feedback through a local Next.js route at
 
 See [Page feedback](/docs/configuration#page-feedback) for framework-specific notes. The built-in
 UI does not require a separate client bridge file.
+
+### `AgentFeedbackConfig`
+
+Optional machine-facing feedback routes for agents, scripts, or evaluation flows.
+
+| Property      | Type                                                | Default                            | Description |
+| ------------- | --------------------------------------------------- | ---------------------------------- | ----------- |
+| `enabled`     | `boolean`                                           | `true` when `agent` is provided    | Enable or disable the agent feedback endpoints |
+| `route`       | `string`                                            | `"/api/docs/agent/feedback"`       | Public HTTP route for feedback submission |
+| `schemaRoute` | `string`                                            | `${route}/schema`                  | Public HTTP route for the machine-readable schema |
+| `schema`      | `Record<string, unknown>`                           | built-in payload schema            | Schema used to validate the `payload` object |
+| `onFeedback`  | `(data: DocsAgentFeedbackData) => Promise<void> \| void` | —                              | Async callback fired after a valid submission |
+
+Notes:
+
+- `feedback.agent` does not enable the human footer UI by itself
+- the request body always uses `{ context?, payload }`
+- in Next.js, `withDocs()` adds the public route rewrites automatically
+- the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
+
+### `DocsAgentFeedbackContext`
+
+| Property | Type                    | Description |
+| -------- | ----------------------- | ----------- |
+| `page`   | `string \| undefined`   | Docs page path such as `"/docs/installation"` |
+| `url`    | `string \| undefined`   | Full docs URL when available |
+| `slug`   | `string \| undefined`   | Docs slug relative to the entry root |
+| `locale` | `string \| undefined`   | Active locale when docs i18n is enabled |
+| `source` | `string \| undefined`   | Arbitrary source label such as `"md-route"`, `"mcp"`, or `"api"` |
+
+### `DocsAgentFeedbackData`
+
+| Property  | Type                                  | Description |
+| --------- | ------------------------------------- | ----------- |
+| `context` | `DocsAgentFeedbackContext \| undefined` | Optional docs/page transport context |
+| `payload` | `Record<string, unknown>`             | Agent feedback payload validated by `feedback.agent.schema` |
+
+```ts title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  feedback: {
+    agent: {
+      enabled: true,
+      route: "/api/docs/agent/feedback",
+      async onFeedback(data) {
+        console.log(data.context?.page, data.payload);
+      },
+    },
+  },
+});
+```
+
+```json title="default request body"
+{
+  "context": {
+    "page": "/docs/installation",
+    "source": "md-route"
+  },
+  "payload": {
+    "task": "install docs in an existing Next.js app",
+    "understanding": "partial",
+    "outcome": "implemented",
+    "confidence": 0.78
+  }
+}
+```
+
+Quick checks:
+
+```bash
+curl "http://127.0.0.1:3000/api/docs/agent/feedback/schema"
+
+curl -X POST "http://127.0.0.1:3000/api/docs/agent/feedback" \
+  -H "content-type: application/json" \
+  -d '{"payload":{"task":"demo","outcome":"implemented"}}'
+```
 
 ---
 

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds docs for machine-readable agent feedback so agents can report outcomes via `/api/docs/agent/feedback` or `/api/docs?feedback=agent`. Also updates config/reference pages with examples and clarifications, and fixes a Next.js types import path.

- **New Features**
  - Documented agent feedback endpoints and schema: default routes (`GET /api/docs/agent/feedback/schema`, `POST /api/docs/agent/feedback`), stable `{ context, payload }` envelope, query-param access (`/api/docs?feedback=agent` with `schema=1`), customization (`route`, `schemaRoute`, `schema`), and notes that Next.js `withDocs()` wires routes and this doesn’t enable the human footer UI.
  - Updated README, Configuration, Reference, Getting Started, Agent Primitive, and Skills pages with examples, curl tests, and guidance for pointing agents at the endpoints.

- **Bug Fixes**
  - Corrected `website/next-env.d.ts` to import `./.next/types/routes.d.ts`.

<sup>Written for commit d80557d14a1d0bdf6d1647f22f744bae757c1a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

