### PR TITLE
feat: site agent discovery spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,8 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns the docs API route, markdown URL patterns, `llms.txt` routes, skills install
-metadata, MCP endpoint and tool toggles, and agent feedback schema/submit routes based on
+The spec returns site identity, the docs API route, markdown URL patterns, `llms.txt` routes, skills
+install metadata, MCP endpoint and tool toggles, and agent feedback schema/submit routes based on
 `docs.config`.
 
 This does **not** require a separate `docs.config` flag.

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@astrojs/vercel": "^9.0.4",
-    "@farming-labs/astro": "0.1.22",
-    "@farming-labs/astro-theme": "0.1.22",
-    "@farming-labs/docs": "0.1.22",
+    "@farming-labs/astro": "0.1.25",
+    "@farming-labs/astro-theme": "0.1.25",
+    "@farming-labs/docs": "0.1.25",
     "astro": "^5.7.0",
     "three": "^0.180.0"
   }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,9 +9,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.22",
-    "@farming-labs/theme": "0.1.22",
-    "@farming-labs/next": "0.1.22",
+    "@farming-labs/docs": "0.1.25",
+    "@farming-labs/theme": "0.1.25",
+    "@farming-labs/next": "0.1.25",
     "lucide-react": "^0.564.0",
     "next": "16.2.3",
     "react": "^19.0.0",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -10,9 +10,9 @@
     "preview": "nuxt preview"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.22",
-    "@farming-labs/nuxt": "0.1.22",
-    "@farming-labs/nuxt-theme": "0.1.22",
+    "@farming-labs/docs": "0.1.25",
+    "@farming-labs/nuxt": "0.1.25",
+    "@farming-labs/nuxt-theme": "0.1.25",
     "three": "^0.180.0"
   },
   "devDependencies": {

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.22",
-    "@farming-labs/svelte": "0.1.22",
-    "@farming-labs/svelte-theme": "0.1.22",
+    "@farming-labs/docs": "0.1.25",
+    "@farming-labs/svelte": "0.1.25",
+    "@farming-labs/svelte-theme": "0.1.25",
     "three": "^0.180.0"
   },
   "devDependencies": {

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -9,9 +9,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.22",
-    "@farming-labs/theme": "0.1.22",
-    "@farming-labs/tanstack-start": "0.1.22",
+    "@farming-labs/docs": "0.1.25",
+    "@farming-labs/theme": "0.1.25",
+    "@farming-labs/tanstack-start": "0.1.25",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "lucide-react": "^0.564.0",

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -513,7 +513,14 @@ title: "Home"
     writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
     writeFileSync(
       join(rootDir, "docs.config.ts"),
-      `export default { llmsTxt: { enabled: true, siteTitle: "Agent Docs" } };`,
+      `export default {
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Agent Docs",
+    siteDescription: "Machine-readable documentation",
+    baseUrl: "https://docs.example.com",
+  },
+};`,
     );
 
     process.chdir(rootDir);
@@ -546,6 +553,7 @@ title: "Home"
 
     const spec = (await response.json()) as {
       version: string;
+      site: { title: string; description?: string; entry: string; baseUrl: string };
       api: Record<string, string>;
       markdown: Record<string, unknown>;
       llms: { enabled: boolean; txt: string; full: string };
@@ -567,6 +575,12 @@ title: "Home"
     };
 
     expect(spec.version).toBe("1");
+    expect(spec.site).toEqual({
+      title: "Agent Docs",
+      description: "Machine-readable documentation",
+      entry: "docs",
+      baseUrl: "https://docs.example.com",
+    });
     expect(spec.api).toMatchObject({
       docs: "/api/docs",
       agentSpec: "/api/docs/agent/spec",
@@ -641,6 +655,7 @@ title: "Home"
     const response = await GET(new Request("http://localhost/api/docs?agent=spec"));
     expect(response.status).toBe(200);
     const spec = (await response.json()) as {
+      site: { title: string; entry: string; baseUrl: string };
       markdown: { pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
       skills: { enabled: boolean; registry: string; install: string };
@@ -648,6 +663,11 @@ title: "Home"
       feedback: { enabled: boolean; schema: string; submit: string };
     };
 
+    expect(spec.site).toEqual({
+      title: "Documentation",
+      entry: "guides",
+      baseUrl: "http://localhost",
+    });
     expect(spec.markdown).toMatchObject({
       pagePattern: "/guides/{slug}.md",
       rootPage: "/guides.md",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -288,6 +288,12 @@ function buildAgentSpec({ origin, entry, mcp, feedback, llms }: AgentSpecOptions
     version: "1",
     name: "@farming-labs/docs",
     baseUrl: origin,
+    site: {
+      title: llms.siteTitle ?? "Documentation",
+      description: llms.siteDescription,
+      entry: normalizedEntry,
+      baseUrl: llms.baseUrl ?? origin,
+    },
     api: {
       docs: DEFAULT_DOCS_API_ROUTE,
       agentSpec: DEFAULT_AGENT_SPEC_ROUTE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,13 +73,13 @@ importers:
         specifier: ^9.0.4
         version: 9.0.4(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@6.4.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@5.17.3(@types/node@22.19.11)(@vercel/functions@2.2.13)(db0@0.3.4)(ioredis@5.9.3)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       '@farming-labs/astro':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/docs
       astro:
         specifier: ^5.7.0
@@ -91,13 +91,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -146,13 +146,13 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/nuxt-theme
       three:
         specifier: ^0.180.0
@@ -171,13 +171,13 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/svelte-theme
       three:
         specifier: ^0.180.0
@@ -205,13 +205,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.1.22
+        specifier: 0.1.25
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,8 +984,8 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-the markdown route pattern, `llms.txt` routes, Skills CLI install metadata, MCP endpoint and enabled
-tools, and the active agent feedback schema and submit endpoints.
+site identity, the markdown route pattern, `llms.txt` routes, Skills CLI install metadata, MCP
+endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -35,6 +35,7 @@ Fetch `GET /api/docs/agent/spec` before choosing how to read or report on the do
 
 The spec is generated from `docs.config` and includes:
 
+- site title, description, docs entry, and base URL
 - shared docs API route
 - markdown route patterns
 - `llms.txt` and `llms-full.txt` routes

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -116,6 +116,7 @@ That works especially well when:
 
 Agents should fetch it before choosing a transport. It tells them:
 
+- which docs site and entry they are reading
 - where the shared docs API lives
 - which markdown URL pattern to use for page reads
 - where to fetch `llms.txt` and `llms-full.txt` content

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover the active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover site identity plus active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds site identity to the agent discovery spec so agents know which docs they’re reading and the canonical base URL. Also updates docs/tests and bumps example apps to `0.1.25`.

- **New Features**
  - `/api/docs/agent/spec` now includes `site: { title, description?, entry, baseUrl }`.
  - Defaults: title → "Documentation", baseUrl → request origin when not set.
  - Updated docs and tests to reflect the new spec shape.

- **Dependencies**
  - Bumped example apps to `@farming-labs/*` `0.1.25`.

<sup>Written for commit 1c140460c895da68cfe635ac9cce6d5f6870fa23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

