### PR TITLE
feat: agent well known default discovery spec 

### DIFF
--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -727,6 +727,8 @@ title: "Home"
     expect(spec.api).toMatchObject({
       docs: "/api/docs",
       agentSpec: "/api/docs/agent/spec",
+      agentSpecDefault: "/.well-known/agent.json",
+      agentSpecFallback: "/.well-known/agent",
       agentSpecWellKnown: "/.well-known/agent",
       agentSpecWellKnownJson: "/.well-known/agent.json",
       agentSpecQuery: "/api/docs?agent=spec",
@@ -740,6 +742,8 @@ title: "Home"
     });
     expect(spec.llms).toEqual({
       enabled: true,
+      defaultTxt: "/llms.txt",
+      defaultFull: "/llms-full.txt",
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
       publicTxt: "/llms.txt",
@@ -867,6 +871,8 @@ title: "Home"
     });
     expect(spec.llms).toEqual({
       enabled: false,
+      defaultTxt: "/llms.txt",
+      defaultFull: "/llms-full.txt",
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
       publicTxt: "/llms.txt",

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -674,7 +674,7 @@ title: "Home"
       capabilities: Record<string, boolean>;
       api: Record<string, string>;
       markdown: Record<string, unknown>;
-      llms: { enabled: boolean; txt: string; full: string };
+      llms: Record<string, string | boolean>;
       search: {
         enabled: boolean;
         endpoint: string;
@@ -727,6 +727,8 @@ title: "Home"
     expect(spec.api).toMatchObject({
       docs: "/api/docs",
       agentSpec: "/api/docs/agent/spec",
+      agentSpecWellKnown: "/.well-known/agent",
+      agentSpecWellKnownJson: "/.well-known/agent.json",
       agentSpecQuery: "/api/docs?agent=spec",
     });
     expect(spec.markdown).toMatchObject({
@@ -740,6 +742,10 @@ title: "Home"
       enabled: true,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+      publicTxt: "/llms.txt",
+      publicFull: "/llms-full.txt",
+      wellKnownTxt: "/.well-known/llms.txt",
+      wellKnownFull: "/.well-known/llms-full.txt",
     });
     expect(spec.search).toEqual({
       enabled: true,
@@ -783,6 +789,13 @@ title: "Home"
       readFeedbackSchemaBeforeSubmitting: true,
       doNotAssumeFeedbackPayloadShape: true,
     });
+
+    for (const path of ["/.well-known/agent", "/.well-known/agent.json"]) {
+      const wellKnownResponse = await GET(new Request(`http://localhost${path}`));
+      expect(wellKnownResponse.status).toBe(200);
+      expect(wellKnownResponse.headers.get("content-type")).toContain("application/json");
+      expect(await wellKnownResponse.json()).toEqual(spec);
+    }
   });
 
   it("serves the agent discovery spec through the rewritten query form", async () => {
@@ -817,7 +830,7 @@ title: "Home"
       };
       capabilities: Record<string, boolean>;
       markdown: { acceptHeader: string; pagePattern: string; rootPage: string };
-      llms: { enabled: boolean; txt: string; full: string };
+      llms: Record<string, string | boolean>;
       search: { enabled: boolean; endpoint: string; method: string };
       skills: { enabled: boolean; registry: string; install: string };
       mcp: { enabled: boolean; endpoint: string };
@@ -856,6 +869,10 @@ title: "Home"
       enabled: false,
       txt: "/api/docs?format=llms",
       full: "/api/docs?format=llms-full",
+      publicTxt: "/llms.txt",
+      publicFull: "/llms-full.txt",
+      wellKnownTxt: "/.well-known/llms.txt",
+      wellKnownFull: "/.well-known/llms-full.txt",
     });
     expect(spec.search).toMatchObject({
       enabled: false,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -114,6 +114,10 @@ const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
+const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
+const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
+const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
+const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
   type: "object",
@@ -332,6 +336,8 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
     api: {
       docs: DEFAULT_DOCS_API_ROUTE,
       agentSpec: DEFAULT_AGENT_SPEC_ROUTE,
+      agentSpecDefault: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
+      agentSpecFallback: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
       agentSpecWellKnown: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
       agentSpecWellKnownJson: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
       agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
@@ -349,12 +355,14 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
     },
     llms: {
       enabled: llms.enabled,
+      defaultTxt: DEFAULT_LLMS_TXT_ROUTE,
+      defaultFull: DEFAULT_LLMS_FULL_TXT_ROUTE,
       txt: `${DEFAULT_DOCS_API_ROUTE}?format=llms`,
       full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
-      publicTxt: "/llms.txt",
-      publicFull: "/llms-full.txt",
-      wellKnownTxt: "/.well-known/llms.txt",
-      wellKnownFull: "/.well-known/llms-full.txt",
+      publicTxt: DEFAULT_LLMS_TXT_ROUTE,
+      publicFull: DEFAULT_LLMS_FULL_TXT_ROUTE,
+      wellKnownTxt: DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE,
+      wellKnownFull: DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
     },
     search: {
       enabled: searchEnabled,
@@ -1253,11 +1261,14 @@ function resolveMarkdownRequest(
 function resolveLlmsTxtFormat(url: URL): "llms" | "llms-full" | null {
   const pathname = normalizeUrlPath(url.pathname);
 
-  if (pathname === "/llms.txt" || pathname === "/.well-known/llms.txt") {
+  if (pathname === DEFAULT_LLMS_TXT_ROUTE || pathname === DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE) {
     return "llms";
   }
 
-  if (pathname === "/llms-full.txt" || pathname === "/.well-known/llms-full.txt") {
+  if (
+    pathname === DEFAULT_LLMS_FULL_TXT_ROUTE ||
+    pathname === DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE
+  ) {
     return "llms-full";
   }
 

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -112,6 +112,8 @@ interface DocsMCPAPIOptions {
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
+const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
+const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
   type: "object",
@@ -280,7 +282,12 @@ function resolveAgentFeedbackRequest(
 
 function resolveAgentSpecRequest(url: URL): boolean {
   if (url.searchParams.get("agent")?.trim() === "spec") return true;
-  return normalizeUrlPath(url.pathname) === DEFAULT_AGENT_SPEC_ROUTE;
+  const pathname = normalizeUrlPath(url.pathname);
+  return (
+    pathname === DEFAULT_AGENT_SPEC_ROUTE ||
+    pathname === DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE ||
+    pathname === DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE
+  );
 }
 
 function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
@@ -325,6 +332,8 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
     api: {
       docs: DEFAULT_DOCS_API_ROUTE,
       agentSpec: DEFAULT_AGENT_SPEC_ROUTE,
+      agentSpecWellKnown: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
+      agentSpecWellKnownJson: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
       agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
     },
     // Always-on agent content surfaces. If these ever become configurable,
@@ -342,6 +351,10 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       enabled: llms.enabled,
       txt: `${DEFAULT_DOCS_API_ROUTE}?format=llms`,
       full: `${DEFAULT_DOCS_API_ROUTE}?format=llms-full`,
+      publicTxt: "/llms.txt",
+      publicFull: "/llms-full.txt",
+      wellKnownTxt: "/.well-known/llms.txt",
+      wellKnownFull: "/.well-known/llms-full.txt",
     },
     search: {
       enabled: searchEnabled,

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -265,6 +265,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?agent=spec",
         }),
         expect.objectContaining({
+          source: "/.well-known/agent",
+          destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/agent.json",
+          destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
           source: "/llms.txt",
           destination: "/api/docs?format=llms",
         }),
@@ -531,12 +539,28 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?agent=spec",
         }),
         expect.objectContaining({
+          source: "/.well-known/agent",
+          destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/agent.json",
+          destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
           source: "/llms.txt",
           destination: "/api/docs?format=llms",
         }),
         expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
           source: "/.well-known/llms.txt",
           destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
         }),
         expect.objectContaining({
           source: "/docs.md",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1009,6 +1009,14 @@ function buildAgentSpecRewrites(): NextRewrite[] {
       source: DEFAULT_AGENT_SPEC_ROUTE,
       destination: "/api/docs?agent=spec",
     },
+    {
+      source: "/.well-known/agent",
+      destination: "/api/docs?agent=spec",
+    },
+    {
+      source: "/.well-known/agent.json",
+      destination: "/api/docs?agent=spec",
+    },
   ];
 }
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -168,7 +168,13 @@ const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
+const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
+const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
+const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
+const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
+const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
+const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 const MARKDOWN_ACCEPT_HEADER_VALUE = [
   "(?:^|.*,\\s*)",
   "text/markdown",
@@ -1010,11 +1016,11 @@ function buildAgentSpecRewrites(): NextRewrite[] {
       destination: "/api/docs?agent=spec",
     },
     {
-      source: "/.well-known/agent",
+      source: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
       destination: "/api/docs?agent=spec",
     },
     {
-      source: "/.well-known/agent.json",
+      source: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
       destination: "/api/docs?agent=spec",
     },
   ];
@@ -1023,19 +1029,19 @@ function buildAgentSpecRewrites(): NextRewrite[] {
 function buildLlmsTxtRewrites(): NextRewrite[] {
   return [
     {
-      source: "/llms.txt",
+      source: DEFAULT_LLMS_TXT_ROUTE,
       destination: "/api/docs?format=llms",
     },
     {
-      source: "/llms-full.txt",
+      source: DEFAULT_LLMS_FULL_TXT_ROUTE,
       destination: "/api/docs?format=llms-full",
     },
     {
-      source: "/.well-known/llms.txt",
+      source: DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE,
       destination: "/api/docs?format=llms",
     },
     {
-      source: "/.well-known/llms-full.txt",
+      source: DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
       destination: "/api/docs?format=llms-full",
     },
   ];

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -995,9 +995,9 @@ export async function POST(request: Request) {
 Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware
 automation. This is separate from the built-in page footer UI.
 
-Agents can discover the configured routes first with `GET /api/docs/agent/spec`. In Next.js,
-`GET /.well-known/agent` and `GET /.well-known/agent.json` return the same JSON through public
-discovery aliases. The spec includes
+Agents should discover the configured routes first with `GET /.well-known/agent.json`. In Next.js,
+`GET /.well-known/agent` is the fallback public alias, and `GET /api/docs/agent/spec` is the
+canonical framework route. All three return the same JSON. The spec includes
 site identity, locale config, capability flags, the search endpoint, markdown route pattern and
 `Accept: text/markdown` contract, API and public `llms.txt` routes, Skills CLI install metadata,
 MCP endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
@@ -1018,8 +1018,10 @@ export default defineDocs({
 
 Default behavior:
 
-- `GET /api/docs/agent/spec` returns the machine-readable route/config discovery document
-- `GET /.well-known/agent` and `GET /.well-known/agent.json` return the same discovery document in Next.js
+- `GET /.well-known/agent.json` is the preferred public agent discovery URL in Next.js
+- `GET /.well-known/agent` is the public fallback discovery URL in Next.js
+- `GET /api/docs/agent/spec` returns the canonical framework discovery document
+- the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, and the `llms.txt` defaults
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler is still the source of truth

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -995,10 +995,12 @@ export async function POST(request: Request) {
 Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware
 automation. This is separate from the built-in page footer UI.
 
-Agents can discover the configured routes first with `GET /api/docs/agent/spec`. The spec includes
+Agents can discover the configured routes first with `GET /api/docs/agent/spec`. In Next.js,
+`GET /.well-known/agent` and `GET /.well-known/agent.json` return the same JSON through public
+discovery aliases. The spec includes
 site identity, locale config, capability flags, the search endpoint, markdown route pattern and
-`Accept: text/markdown` contract, `llms.txt` routes, Skills CLI install metadata, MCP endpoint and
-enabled tools, and the active agent feedback schema and submit endpoints.
+`Accept: text/markdown` contract, API and public `llms.txt` routes, Skills CLI install metadata,
+MCP endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({
@@ -1017,6 +1019,7 @@ export default defineDocs({
 Default behavior:
 
 - `GET /api/docs/agent/spec` returns the machine-readable route/config discovery document
+- `GET /.well-known/agent` and `GET /.well-known/agent.json` return the same discovery document in Next.js
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler is still the source of truth

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -17,7 +17,8 @@ The same page model also powers the built-in machine-readable routes:
 - the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - in Next.js, `withDocs()` also serves `/docs/<slug>.md`
 - in Next.js, `Accept: text/markdown` on `/docs/<slug>` returns the same markdown
-- agents can discover the configured contract with `GET /api/docs/agent/spec`
+- agents can discover the configured contract with `GET /api/docs/agent/spec`,
+  `GET /.well-known/agent`, or `GET /.well-known/agent.json`
 
 <Callout type="info" title="Same URL, different representation">
   `/docs/installation` stays the human HTML page by default. Send `Accept: text/markdown` to that
@@ -156,7 +157,9 @@ That works especially well when:
 
 ## Agent Discovery
 
-`GET /api/docs/agent/spec` returns a small JSON document generated from `docs.config`.
+`GET /api/docs/agent/spec` returns a small JSON document generated from `docs.config`. In Next.js,
+`GET /.well-known/agent` and `GET /.well-known/agent.json` are public discovery aliases for the
+same JSON.
 
 Agents should fetch it before choosing a transport. It tells them:
 
@@ -166,13 +169,14 @@ Agents should fetch it before choosing a transport. It tells them:
 - where the shared docs API lives
 - where to search the docs with a query
 - which markdown URL pattern to use for page reads
-- where to fetch `llms.txt` and `llms-full.txt` content
+- where to fetch `llms.txt` and `llms-full.txt` content, including the public `/.well-known`
+  aliases when available
 - how to install the published Skills pack and which skill is recommended first
 - whether MCP is enabled, which endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 
-For Next.js apps, `withDocs()` wires `/api/docs/agent/spec` into the same shared `/api/docs`
-handler automatically.
+For Next.js apps, `withDocs()` wires `/api/docs/agent/spec`, `/.well-known/agent`, and
+`/.well-known/agent.json` into the same shared `/api/docs` handler automatically.
 
 ## Choosing Between Them
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -17,8 +17,8 @@ The same page model also powers the built-in machine-readable routes:
 - the shared docs API supports `GET /api/docs?format=markdown&path=<slug>`
 - in Next.js, `withDocs()` also serves `/docs/<slug>.md`
 - in Next.js, `Accept: text/markdown` on `/docs/<slug>` returns the same markdown
-- agents can discover the configured contract with `GET /api/docs/agent/spec`,
-  `GET /.well-known/agent`, or `GET /.well-known/agent.json`
+- agents can discover the configured contract with `GET /.well-known/agent.json`, fall back to
+  `GET /.well-known/agent`, or use the canonical framework route at `GET /api/docs/agent/spec`
 
 <Callout type="info" title="Same URL, different representation">
   `/docs/installation` stays the human HTML page by default. Send `Accept: text/markdown` to that
@@ -74,13 +74,14 @@ Human-facing overview.
 <Agent>
 You are reading this docs site as an implementation agent.
 
-Before implementing from these docs, fetch `/api/docs/agent/spec` from the same origin. Use that
-JSON as the source of truth for the docs entry path, markdown route pattern, search endpoint, MCP
-endpoint, `llms.txt` routes, skills install command, locale handling, and feedback endpoints.
+Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
+is unavailable, fall back to `/.well-known/agent` or `/api/docs/agent/spec`. Use that JSON as the
+source of truth for the docs entry path, markdown route pattern, search endpoint, MCP endpoint,
+`llms.txt` routes, skills install command, locale handling, and feedback endpoints.
 
 Recommended bootstrap flow:
 
-1. Fetch `/api/docs/agent/spec`.
+1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent` or `/api/docs/agent/spec`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page first.
 4. Use `spec.mcp.endpoint` and tools when MCP is enabled and your environment supports MCP.
@@ -157,9 +158,9 @@ That works especially well when:
 
 ## Agent Discovery
 
-`GET /api/docs/agent/spec` returns a small JSON document generated from `docs.config`. In Next.js,
-`GET /.well-known/agent` and `GET /.well-known/agent.json` are public discovery aliases for the
-same JSON.
+`GET /.well-known/agent.json` is the preferred public discovery URL. `GET /.well-known/agent` is the
+public fallback, and `GET /api/docs/agent/spec` is the canonical framework route. In Next.js, all
+three return the same small JSON document generated from `docs.config`.
 
 Agents should fetch it before choosing a transport. It tells them:
 
@@ -167,16 +168,20 @@ Agents should fetch it before choosing a transport. It tells them:
 - which locales are configured and which query parameter selects one
 - which agent-facing capabilities are enabled
 - where the shared docs API lives
+- which agent discovery URL is the default and which public route to use as fallback
 - where to search the docs with a query
 - which markdown URL pattern to use for page reads
-- where to fetch `llms.txt` and `llms-full.txt` content, including the public `/.well-known`
-  aliases when available
+- where to fetch `llms.txt` and `llms-full.txt` content, including the default public URLs and the
+  public `/.well-known` aliases when available
 - how to install the published Skills pack and which skill is recommended first
 - whether MCP is enabled, which endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 
-For Next.js apps, `withDocs()` wires `/api/docs/agent/spec`, `/.well-known/agent`, and
-`/.well-known/agent.json` into the same shared `/api/docs` handler automatically.
+For Next.js apps, `withDocs()` wires `/.well-known/agent.json`, `/.well-known/agent`, and
+`/api/docs/agent/spec` into the same shared `/api/docs` handler automatically. The generated spec
+also includes `agentSpecDefault: "/.well-known/agent.json"` and
+`agentSpecFallback: "/.well-known/agent"` so downstream integrations do not need to hard-code the
+preference themselves.
 
 ## Choosing Between Them
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -14,8 +14,8 @@ Serve <HoverLink href="https://llmstxt.org" title="llms.txt" description="An ope
 `llms.txt` is a standard for making website content accessible to LLMs. In Next.js, `withDocs()`
 serves conventional public aliases that rewrite to your existing `/api/docs` endpoint:
 
-- **`/llms.txt`** — A concise markdown listing of all pages with titles, URLs, and descriptions
-- **`/llms-full.txt`** — The full stripped content of every page, ready for LLM consumption
+- **`/llms.txt`** — The default concise markdown listing of all pages with titles, URLs, and descriptions
+- **`/llms-full.txt`** — The default full stripped content of every page, ready for LLM consumption
 - **`/.well-known/llms.txt`** — Alias for `/llms.txt`
 - **`/.well-known/llms-full.txt`** — Alias for `/llms-full.txt`
 
@@ -99,14 +99,18 @@ No extra route files are needed. The existing API handler (`/api/docs` on Next.j
 
 In Next.js, `withDocs()` also adds the crawler-friendly public aliases automatically:
 
-- `GET /llms.txt`
-- `GET /llms-full.txt`
+- `GET /llms.txt` — default concise route
+- `GET /llms-full.txt` — default full-content route
 - `GET /.well-known/llms.txt`
 - `GET /.well-known/llms-full.txt`
-- `GET /.well-known/agent` and `GET /.well-known/agent.json` for the agent discovery spec that references those `llms.txt` routes
+- `GET /.well-known/agent.json` for the preferred agent discovery spec that references those `llms.txt` routes
+- `GET /.well-known/agent` as the fallback agent discovery alias
 
 Those aliases rewrite to the same shared API output, so there is still only one content pipeline.
-TanStack Start, SvelteKit, Astro, and Nuxt can use the shared API query routes directly.
+The agent discovery spec also advertises `defaultTxt: "/llms.txt"` and
+`defaultFull: "/llms-full.txt"` so integrations can use the intended defaults without adding their
+own framework-specific routes. TanStack Start, SvelteKit, Astro, and Nuxt can use the shared API
+query routes directly.
 
 ---
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -103,6 +103,7 @@ In Next.js, `withDocs()` also adds the crawler-friendly public aliases automatic
 - `GET /llms-full.txt`
 - `GET /.well-known/llms.txt`
 - `GET /.well-known/llms-full.txt`
+- `GET /.well-known/agent` and `GET /.well-known/agent.json` for the agent discovery spec that references those `llms.txt` routes
 
 Those aliases rewrite to the same shared API output, so there is still only one content pipeline.
 TanStack Start, SvelteKit, Astro, and Nuxt can use the shared API query routes directly.


### PR DESCRIPTION
- **feat: agent discovery  endpoint**
- **chore: default and update docs**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds well-known agent discovery endpoints and expands the spec to advertise default and public `llms.txt` routes, with Next.js rewrites so agents can use simple, stable URLs.

- New Features
  - Serve agent discovery at `/.well-known/agent.json` (preferred) and `/.well-known/agent`, in addition to `/api/docs/agent/spec` (all return the same JSON).
  - `withDocs()` adds rewrites for the well-known agent spec and `llms.txt` routes to `/api/docs`.
  - Agent spec JSON now includes `agentSpecDefault`, `agentSpecFallback`, `agentSpecWellKnown`, and `agentSpecWellKnownJson`.
  - `llms` section now exposes `defaultTxt`, `defaultFull`, `publicTxt`, `publicFull`, `wellKnownTxt`, and `wellKnownFull` (existing `txt` and `full` remain).
  - Docs updated to recommend `GET /.well-known/agent.json` for discovery.

- Migration
  - Agents should fetch `/.well-known/agent.json` first, fall back to `/.well-known/agent`, then `/api/docs/agent/spec`.
  - If you relied on `llms.txt` URLs from the spec, continue using `txt`/`full`, or switch to `defaultTxt`/`defaultFull` for the public defaults.

<sup>Written for commit de18798cb08ff0080fae3795242d5c73e0a4a2b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

