### PR TITLE
feat: mcp rewrite base route

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -632,7 +632,7 @@ export interface DocsMcpToolsConfig {
  * Built-in MCP server configuration.
  *
  * When enabled, adapters can expose a Streamable HTTP endpoint for your docs
- * at `/api/docs/mcp` by default. The same config is also reused by the local
+ * at `/mcp` in Next.js, backed by the canonical `/api/docs/mcp` route. The same config is also reused by the local
  * `docs mcp` stdio command.
  */
 export interface DocsMcpConfig {
@@ -640,7 +640,7 @@ export interface DocsMcpConfig {
   enabled?: boolean;
   /**
    * Streamable HTTP route for the MCP endpoint.
-   * Defaults to `/api/docs/mcp`.
+   * Defaults to `/api/docs/mcp`; Next.js also exposes it publicly at `/mcp`.
    */
   route?: string;
   /**
@@ -787,7 +787,7 @@ export interface McpDocsSearchConfig {
   provider: "mcp";
   enabled?: boolean;
   /**
-   * Streamable HTTP MCP endpoint. Relative paths like `/api/docs/mcp` are resolved
+   * Streamable HTTP MCP endpoint. Relative paths like `/mcp` are resolved
    * against the current docs API request URL.
    */
   endpoint: string;
@@ -1695,8 +1695,8 @@ export interface DocsConfig {
   /**
    * Built-in MCP server for agent/assistant access to your docs content.
    *
-   * - omitted → enable the default MCP surface at `/api/docs/mcp`
-   * - `true` → enable the default MCP surface at `/api/docs/mcp`
+   * - omitted → enable the default MCP surface at `/mcp` in Next.js, backed by `/api/docs/mcp`
+   * - `true` → enable the default MCP surface at `/mcp` in Next.js, backed by `/api/docs/mcp`
    * - `{ route: "/api/docs/mcp" }` → enable with explicit route/config
    * - `false` or `{ enabled: false }` → disable MCP explicitly
    */

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -691,6 +691,9 @@ title: "Home"
       mcp: {
         enabled: boolean;
         endpoint: string;
+        defaultEndpoint: string;
+        publicEndpoint: string;
+        canonicalEndpoint: string;
         name: string;
         version: string;
         tools: Record<string, boolean>;
@@ -773,6 +776,9 @@ title: "Home"
     expect(spec.mcp).toEqual({
       enabled: true,
       endpoint: "/internal/docs/mcp",
+      defaultEndpoint: "/mcp",
+      publicEndpoint: "/mcp",
+      canonicalEndpoint: "/api/docs/mcp",
       name: "Agent Docs",
       version: "0.0.0",
       tools: {
@@ -837,7 +843,13 @@ title: "Home"
       llms: Record<string, string | boolean>;
       search: { enabled: boolean; endpoint: string; method: string };
       skills: { enabled: boolean; registry: string; install: string };
-      mcp: { enabled: boolean; endpoint: string };
+      mcp: {
+        enabled: boolean;
+        endpoint: string;
+        defaultEndpoint: string;
+        publicEndpoint: string;
+        canonicalEndpoint: string;
+      };
       feedback: { enabled: boolean; schema: string; submit: string };
     };
 
@@ -893,6 +905,9 @@ title: "Home"
     expect(spec.mcp).toMatchObject({
       enabled: false,
       endpoint: "/api/docs/mcp",
+      defaultEndpoint: "/mcp",
+      publicEndpoint: "/mcp",
+      canonicalEndpoint: "/api/docs/mcp",
     });
     expect(spec.feedback).toMatchObject({
       enabled: false,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -114,6 +114,8 @@ const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
+const DEFAULT_MCP_ROUTE = "/api/docs/mcp";
+const DEFAULT_MCP_PUBLIC_ROUTE = "/mcp";
 const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
 const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
@@ -388,6 +390,9 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
     mcp: {
       enabled: mcp.enabled,
       endpoint: mcp.route,
+      defaultEndpoint: DEFAULT_MCP_PUBLIC_ROUTE,
+      publicEndpoint: DEFAULT_MCP_PUBLIC_ROUTE,
+      canonicalEndpoint: DEFAULT_MCP_ROUTE,
       name: mcp.name,
       version: mcp.version,
       tools: mcp.tools,

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -273,6 +273,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?agent=spec",
         }),
         expect.objectContaining({
+          source: "/mcp",
+          destination: "/api/docs/mcp",
+        }),
+        expect.objectContaining({
           source: "/llms.txt",
           destination: "/api/docs?format=llms",
         }),
@@ -392,14 +396,23 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(existsSync(join(tmpDir, "app/changelogs/page.tsx"))).toBe(false);
   });
 
-  it("skips default MCP route generation when a custom route is configured", () => {
+  it("skips default MCP route generation and aliases /mcp when a custom route is configured", async () => {
     writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_CUSTOM_MCP_ROUTE, "utf-8");
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
 
-    withDocs({});
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
 
     expect(existsSync(join(tmpDir, "app/api/docs/mcp/route.ts"))).toBe(false);
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/mcp",
+          destination: "/api/internal/docs/mcp",
+        }),
+      ]),
+    );
   });
 
   it("skips API reference generation for static export", () => {
@@ -545,6 +558,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/.well-known/agent.json",
           destination: "/api/docs?agent=spec",
+        }),
+        expect.objectContaining({
+          source: "/mcp",
+          destination: "/api/docs/mcp",
         }),
         expect.objectContaining({
           source: "/llms.txt",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -171,6 +171,8 @@ const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
+const DEFAULT_MCP_ROUTE = "/api/docs/mcp";
+const DEFAULT_MCP_PUBLIC_ROUTE = "/mcp";
 const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
 const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
@@ -873,11 +875,11 @@ function readMcpConfig(root: string): {
       const content = readFileSync(configPath, "utf-8");
 
       if (content.match(/mcp\s*:\s*false/)) {
-        return { enabled: false, route: "/api/docs/mcp" };
+        return { enabled: false, route: DEFAULT_MCP_ROUTE };
       }
 
       if (content.match(/mcp\s*:\s*true/)) {
-        return { enabled: true, route: "/api/docs/mcp" };
+        return { enabled: true, route: DEFAULT_MCP_ROUTE };
       }
 
       const block = extractObjectLiteral(content, "mcp");
@@ -888,19 +890,19 @@ function readMcpConfig(root: string): {
 
       return {
         enabled: enabledMatch ? enabledMatch[1] !== "false" : true,
-        route: normalizeRoutePath(routeMatch?.[1] ?? "/api/docs/mcp"),
+        route: normalizeRoutePath(routeMatch?.[1] ?? DEFAULT_MCP_ROUTE),
       };
     } catch {
-      return { enabled: true, route: "/api/docs/mcp" };
+      return { enabled: true, route: DEFAULT_MCP_ROUTE };
     }
   }
 
-  return { enabled: true, route: "/api/docs/mcp" };
+  return { enabled: true, route: DEFAULT_MCP_ROUTE };
 }
 
 function normalizeRoutePath(route: string): string {
   const normalized = `/${route}`.replace(/\/+/g, "/");
-  return normalized !== "/" ? normalized.replace(/\/+$/, "") : "/api/docs/mcp";
+  return normalized !== "/" ? normalized.replace(/\/+$/, "") : DEFAULT_MCP_ROUTE;
 }
 
 function normalizeAgentFeedbackRoute(
@@ -1047,6 +1049,17 @@ function buildLlmsTxtRewrites(): NextRewrite[] {
   ];
 }
 
+function buildMcpRewrites(config: { enabled: boolean; route: string }): NextRewrite[] {
+  if (!config.enabled || config.route === DEFAULT_MCP_PUBLIC_ROUTE) return [];
+
+  return [
+    {
+      source: DEFAULT_MCP_PUBLIC_ROUTE,
+      destination: config.route,
+    },
+  ];
+}
+
 function buildAgentFeedbackRewrites(config: {
   enabled: boolean;
   route: string;
@@ -1082,6 +1095,10 @@ function dedupeRewrites(rewrites: NextRewrite[]): NextRewrite[] {
 
 function mergeDocsMarkdownRewrites(
   entry: string,
+  mcp: {
+    enabled: boolean;
+    route: string;
+  },
   agentFeedback: {
     enabled: boolean;
     route: string;
@@ -1091,6 +1108,7 @@ function mergeDocsMarkdownRewrites(
 ): NextRewriteResult {
   const autoRewrites = [
     ...buildAgentSpecRewrites(),
+    ...buildMcpRewrites(mcp),
     ...buildLlmsTxtRewrites(),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
@@ -1162,7 +1180,7 @@ export function withDocs(nextConfig: Record<string, unknown> = {}) {
   const docsMcpRouteDir = join(root, appDir, "api", "docs", "mcp");
   if (
     mcp.enabled &&
-    mcp.route === "/api/docs/mcp" &&
+    mcp.route === DEFAULT_MCP_ROUTE &&
     !isStaticExport &&
     !hasFile(docsMcpRouteDir, "route")
   ) {
@@ -1431,15 +1449,15 @@ export function withDocs(nextConfig: Record<string, unknown> = {}) {
     nextConfig.rewrites = async () => {
       const rewrites =
         typeof existingRewrites === "function" ? await existingRewrites() : existingRewrites;
-      return mergeDocsMarkdownRewrites(entry, agentFeedback, rewrites);
+      return mergeDocsMarkdownRewrites(entry, mcp, agentFeedback, rewrites);
     };
   }
 
   nextConfig.outputFileTracingIncludes = {
     ...existingTracingIncludes,
     "/api/docs": [...new Set([...(existingTracingIncludes["/api/docs"] ?? []), docsTraceGlob])],
-    "/api/docs/mcp": [
-      ...new Set([...(existingTracingIncludes["/api/docs/mcp"] ?? []), docsTraceGlob]),
+    [DEFAULT_MCP_ROUTE]: [
+      ...new Set([...(existingTracingIncludes[DEFAULT_MCP_ROUTE] ?? []), docsTraceGlob]),
     ],
   };
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -132,7 +132,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
-| `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio and `/api/docs/mcp` |
+| `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio and `/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |
 | `i18n`        | `DocsI18nConfig`               | —               | Query-param locale support and locale switcher     |
 | `metadata`    | `DocsMetadata`                 | —               | SEO metadata template                              |
@@ -270,7 +270,7 @@ export default defineDocs({
   theme: fumadocs(),
   search: {
     provider: "mcp",
-    endpoint: "/api/docs/mcp",
+    endpoint: "/mcp",
   },
   mcp: {
     enabled: true,
@@ -317,7 +317,7 @@ Notes:
 - `chunking.strategy` defaults to `"section"` and can be changed to `"page"` for one-document-per-page indexing
 - Typesense and Algolia can sync documents automatically on the first search request when `adminApiKey` is present
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want manual indexing as a CLI step
-- `provider: "mcp"` can target a relative route like `/api/docs/mcp` or an absolute remote MCP endpoint
+- `provider: "mcp"` can target a relative route like `/mcp` or an absolute remote MCP endpoint
 - when MCP search points at the same site's relative MCP route, the MCP `search_docs` tool falls back to built-in simple search to avoid recursive loops
 - If you use a custom Next.js docs API route, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search` so your adapter config reaches the route handler
 - Search requires the docs API route; with `staticExport: true` the UI is hidden because there is no server route
@@ -357,13 +357,14 @@ export default defineDocs({
 
 Default behavior:
 
-- **HTTP route:** `/api/docs/mcp`
+- **Public HTTP route:** `/mcp`
+- **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
 
 Framework notes:
 
-- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route
+- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` rewrite
 - **TanStack Start / SvelteKit / Astro / Nuxt:** add the framework route file and reuse the built-in handler from the docs server helper
 - **Custom routes:** set `mcp.route` in `docs.config` and add the matching route file manually so the configured path and the actual endpoint stay aligned
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -84,7 +84,7 @@ Recommended bootstrap flow:
 1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page first.
-4. Use `spec.mcp.endpoint` and tools when MCP is enabled and your environment supports MCP.
+4. Use `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
 5. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server"
-description: "Expose your docs as MCP tools and resources over stdio or /api/docs/mcp"
+description: "Expose your docs as MCP tools and resources over stdio or /mcp"
 icon: "bot"
 order: 8
 ---
@@ -35,15 +35,15 @@ export default defineDocs({
 });
 ```
 
-That gives you the built-in MCP surface with the default Streamable HTTP route:
+That gives you the built-in MCP surface with the default public Streamable HTTP route:
 
-```txt title="/api/docs/mcp"
-/api/docs/mcp
+```txt title="/mcp"
+/mcp
 ```
 
 <Callout type="info" title="This docs site already exposes it live">
   The hosted docs site has MCP enabled at
-  `https://docs.farming-labs.dev/api/docs/mcp`.
+  `https://docs.farming-labs.dev/mcp`.
 </Callout>
 
 Opt out explicitly:
@@ -57,13 +57,14 @@ export default defineDocs({
 });
 ```
 
-## Default HTTP route
+## Default HTTP Routes
 
-`/api/docs/mcp` is the default MCP endpoint across the framework adapters.
+`/mcp` is the preferred public MCP endpoint in Next.js. It rewrites to the canonical framework route
+at `/api/docs/mcp`, so the MCP handler still lives in one place.
 
 <Callout type="info" title="Minimal route behavior">
-  **Next.js** auto-generates the default `/api/docs/mcp` route when you use `withDocs()`, unless
-  you explicitly disable MCP.
+  **Next.js** auto-generates the default `/api/docs/mcp` route when you use `withDocs()`, and also
+  adds the public `/mcp` rewrite unless you explicitly disable MCP.
 
   **TanStack Start**, **SvelteKit**, **Astro**, and **Nuxt** still need the framework route file,
   but they all reuse the built-in MCP handler from the docs server helper.
@@ -192,7 +193,7 @@ export default defineDocs({
   entry: "docs",
   search: {
     provider: "mcp",
-    endpoint: "/api/docs/mcp",
+    endpoint: "/mcp",
   },
   mcp: {
     enabled: true,
@@ -200,9 +201,10 @@ export default defineDocs({
 });
 ```
 
-For local self-hosted setups, relative MCP endpoints like `/api/docs/mcp` are supported. The
-built-in `search_docs` tool automatically falls back to simple search internally when it detects
-that same-route loop, so the route stays usable for testing and local examples.
+For local self-hosted setups, relative MCP endpoints like `/mcp` are supported. The canonical
+`/api/docs/mcp` route remains available too. The built-in `search_docs` tool automatically falls
+back to simple search internally when it detects that same-route loop, so the route stays usable for
+testing and local examples.
 
 ## Stdio transport
 
@@ -229,7 +231,7 @@ pnpm exec docs mcp --config src/lib/docs.config.ts
 If you just want to try the live docs server, you can point your MCP client at:
 
 ```txt title="Live MCP endpoint"
-https://docs.farming-labs.dev/api/docs/mcp
+https://docs.farming-labs.dev/mcp
 ```
 
 <DocsMcpAccess />
@@ -248,7 +250,7 @@ Cursor project or global config:
 {
   "mcpServers": {
     "farming-labs-docs": {
-      "url": "https://docs.farming-labs.dev/api/docs/mcp"
+      "url": "https://docs.farming-labs.dev/mcp"
     }
   }
 }
@@ -261,7 +263,7 @@ VS Code workspace config:
   "servers": {
     "farming-labs-docs": {
       "type": "http",
-      "url": "https://docs.farming-labs.dev/api/docs/mcp"
+      "url": "https://docs.farming-labs.dev/mcp"
     }
   }
 }
@@ -270,11 +272,11 @@ VS Code workspace config:
 Claude Code:
 
 ```bash title="terminal"
-claude mcp add-json farming-labs-docs '{"type":"http","url":"https://docs.farming-labs.dev/api/docs/mcp"}'
+claude mcp add-json farming-labs-docs '{"type":"http","url":"https://docs.farming-labs.dev/mcp"}'
 ```
 
 <Callout type="tip" title="Local development uses http, not https">
-  If you are connecting to a local Next dev server, use `http://127.0.0.1:3000/api/docs/mcp`.
+  If you are connecting to a local Next dev server, use `http://127.0.0.1:3000/mcp`.
   Using `https://localhost:3000/...` against a non-TLS dev server will fail with SSL errors.
 </Callout>
 
@@ -291,7 +293,7 @@ pnpm --dir examples/next dev
 Then connect your MCP client or inspector to:
 
 ```txt title="~"
-http://127.0.0.1:3000/api/docs/mcp
+http://127.0.0.1:3000/mcp
 ```
 
 The built-in HTTP route exposes the full MCP surface:

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -19,7 +19,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[OG Images](/docs/customization/og-images)** — Dynamic or static Open Graph images; what context your image generator receives; how the docs website does it
 - **[Ask AI](/docs/customization/ai-chat)** — RAG-powered AI chat with configurable LLM, floating/search modes, and more
 - **[Page Actions](/docs/customization/page-actions)** — "Copy Markdown" and "Open in LLM" buttons on doc pages
-- **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio and `/api/docs/mcp`
+- **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio and `/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
 
 All customization happens through the `theme` and top-level config options in `docs.config.ts`.

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -21,7 +21,7 @@ Recommended bootstrap flow:
 1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read the exact docs pages you need as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page before reading it.
-4. Use `spec.mcp.endpoint` and tools when MCP is enabled and the environment supports MCP.
+4. Use `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
 5. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -48,7 +48,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
-| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio and `/api/docs/mcp`                                   |
+| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio and `/mcp`                                            |
 | `apiReference` | `boolean \| ApiReferenceConfig`               | `false`          | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON |
 | `changelog`   | `boolean \| ChangelogConfig`                    | `false`          | Generated changelog feed and entry pages from dated MDX entries                      |
 | `ordering`    | `"alphabetical" \| "numeric" \| OrderingItem[]` | `"alphabetical"` | Sidebar page ordering strategy                                                       |
@@ -191,13 +191,14 @@ export default defineDocs({
 
 Default MCP surface:
 
-- **HTTP route:** `/api/docs/mcp`
+- **Public HTTP route:** `/mcp`
+- **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
 
 Framework notes:
 
-- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route
+- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` rewrite
 - **TanStack Start / SvelteKit / Astro / Nuxt:** add the matching framework route file and forward to the built-in `MCP` handler from the docs server helper
 - **Custom routes:** set `mcp.route` in `docs.config` and add the matching route file manually so the configured path and the actual endpoint stay aligned
 
@@ -320,7 +321,7 @@ pnpm dlx @farming-labs/docs search sync --algolia
 ```ts title="docs.config.ts"
 search: {
   provider: "mcp",
-  endpoint: "/api/docs/mcp",
+  endpoint: "/mcp",
 },
 ```
 
@@ -404,7 +405,7 @@ Notes:
 - `search: false` disables search entirely
 - Search requires the docs API route; static export hides the UI because there is no server route
 - On Next.js, generated routes from `withDocs()` already forward `docsConfig.search`
-- MCP-backed search works with relative endpoints like `/api/docs/mcp` and absolute remote endpoints like `https://docs.example.com/api/docs/mcp`
+- MCP-backed search works with relative endpoints like `/mcp` and absolute remote endpoints like `https://docs.example.com/mcp`
 - If MCP-backed search points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally to avoid recursive loops
 - On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `/mcp` the public MCP endpoint for Next.js, backed by the canonical `/api/docs/mcp`. Adds a rewrite, updates the agent spec, and refreshes docs/examples to prefer `/mcp` without breaking existing links.

- New Features
  - Adds rewrite `/mcp` → `/api/docs/mcp`; when a custom `mcp.route` is set, `/mcp` aliases to that route.
  - Agent spec now includes `defaultEndpoint`, `publicEndpoint`, and `canonicalEndpoint` alongside `mcp.endpoint`.
  - Keeps autogeneration of the canonical `/api/docs/mcp` route; only generated when using the default.
  - Updates types, tests, and docs to default MCP search endpoints and examples to `/mcp`.

- Migration
  - No breaking changes; `/api/docs/mcp` still works.
  - Use `/mcp` in clients and `DocsSearchConfig` going forward.
  - Custom MCP routes continue to work; `/mcp` is auto-aliased to your configured route.

<sup>Written for commit b8981e82faac0e7952a7e121c9374a85f9afb154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

