### PR TITLE
feat: framework agnostic skills route

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -47,6 +47,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
@@ -805,7 +806,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
-    if (isDocsSkillRequest(url)) {
+    if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
           renderDocsSkillDocument({

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -10,6 +10,7 @@ import {
   renderDocsSkillDocument,
   resolveDocsAgentMdxContent,
   resolveDocsLlmsTxtFormat,
+  resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
 } from "./agent.js";
 
@@ -36,6 +37,13 @@ describe("agent route helpers", () => {
     expect(isDocsSkillRequest(new URL("https://example.com/.well-known/skill.md"))).toBe(true);
     expect(isDocsSkillRequest(new URL("https://example.com/api/docs?format=skill"))).toBe(true);
     expect(isDocsSkillRequest(new URL("https://example.com/blog?format=skill"))).toBe(false);
+    expect(resolveDocsSkillFormat(new URL("https://example.com/api/docs?format=skill"))).toBe(
+      "skill",
+    );
+    expect(resolveDocsSkillFormat(new URL("https://example.com/internal/docs?format=skill"))).toBe(
+      "skill",
+    );
+    expect(resolveDocsSkillFormat(new URL("https://example.com/internal/docs?format=llms"))).toBeNull();
   });
 
   it("detects public docs forwarder requests without taking over api/docs", () => {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -43,7 +43,9 @@ describe("agent route helpers", () => {
     expect(resolveDocsSkillFormat(new URL("https://example.com/internal/docs?format=skill"))).toBe(
       "skill",
     );
-    expect(resolveDocsSkillFormat(new URL("https://example.com/internal/docs?format=llms"))).toBeNull();
+    expect(
+      resolveDocsSkillFormat(new URL("https://example.com/internal/docs?format=llms")),
+    ).toBeNull();
   });
 
   it("detects public docs forwarder requests without taking over api/docs", () => {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -108,7 +108,11 @@ export function isDocsSkillRequest(url: URL): boolean {
     return true;
   }
 
-  return pathname === DEFAULT_DOCS_API_ROUTE && url.searchParams.get("format")?.trim() === "skill";
+  return pathname === DEFAULT_DOCS_API_ROUTE && resolveDocsSkillFormat(url) === "skill";
+}
+
+export function resolveDocsSkillFormat(url: URL): "skill" | null {
+  return url.searchParams.get("format")?.trim() === "skill" ? "skill" : null;
 }
 
 export function isDocsPublicGetRequest(entry: string, url: URL, request: Request): boolean {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -43,6 +43,7 @@ export {
   renderDocsSkillDocument,
   resolveDocsAgentMdxContent,
   resolveDocsLlmsTxtFormat,
+  resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
 } from "./agent.js";
 export {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -36,6 +36,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
@@ -794,7 +795,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
-    if (isDocsSkillRequest(url)) {
+    if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
           renderDocsSkillDocument({

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -47,6 +47,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
@@ -813,7 +814,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
-    if (isDocsSkillRequest(event.url)) {
+    if (isDocsSkillRequest(event.url) || resolveDocsSkillFormat(event.url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
           renderDocsSkillDocument({

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -17,6 +17,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
@@ -787,7 +788,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       );
     }
 
-    if (isDocsSkillRequest(url)) {
+    if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
           renderDocsSkillDocument({


### PR DESCRIPTION
- **feat: framework agnostic skills route**
- **chore: lint**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Skills route framework-agnostic by detecting `?format=skill` on any path and serving the root skill document across integrations. This enables internal forwarders and custom routes to expose the skill doc without relying on `/api/docs`.

- **New Features**
  - Added `resolveDocsSkillFormat` in `@farming-labs/docs` and exported for reuse.
  - Updated servers in `@farming-labs/astro`, `@farming-labs/nuxt`, `@farming-labs/svelte`, and `@farming-labs/tanstack-start` to serve the skill document when `isDocsSkillRequest(url)` or `resolveDocsSkillFormat(url) === "skill"`, allowing non-standard paths.

<sup>Written for commit 33776ae04ae9ab4e4af2572ce3b30e121a533876. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

