### PR TITLE
feat: markdown accept headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,15 @@ In **Next.js**, `withDocs()` also exposes public page-level markdown routes auto
 /docs/quickstart.md
 ```
 
+It also supports HTTP content negotiation on the normal docs URL:
+
+```bash
+curl https://docs.example.com/docs/quickstart -H "Accept: text/markdown"
+```
+
+That returns the same machine-readable markdown as `/docs/quickstart.md`, while a normal browser
+request to `/docs/quickstart` still renders the HTML docs page.
+
 Use embedded `Agent` blocks when the normal page only needs extra machine context, and add a
 sibling `agent.md` only when a page needs a machine-specific override:
 
@@ -593,12 +602,14 @@ Behavior:
 - `/docs/<slug>` stays the normal HTML page
 - embedded `<Agent>...</Agent>` blocks are hidden in the normal UI
 - if `agent.md` exists, `/docs/<slug>.md` returns that file
+- if a request to `/docs/<slug>` sends `Accept: text/markdown`, it returns the same markdown output
 - if `agent.md` does not exist, the markdown route falls back to the normal page markdown
 - on that fallback path, embedded `Agent` blocks are included in the machine-readable output
 - MCP `read_page("/docs/<slug>")` uses the same page source and sees the same override or `Agent` fallback
 
-In Next.js, the public `.md` route rewrites into the existing `/api/docs` handler with
-`format=markdown`, so the shared docs API remains the source of truth.
+In Next.js, the public `.md` route and `Accept: text/markdown` requests both rewrite into the
+existing `/api/docs` handler with `format=markdown`, so the shared docs API remains the source of
+truth.
 
 Agents can discover the configured machine-readable surface first:
 
@@ -607,8 +618,8 @@ GET /api/docs/agent/spec
 ```
 
 The spec returns site identity, locale config, capability flags, the docs API route, search endpoint,
-markdown URL patterns, `llms.txt` routes, skills install metadata, MCP endpoint and tool toggles,
-and agent feedback schema/submit routes based on `docs.config`.
+markdown URL patterns and `Accept` header contract, `llms.txt` routes, skills install metadata, MCP
+endpoint and tool toggles, and agent feedback schema/submit routes based on `docs.config`.
 
 This does **not** require a separate `docs.config` flag.
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -474,6 +474,25 @@ This embedded agent block should be ignored because agent.md overrides the page.
     const rewrittenAgentResponse = await GET(new Request("http://localhost/docs/overview.md"));
     expect(rewrittenAgentResponse.status).toBe(200);
     expect(await rewrittenAgentResponse.text()).toBe("Use this page as the implementation map.\n");
+
+    const acceptFallbackResponse = await GET(
+      new Request("http://localhost/docs/getting-started/quickstart", {
+        headers: { accept: "text/markdown" },
+      }),
+    );
+    expect(acceptFallbackResponse.status).toBe(200);
+    expect(acceptFallbackResponse.headers.get("content-type")).toContain("text/markdown");
+    expect(await acceptFallbackResponse.text()).toContain(
+      "Verify the onboarding command examples before changing this page.",
+    );
+
+    const acceptAgentResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { accept: "text/markdown, */*" },
+      }),
+    );
+    expect(acceptAgentResponse.status).toBe(200);
+    expect(await acceptAgentResponse.text()).toBe("Use this page as the implementation map.\n");
   });
 
   it("returns 404 for markdown mode when the requested page does not exist", async () => {
@@ -625,6 +644,7 @@ title: "Home"
     });
     expect(spec.markdown).toMatchObject({
       enabled: true,
+      acceptHeader: "text/markdown",
       pagePattern: "/docs/{slug}.md",
       rootPage: "/docs.md",
       apiPattern: "/api/docs?format=markdown&path={slug}",
@@ -709,7 +729,7 @@ title: "Home"
         fallbackQueryParam: string;
       };
       capabilities: Record<string, boolean>;
-      markdown: { pagePattern: string; rootPage: string };
+      markdown: { acceptHeader: string; pagePattern: string; rootPage: string };
       llms: { enabled: boolean; txt: string; full: string };
       search: { enabled: boolean; endpoint: string; method: string };
       skills: { enabled: boolean; registry: string; install: string };
@@ -741,6 +761,7 @@ title: "Home"
       locales: false,
     });
     expect(spec.markdown).toMatchObject({
+      acceptHeader: "text/markdown",
       pagePattern: "/guides/{slug}.md",
       rootPage: "/guides.md",
     });

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -493,6 +493,33 @@ This embedded agent block should be ignored because agent.md overrides the page.
     );
     expect(acceptAgentResponse.status).toBe(200);
     expect(await acceptAgentResponse.text()).toBe("Use this page as the implementation map.\n");
+
+    const weightedAcceptAgentResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { accept: "application/json, text/markdown;q=0.5" },
+      }),
+    );
+    expect(weightedAcceptAgentResponse.status).toBe(200);
+    expect(weightedAcceptAgentResponse.headers.get("content-type")).toContain("text/markdown");
+    expect(await weightedAcceptAgentResponse.text()).toBe(
+      "Use this page as the implementation map.\n",
+    );
+
+    const zeroQualityAcceptResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { accept: "application/json, text/markdown;profile=agent;q=0" },
+      }),
+    );
+    expect(zeroQualityAcceptResponse.headers.get("content-type")).not.toContain("text/markdown");
+    expect(await zeroQualityAcceptResponse.text()).toBe("[]");
+
+    const substringAcceptResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { accept: "application/not-text/markdownish" },
+      }),
+    );
+    expect(substringAcceptResponse.headers.get("content-type")).not.toContain("text/markdown");
+    expect(await substringAcceptResponse.text()).toBe("[]");
   });
 
   it("returns 404 for markdown mode when the requested page does not exist", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -1182,8 +1182,18 @@ function acceptsMarkdown(request: Request): boolean {
   if (!accept) return false;
   return accept
     .split(",")
-    .map((value) => value.trim().toLowerCase())
-    .some((value) => value === "text/markdown" || value.startsWith("text/markdown;"));
+    .map((value) => value.trim())
+    .some((value) => {
+      const [mediaType, ...params] = value.split(";").map((part) => part.trim().toLowerCase());
+      if (mediaType !== "text/markdown") return false;
+
+      const qualityParam = params.find((param) => param.split("=", 1)[0]?.trim() === "q");
+      if (!qualityParam) return true;
+
+      const qualityValue = qualityParam.slice(qualityParam.indexOf("=") + 1).trim();
+      const quality = Number.parseFloat(qualityValue);
+      return Number.isFinite(quality) ? quality > 0 : true;
+    });
 }
 
 function resolveMarkdownRequest(

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -332,6 +332,7 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
     // continuing to report literal true values.
     markdown: {
       enabled: true,
+      acceptHeader: "text/markdown",
       pagePattern: `/${normalizedEntry}/{slug}.md`,
       rootPage: `/${normalizedEntry}.md`,
       apiPattern: `${DEFAULT_DOCS_API_ROUTE}?format=markdown&path={slug}`,
@@ -1176,7 +1177,20 @@ function findDocsMcpPage(
   return null;
 }
 
-function resolveMarkdownRequest(entry: string, url: URL): { requestedPath: string } | null {
+function acceptsMarkdown(request: Request): boolean {
+  const accept = request.headers.get("accept");
+  if (!accept) return false;
+  return accept
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .some((value) => value === "text/markdown" || value.startsWith("text/markdown;"));
+}
+
+function resolveMarkdownRequest(
+  entry: string,
+  url: URL,
+  request: Request,
+): { requestedPath: string } | null {
   const format = url.searchParams.get("format")?.trim();
   if (format === "markdown") {
     return {
@@ -1196,6 +1210,18 @@ function resolveMarkdownRequest(entry: string, url: URL): { requestedPath: strin
     return {
       requestedPath: pathname.slice(slugPrefix.length, -3),
     };
+  }
+
+  if (acceptsMarkdown(request)) {
+    if (pathname === normalizedEntry) {
+      return { requestedPath: "" };
+    }
+
+    if (pathname.startsWith(slugPrefix)) {
+      return {
+        requestedPath: pathname.slice(slugPrefix.length),
+      };
+    }
   }
 
   return null;
@@ -1721,7 +1747,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         });
       }
 
-      const markdownRequest = resolveMarkdownRequest(entry, url);
+      const markdownRequest = resolveMarkdownRequest(entry, url, request);
 
       if (markdownRequest) {
         const document = await getMarkdownDocument(ctx, markdownRequest.requestedPath);

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -41,6 +41,19 @@ function getAfterFilesRewrites(result: TestRewriteResult): TestRewrite[] {
 const DOCS_CONFIG = `export default { entry: "docs" };
 `;
 
+const MARKDOWN_ACCEPT_HEADER = {
+  type: "header",
+  key: "accept",
+  value: [
+    "(?:^|.*,\\s*)",
+    "text/markdown",
+    "(?:\\s*;",
+    "(?!\\s*(?:[^,;]*;\\s*)*q\\s*=\\s*(?:0+(?:\\.0*)?|\\.0+)\\s*(?:;|,|$))",
+    "[^,]*)?",
+    "(?:\\s*,.*|$)",
+  ].join(""),
+};
+
 const DOCS_CONFIG_WITH_API_REFERENCE = `export default {
   entry: "docs",
   apiReference: {
@@ -261,28 +274,24 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
         expect.objectContaining({
           source: "/docs",
-          has: [
-            {
-              type: "header",
-              key: "accept",
-              value: ".*text/markdown.*",
-            },
-          ],
+          has: [MARKDOWN_ACCEPT_HEADER],
           destination: "/api/docs?format=markdown",
         }),
         expect.objectContaining({
           source: "/docs/:slug*",
-          has: [
-            {
-              type: "header",
-              key: "accept",
-              value: ".*text/markdown.*",
-            },
-          ],
+          has: [MARKDOWN_ACCEPT_HEADER],
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
       ]),
     );
+
+    const acceptPattern = new RegExp(MARKDOWN_ACCEPT_HEADER.value);
+    expect(acceptPattern.test("text/markdown")).toBe(true);
+    expect(acceptPattern.test("application/json, text/markdown;q=0.5")).toBe(true);
+    expect(acceptPattern.test("application/json, text/markdown;q=0")).toBe(false);
+    expect(acceptPattern.test("application/json, text/markdown;profile=agent;q=0")).toBe(false);
+    expect(acceptPattern.test("text/markdown-v2")).toBe(false);
+    expect(acceptPattern.test("application/not-text/markdownish")).toBe(false);
   });
 
   it("adds agent feedback rewrites through the shared docs api handler when configured", async () => {
@@ -515,13 +524,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
         expect.objectContaining({
           source: "/docs/:slug*",
-          has: [
-            {
-              type: "header",
-              key: "accept",
-              value: ".*text/markdown.*",
-            },
-          ],
+          has: [MARKDOWN_ACCEPT_HEADER],
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
       ]),

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -12,6 +12,32 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { withDocs } from "./config.js";
 
+type TestRewrite = {
+  source: string;
+  destination: string;
+  has?: Array<Record<string, string>>;
+};
+
+type TestRewriteResult =
+  | TestRewrite[]
+  | {
+      beforeFiles?: TestRewrite[];
+      afterFiles?: TestRewrite[];
+      fallback?: TestRewrite[];
+    };
+
+async function readRewrites(nextConfig: ReturnType<typeof withDocs>) {
+  return (nextConfig.rewrites as () => Promise<TestRewriteResult>)();
+}
+
+function getBeforeFilesRewrites(result: TestRewriteResult): TestRewrite[] {
+  return Array.isArray(result) ? result : (result.beforeFiles ?? []);
+}
+
+function getAfterFilesRewrites(result: TestRewriteResult): TestRewrite[] {
+  return Array.isArray(result) ? [] : (result.afterFiles ?? []);
+}
+
 const DOCS_CONFIG = `export default { entry: "docs" };
 `;
 
@@ -217,9 +243,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     expect(existsSync(join(tmpDir, "app/api/docs/markdown/[[...slug]]/route.ts"))).toBe(false);
 
-    const rewrites = await (
-      nextConfig.rewrites as () => Promise<Array<{ source: string; destination: string }>>
-    )();
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
 
     expect(rewrites).toEqual(
       expect.arrayContaining([
@@ -235,6 +259,28 @@ describe("withDocs (app dir: src/app vs app)", () => {
           source: "/docs/:slug*.md",
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
+        expect.objectContaining({
+          source: "/docs",
+          has: [
+            {
+              type: "header",
+              key: "accept",
+              value: ".*text/markdown.*",
+            },
+          ],
+          destination: "/api/docs?format=markdown",
+        }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [
+            {
+              type: "header",
+              key: "accept",
+              value: ".*text/markdown.*",
+            },
+          ],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
       ]),
     );
   });
@@ -245,9 +291,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     process.chdir(tmpDir);
 
     const nextConfig = withDocs({});
-    const rewrites = await (
-      nextConfig.rewrites as () => Promise<Array<{ source: string; destination: string }>>
-    )();
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
 
     expect(rewrites).toEqual(
       expect.arrayContaining([
@@ -269,9 +313,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     process.chdir(tmpDir);
 
     const nextConfig = withDocs({});
-    const rewrites = await (
-      nextConfig.rewrites as () => Promise<Array<{ source: string; destination: string }>>
-    )();
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
 
     expect(rewrites).toEqual(
       expect.arrayContaining([
@@ -453,11 +495,11 @@ describe("withDocs (app dir: src/app vs app)", () => {
       ],
     });
 
-    const rewrites = await (
-      nextConfig.rewrites as () => Promise<Array<{ source: string; destination: string }>>
-    )();
+    const rewritesResult = await readRewrites(nextConfig);
+    const beforeFiles = getBeforeFilesRewrites(rewritesResult);
+    const afterFiles = getAfterFilesRewrites(rewritesResult);
 
-    expect(rewrites).toEqual(
+    expect(beforeFiles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           source: "/api/docs/agent/spec",
@@ -471,6 +513,21 @@ describe("withDocs (app dir: src/app vs app)", () => {
           source: "/docs/:slug*.md",
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [
+            {
+              type: "header",
+              key: "accept",
+              value: ".*text/markdown.*",
+            },
+          ],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
+      ]),
+    );
+    expect(afterFiles).toEqual(
+      expect.arrayContaining([
         expect.objectContaining({
           source: "/legacy",
           destination: "/docs/getting-started/quickstart",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -169,6 +169,14 @@ const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
+const MARKDOWN_ACCEPT_HEADER_VALUE = [
+  "(?:^|.*,\\s*)",
+  "text/markdown",
+  "(?:\\s*;",
+  "(?!\\s*(?:[^,;]*;\\s*)*q\\s*=\\s*(?:0+(?:\\.0*)?|\\.0+)\\s*(?:;|,|$))",
+  "[^,]*)?",
+  "(?:\\s*,.*|$)",
+].join("");
 
 function resolvePackageAlias(packageName: string, fallbacks: string[] = []): string | undefined {
   const candidates = [
@@ -969,7 +977,8 @@ function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
   const markdownAcceptHeader = {
     type: "header",
     key: "accept",
-    value: ".*text/markdown.*",
+    // Keep this aligned with acceptsMarkdown(); the rewrite forces format=markdown.
+    value: MARKDOWN_ACCEPT_HEADER_VALUE,
   };
 
   return [

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -966,6 +966,11 @@ type NextRewriteResult =
 
 function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
   const normalizedEntry = entry.replace(/^\/+|\/+$/g, "") || "docs";
+  const markdownAcceptHeader = {
+    type: "header",
+    key: "accept",
+    value: ".*text/markdown.*",
+  };
 
   return [
     {
@@ -974,6 +979,16 @@ function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
     },
     {
       source: `/${normalizedEntry}/:slug*.md`,
+      destination: "/api/docs?format=markdown&path=:slug*",
+    },
+    {
+      source: `/${normalizedEntry}`,
+      has: [markdownAcceptHeader],
+      destination: "/api/docs?format=markdown",
+    },
+    {
+      source: `/${normalizedEntry}/:slug*`,
+      has: [markdownAcceptHeader],
       destination: "/api/docs?format=markdown&path=:slug*",
     },
   ];
@@ -1035,10 +1050,17 @@ function mergeDocsMarkdownRewrites(
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
-  if (!result) return [...autoRewrites];
+  if (!result) {
+    return {
+      beforeFiles: dedupeRewrites(autoRewrites),
+    };
+  }
 
   if (Array.isArray(result)) {
-    return dedupeRewrites([...autoRewrites, ...result]);
+    return {
+      beforeFiles: dedupeRewrites(autoRewrites),
+      afterFiles: result,
+    };
   }
 
   return {

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown routes with embedded `Agent` blocks or `agent.md` overrides).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown routes with embedded `Agent` blocks, `agent.md` overrides, or `Accept: text/markdown` negotiation).
 
 The repo also includes a runnable Next example for testing MCP plus external search providers:
 
@@ -18,6 +18,7 @@ Useful routes:
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`
 - Agent feedback schema: `http://127.0.0.1:3000/api/docs/agent/feedback/schema`
 - Public markdown page with embedded `Agent` block (Next.js): `http://127.0.0.1:3000/docs/quickstart.md`
+- Header-negotiated markdown page (Next.js): `curl http://127.0.0.1:3000/docs/quickstart -H "Accept: text/markdown"`
 - Agent override example (Next.js): `http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md`
 
 The agent discovery spec also advertises this Skills pack through

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -79,6 +79,7 @@ Default behavior:
 
 - the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - **Next.js:** `withDocs()` also serves `/docs/<slug>.md`
+- **Next.js:** `Accept: text/markdown` on `/docs/<slug>` returns the same markdown response
 - embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI and are included in the markdown fallback
 - if a page folder has `agent.md`, that file becomes the markdown response for that page
 - if `agent.md` is missing, the markdown response falls back to the normal page markdown
@@ -116,6 +117,7 @@ Useful checks:
 ```bash
 curl "http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart"
 curl "http://127.0.0.1:3000/docs/quickstart.md"
+curl "http://127.0.0.1:3000/docs/quickstart" -H "Accept: text/markdown"
 curl "http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md"
 ```
 
@@ -309,7 +311,7 @@ feedback: {
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, capability flags, search, markdown, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
+- `GET /api/docs/agent/spec` returns the configured agent discovery document with site identity, locale config, capability flags, search, markdown route/header access, `llms.txt`, Skills CLI install metadata, MCP, and feedback routes
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler remains the source of truth

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -121,6 +121,10 @@ curl "http://127.0.0.1:3000/docs/quickstart" -H "Accept: text/markdown"
 curl "http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md"
 ```
 
+Call out content negotiation when relevant: `/docs/<slug>` remains the normal HTML page for browsers,
+but agents/scripts can send `Accept: text/markdown` to the same URL and receive the machine-readable
+markdown representation without appending `.md`.
+
 ---
 
 ## GitHub (Edit on GitHub and openDocs)

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -46,7 +46,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
 - **Built-in MCP server** — enabled by default at `/api/docs/mcp` and for local stdio tools. Opt out with `mcp: false` or `mcp: { enabled: false }`.
-- **Machine-readable markdown routes** — Next.js serves `/docs/<slug>.md` automatically with `withDocs()`. Use embedded `<Agent>...</Agent>` blocks inside `page.mdx` when the normal page only needs extra machine context; add a sibling `agent.md` when the whole machine-readable page should be overridden. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`.
+- **Machine-readable markdown routes** — Next.js serves `/docs/<slug>.md` automatically with `withDocs()` and also returns the same markdown from `/docs/<slug>` when the request sends `Accept: text/markdown`. Use embedded `<Agent>...</Agent>` blocks inside `page.mdx` when the normal page only needs extra machine context; add a sibling `agent.md` when the whole machine-readable page should be overridden. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`.
 
 ### MCP quick test
 

--- a/skills/farming-labs/page-actions/SKILL.md
+++ b/skills/farming-labs/page-actions/SKILL.md
@@ -124,9 +124,10 @@ interface OpenDocsProvider {
 | `{mdxUrl}` | Raw `.mdx` source URL for the page |
 | `{githubUrl}` | GitHub **edit** URL for the current page. Requires `github` in config. Use `urlTemplate: "{githubUrl}"` for "Open in GitHub". |
 
-If the project exposes machine-readable markdown routes, use `{url}.md` when you want the public
-page markdown instead of the raw source file. In Next.js, that route can return a sibling
-`agent.md` when the page has one.
+If the project exposes machine-readable markdown routes, use `{url}.md` when you want a link to the
+public page markdown instead of the raw source file. In Next.js, that route can return a sibling
+`agent.md` when the page has one. HTTP clients that can send custom headers can also request the
+normal page URL with `Accept: text/markdown` for the same markdown response.
 
 ### Custom providers example
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -148,6 +148,17 @@ No separate config flag is required for machine-readable page markdown.
 - Embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI but are included in the `.md` fallback and MCP `read_page`
 - When a page folder has `agent.md`, that file is returned instead of the normal page markdown
 
+<Callout type="info" title="Markdown via content negotiation">
+  You can keep the canonical docs URL and ask for markdown with an HTTP header:
+
+  ```bash
+  curl "https://docs.example.com/docs/installation" -H "Accept: text/markdown"
+  ```
+
+  Browsers still receive HTML from `/docs/installation`; agents, scripts, and crawlers that send
+  `Accept: text/markdown` receive the same machine-readable output as `/docs/installation.md`.
+</Callout>
+
 See [Agent Primitive](/docs/customization/agent-primitive) for the page-level authoring model.
 
 ## Static export

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -144,6 +144,7 @@ No separate config flag is required for machine-readable page markdown.
 
 - The shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - In Next.js, `withDocs()` also serves `/docs/<slug>.md`
+- In Next.js, sending `Accept: text/markdown` to `/docs/<slug>` returns the same markdown response
 - Embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI but are included in the `.md` fallback and MCP `read_page`
 - When a page folder has `agent.md`, that file is returned instead of the normal page markdown
 
@@ -984,9 +985,9 @@ Use `feedback.agent` when you want machine-readable feedback routes for coding a
 automation. This is separate from the built-in page footer UI.
 
 Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
-site identity, locale config, capability flags, the search endpoint, markdown route pattern,
-`llms.txt` routes, Skills CLI install metadata, MCP endpoint and enabled tools, and the active agent
-feedback schema and submit endpoints.
+site identity, locale config, capability flags, the search endpoint, markdown route pattern and
+`Accept: text/markdown` contract, `llms.txt` routes, Skills CLI install metadata, MCP endpoint and
+enabled tools, and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -16,6 +16,7 @@ The same page model also powers the built-in machine-readable routes:
 
 - the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - in Next.js, `withDocs()` also serves `/docs/<slug>.md`
+- in Next.js, `Accept: text/markdown` on `/docs/<slug>` returns the same markdown
 - agents can discover the configured contract with `GET /api/docs/agent/spec`
 
 Use `Agent` when the human page is already mostly correct and just needs a little extra implementation
@@ -48,6 +49,7 @@ That gives you:
 
 - `/docs/installation` for the normal UI page
 - `/docs/installation.md` for machine-readable markdown that includes the `Agent` block
+- `/docs/installation` with `Accept: text/markdown` for the same machine-readable markdown
 - MCP `read_page("/docs/installation")` with the same page-level machine context
 
 ## Use `agent.md` For A Full Override

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -19,6 +19,11 @@ The same page model also powers the built-in machine-readable routes:
 - in Next.js, `Accept: text/markdown` on `/docs/<slug>` returns the same markdown
 - agents can discover the configured contract with `GET /api/docs/agent/spec`
 
+<Callout type="info" title="Same URL, different representation">
+  `/docs/installation` stays the human HTML page by default. Send `Accept: text/markdown` to that
+  same URL when an agent or script wants the machine-readable version without appending `.md`.
+</Callout>
+
 Use `Agent` when the human page is already mostly correct and just needs a little extra implementation
 context. Use `agent.md` when the entire machine-readable page should be more operational, more
 structured, or fully different from the visible UI page.

--- a/website/app/docs/customization/page-actions/page.mdx
+++ b/website/app/docs/customization/page-actions/page.mdx
@@ -147,7 +147,8 @@ The `urlTemplate` string supports these placeholders:
 <Callout type="info" title="Use `{url}.md` for agent-ready page markdown">
   `{mdxUrl}` points at the raw source file. If you want the built-in machine-readable docs page
   instead, use `{url}.md`. In Next.js, that route can return a sibling `agent.md` when the page
-  has one. See [Agent Primitive](/docs/customization/agent-primitive).
+  has one. HTTP clients can also request the normal page URL with `Accept: text/markdown` for the
+  same response. See [Agent Primitive](/docs/customization/agent-primitive).
 </Callout>
 
 ### Custom Providers Example

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover site identity, locale config, capability flags, search, active markdown, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents can discover site identity, locale config, capability flags, search, active markdown routes and `Accept: text/markdown` support, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION
- **feat: markdown accept header**
- **chore: fmt**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTP content negotiation so `Accept: text/markdown` on `/docs` and `/docs/:slug` returns machine-readable markdown (same as `.md` routes), while normal visits still render HTML.

- **New Features**
  - Next.js `withDocs()` adds rewrites to route `Accept: text/markdown` on `/docs` and `/docs/:slug` to `/api/docs?format=markdown`; rewrites are placed in `beforeFiles` and keep any user rewrites in `afterFiles`.
  - `fumadocs` Docs API detects the `Accept` header with exact matching and quality parsing (ignores `q=0`, no substring matches) and serves markdown; the agent discovery spec now includes `acceptHeader: "text/markdown"`.
  - Docs and skills examples updated with `curl` usage; tests cover rewrite shape, content negotiation behavior, and the new spec field.

<sup>Written for commit 1941ccbcc8654e54d8fe3ec11a6df8f5c0b77732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

