### PR TITLE
fix: add `well-known` agent discovery and public llms.txt

### DIFF
--- a/packages/fumadocs/src/docs-page-client.test.ts
+++ b/packages/fumadocs/src/docs-page-client.test.ts
@@ -25,16 +25,13 @@ import { DocsPageClient } from "./docs-page-client.js";
 describe("DocsPageClient llms.txt footer links", () => {
   it("uses the public llms.txt defaults instead of docs api query routes", () => {
     const html = renderToStaticMarkup(
-      React.createElement(
-        DocsPageClient,
-        {
-          tocEnabled: false,
-          breadcrumbEnabled: false,
-          llmsTxtEnabled: true,
-          locale: "en",
-          children: React.createElement("article", null, "Docs"),
-        },
-      ),
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        llmsTxtEnabled: true,
+        locale: "en",
+        children: React.createElement("article", null, "Docs"),
+      }),
     );
 
     expect(html).toContain('href="/llms.txt?lang=en"');

--- a/packages/fumadocs/src/docs-page-client.test.ts
+++ b/packages/fumadocs/src/docs-page-client.test.ts
@@ -1,0 +1,44 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("fumadocs-core/framework", () => ({
+  usePathname: () => "/docs/installation",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("fumadocs-ui/layouts/docs/page", async () => {
+  const ReactModule = await import("react");
+
+  return {
+    DocsPage: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("main", null, children),
+    DocsBody: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement("section", null, children),
+    EditOnGitHub: ({ href }: { href: string }) =>
+      ReactModule.createElement("a", { href }, "Edit on GitHub"),
+  };
+});
+
+import { DocsPageClient } from "./docs-page-client.js";
+
+describe("DocsPageClient llms.txt footer links", () => {
+  it("uses the public llms.txt defaults instead of docs api query routes", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        DocsPageClient,
+        {
+          tocEnabled: false,
+          breadcrumbEnabled: false,
+          llmsTxtEnabled: true,
+          locale: "en",
+          children: React.createElement("article", null, "Docs"),
+        },
+      ),
+    );
+
+    expect(html).toContain('href="/llms.txt?lang=en"');
+    expect(html).toContain('href="/llms-full.txt?lang=en"');
+    expect(html).not.toContain("/api/docs?format=llms");
+  });
+});

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -340,7 +340,7 @@ export function DocsPageClient({
   const pathname = usePathname();
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
-  const llmsLangParam = activeLocale ? `&lang=${encodeURIComponent(activeLocale)}` : "";
+  const llmsLangQuery = activeLocale ? `?lang=${encodeURIComponent(activeLocale)}` : "";
 
   const pageDescription = description ?? descriptionMap?.[pathname.replace(/\/$/, "") || "/"];
   const normalizedPath = (browserPath ?? pathname).replace(/\/$/, "") || "/";
@@ -580,7 +580,7 @@ export function DocsPageClient({
             {llmsTxtEnabled && (
               <span className="fd-llms-txt-links">
                 <a
-                  href={`/api/docs?format=llms${llmsLangParam}`}
+                  href={`/llms.txt${llmsLangQuery}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="fd-llms-txt-link"
@@ -588,7 +588,7 @@ export function DocsPageClient({
                   llms.txt
                 </a>
                 <a
-                  href={`/api/docs?format=llms-full${llmsLangParam}`}
+                  href={`/llms-full.txt${llmsLangQuery}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="fd-llms-txt-link"

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -75,13 +75,13 @@ Human-facing overview.
 You are reading this docs site as an implementation agent.
 
 Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
-is unavailable, fall back to `/.well-known/agent` or `/api/docs/agent/spec`. Use that JSON as the
-source of truth for the docs entry path, markdown route pattern, search endpoint, MCP endpoint,
-`llms.txt` routes, skills install command, locale handling, and feedback endpoints.
+is unavailable, fall back to `/.well-known/agent`. Use that JSON as the source of truth for the docs
+entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes, skills install
+command, locale handling, and feedback endpoints.
 
 Recommended bootstrap flow:
 
-1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent` or `/api/docs/agent/spec`.
+1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page first.
 4. Use `spec.mcp.endpoint` and tools when MCP is enabled and your environment supports MCP.

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -160,7 +160,7 @@ Full page content here...
 
 ## Footer Links
 
-When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to the shared `/api/docs?format=llms` and `/api/docs?format=llms-full` routes.
+When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to the public `/llms.txt` and `/llms-full.txt` routes.
 
 ## Full Example
 

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -11,13 +11,14 @@ An AI-native documentation framework built on top of <HoverLink href="https://fu
 <Agent>
 You are reading the machine-readable entry page for `@farming-labs/docs`.
 
-Before implementing from this docs site, fetch `/api/docs/agent/spec` from the same origin. Treat
-that JSON as the source of truth for the docs entry path, markdown route pattern, search endpoint,
-MCP endpoint, `llms.txt` routes, skills install command, locale handling, and feedback endpoints.
+Before implementing from this docs site, fetch `/.well-known/agent.json` from the same origin. If
+that is unavailable, fall back to `/.well-known/agent`. Treat that JSON as the source of truth for
+the docs entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes,
+skills install command, locale handling, and feedback endpoints.
 
 Recommended bootstrap flow:
 
-1. Fetch `/api/docs/agent/spec`.
+1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read the exact docs pages you need as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page before reading it.
 4. Use `spec.mcp.endpoint` and tools when MCP is enabled and the environment supports MCP.

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -722,7 +722,7 @@ Notes:
 - the request body always uses `{ context?, payload }`
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents can discover site identity, locale config, capability flags, search, active markdown routes and `Accept: text/markdown` support, `llms.txt`, skills, MCP, and feedback routes with `GET /api/docs/agent/spec`
+- agents should discover site identity, locale config, capability flags, search, active markdown routes and `Accept: text/markdown` support, `llms.txt`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
 
 ### `DocsAgentFeedbackContext`
 
@@ -776,7 +776,7 @@ export default defineDocs({
 Quick checks:
 
 ```bash
-curl "http://127.0.0.1:3000/api/docs/agent/spec"
+curl "http://127.0.0.1:3000/.well-known/agent.json"
 
 curl "http://127.0.0.1:3000/api/docs/agent/feedback/schema"
 

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -149,8 +149,8 @@ Beyond being token-efficient to work with, `@farming-labs/docs` includes feature
 Your docs are automatically served in LLM-optimized format — no extra routes needed:
 
 ```text
-/api/docs?format=llms       → llms.txt (index of all pages)
-/api/docs?format=llms-full  → llms-full.txt (full content)
+/llms.txt       → llms.txt (index of all pages)
+/llms-full.txt  → llms-full.txt (full content)
 ```
 
 See the [llms.txt docs](/docs/customization/llms-txt) for details.


### PR DESCRIPTION
- **feat: add well-known agent discovery and public llms.txt defaults**
- **chore: docs**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default llms.txt footer links to the public `/llms.txt` and `/llms-full.txt` routes (with `?lang=`), replacing the old `/api/docs?format=...` URLs. Adds well-known agent discovery at `/.well-known/agent.json` with fallback to `/.well-known/agent`, updates docs to match, and includes a test to lock this behavior.

<sup>Written for commit f879d794a1e2e002febc0049ce2c8d6445728037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

