### PR TITLE
feat: llms format agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,8 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns the docs API route, markdown URL patterns, MCP endpoint and tool toggles, and agent
-feedback schema/submit routes based on `docs.config`.
+The spec returns the docs API route, markdown URL patterns, `llms.txt` routes, MCP endpoint and tool
+toggles, and agent feedback schema/submit routes based on `docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -511,6 +511,10 @@ title: "Home"
 
     mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
     writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `export default { llmsTxt: { enabled: true, siteTitle: "Agent Docs" } };`,
+    );
 
     process.chdir(rootDir);
 
@@ -544,6 +548,7 @@ title: "Home"
       version: string;
       api: Record<string, string>;
       markdown: Record<string, unknown>;
+      llms: { enabled: boolean; txt: string; full: string };
       mcp: {
         enabled: boolean;
         endpoint: string;
@@ -567,10 +572,15 @@ title: "Home"
       rootPage: "/docs.md",
       apiPattern: "/api/docs?format=markdown&path={slug}",
     });
+    expect(spec.llms).toEqual({
+      enabled: true,
+      txt: "/api/docs?format=llms",
+      full: "/api/docs?format=llms-full",
+    });
     expect(spec.mcp).toEqual({
       enabled: true,
       endpoint: "/internal/docs/mcp",
-      name: "Documentation",
+      name: "Agent Docs",
       version: "0.0.0",
       tools: {
         listPages: true,
@@ -614,6 +624,7 @@ title: "Home"
     expect(response.status).toBe(200);
     const spec = (await response.json()) as {
       markdown: { pagePattern: string; rootPage: string };
+      llms: { enabled: boolean; txt: string; full: string };
       mcp: { enabled: boolean; endpoint: string };
       feedback: { enabled: boolean; schema: string; submit: string };
     };
@@ -621,6 +632,11 @@ title: "Home"
     expect(spec.markdown).toMatchObject({
       pagePattern: "/guides/{slug}.md",
       rootPage: "/guides.md",
+    });
+    expect(spec.llms).toEqual({
+      enabled: false,
+      txt: "/api/docs?format=llms",
+      full: "/api/docs?format=llms-full",
     });
     expect(spec.mcp).toMatchObject({
       enabled: false,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -175,6 +175,7 @@ interface AgentSpecOptions {
   entry: string;
   mcp: ReturnType<typeof resolveDocsMcpConfig>;
   feedback: ResolvedAgentFeedbackConfig;
+  llms: LlmsTxtOptions & { enabled: boolean };
 }
 
 function normalizeAgentFeedbackRoute(
@@ -280,7 +281,7 @@ function resolveAgentSpecRequest(url: URL): boolean {
   return normalizeUrlPath(url.pathname) === DEFAULT_AGENT_SPEC_ROUTE;
 }
 
-function buildAgentSpec({ origin, entry, mcp, feedback }: AgentSpecOptions) {
+function buildAgentSpec({ origin, entry, mcp, feedback, llms }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
 
   return {
@@ -298,6 +299,11 @@ function buildAgentSpec({ origin, entry, mcp, feedback }: AgentSpecOptions) {
       rootPage: `/${normalizedEntry}.md`,
       apiPattern: `${DEFAULT_DOCS_API_ROUTE}?format=markdown&path={slug}`,
       resolutionOrder: ["agent.md", "Agent blocks", "page markdown"],
+    },
+    llms: {
+      enabled: llms.enabled,
+      txt: `${DEFAULT_DOCS_API_ROUTE}?format=llms`,
+      full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
     },
     mcp: {
       enabled: mcp.enabled,
@@ -1620,6 +1626,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             entry,
             mcp: mcpConfig,
             feedback: agentFeedbackConfig,
+            llms: llmsConfig,
           }),
           {
             headers: {

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, agent feedback endpoints, API reference, MCP, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
 
 The repo also includes a runnable Next example for testing MCP plus external search providers:
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, `llms.txt`, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, `llms.txt` routes, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,8 +984,8 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-the markdown route pattern, MCP endpoint and enabled tools, and the active agent feedback schema and
-submit endpoints.
+the markdown route pattern, `llms.txt` routes, MCP endpoint and enabled tools, and the active agent
+feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -37,6 +37,7 @@ The spec is generated from `docs.config` and includes:
 
 - shared docs API route
 - markdown route patterns
+- `llms.txt` and `llms-full.txt` routes
 - MCP enabled state, endpoint, server name, version, and tool toggles
 - agent feedback enabled state, schema route, and submit route
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -118,6 +118,7 @@ Agents should fetch it before choosing a transport. It tells them:
 
 - where the shared docs API lives
 - which markdown URL pattern to use for page reads
+- where to fetch `llms.txt` and `llms-full.txt` content
 - whether MCP is enabled, which endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover the active markdown, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover the active markdown, `llms.txt`, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `llms.txt` route discovery to `/api/docs/agent/spec` so agents can find both compact and full content via `?format=llms` and `?format=llms-full`. Docs and tests updated; no breaking changes.

- **New Features**
  - Agent spec now includes `llms` with `{ enabled, txt: "/api/docs?format=llms", full: "/api/docs?format=llms-full" }`, driven by `llmsTxt.enabled` in `docs.config`.
  - Keeps using the shared `/api/docs` handler; updated `packages/fumadocs` implementation, tests, and docs to reflect the new routes.

<sup>Written for commit 5a6891d68f6a252a882e66cb38e548cfe52fde8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

