### PR TITLE
feat: capability agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ Agents can discover the configured machine-readable surface first:
 GET /api/docs/agent/spec
 ```
 
-The spec returns site identity, locale config, the docs API route, search endpoint, markdown URL
-patterns, `llms.txt` routes, skills install metadata, MCP endpoint and tool toggles, and agent
-feedback schema/submit routes based on `docs.config`.
+The spec returns site identity, locale config, capability flags, the docs API route, search endpoint,
+markdown URL patterns, `llms.txt` routes, skills install metadata, MCP endpoint and tool toggles,
+and agent feedback schema/submit routes based on `docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -565,6 +565,7 @@ title: "Home"
         queryParam: string;
         fallbackQueryParam: string;
       };
+      capabilities: Record<string, boolean>;
       api: Record<string, string>;
       markdown: Record<string, unknown>;
       llms: { enabled: boolean; txt: string; full: string };
@@ -605,6 +606,17 @@ title: "Home"
       default: "fr",
       queryParam: "lang",
       fallbackQueryParam: "locale",
+    });
+    expect(spec.capabilities).toEqual({
+      markdownRoutes: true,
+      agentMdOverrides: true,
+      agentBlocks: true,
+      llms: true,
+      skills: true,
+      mcp: true,
+      search: true,
+      agentFeedback: true,
+      locales: true,
     });
     expect(spec.api).toMatchObject({
       docs: "/api/docs",
@@ -696,6 +708,7 @@ title: "Home"
         queryParam: string;
         fallbackQueryParam: string;
       };
+      capabilities: Record<string, boolean>;
       markdown: { pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
       search: { enabled: boolean; endpoint: string; method: string };
@@ -715,6 +728,17 @@ title: "Home"
       default: null,
       queryParam: "lang",
       fallbackQueryParam: "locale",
+    });
+    expect(spec.capabilities).toEqual({
+      markdownRoutes: true,
+      agentMdOverrides: true,
+      agentBlocks: true,
+      llms: false,
+      skills: true,
+      mcp: false,
+      search: false,
+      agentFeedback: false,
+      locales: false,
     });
     expect(spec.markdown).toMatchObject({
       pagePattern: "/guides/{slug}.md",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -327,6 +327,9 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       agentSpec: DEFAULT_AGENT_SPEC_ROUTE,
       agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
     },
+    // Always-on agent content surfaces. If these ever become configurable,
+    // this spec must be wired to the same docs.config toggles instead of
+    // continuing to report literal true values.
     markdown: {
       enabled: true,
       pagePattern: `/${normalizedEntry}/{slug}.md`,
@@ -346,6 +349,8 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       queryParam: "query",
       localeParam: "lang",
     },
+    // Skills metadata is bundled with this package today; there is no runtime
+    // config switch for disabling it from the discovery spec.
     skills: {
       enabled: true,
       registry: "skills.sh",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -291,6 +291,8 @@ function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
 
 function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
+  const localesEnabled = i18n !== null;
+  const searchEnabled = isSearchEnabled(search);
 
   return {
     version: "1",
@@ -303,11 +305,22 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       baseUrl: llms.baseUrl ?? origin,
     },
     locales: {
-      enabled: i18n !== null,
+      enabled: localesEnabled,
       available: i18n?.locales ?? [],
       default: i18n?.defaultLocale ?? null,
       queryParam: "lang",
       fallbackQueryParam: "locale",
+    },
+    capabilities: {
+      markdownRoutes: true,
+      agentMdOverrides: true,
+      agentBlocks: true,
+      llms: llms.enabled,
+      skills: true,
+      mcp: mcp.enabled,
+      search: searchEnabled,
+      agentFeedback: feedback.enabled,
+      locales: localesEnabled,
     },
     api: {
       docs: DEFAULT_DOCS_API_ROUTE,
@@ -327,7 +340,7 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
     },
     search: {
-      enabled: isSearchEnabled(search),
+      enabled: searchEnabled,
       endpoint: `${DEFAULT_DOCS_API_ROUTE}?query={query}`,
       method: "GET",
       queryParam: "query",

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -309,7 +309,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, search, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, capability flags, search, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, locale config, search, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents can call `/api/docs/agent/spec` to discover site identity, locale config, capability flags, search, markdown routes, `llms.txt` routes, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -984,9 +984,9 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-site identity, locale config, the search endpoint, markdown route pattern, `llms.txt` routes, Skills
-CLI install metadata, MCP endpoint and enabled tools, and the active agent feedback schema and submit
-endpoints.
+site identity, locale config, capability flags, the search endpoint, markdown route pattern,
+`llms.txt` routes, Skills CLI install metadata, MCP endpoint and enabled tools, and the active agent
+feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -37,6 +37,7 @@ The spec is generated from `docs.config` and includes:
 
 - site title, description, docs entry, and base URL
 - configured locales and the `lang`/`locale` query parameters
+- capability flags for markdown, MCP, search, feedback, skills, and `llms.txt`
 - shared docs API route
 - search endpoint and query parameter
 - markdown route patterns

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -118,6 +118,7 @@ Agents should fetch it before choosing a transport. It tells them:
 
 - which docs site and entry they are reading
 - which locales are configured and which query parameter selects one
+- which agent-facing capabilities are enabled
 - where the shared docs API lives
 - where to search the docs with a query
 - which markdown URL pattern to use for page reads

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover site identity, locale config, search, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover site identity, locale config, capability flags, search, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add capability flags to the agent discovery spec so agents can detect which features are enabled (search, LLMS, MCP, markdown, feedback, locales) and adapt behavior accordingly.

- **New Features**
  - `/api/docs/agent/spec` now includes a `capabilities` object with booleans for: `markdownRoutes`, `agentMdOverrides`, `agentBlocks`, `llms`, `skills`, `mcp`, `search`, `agentFeedback`, `locales`.
  - Centralized `searchEnabled` and `localesEnabled` checks and reused them for the spec’s `search.enabled` and `locales.enabled`.
  - Added tests for enabled/disabled states and updated docs (`README`, Skills guides, and website pages) to reference capability flags and clarify always-on agent surfaces.

<sup>Written for commit 4e4d79b5db818bdfe8af415ee0ade334af53bd65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

