### PR TITLE
feat: skill agent discovery manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,9 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns the docs API route, markdown URL patterns, `llms.txt` routes, MCP endpoint and tool
-toggles, and agent feedback schema/submit routes based on `docs.config`.
+The spec returns the docs API route, markdown URL patterns, `llms.txt` routes, skills install
+metadata, MCP endpoint and tool toggles, and agent feedback schema/submit routes based on
+`docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -549,6 +549,12 @@ title: "Home"
       api: Record<string, string>;
       markdown: Record<string, unknown>;
       llms: { enabled: boolean; txt: string; full: string };
+      skills: {
+        enabled: boolean;
+        registry: string;
+        install: string;
+        recommended: Array<{ name: string; description: string }>;
+      };
       mcp: {
         enabled: boolean;
         endpoint: string;
@@ -576,6 +582,18 @@ title: "Home"
       enabled: true,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+    });
+    expect(spec.skills).toEqual({
+      enabled: true,
+      registry: "skills.sh",
+      install: "npx skills add farming-labs/docs",
+      recommended: [
+        {
+          name: "getting-started",
+          description:
+            "Use for installation, init, framework setup, theme CSS, and first docs.config wiring.",
+        },
+      ],
     });
     expect(spec.mcp).toEqual({
       enabled: true,
@@ -625,6 +643,7 @@ title: "Home"
     const spec = (await response.json()) as {
       markdown: { pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
+      skills: { enabled: boolean; registry: string; install: string };
       mcp: { enabled: boolean; endpoint: string };
       feedback: { enabled: boolean; schema: string; submit: string };
     };
@@ -637,6 +656,11 @@ title: "Home"
       enabled: false,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+    });
+    expect(spec.skills).toMatchObject({
+      enabled: true,
+      registry: "skills.sh",
+      install: "npx skills add farming-labs/docs",
     });
     expect(spec.mcp).toMatchObject({
       enabled: false,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -305,6 +305,18 @@ function buildAgentSpec({ origin, entry, mcp, feedback, llms }: AgentSpecOptions
       txt: `${DEFAULT_DOCS_API_ROUTE}?format=llms`,
       full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
     },
+    skills: {
+      enabled: true,
+      registry: "skills.sh",
+      install: "npx skills add farming-labs/docs",
+      recommended: [
+        {
+          name: "getting-started",
+          description:
+            "Use for installation, init, framework setup, theme CSS, and first docs.config wiring.",
+        },
+      ],
+    },
     mcp: {
       enabled: mcp.enabled,
       endpoint: mcp.route,

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -20,6 +20,9 @@ Useful routes:
 - Public markdown page with embedded `Agent` block (Next.js): `http://127.0.0.1:3000/docs/quickstart.md`
 - Agent override example (Next.js): `http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md`
 
+The agent discovery spec also advertises this Skills pack through
+`npx skills add farming-labs/docs` and recommends the `getting-started` skill for first-run setup.
+
 ---
 
 ## Available skills

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, `llms.txt`, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, `llms.txt` routes, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,8 +984,8 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-the markdown route pattern, `llms.txt` routes, MCP endpoint and enabled tools, and the active agent
-feedback schema and submit endpoints.
+the markdown route pattern, `llms.txt` routes, Skills CLI install metadata, MCP endpoint and enabled
+tools, and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -38,6 +38,7 @@ The spec is generated from `docs.config` and includes:
 - shared docs API route
 - markdown route patterns
 - `llms.txt` and `llms-full.txt` routes
+- Skills CLI install command and recommended skill metadata
 - MCP enabled state, endpoint, server name, version, and tool toggles
 - agent feedback enabled state, schema route, and submit route
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -119,6 +119,7 @@ Agents should fetch it before choosing a transport. It tells them:
 - where the shared docs API lives
 - which markdown URL pattern to use for page reads
 - where to fetch `llms.txt` and `llms-full.txt` content
+- how to install the published Skills pack and which skill is recommended first
 - whether MCP is enabled, which endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover the active markdown, `llms.txt`, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover the active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Skills metadata to the agent discovery spec so agents can auto-install the `farming-labs/docs` pack and see a recommended first skill. Updates tests and docs; no config changes required.

- **New Features**
  - `/api/docs/agent/spec` now returns `skills` with `{ enabled, registry, install, recommended[] }`.
  - Defaults: `registry: "skills.sh"`, `install: "npx skills add farming-labs/docs"`, recommends `getting-started`.
  - Updated `packages/fumadocs` tests and site docs to reflect the new fields.
  - No new flags; spec continues to derive from `docs.config`.

<sup>Written for commit 02f5cd712d3dd739dca1ea11335600bc0b22c891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

