### PR TITLE
feat: `/.well-known` mcp endpoint

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -632,15 +632,15 @@ export interface DocsMcpToolsConfig {
  * Built-in MCP server configuration.
  *
  * When enabled, adapters can expose a Streamable HTTP endpoint for your docs
- * at `/mcp` in Next.js, backed by the canonical `/api/docs/mcp` route. The same config is also reused by the local
- * `docs mcp` stdio command.
+ * at `/mcp` and `/.well-known/mcp` in Next.js, backed by the canonical `/api/docs/mcp` route.
+ * The same config is also reused by the local `docs mcp` stdio command.
  */
 export interface DocsMcpConfig {
   /** Whether to enable the built-in MCP server. Defaults to `true` when this object is provided. */
   enabled?: boolean;
   /**
    * Streamable HTTP route for the MCP endpoint.
-   * Defaults to `/api/docs/mcp`; Next.js also exposes it publicly at `/mcp`.
+   * Defaults to `/api/docs/mcp`; Next.js also exposes it publicly at `/mcp` and `/.well-known/mcp`.
    */
   route?: string;
   /**
@@ -787,8 +787,8 @@ export interface McpDocsSearchConfig {
   provider: "mcp";
   enabled?: boolean;
   /**
-   * Streamable HTTP MCP endpoint. Relative paths like `/mcp` are resolved
-   * against the current docs API request URL.
+   * Streamable HTTP MCP endpoint. Relative paths like `/mcp` or `/.well-known/mcp`
+   * are resolved against the current docs API request URL.
    */
   endpoint: string;
   /**
@@ -1695,8 +1695,8 @@ export interface DocsConfig {
   /**
    * Built-in MCP server for agent/assistant access to your docs content.
    *
-   * - omitted → enable the default MCP surface at `/mcp` in Next.js, backed by `/api/docs/mcp`
-   * - `true` → enable the default MCP surface at `/mcp` in Next.js, backed by `/api/docs/mcp`
+   * - omitted → enable the default MCP surface at `/mcp` and `/.well-known/mcp` in Next.js, backed by `/api/docs/mcp`
+   * - `true` → enable the default MCP surface at `/mcp` and `/.well-known/mcp` in Next.js, backed by `/api/docs/mcp`
    * - `{ route: "/api/docs/mcp" }` → enable with explicit route/config
    * - `false` or `{ enabled: false }` → disable MCP explicitly
    */

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -693,6 +693,8 @@ title: "Home"
         endpoint: string;
         defaultEndpoint: string;
         publicEndpoint: string;
+        wellKnownEndpoint: string;
+        publicEndpoints: string[];
         canonicalEndpoint: string;
         name: string;
         version: string;
@@ -778,6 +780,8 @@ title: "Home"
       endpoint: "/internal/docs/mcp",
       defaultEndpoint: "/mcp",
       publicEndpoint: "/mcp",
+      wellKnownEndpoint: "/.well-known/mcp",
+      publicEndpoints: ["/mcp", "/.well-known/mcp"],
       canonicalEndpoint: "/api/docs/mcp",
       name: "Agent Docs",
       version: "0.0.0",
@@ -848,6 +852,8 @@ title: "Home"
         endpoint: string;
         defaultEndpoint: string;
         publicEndpoint: string;
+        wellKnownEndpoint: string;
+        publicEndpoints: string[];
         canonicalEndpoint: string;
       };
       feedback: { enabled: boolean; schema: string; submit: string };
@@ -907,6 +913,8 @@ title: "Home"
       endpoint: "/api/docs/mcp",
       defaultEndpoint: "/mcp",
       publicEndpoint: "/mcp",
+      wellKnownEndpoint: "/.well-known/mcp",
+      publicEndpoints: ["/mcp", "/.well-known/mcp"],
       canonicalEndpoint: "/api/docs/mcp",
     });
     expect(spec.feedback).toMatchObject({

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -116,6 +116,7 @@ const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
 const DEFAULT_MCP_ROUTE = "/api/docs/mcp";
 const DEFAULT_MCP_PUBLIC_ROUTE = "/mcp";
+const DEFAULT_MCP_WELL_KNOWN_ROUTE = "/.well-known/mcp";
 const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
 const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
@@ -392,6 +393,8 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       endpoint: mcp.route,
       defaultEndpoint: DEFAULT_MCP_PUBLIC_ROUTE,
       publicEndpoint: DEFAULT_MCP_PUBLIC_ROUTE,
+      wellKnownEndpoint: DEFAULT_MCP_WELL_KNOWN_ROUTE,
+      publicEndpoints: [DEFAULT_MCP_PUBLIC_ROUTE, DEFAULT_MCP_WELL_KNOWN_ROUTE],
       canonicalEndpoint: DEFAULT_MCP_ROUTE,
       name: mcp.name,
       version: mcp.version,

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -277,6 +277,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs/mcp",
         }),
         expect.objectContaining({
+          source: "/.well-known/mcp",
+          destination: "/api/docs/mcp",
+        }),
+        expect.objectContaining({
           source: "/llms.txt",
           destination: "/api/docs?format=llms",
         }),
@@ -396,7 +400,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(existsSync(join(tmpDir, "app/changelogs/page.tsx"))).toBe(false);
   });
 
-  it("skips default MCP route generation and aliases /mcp when a custom route is configured", async () => {
+  it("skips default MCP route generation and aliases public MCP routes when a custom route is configured", async () => {
     writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_CUSTOM_MCP_ROUTE, "utf-8");
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
@@ -409,6 +413,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
       expect.arrayContaining([
         expect.objectContaining({
           source: "/mcp",
+          destination: "/api/internal/docs/mcp",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/mcp",
           destination: "/api/internal/docs/mcp",
         }),
       ]),
@@ -561,6 +569,10 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
         expect.objectContaining({
           source: "/mcp",
+          destination: "/api/docs/mcp",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/mcp",
           destination: "/api/docs/mcp",
         }),
         expect.objectContaining({

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -173,6 +173,7 @@ const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 const DEFAULT_MCP_ROUTE = "/api/docs/mcp";
 const DEFAULT_MCP_PUBLIC_ROUTE = "/mcp";
+const DEFAULT_MCP_WELL_KNOWN_ROUTE = "/.well-known/mcp";
 const DEFAULT_LLMS_TXT_ROUTE = "/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_ROUTE = "/llms-full.txt";
 const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
@@ -1050,14 +1051,14 @@ function buildLlmsTxtRewrites(): NextRewrite[] {
 }
 
 function buildMcpRewrites(config: { enabled: boolean; route: string }): NextRewrite[] {
-  if (!config.enabled || config.route === DEFAULT_MCP_PUBLIC_ROUTE) return [];
+  if (!config.enabled) return [];
 
-  return [
-    {
-      source: DEFAULT_MCP_PUBLIC_ROUTE,
+  return [DEFAULT_MCP_PUBLIC_ROUTE, DEFAULT_MCP_WELL_KNOWN_ROUTE]
+    .filter((source) => source !== config.route)
+    .map((source) => ({
+      source,
       destination: config.route,
-    },
-  ];
+    }));
 }
 
 function buildAgentFeedbackRewrites(config: {

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -13,7 +13,7 @@ pnpm --dir examples/next dev
 Useful routes:
 
 - Agent discovery spec: `http://127.0.0.1:3000/api/docs/agent/spec`
-- MCP: `http://127.0.0.1:3000/api/docs/mcp`
+- MCP: `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`
 - Agent feedback schema: `http://127.0.0.1:3000/api/docs/agent/feedback/schema`

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -156,7 +156,7 @@ The built-in MCP surface currently includes:
 - `search_docs`
 - `read_page`
 
-Use the docs config `mcp` block when you also want the HTTP route version at `/api/docs/mcp`.
+Use the docs config `mcp` block when you also want the HTTP route version at `/mcp` or `/.well-known/mcp`.
 
 ## Search Sync
 
@@ -218,7 +218,7 @@ pnpm --dir examples/next exec docs search sync --algolia --config docs.config.ts
 
 Then verify:
 
-- MCP: `http://127.0.0.1:3000/api/docs/mcp`
+- MCP: `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`
 - Search: `http://127.0.0.1:3000/api/docs?query=session`
 
 ---

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -46,7 +46,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `ai` | `AIConfig` | — | RAG-powered AI chat (see `ask-ai` skill) |
 | `search` | `boolean \| DocsSearchConfig` | `true` | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `changelog` | `boolean \| ChangelogConfig` | `false` | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
-| `mcp` | `boolean \| DocsMcpConfig` | enabled | Built-in MCP server over stdio and `/api/docs/mcp` |
+| `mcp` | `boolean \| DocsMcpConfig` | enabled | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false` | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON document |
 | `metadata` | `DocsMetadata` | — | SEO: titleTemplate, description, etc. |
 | `og` | `OGConfig` | — | Dynamic Open Graph images |
@@ -201,7 +201,7 @@ MCP example:
 ```ts
 search: {
   provider: "mcp",
-  endpoint: "/api/docs/mcp",
+  endpoint: "/mcp",
 },
 mcp: {
   enabled: true,
@@ -232,7 +232,7 @@ Important notes:
 
 - `chunking.strategy` defaults to `"section"` and can be changed to `"page"`
 - Typesense and Algolia can sync the index on first request when `adminApiKey` is present
-- `provider: "mcp"` supports relative endpoints like `/api/docs/mcp` and absolute remote endpoints
+- `provider: "mcp"` supports relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints
 - if `provider: "mcp"` points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally so the route does not recurse forever
 - On custom/manual Next routes, forward `search: docsConfig.search` into `createDocsAPI(...)`
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want to push external indexes from the CLI instead of waiting for the first request
@@ -386,12 +386,14 @@ mcp: {
 
 Default behavior:
 
-- **HTTP route:** `/api/docs/mcp`
+- **Public HTTP route:** `/mcp`
+- **Well-known HTTP route:** `/.well-known/mcp`
+- **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
 
 Framework notes:
-- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route
+- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites
 - **TanStack Start / SvelteKit / Astro / Nuxt:** add the framework route file and reuse the built-in `MCP` handler from the docs server helper
 - **Custom routes:** set `mcp.route` in `docs.config` and add the matching route file manually so the configured path and the actual endpoint stay aligned
 
@@ -401,14 +403,15 @@ Testing tip:
 pnpm --dir examples/next dev
 ```
 
-Then point an MCP client or inspector at `http://127.0.0.1:3000/api/docs/mcp` to verify the
-default route.
+Then point an MCP client or inspector at `http://127.0.0.1:3000/mcp` or
+`http://127.0.0.1:3000/.well-known/mcp` to verify the default route.
 
 Hosted example:
 
-- The docs site itself exposes MCP at `https://docs.farming-labs.dev/api/docs/mcp`
+- The docs site itself exposes MCP at `https://docs.farming-labs.dev/mcp` and
+  `https://docs.farming-labs.dev/.well-known/mcp`
 - Cursor can install it from a deeplink:
-  `cursor://anysphere.cursor-deeplink/mcp/install?name=farming-labs-docs&config=eyJ1cmwiOiJodHRwczovL2RvY3MuZmFybWluZy1sYWJzLmRldi9hcGkvZG9jcy9tY3AifQ==`
+  `cursor://anysphere.cursor-deeplink/mcp/install?name=farming-labs-docs&config=eyJ1cmwiOiJodHRwczovL2RvY3MuZmFybWluZy1sYWJzLmRldi8ud2VsbC1rbm93bi9tY3AifQ==`
 
 See the full guide: [docs.farming-labs.dev/docs/customization/mcp](https://docs.farming-labs.dev/docs/customization/mcp)
 
@@ -513,7 +516,7 @@ Use `ordering: "numeric"` (default) so sidebar order follows frontmatter `order`
 3. **SvelteKit/Astro:** Server-side docs loader must receive config and (for AI) env vars; see framework docs.
 4. **Nuxt:** `defineDocsHandler(config, useStorage)` in `server/api/docs.ts`; config is imported from root `docs.config.ts`.
 5. **Feedback callbacks:** Astro cannot serialize config functions into client scripts; use the built-in custom event hooks if you need analytics there.
-6. **MCP custom routes:** Only the default Next.js `/api/docs/mcp` route is auto-generated. If the user sets `mcp.route`, keep that path in config and add the matching route file manually.
+6. **MCP custom routes:** Only the default Next.js `/api/docs/mcp` route is auto-generated. If the user sets `mcp.route`, keep that path in config and add the matching route file manually; `/mcp` and `/.well-known/mcp` will rewrite to that route when MCP is enabled.
 
 ---
 

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -45,7 +45,7 @@ Ten built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-border
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
-- **Built-in MCP server** — enabled by default at `/api/docs/mcp` and for local stdio tools. Opt out with `mcp: false` or `mcp: { enabled: false }`.
+- **Built-in MCP server** — enabled by default at `/mcp` and `/.well-known/mcp` in Next.js, backed by `/api/docs/mcp`, and for local stdio tools. Opt out with `mcp: false` or `mcp: { enabled: false }`.
 - **Machine-readable markdown routes** — Next.js serves `/docs/<slug>.md` automatically with `withDocs()` and also returns the same markdown from `/docs/<slug>` when the request sends `Accept: text/markdown`. Use embedded `<Agent>...</Agent>` blocks inside `page.mdx` when the normal page only needs extra machine context; add a sibling `agent.md` when the whole machine-readable page should be overridden. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`.
 
 ### MCP quick test
@@ -56,7 +56,7 @@ To verify the HTTP MCP route in this repo, use the Next example:
 pnpm --dir examples/next dev
 ```
 
-Then point your MCP client or inspector at `http://127.0.0.1:3000/api/docs/mcp`.
+Then point your MCP client or inspector at `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -150,7 +150,8 @@ pnpm --dir examples/next dev
 Then point your MCP client or inspector at:
 
 ```txt title="~"
-http://127.0.0.1:3000/api/docs/mcp
+http://127.0.0.1:3000/mcp
+http://127.0.0.1:3000/.well-known/mcp
 ```
 
 ### Sync an external search index

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -132,7 +132,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
-| `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio and `/mcp` |
+| `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |
 | `i18n`        | `DocsI18nConfig`               | —               | Query-param locale support and locale switcher     |
 | `metadata`    | `DocsMetadata`                 | —               | SEO metadata template                              |
@@ -317,7 +317,7 @@ Notes:
 - `chunking.strategy` defaults to `"section"` and can be changed to `"page"` for one-document-per-page indexing
 - Typesense and Algolia can sync documents automatically on the first search request when `adminApiKey` is present
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want manual indexing as a CLI step
-- `provider: "mcp"` can target a relative route like `/mcp` or an absolute remote MCP endpoint
+- `provider: "mcp"` can target a relative route like `/mcp` or `/.well-known/mcp` or an absolute remote MCP endpoint
 - when MCP search points at the same site's relative MCP route, the MCP `search_docs` tool falls back to built-in simple search to avoid recursive loops
 - If you use a custom Next.js docs API route, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search` so your adapter config reaches the route handler
 - Search requires the docs API route; with `staticExport: true` the UI is hidden because there is no server route
@@ -358,13 +358,14 @@ export default defineDocs({
 Default behavior:
 
 - **Public HTTP route:** `/mcp`
+- **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
 
 Framework notes:
 
-- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` rewrite
+- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites
 - **TanStack Start / SvelteKit / Astro / Nuxt:** add the framework route file and reuse the built-in handler from the docs server helper
 - **Custom routes:** set `mcp.route` in `docs.config` and add the matching route file manually so the configured path and the actual endpoint stay aligned
 
@@ -1001,7 +1002,8 @@ Agents should discover the configured routes first with `GET /.well-known/agent.
 canonical framework route. All three return the same JSON. The spec includes
 site identity, locale config, capability flags, the search endpoint, markdown route pattern and
 `Accept: text/markdown` contract, API and public `llms.txt` routes, Skills CLI install metadata,
-MCP endpoint and enabled tools, and the active agent feedback schema and submit endpoints.
+MCP public/well-known endpoints and enabled tools, and the active agent feedback schema and submit
+endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -65,7 +65,7 @@ Recommended bootstrap flow:
 1. Fetch `/api/docs/agent/spec`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page first.
-4. Use `spec.mcp.endpoint` and tools when MCP is enabled and your environment supports MCP.
+4. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
 5. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -76,7 +76,7 @@ You are reading this docs site as an implementation agent.
 
 Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
 is unavailable, fall back to `/.well-known/agent`. Use that JSON as the source of truth for the docs
-entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes, skills install
+entry path, markdown route pattern, search endpoint, MCP endpoints, `llms.txt` routes, skills install
 command, locale handling, and feedback endpoints.
 
 Recommended bootstrap flow:
@@ -84,7 +84,7 @@ Recommended bootstrap flow:
 1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page first.
-4. Use `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
+4. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
 5. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the
@@ -174,7 +174,7 @@ Agents should fetch it before choosing a transport. It tells them:
 - where to fetch `llms.txt` and `llms-full.txt` content, including the default public URLs and the
   public `/.well-known` aliases when available
 - how to install the published Skills pack and which skill is recommended first
-- whether MCP is enabled, which endpoint to call, and which tools are available
+- whether MCP is enabled, which public/well-known endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 
 For Next.js apps, `withDocs()` wires `/.well-known/agent.json`, `/.well-known/agent`, and

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Server"
-description: "Expose your docs as MCP tools and resources over stdio or /mcp"
+description: "Expose your docs as MCP tools and resources over stdio, /mcp, or /.well-known/mcp"
 icon: "bot"
 order: 8
 ---
@@ -35,15 +35,16 @@ export default defineDocs({
 });
 ```
 
-That gives you the built-in MCP surface with the default public Streamable HTTP route:
+That gives you the built-in MCP surface with the default public Streamable HTTP routes:
 
-```txt title="/mcp"
+```txt title="Public MCP routes"
 /mcp
+/.well-known/mcp
 ```
 
 <Callout type="info" title="This docs site already exposes it live">
-  The hosted docs site has MCP enabled at
-  `https://docs.farming-labs.dev/mcp`.
+  The hosted docs site has MCP enabled at `https://docs.farming-labs.dev/mcp` and
+  `https://docs.farming-labs.dev/.well-known/mcp`.
 </Callout>
 
 Opt out explicitly:
@@ -59,12 +60,13 @@ export default defineDocs({
 
 ## Default HTTP Routes
 
-`/mcp` is the preferred public MCP endpoint in Next.js. It rewrites to the canonical framework route
-at `/api/docs/mcp`, so the MCP handler still lives in one place.
+`/mcp` is the short public MCP endpoint in Next.js, and `/.well-known/mcp` is the discovery-friendly
+public MCP endpoint. Both rewrite to the canonical framework route at `/api/docs/mcp`, so the MCP
+handler still lives in one place.
 
 <Callout type="info" title="Minimal route behavior">
   **Next.js** auto-generates the default `/api/docs/mcp` route when you use `withDocs()`, and also
-  adds the public `/mcp` rewrite unless you explicitly disable MCP.
+  adds public `/mcp` and `/.well-known/mcp` rewrites unless you explicitly disable MCP.
 
   **TanStack Start**, **SvelteKit**, **Astro**, and **Nuxt** still need the framework route file,
   but they all reuse the built-in MCP handler from the docs server helper.
@@ -201,10 +203,10 @@ export default defineDocs({
 });
 ```
 
-For local self-hosted setups, relative MCP endpoints like `/mcp` are supported. The canonical
-`/api/docs/mcp` route remains available too. The built-in `search_docs` tool automatically falls
-back to simple search internally when it detects that same-route loop, so the route stays usable for
-testing and local examples.
+For local self-hosted setups, relative MCP endpoints like `/mcp` and `/.well-known/mcp` are
+supported. The canonical `/api/docs/mcp` route remains available too. The built-in `search_docs`
+tool automatically falls back to simple search internally when it detects that same-route loop, so
+the route stays usable for testing and local examples.
 
 ## Stdio transport
 
@@ -232,6 +234,7 @@ If you just want to try the live docs server, you can point your MCP client at:
 
 ```txt title="Live MCP endpoint"
 https://docs.farming-labs.dev/mcp
+https://docs.farming-labs.dev/.well-known/mcp
 ```
 
 <DocsMcpAccess />
@@ -276,7 +279,8 @@ claude mcp add-json farming-labs-docs '{"type":"http","url":"https://docs.farmin
 ```
 
 <Callout type="tip" title="Local development uses http, not https">
-  If you are connecting to a local Next dev server, use `http://127.0.0.1:3000/mcp`.
+  If you are connecting to a local Next dev server, use `http://127.0.0.1:3000/mcp` or
+  `http://127.0.0.1:3000/.well-known/mcp`.
   Using `https://localhost:3000/...` against a non-TLS dev server will fail with SSL errors.
 </Callout>
 
@@ -294,6 +298,7 @@ Then connect your MCP client or inspector to:
 
 ```txt title="~"
 http://127.0.0.1:3000/mcp
+http://127.0.0.1:3000/.well-known/mcp
 ```
 
 The built-in HTTP route exposes the full MCP surface:

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -19,7 +19,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[OG Images](/docs/customization/og-images)** — Dynamic or static Open Graph images; what context your image generator receives; how the docs website does it
 - **[Ask AI](/docs/customization/ai-chat)** — RAG-powered AI chat with configurable LLM, floating/search modes, and more
 - **[Page Actions](/docs/customization/page-actions)** — "Copy Markdown" and "Open in LLM" buttons on doc pages
-- **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio and `/mcp`
+- **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio, `/mcp`, and `/.well-known/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
 
 All customization happens through the `theme` and top-level config options in `docs.config.ts`.

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -21,7 +21,7 @@ Recommended bootstrap flow:
 1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read the exact docs pages you need as markdown.
 3. Use `spec.search.endpoint` when you need to find the right page before reading it.
-4. Use `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
+4. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
 5. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -48,7 +48,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
-| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio and `/mcp`                                            |
+| `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp`                       |
 | `apiReference` | `boolean \| ApiReferenceConfig`               | `false`          | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON |
 | `changelog`   | `boolean \| ChangelogConfig`                    | `false`          | Generated changelog feed and entry pages from dated MDX entries                      |
 | `ordering`    | `"alphabetical" \| "numeric" \| OrderingItem[]` | `"alphabetical"` | Sidebar page ordering strategy                                                       |
@@ -192,13 +192,14 @@ export default defineDocs({
 Default MCP surface:
 
 - **Public HTTP route:** `/mcp`
+- **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
 
 Framework notes:
 
-- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` rewrite
+- **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites
 - **TanStack Start / SvelteKit / Astro / Nuxt:** add the matching framework route file and forward to the built-in `MCP` handler from the docs server helper
 - **Custom routes:** set `mcp.route` in `docs.config` and add the matching route file manually so the configured path and the actual endpoint stay aligned
 
@@ -405,7 +406,7 @@ Notes:
 - `search: false` disables search entirely
 - Search requires the docs API route; static export hides the UI because there is no server route
 - On Next.js, generated routes from `withDocs()` already forward `docsConfig.search`
-- MCP-backed search works with relative endpoints like `/mcp` and absolute remote endpoints like `https://docs.example.com/mcp`
+- MCP-backed search works with relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints like `https://docs.example.com/mcp`
 - If MCP-backed search points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally to avoid recursive loops
 - On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a well-known MCP endpoint at `/.well-known/mcp` alongside `/mcp`, and expose both in the agent spec and Next.js rewrites. This improves MCP discovery while keeping the canonical handler at `/api/docs/mcp`.

- **New Features**
  - Next.js rewrites now map `/mcp` and `/.well-known/mcp` to `/api/docs/mcp`; custom `mcp.route` also receives both public rewrites.
  - Agent spec adds `wellKnownEndpoint` and `publicEndpoints` for MCP; tests updated.
  - Types and docs updated to support relative MCP endpoints like `/mcp` or `/.well-known/mcp` for search and server config.

- **Migration**
  - No breaking changes; `/mcp` continues to work.
  - MCP search configs may now target `/.well-known/mcp` for easier discovery.

<sup>Written for commit 8e8769966e4adcea002a9b1bf6fcd9514ca2bfcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

