### PR TITLE
fix: framework layer for Agent component

### DIFF
--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import type { DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
 import { createHighlighter, type Highlighter } from "shiki";
 
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -284,7 +284,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = content;
+  let result = resolveDocsAgentMdxContent(content, "human");
 
   // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   const tabsBlocks: string[] = [];

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -603,7 +603,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const html = await renderMarkdown(content, { theme: config.theme });
+    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
     const currentIndex = flatPages.findIndex((p) => p.url === currentUrl);
@@ -627,7 +628,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,
-      rawMarkdown: content,
+      rawMarkdown: humanRawContent,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import type { DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
 import { createHighlighter, type Highlighter } from "shiki";
 
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -284,7 +284,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = content;
+  let result = resolveDocsAgentMdxContent(content, "human");
 
   // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   const tabsBlocks: string[] = [];

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -593,7 +593,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const html = await renderMarkdown(content, { theme: config.theme });
+    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
     const currentIndex = flatPages.findIndex((p) => p.url === currentUrl);

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import type { DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
 import { createHighlighter, type Highlighter } from "shiki";
 
 let highlighterPromise: Promise<Highlighter> | undefined;
@@ -284,7 +284,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = content;
+  let result = resolveDocsAgentMdxContent(content, "human");
 
   // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   const tabsBlocks: string[] = [];

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -613,7 +613,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const html = await renderMarkdown(content, { theme: config.theme });
+    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
     const currentIndex = flatPages.findIndex((p) => p.url === currentUrl);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route docs MDX through `resolveDocsAgentMdxContent(content, "human")` in `astro`, `nuxt`, and `svelte` to fix the Agent component framework layer. Ensures the human variant renders consistently and `rawMarkdown` matches the output.

- **Bug Fixes**
  - Import `resolveDocsAgentMdxContent` from `@farming-labs/docs` in each framework’s markdown module.
  - Transform content to the "human" variant before rendering; set `rawMarkdown` to the same value.
  - Apply the change in `packages/*/{markdown.ts,server.ts}` to prevent role-specific MDX mismatches for Agent docs.

<sup>Written for commit 5d075ff6914dd611c252d7dc2faca71d3f76aec8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

