### PR TITLE
feat: search agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns site identity, locale config, the docs API route, markdown URL patterns, `llms.txt`
-routes, skills install metadata, MCP endpoint and tool toggles, and agent feedback schema/submit
-routes based on `docs.config`.
+The spec returns site identity, locale config, the docs API route, search endpoint, markdown URL
+patterns, `llms.txt` routes, skills install metadata, MCP endpoint and tool toggles, and agent
+feedback schema/submit routes based on `docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -568,6 +568,13 @@ title: "Home"
       api: Record<string, string>;
       markdown: Record<string, unknown>;
       llms: { enabled: boolean; txt: string; full: string };
+      search: {
+        enabled: boolean;
+        endpoint: string;
+        method: string;
+        queryParam: string;
+        localeParam: string;
+      };
       skills: {
         enabled: boolean;
         registry: string;
@@ -614,6 +621,13 @@ title: "Home"
       enabled: true,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+    });
+    expect(spec.search).toEqual({
+      enabled: true,
+      endpoint: "/api/docs?query={query}",
+      method: "GET",
+      queryParam: "query",
+      localeParam: "lang",
     });
     expect(spec.skills).toEqual({
       enabled: true,
@@ -667,6 +681,7 @@ title: "Home"
       feedback: {
         agent: false,
       },
+      search: false,
       mcp: false,
     });
 
@@ -683,6 +698,7 @@ title: "Home"
       };
       markdown: { pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
+      search: { enabled: boolean; endpoint: string; method: string };
       skills: { enabled: boolean; registry: string; install: string };
       mcp: { enabled: boolean; endpoint: string };
       feedback: { enabled: boolean; schema: string; submit: string };
@@ -708,6 +724,11 @@ title: "Home"
       enabled: false,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+    });
+    expect(spec.search).toMatchObject({
+      enabled: false,
+      endpoint: "/api/docs?query={query}",
+      method: "GET",
     });
     expect(spec.skills).toMatchObject({
       enabled: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -174,6 +174,7 @@ interface AgentSpecOptions {
   origin: string;
   entry: string;
   i18n: ReturnType<typeof resolveDocsI18n>;
+  search?: boolean | DocsSearchConfig;
   mcp: ReturnType<typeof resolveDocsMcpConfig>;
   feedback: ResolvedAgentFeedbackConfig;
   llms: LlmsTxtOptions & { enabled: boolean };
@@ -282,7 +283,13 @@ function resolveAgentSpecRequest(url: URL): boolean {
   return normalizeUrlPath(url.pathname) === DEFAULT_AGENT_SPEC_ROUTE;
 }
 
-function buildAgentSpec({ origin, entry, i18n, mcp, feedback, llms }: AgentSpecOptions) {
+function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
+  if (search === false) return false;
+  if (search && typeof search === "object" && search.enabled === false) return false;
+  return true;
+}
+
+function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
 
   return {
@@ -318,6 +325,13 @@ function buildAgentSpec({ origin, entry, i18n, mcp, feedback, llms }: AgentSpecO
       enabled: llms.enabled,
       txt: `${DEFAULT_DOCS_API_ROUTE}?format=llms`,
       full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
+    },
+    search: {
+      enabled: isSearchEnabled(search),
+      endpoint: `${DEFAULT_DOCS_API_ROUTE}?query={query}`,
+      method: "GET",
+      queryParam: "query",
+      localeParam: "lang",
     },
     skills: {
       enabled: true,
@@ -1651,6 +1665,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             origin: url.origin,
             entry,
             i18n,
+            search: searchConfig,
             mcp: mcpConfig,
             feedback: agentFeedbackConfig,
             llms: llmsConfig,

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, search, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, locale config, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, locale config, search, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,8 +984,9 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-site identity, locale config, the markdown route pattern, `llms.txt` routes, Skills CLI install
-metadata, MCP endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
+site identity, locale config, the search endpoint, markdown route pattern, `llms.txt` routes, Skills
+CLI install metadata, MCP endpoint and enabled tools, and the active agent feedback schema and submit
+endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -38,6 +38,7 @@ The spec is generated from `docs.config` and includes:
 - site title, description, docs entry, and base URL
 - configured locales and the `lang`/`locale` query parameters
 - shared docs API route
+- search endpoint and query parameter
 - markdown route patterns
 - `llms.txt` and `llms-full.txt` routes
 - Skills CLI install command and recommended skill metadata

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -119,6 +119,7 @@ Agents should fetch it before choosing a transport. It tells them:
 - which docs site and entry they are reading
 - which locales are configured and which query parameter selects one
 - where the shared docs API lives
+- where to search the docs with a query
 - which markdown URL pattern to use for page reads
 - where to fetch `llms.txt` and `llms-full.txt` content
 - how to install the published Skills pack and which skill is recommended first

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover site identity, locale config, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover site identity, locale config, search, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added search discovery to the agent spec so agents know where and how to query docs. Enabled by default and configurable via `search` in `docs.config`.

- **New Features**
  - Agent spec now includes `search`: `enabled`, `endpoint`, `method`, `queryParam`, `localeParam`.
  - Defaults to `GET /api/docs?query={query}` with `query` and `lang`; disable via `search: false` or `search: { enabled: false }`. Updated tests and docs to cover both paths.

<sup>Written for commit 71d174c994b33c453db760a08a6090dd21d3265b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

