### PR TITLE
feat: llms.txt re-write to spec standard

### DIFF
--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -356,6 +356,66 @@ Install and configure the docs framework.
     expect(payload[0]?.content).toContain("Quickstart");
   });
 
+  it("serves llms.txt aliases through the shared docs api handler", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-alias-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+description: "Start here"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `export default {
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Alias Docs",
+  },
+};`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    const llmsApi = await GET(new Request("http://localhost/api/docs?format=llms"));
+    const llmsApiText = await llmsApi.text();
+    expect(llmsApi.status).toBe(200);
+    expect(llmsApi.headers.get("content-type")).toContain("text/plain");
+    expect(llmsApiText).toContain("# Alias Docs");
+
+    for (const path of ["/llms.txt", "/.well-known/llms.txt"]) {
+      const response = await GET(new Request(`http://localhost${path}`));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/plain");
+      expect(await response.text()).toBe(llmsApiText);
+    }
+
+    const llmsFullApi = await GET(new Request("http://localhost/api/docs?format=llms-full"));
+    const llmsFullApiText = await llmsFullApi.text();
+    expect(llmsFullApi.status).toBe(200);
+    expect(llmsFullApiText).toContain("Welcome to the docs.");
+
+    for (const path of ["/llms-full.txt", "/.well-known/llms-full.txt"]) {
+      const response = await GET(new Request(`http://localhost${path}`));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/plain");
+      expect(await response.text()).toBe(llmsFullApiText);
+    }
+  });
+
   it("keeps Agent blocks out of the normal search index", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-search-route-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -1237,6 +1237,21 @@ function resolveMarkdownRequest(
   return null;
 }
 
+function resolveLlmsTxtFormat(url: URL): "llms" | "llms-full" | null {
+  const pathname = normalizeUrlPath(url.pathname);
+
+  if (pathname === "/llms.txt" || pathname === "/.well-known/llms.txt") {
+    return "llms";
+  }
+
+  if (pathname === "/llms-full.txt" || pathname === "/.well-known/llms-full.txt") {
+    return "llms-full";
+  }
+
+  const format = url.searchParams.get("format");
+  return format === "llms" || format === "llms-full" ? format : null;
+}
+
 function renderMarkdownDocument(page: DocsMcpPage | DocsSearchSourcePage): string {
   if ("agentRawContent" in page && page.agentRawContent !== undefined) return page.agentRawContent;
 
@@ -1781,8 +1796,8 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         });
       }
 
-      const format = url.searchParams.get("format");
-      if (format === "llms") {
+      const llmsFormat = resolveLlmsTxtFormat(url);
+      if (llmsFormat === "llms") {
         return new Response(getLlmsContent(ctx).llmsTxt, {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
@@ -1791,7 +1806,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         });
       }
 
-      if (format === "llms-full") {
+      if (llmsFormat === "llms-full") {
         return new Response(getLlmsContent(ctx).llmsFullTxt, {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -265,6 +265,22 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?agent=spec",
         }),
         expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
           source: "/docs.md",
           destination: "/api/docs?format=markdown",
         }),
@@ -513,6 +529,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/api/docs/agent/spec",
           destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms.txt",
+          destination: "/api/docs?format=llms",
         }),
         expect.objectContaining({
           source: "/docs.md",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1012,6 +1012,27 @@ function buildAgentSpecRewrites(): NextRewrite[] {
   ];
 }
 
+function buildLlmsTxtRewrites(): NextRewrite[] {
+  return [
+    {
+      source: "/llms.txt",
+      destination: "/api/docs?format=llms",
+    },
+    {
+      source: "/llms-full.txt",
+      destination: "/api/docs?format=llms-full",
+    },
+    {
+      source: "/.well-known/llms.txt",
+      destination: "/api/docs?format=llms",
+    },
+    {
+      source: "/.well-known/llms-full.txt",
+      destination: "/api/docs?format=llms-full",
+    },
+  ];
+}
+
 function buildAgentFeedbackRewrites(config: {
   enabled: boolean;
   route: string;
@@ -1056,6 +1077,7 @@ function mergeDocsMarkdownRewrites(
 ): NextRewriteResult {
   const autoRewrites = [
     ...buildAgentSpecRewrites(),
+    ...buildLlmsTxtRewrites(),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -11,7 +11,15 @@ Serve <HoverLink href="https://llmstxt.org" title="llms.txt" description="An ope
 
 ## What is llms.txt?
 
-`llms.txt` is a standard for making website content accessible to LLMs. It's served via query params on your existing `/api/docs` endpoint:
+`llms.txt` is a standard for making website content accessible to LLMs. In Next.js, `withDocs()`
+serves conventional public aliases that rewrite to your existing `/api/docs` endpoint:
+
+- **`/llms.txt`** — A concise markdown listing of all pages with titles, URLs, and descriptions
+- **`/llms-full.txt`** — The full stripped content of every page, ready for LLM consumption
+- **`/.well-known/llms.txt`** — Alias for `/llms.txt`
+- **`/.well-known/llms-full.txt`** — Alias for `/llms-full.txt`
+
+The shared API handler remains the source of truth:
 
 - **`/api/docs?format=llms`** — A concise markdown listing of all pages with titles, URLs, and descriptions
 - **`/api/docs?format=llms-full`** — The full stripped content of every page, ready for LLM consumption
@@ -89,7 +97,15 @@ No extra route files are needed. The existing API handler (`/api/docs` on Next.j
 - `GET /api/docs?format=llms` — concise page listing
 - `GET /api/docs?format=llms-full` — full page content
 
-This works identically across Next.js, TanStack Start, SvelteKit, Astro, and Nuxt — just enable `llmsTxt` in your config and the existing `createDocsAPI()` / `createDocsServer()` handler takes care of the rest.
+In Next.js, `withDocs()` also adds the crawler-friendly public aliases automatically:
+
+- `GET /llms.txt`
+- `GET /llms-full.txt`
+- `GET /.well-known/llms.txt`
+- `GET /.well-known/llms-full.txt`
+
+Those aliases rewrite to the same shared API output, so there is still only one content pipeline.
+TanStack Start, SvelteKit, Astro, and Nuxt can use the shared API query routes directly.
 
 ---
 
@@ -139,7 +155,7 @@ Full page content here...
 
 ## Footer Links
 
-When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to `/api/docs?format=llms` and `/api/docs?format=llms-full` respectively.
+When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to the shared `/api/docs?format=llms` and `/api/docs?format=llms-full` routes.
 
 ## Full Example
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds spec-compliant `llms.txt` and `llms-full.txt` endpoints at `/llms.txt` and `/.well-known/*` that rewrite to `/api/docs`, improving LLM crawler compatibility without adding new routes.

- **New Features**
  - Next.js `withDocs()` adds rewrites:
    - `/llms.txt` → `/api/docs?format=llms`
    - `/llms-full.txt` → `/api/docs?format=llms-full`
    - `/.well-known/llms.txt` → `/api/docs?format=llms`
    - `/.well-known/llms-full.txt` → `/api/docs?format=llms-full`
  - `createDocsAPI()` now recognizes these paths and serves the same text output as the query routes with `Content-Type: text/plain; charset=utf-8`.
  - Tests added in `packages/fumadocs` and `packages/next` to cover alias rewrites and handler behavior.
  - Docs updated to explain the new public aliases and that the shared `/api/docs` handler remains the source of truth.

<sup>Written for commit 32c56d8f5d99838bfbdd04e4b8100c48c6dc3ce7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

