### PR TITLE
feat: agent discovery manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,15 @@ Behavior:
 In Next.js, the public `.md` route rewrites into the existing `/api/docs` handler with
 `format=markdown`, so the shared docs API remains the source of truth.
 
+Agents can discover the configured machine-readable surface first:
+
+```txt
+GET /api/docs/agent/spec
+```
+
+The spec returns the docs API route, markdown URL patterns, MCP endpoint and tool toggles, and agent
+feedback schema/submit routes based on `docs.config`.
+
 This does **not** require a separate `docs.config` flag.
 
 See:

--- a/examples/next/app/api/docs/route.ts
+++ b/examples/next/app/api/docs/route.ts
@@ -7,6 +7,7 @@ export const { GET, POST } = createDocsAPI({
   i18n: docsConfig.i18n,
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
+  mcp: docsConfig.mcp,
   search: docsConfig.search,
   ai: docsConfig.ai,
 });

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -505,6 +505,134 @@ title: "Home"
     expect(await response.text()).toBe("Not Found");
   });
 
+  it("serves the agent discovery spec through the shared docs api handler", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-spec-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      feedback: {
+        agent: {
+          enabled: true,
+          route: "/internal/agent-feedback",
+          schemaRoute: "/internal/agent-feedback/schema",
+        },
+      },
+      mcp: {
+        enabled: true,
+        route: "/internal/docs/mcp",
+        tools: {
+          listPages: true,
+          readPage: true,
+          searchDocs: false,
+          getNavigation: true,
+        },
+      },
+    });
+
+    const response = await GET(new Request("http://localhost/api/docs/agent/spec"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+
+    const spec = (await response.json()) as {
+      version: string;
+      api: Record<string, string>;
+      markdown: Record<string, unknown>;
+      mcp: {
+        enabled: boolean;
+        endpoint: string;
+        name: string;
+        version: string;
+        tools: Record<string, boolean>;
+      };
+      feedback: { enabled: boolean; schema: string; submit: string };
+      instructions: Record<string, boolean>;
+    };
+
+    expect(spec.version).toBe("1");
+    expect(spec.api).toMatchObject({
+      docs: "/api/docs",
+      agentSpec: "/api/docs/agent/spec",
+      agentSpecQuery: "/api/docs?agent=spec",
+    });
+    expect(spec.markdown).toMatchObject({
+      enabled: true,
+      pagePattern: "/docs/{slug}.md",
+      rootPage: "/docs.md",
+      apiPattern: "/api/docs?format=markdown&path={slug}",
+    });
+    expect(spec.mcp).toEqual({
+      enabled: true,
+      endpoint: "/internal/docs/mcp",
+      name: "Documentation",
+      version: "0.0.0",
+      tools: {
+        listPages: true,
+        readPage: true,
+        searchDocs: false,
+        getNavigation: true,
+      },
+    });
+    expect(spec.feedback).toMatchObject({
+      enabled: true,
+      schema: "/internal/agent-feedback/schema",
+      submit: "/internal/agent-feedback",
+    });
+    expect(spec.instructions).toMatchObject({
+      preferMarkdownRoutes: true,
+      useMcpWhenAvailable: true,
+      readFeedbackSchemaBeforeSubmitting: true,
+      doNotAssumeFeedbackPayloadShape: true,
+    });
+  });
+
+  it("serves the agent discovery spec through the rewritten query form", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-spec-query-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "guides"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "guides", "page.mdx"), "# Home\n");
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "guides",
+      feedback: {
+        agent: false,
+      },
+      mcp: false,
+    });
+
+    const response = await GET(new Request("http://localhost/api/docs?agent=spec"));
+    expect(response.status).toBe(200);
+    const spec = (await response.json()) as {
+      markdown: { pagePattern: string; rootPage: string };
+      mcp: { enabled: boolean; endpoint: string };
+      feedback: { enabled: boolean; schema: string; submit: string };
+    };
+
+    expect(spec.markdown).toMatchObject({
+      pagePattern: "/guides/{slug}.md",
+      rootPage: "/guides.md",
+    });
+    expect(spec.mcp).toMatchObject({
+      enabled: false,
+      endpoint: "/api/docs/mcp",
+    });
+    expect(spec.feedback).toMatchObject({
+      enabled: false,
+      schema: "/api/docs/agent/feedback/schema",
+      submit: "/api/docs/agent/feedback",
+    });
+  });
+
   it("serves the default agent feedback schema through the shared docs api handler", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-feedback-schema-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -24,7 +24,6 @@ import matter from "gray-matter";
 import { getNextAppDir } from "./get-app-dir.js";
 import { resolveChangelogConfig, resolveDocsI18n, resolveDocsLocale } from "@farming-labs/docs";
 import type {
-  AgentFeedbackConfig,
   ChangelogConfig,
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
@@ -34,6 +33,7 @@ import type {
 import {
   createDocsMcpHttpHandler,
   createFilesystemDocsMcpSource,
+  resolveDocsMcpConfig,
   type DocsMcpPage,
 } from "@farming-labs/docs/server";
 import { performDocsSearch, resolveSearchRequestConfig } from "@farming-labs/docs";
@@ -93,6 +93,8 @@ interface DocsAPIOptions {
   search?: boolean | DocsSearchConfig;
   /** Feedback configuration */
   feedback?: boolean | FeedbackConfig;
+  /** MCP configuration used for the agent discovery spec. */
+  mcp?: boolean | DocsMcpConfig;
 }
 
 interface DocsMCPAPIOptions {
@@ -108,6 +110,8 @@ interface DocsMCPAPIOptions {
 // ─── Helpers ────────────────────────────────────────────────────────
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
+const DEFAULT_DOCS_API_ROUTE = "/api/docs";
+const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
   type: "object",
@@ -164,6 +168,13 @@ interface ResolvedAgentFeedbackConfig {
 
 interface AgentFeedbackRequest {
   kind: "schema" | "submit";
+}
+
+interface AgentSpecOptions {
+  origin: string;
+  entry: string;
+  mcp: ReturnType<typeof resolveDocsMcpConfig>;
+  feedback: ResolvedAgentFeedbackConfig;
 }
 
 function normalizeAgentFeedbackRoute(
@@ -262,6 +273,53 @@ function resolveAgentFeedbackRequest(
   if (pathname === feedback.route) return { kind: "submit" };
 
   return null;
+}
+
+function resolveAgentSpecRequest(url: URL): boolean {
+  if (url.searchParams.get("agent")?.trim() === "spec") return true;
+  return normalizeUrlPath(url.pathname) === DEFAULT_AGENT_SPEC_ROUTE;
+}
+
+function buildAgentSpec({ origin, entry, mcp, feedback }: AgentSpecOptions) {
+  const normalizedEntry = normalizePathSegment(entry) || "docs";
+
+  return {
+    version: "1",
+    name: "@farming-labs/docs",
+    baseUrl: origin,
+    api: {
+      docs: DEFAULT_DOCS_API_ROUTE,
+      agentSpec: DEFAULT_AGENT_SPEC_ROUTE,
+      agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
+    },
+    markdown: {
+      enabled: true,
+      pagePattern: `/${normalizedEntry}/{slug}.md`,
+      rootPage: `/${normalizedEntry}.md`,
+      apiPattern: `${DEFAULT_DOCS_API_ROUTE}?format=markdown&path={slug}`,
+      resolutionOrder: ["agent.md", "Agent blocks", "page markdown"],
+    },
+    mcp: {
+      enabled: mcp.enabled,
+      endpoint: mcp.route,
+      name: mcp.name,
+      version: mcp.version,
+      tools: mcp.tools,
+    },
+    feedback: {
+      enabled: feedback.enabled,
+      schema: feedback.schemaRoute,
+      submit: feedback.route,
+      schemaQuery: `${DEFAULT_DOCS_API_ROUTE}?feedback=agent&schema=1`,
+      submitQuery: `${DEFAULT_DOCS_API_ROUTE}?feedback=agent`,
+    },
+    instructions: {
+      preferMarkdownRoutes: true,
+      useMcpWhenAvailable: true,
+      readFeedbackSchemaBeforeSubmitting: true,
+      doNotAssumeFeedbackPayloadShape: true,
+    },
+  };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -1364,6 +1422,9 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
   // Read llms.txt config
   const llmsConfig = readLlmsTxtConfig(root);
+  const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
+    defaultName: llmsConfig.siteTitle ?? "Documentation",
+  });
 
   type DocsContext = {
     entryPath: string;
@@ -1552,6 +1613,23 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     async GET(request: Request) {
       const ctx = resolveContextFromRequest(request);
       const url = new URL(request.url);
+      if (resolveAgentSpecRequest(url)) {
+        return Response.json(
+          buildAgentSpec({
+            origin: url.origin,
+            entry,
+            mcp: mcpConfig,
+            feedback: agentFeedbackConfig,
+          }),
+          {
+            headers: {
+              "Cache-Control": "public, max-age=0, s-maxage=3600",
+              "X-Robots-Tag": "noindex",
+            },
+          },
+        );
+      }
+
       const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
 
       if (agentFeedbackRequest) {

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -127,6 +127,9 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(readFileSync(join(tmpDir, "src/app/api/docs/route.ts"), "utf-8")).toContain(
       "feedback: docsConfig.feedback",
     );
+    expect(readFileSync(join(tmpDir, "src/app/api/docs/route.ts"), "utf-8")).toContain(
+      "mcp: docsConfig.mcp",
+    );
     expect(existsSync(join(tmpDir, "app/docs/layout.tsx"))).toBe(false);
     expect(existsSync(join(tmpDir, "app/api/docs/route.ts"))).toBe(false);
   });
@@ -220,6 +223,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     expect(rewrites).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          source: "/api/docs/agent/spec",
+          destination: "/api/docs?agent=spec",
+        }),
         expect.objectContaining({
           source: "/docs.md",
           destination: "/api/docs?format=markdown",
@@ -452,6 +459,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     expect(rewrites).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          source: "/api/docs/agent/spec",
+          destination: "/api/docs?agent=spec",
+        }),
         expect.objectContaining({
           source: "/docs.md",
           destination: "/api/docs?format=markdown",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -94,6 +94,7 @@ export const { GET, POST } = createDocsAPI({
   i18n: docsConfig.i18n,
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
+  mcp: docsConfig.mcp,
   search: docsConfig.search,
   ai: docsConfig.ai,
 });
@@ -166,6 +167,7 @@ export default function HiddenChangelogSourceLayout() {
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 
 function resolvePackageAlias(packageName: string, fallbacks: string[] = []): string | undefined {
@@ -977,6 +979,15 @@ function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
   ];
 }
 
+function buildAgentSpecRewrites(): NextRewrite[] {
+  return [
+    {
+      source: DEFAULT_AGENT_SPEC_ROUTE,
+      destination: "/api/docs?agent=spec",
+    },
+  ];
+}
+
 function buildAgentFeedbackRewrites(config: {
   enabled: boolean;
   route: string;
@@ -1020,6 +1031,7 @@ function mergeDocsMarkdownRewrites(
   result?: NextRewriteResult,
 ): NextRewriteResult {
   const autoRewrites = [
+    ...buildAgentSpecRewrites(),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent feedback endpoints, API reference, MCP, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, agent feedback endpoints, API reference, MCP, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
 
 The repo also includes a runnable Next example for testing MCP plus external search providers:
 
@@ -12,6 +12,7 @@ pnpm --dir examples/next dev
 
 Useful routes:
 
+- Agent discovery spec: `http://127.0.0.1:3000/api/docs/agent/spec`
 - MCP: `http://127.0.0.1:3000/api/docs/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,6 +309,7 @@ feedback: {
 
 Default behavior:
 
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,6 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/api/docs/route.ts
+++ b/website/app/api/docs/route.ts
@@ -7,6 +7,7 @@ export const { GET, POST } = createDocsAPI({
   i18n: docsConfig.i18n,
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
+  mcp: docsConfig.mcp,
   search: docsConfig.search,
   ai: docsConfig.ai,
 });

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -983,6 +983,10 @@ export async function POST(request: Request) {
 Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware
 automation. This is separate from the built-in page footer UI.
 
+Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
+the markdown route pattern, MCP endpoint and enabled tools, and the active agent feedback schema and
+submit endpoints.
+
 ```ts title="docs.config.ts"
 export default defineDocs({
   entry: "docs",
@@ -999,6 +1003,7 @@ export default defineDocs({
 
 Default behavior:
 
+- `GET /api/docs/agent/spec` returns the machine-readable route/config discovery document
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler is still the source of truth

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -29,6 +29,19 @@ Use this page when you need the page-level authoring contract for agent-facing d
 - API route: `/api/docs?format=markdown&path=customization/agent-primitive`
 - MCP read target: `/docs/customization/agent-primitive`
 
+## Agent Discovery 
+
+Fetch `GET /api/docs/agent/spec` before choosing how to read or report on the docs.
+
+The spec is generated from `docs.config` and includes:
+
+- shared docs API route
+- markdown route patterns
+- MCP enabled state, endpoint, server name, version, and tool toggles
+- agent feedback enabled state, schema route, and submit route
+
+Use the returned routes instead of hard-coding defaults when the project customizes MCP or feedback.
+
 ## Feedback Contract
 
 If agent feedback is enabled for the site, use these default endpoints:

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -16,6 +16,7 @@ The same page model also powers the built-in machine-readable routes:
 
 - the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - in Next.js, `withDocs()` also serves `/docs/<slug>.md`
+- agents can discover the configured contract with `GET /api/docs/agent/spec`
 
 Use `Agent` when the human page is already mostly correct and just needs a little extra implementation
 context. Use `agent.md` when the entire machine-readable page should be more operational, more
@@ -108,6 +109,20 @@ That works especially well when:
 - the feedback instruction belongs to one page or workflow
 - you want the agent-facing `.md` route to carry the reporting contract
 - the human page should stay uncluttered
+
+## Let Agents Discover The Contract
+
+`GET /api/docs/agent/spec` returns a small JSON document generated from `docs.config`.
+
+Agents should fetch it before choosing a transport. It tells them:
+
+- where the shared docs API lives
+- which markdown URL pattern to use for page reads
+- whether MCP is enabled, which endpoint to call, and which tools are available
+- whether agent feedback is enabled, plus the schema and submit endpoints to use
+
+For Next.js apps, `withDocs()` wires `/api/docs/agent/spec` into the same shared `/api/docs`
+handler automatically.
 
 ## Choosing Between Them
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,6 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
+- agents can discover the active markdown, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 
@@ -775,6 +776,8 @@ export default defineDocs({
 Quick checks:
 
 ```bash
+curl "http://127.0.0.1:3000/api/docs/agent/spec"
+
 curl "http://127.0.0.1:3000/api/docs/agent/feedback/schema"
 
 curl -X POST "http://127.0.0.1:3000/api/docs/agent/feedback" \

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an agent discovery manifest at GET `/api/docs/agent/spec` (or `/api/docs?agent=spec`) so agents can auto-discover markdown routes, MCP config, and feedback endpoints from your `docs.config`. The spec is served by the shared docs API and is wired up automatically in Next.js.

- **New Features**
  - New discovery routes: GET `/api/docs/agent/spec` and `/api/docs?agent=spec`.
  - Spec includes:
    - Docs API base and markdown patterns (page and root).
    - MCP enabled state, endpoint, name, version, and tool toggles.
    - Agent feedback enabled state, schema route, and submit route.
  - Next.js: `withDocs()` adds a rewrite for `/api/docs/agent/spec` to the shared handler.
  - `createDocsAPI` accepts `mcp` (e.g., `mcp: docsConfig.mcp`) for accurate spec output.
  - Responses are JSON with cache headers and `X-Robots-Tag: noindex`.

<sup>Written for commit 30ce91c05be8c17d3577b5bf5f7ca30a98a5d1fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

