### PR TITLE
feat: locale agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns site identity, the docs API route, markdown URL patterns, `llms.txt` routes, skills
-install metadata, MCP endpoint and tool toggles, and agent feedback schema/submit routes based on
-`docs.config`.
+The spec returns site identity, locale config, the docs API route, markdown URL patterns, `llms.txt`
+routes, skills install metadata, MCP endpoint and tool toggles, and agent feedback schema/submit
+routes based on `docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -520,6 +520,10 @@ title: "Home"
     siteDescription: "Machine-readable documentation",
     baseUrl: "https://docs.example.com",
   },
+  i18n: {
+    locales: ["en", "fr"],
+    defaultLocale: "fr",
+  },
 };`,
     );
 
@@ -554,6 +558,13 @@ title: "Home"
     const spec = (await response.json()) as {
       version: string;
       site: { title: string; description?: string; entry: string; baseUrl: string };
+      locales: {
+        enabled: boolean;
+        available: string[];
+        default: string | null;
+        queryParam: string;
+        fallbackQueryParam: string;
+      };
       api: Record<string, string>;
       markdown: Record<string, unknown>;
       llms: { enabled: boolean; txt: string; full: string };
@@ -580,6 +591,13 @@ title: "Home"
       description: "Machine-readable documentation",
       entry: "docs",
       baseUrl: "https://docs.example.com",
+    });
+    expect(spec.locales).toEqual({
+      enabled: true,
+      available: ["en", "fr"],
+      default: "fr",
+      queryParam: "lang",
+      fallbackQueryParam: "locale",
     });
     expect(spec.api).toMatchObject({
       docs: "/api/docs",
@@ -656,6 +674,13 @@ title: "Home"
     expect(response.status).toBe(200);
     const spec = (await response.json()) as {
       site: { title: string; entry: string; baseUrl: string };
+      locales: {
+        enabled: boolean;
+        available: string[];
+        default: string | null;
+        queryParam: string;
+        fallbackQueryParam: string;
+      };
       markdown: { pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
       skills: { enabled: boolean; registry: string; install: string };
@@ -667,6 +692,13 @@ title: "Home"
       title: "Documentation",
       entry: "guides",
       baseUrl: "http://localhost",
+    });
+    expect(spec.locales).toEqual({
+      enabled: false,
+      available: [],
+      default: null,
+      queryParam: "lang",
+      fallbackQueryParam: "locale",
     });
     expect(spec.markdown).toMatchObject({
       pagePattern: "/guides/{slug}.md",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -173,6 +173,7 @@ interface AgentFeedbackRequest {
 interface AgentSpecOptions {
   origin: string;
   entry: string;
+  i18n: ReturnType<typeof resolveDocsI18n>;
   mcp: ReturnType<typeof resolveDocsMcpConfig>;
   feedback: ResolvedAgentFeedbackConfig;
   llms: LlmsTxtOptions & { enabled: boolean };
@@ -281,7 +282,7 @@ function resolveAgentSpecRequest(url: URL): boolean {
   return normalizeUrlPath(url.pathname) === DEFAULT_AGENT_SPEC_ROUTE;
 }
 
-function buildAgentSpec({ origin, entry, mcp, feedback, llms }: AgentSpecOptions) {
+function buildAgentSpec({ origin, entry, i18n, mcp, feedback, llms }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
 
   return {
@@ -293,6 +294,13 @@ function buildAgentSpec({ origin, entry, mcp, feedback, llms }: AgentSpecOptions
       description: llms.siteDescription,
       entry: normalizedEntry,
       baseUrl: llms.baseUrl ?? origin,
+    },
+    locales: {
+      enabled: i18n !== null,
+      available: i18n?.locales ?? [],
+      default: i18n?.defaultLocale ?? null,
+      queryParam: "lang",
+      fallbackQueryParam: "locale",
     },
     api: {
       docs: DEFAULT_DOCS_API_ROUTE,
@@ -1642,6 +1650,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           buildAgentSpec({
             origin: url.origin,
             entry,
+            i18n,
             mcp: mcpConfig,
             feedback: agentFeedbackConfig,
             llms: llmsConfig,

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, locale config, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,8 +984,8 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-site identity, the markdown route pattern, `llms.txt` routes, Skills CLI install metadata, MCP
-endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
+site identity, locale config, the markdown route pattern, `llms.txt` routes, Skills CLI install
+metadata, MCP endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -36,6 +36,7 @@ Fetch `GET /api/docs/agent/spec` before choosing how to read or report on the do
 The spec is generated from `docs.config` and includes:
 
 - site title, description, docs entry, and base URL
+- configured locales and the `lang`/`locale` query parameters
 - shared docs API route
 - markdown route patterns
 - `llms.txt` and `llms-full.txt` routes

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -117,6 +117,7 @@ That works especially well when:
 Agents should fetch it before choosing a transport. It tells them:
 
 - which docs site and entry they are reading
+- which locales are configured and which query parameter selects one
 - where the shared docs API lives
 - which markdown URL pattern to use for page reads
 - where to fetch `llms.txt` and `llms-full.txt` content

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover site identity plus active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover site identity, locale config, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add locale configuration to the agent discovery spec so agents can detect supported languages and select one via query params. Updates `packages/fumadocs` and docs; no new `docs.config` flag required.

- **New Features**
  - `GET /api/docs/agent/spec` now returns `locales`: `{ enabled, available, default, queryParam: "lang", fallbackQueryParam: "locale" }`.
  - When i18n is off, it returns `enabled: false`, `available: []`, `default: null`; added tests for both cases and updated docs to reference locale info.

<sup>Written for commit 2626b8b91897e8fbcd9ea55b9442b1ec45f6d4f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

