### PR TITLE
chore: token compaction

### DIFF
--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -33,6 +33,7 @@ import {
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
+import type { NextConfig } from "next";
 
 /** Resolve Next.js App Router directory: prefer src/app when present, else app. */
 function getNextAppDir(root: string): string {
@@ -1152,7 +1153,7 @@ function mergeDocsMarkdownRewrites(
 
 // ─── withDocs ───────────────────────────────────────────────────────
 
-export function withDocs(nextConfig: Record<string, unknown> = {}) {
+export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   const root = process.cwd();
   const workspaceRoot = findDocsWorkspaceRoot(root);
   const docsConfigPath = readDocsConfigPath(root);

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -2,9 +2,15 @@
 
 This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agent Skills specification](https://agentskills.io/specification)) for **@farming-labs/docs** — an MDX-based documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.
 
-Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search adapters, changelog setup, human page feedback, agent discovery/spec routes, `skill.md`, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown routes with embedded `Agent` blocks, `agent.md` overrides, or `Accept: text/markdown` negotiation).
+Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task
+(getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search
+adapters, changelog setup, human page feedback, `agent.compact`, agent discovery/spec routes,
+`skill.md`, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown
+routes with embedded `Agent` blocks, generated or hand-written `agent.md` overrides, or
+`Accept: text/markdown` negotiation).
 
-The repo also includes a runnable Next example for testing MCP plus external search providers:
+The repo also includes a runnable Next example for testing MCP, external search providers, and
+page-level agent compaction:
 
 ```bash
 pnpm --dir examples/next dev
@@ -22,6 +28,12 @@ Useful routes:
 - Header-negotiated markdown page (Next.js): `curl http://127.0.0.1:3000/docs/quickstart -H "Accept: text/markdown"`
 - Agent override example (Next.js): `http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md`
 
+Useful command:
+
+```bash
+pnpm --dir examples/next exec docs agent compact installation --config docs.config.tsx
+```
+
 The agent discovery spec also advertises the root `skill.md` route, this Skills pack through
 `npx skills add farming-labs/docs`, and recommends the `getting-started` skill for first-run setup.
 
@@ -32,11 +44,11 @@ The agent discovery spec also advertises the root `skill.md` route, this Skills 
 | Skill | Path | When to use |
 | ----- | ---- | ----------- |
 | **Getting started** | [getting-started](./getting-started/SKILL.md) | Setting up docs, init, manual install, theme CSS, docs.config, packages by framework, generated changelog pages in Next.js, machine-readable markdown routes with `Agent` blocks or `agent.md` overrides, and API reference wiring from local routes or a hosted OpenAPI JSON. |
-| **CLI** | [cli](./cli/SKILL.md) | Scaffolding and commands: init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), `init` / `upgrade` / `mcp`, `--template`, `--name`, `--theme`, `--entry`, `--api-reference`, `--framework`, `--config`, package manager commands. |
+| **CLI** | [cli](./cli/SKILL.md) | Scaffolding and commands: init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), `init` / `upgrade` / `agent compact` / `mcp`, `--template`, `--name`, `--theme`, `--entry`, `--api-reference`, `--framework`, `--config`, package manager commands. |
 | **Creating themes** | [creating-themes](./creating-themes/SKILL.md) | Building a custom theme with `createTheme()`, `extendTheme()`, `ui.components` defaults like `HoverLink`, publishing as npm, CSS overrides. |
 | **Ask AI** | [ask-ai](./ask-ai/SKILL.md) | Enabling and configuring the RAG-powered AI chat: mode, floatingStyle, providers, models, suggestedQuestions, apiKey. |
 | **Page actions** | [page-actions](./page-actions/SKILL.md) | Copy Markdown and Open in LLM buttons: copyMarkdown, openDocs, providers, urlTemplate, `{url}.md` markdown route patterns, position, alignment, and provider defaults. |
-| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, human page feedback, agent feedback endpoints, metadata, og, `mcp`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
+| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, `agent.compact`, human page feedback, agent feedback endpoints, metadata, og, `mcp`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
 
 ---
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, sync external search indexes, and run MCP for docs. Use when running init, upgrade, search sync, mcp, or using flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, or --config. Covers init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, compact agent docs, sync external search indexes, and run MCP for docs. Use when running init, upgrade, agent compact, search sync, mcp, or using flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --config, --page, --all, --api-key, or --dry-run. Covers init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
 
-The `@farming-labs/docs` CLI scaffolds, upgrades, syncs external search indexes, and can run the built-in MCP server for documentation projects. Use this skill when the user asks about CLI commands, init, upgrade, search sync, mcp, or scaffolding.
+The `@farming-labs/docs` CLI scaffolds, upgrades, compacts page-level agent docs, syncs external
+search indexes, and can run the built-in MCP server for documentation projects. Use this skill when
+the user asks about CLI commands, init, upgrade, `agent compact`, search sync, mcp, or
+scaffolding.
 
 ---
 
@@ -223,6 +226,66 @@ Then verify:
 
 ---
 
+## Agent compact
+
+Use `agent compact` when the user wants generated `agent.md` files, shorter page-level machine
+docs, or a tighter machine-readable version of existing docs pages.
+
+```bash
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact /docs/installation
+pnpm exec docs agent compact /docs/installation.md
+pnpm exec docs agent compact https://docs.example.com/docs/installation
+pnpm exec docs agent compact . --dry-run
+pnpm exec docs agent compact --page installation --page configuration
+pnpm exec docs agent compact --all
+```
+
+Behavior:
+
+- positional page args are the preferred UX; `--page` is an optional repeatable alias
+- page identifiers can be a slug, docs path, `.md` path, full docs URL, or `.` for the root docs
+  page
+- the command loads `.env` and `.env.local`
+- defaults can come from `agent.compact` in `docs.config.ts` or `docs.config.tsx`
+- it creates missing sibling `agent.md` files and overwrites existing ones
+- the written `agent.md` becomes the machine-readable source for `.md` routes,
+  `GET /api/docs?format=markdown&path=...`, and MCP `read_page()`
+- only folder-based pages can be written automatically
+
+Recommended config:
+
+```ts
+agent: {
+  compact: {
+    apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+    model: "bear-1.2",
+    aggressiveness: 0.3,
+    protectJson: true,
+  },
+}
+```
+
+Alternative `docs.config.tsx` form:
+
+```tsx
+agent: {
+  compact: {
+    apiKey: process.env.TOKEN_COMPANY_API_KEY,
+  },
+}
+```
+
+Useful checks:
+
+```bash
+pnpm exec docs agent compact installation --dry-run
+pnpm exec docs agent compact installation
+curl "http://127.0.0.1:3000/docs/installation.md"
+```
+
+---
+
 ## What init does (Existing project, per framework)
 
 When the user chooses **Existing project**, the CLI detects (or prompts for) framework, then theme (including **Create your own theme** → prompts for theme name, scaffolds `themes/<name>.ts` and `themes/<name>.css`), path aliases, entry path (default `docs`; Enter to accept), optional API reference scaffold, optional i18n scaffolding, and global CSS. If API reference is enabled and the user does not pass `--api-route-root`, the CLI detects a sensible default route root (usually `api`) and shows it as the default in the prompt. Generated files:
@@ -251,4 +314,5 @@ When the user chooses **Existing project**, the CLI detects (or prompts for) fra
 ## Resources
 
 - **Full CLI docs:** [docs.farming-labs.dev/docs/cli](https://docs.farming-labs.dev/docs/cli)
+- **Token efficiency:** [docs.farming-labs.dev/docs/token-efficiency](https://docs.farming-labs.dev/docs/token-efficiency)
 - **Getting started:** use the `getting-started` skill in this repo for install and theme CSS.

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configuration
-description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, metadata, og, apiReference, MCP, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
+description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, agent.compact, metadata, og, apiReference, MCP, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
 ---
 
 # @farming-labs/docs — Configuration
@@ -42,6 +42,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `components` | `Record<string, Component>` | — | Custom MDX components and built-in overrides like `HoverLink` |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | — | Callback when user copies a code block (title, content, url, language) |
 | `feedback` | `boolean \| FeedbackConfig` | `false` | Human page feedback UI plus optional agent feedback endpoints |
+| `agent` | `DocsAgentConfig` | — | Defaults for `docs agent compact` |
 | `pageActions` | `PageActionsConfig` | — | Copy Markdown, Open in LLM (see `page-actions` skill) |
 | `ai` | `AIConfig` | — | RAG-powered AI chat (see `ask-ai` skill) |
 | `search` | `boolean \| DocsSearchConfig` | `true` | Built-in simple search, Typesense, Algolia, or a custom adapter |
@@ -90,6 +91,7 @@ Default behavior:
 - page frontmatter `related` is rendered into a comma-separated machine-readable markdown metadata line beside `Description` for normal page markdown and embedded `<Agent>` fallback
 - MCP `read_page("/docs/<slug>")` uses the same page source and sees the same override
 - a sibling `agent.md` remains a full override; include any `Related:` line manually inside `agent.md` when needed
+- `docs agent compact` can generate those sibling `agent.md` files from the resolved page output
 
 Folder example:
 
@@ -143,6 +145,55 @@ Call out content negotiation when relevant: in Next.js, `/docs/<slug>` remains t
 for browsers, but agents/scripts can send `Accept: text/markdown` to the same URL and receive the
 machine-readable markdown representation without appending `.md`. In other adapters, use
 `/docs/<slug>.md` or the API format route.
+
+---
+
+## Agent compaction
+
+Use `agent.compact` to configure defaults for `docs agent compact`, which writes sibling `agent.md`
+files from resolved docs pages.
+
+```ts
+agent: {
+  compact: {
+    apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+    model: "bear-1.2",
+    aggressiveness: 0.3,
+    protectJson: true,
+  },
+},
+```
+
+Supported fields:
+
+- `apiKey`
+- `apiKeyEnv`
+- `baseUrl`
+- `model`
+- `aggressiveness`
+- `maxOutputTokens`
+- `minOutputTokens`
+- `protectJson`
+
+Notes:
+
+- `.env` and `.env.local` are loaded before the CLI resolves the key
+- `apiKey: process.env.TOKEN_COMPANY_API_KEY` is supported in `docs.config.tsx`
+- the command creates missing `agent.md` files and overwrites existing ones
+- generated `agent.md` becomes the machine-readable source for `.md` routes,
+  `GET /api/docs?format=markdown&path=...`, and MCP `read_page()`
+- the human docs UI still renders the normal page
+
+Common commands:
+
+```bash
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact installation --dry-run
+pnpm exec docs agent compact --all
+```
+
+Use the `cli` skill or `/docs/cli` when the user needs the full command syntax instead of the
+config shape.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -1,16 +1,17 @@
 ---
 title: "CLI"
-description: "Scaffold a docs project with one command"
+description: "Scaffold, upgrade, compact agent docs, sync search, and run MCP"
 icon: "terminal"
 order: 2
 ---
 
 # CLI
 
-The `@farming-labs/docs` CLI has two main jobs:
+The `@farming-labs/docs` CLI has a few main jobs:
 
 - **`init`** — create a new docs app or add docs to an existing app
 - **`upgrade`** — bump the docs packages in an existing project
+- **`agent compact`** — generate sibling `agent.md` files from resolved docs pages
 - **`mcp`** — run the built-in docs MCP server over stdio for local clients and IDE agents
 - **`search sync`** — push docs content into an external search index like Typesense or Algolia
 
@@ -201,6 +202,98 @@ ALGOLIA_APP_ID=your-app-id
 ALGOLIA_ADMIN_API_KEY=your-admin-key
 ALGOLIA_SEARCH_API_KEY=your-search-key
 ```
+
+### Compact page-level agent docs
+
+Use `agent compact` when you want to generate or refresh sibling `agent.md` files from your
+resolved docs pages.
+
+```bash title="terminal"
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact --all
+```
+
+The command writes compact machine-readable page docs without changing the visible HTML page. Those
+generated `agent.md` files then power `.md` routes, `GET /api/docs?format=markdown&path=<slug>`,
+and MCP `read_page()`.
+
+## Agent compact
+
+Use `agent compact` when you want shorter page-level machine docs without hand-writing every
+`agent.md`.
+
+What it does:
+
+- resolves the same machine-readable page the runtime already uses: `agent.md`, then `Agent`
+  blocks, then normal page markdown
+- compresses that document with the Token Company API
+- creates missing sibling `agent.md` files and overwrites existing ones
+- makes the written `agent.md` the new source for `.md` routes, docs API markdown output, and MCP
+  `read_page()`
+
+Common forms:
+
+```bash title="terminal"
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact /docs/installation
+pnpm exec docs agent compact /docs/installation.md
+pnpm exec docs agent compact https://docs.example.com/docs/installation
+pnpm exec docs agent compact . --dry-run
+pnpm exec docs agent compact --page installation --page configuration
+pnpm exec docs agent compact --all
+```
+
+Selection notes:
+
+- positional page arguments are the preferred UX; `--page` is an optional repeatable alias
+- page identifiers can be a slug, docs path, `.md` path, full docs URL, or `.` for the root docs
+  page
+- `--all` compacts every folder-based docs page under the configured `contentDir`
+- only folder-based pages can be written automatically, because the command needs a sibling
+  `agent.md` target
+
+Recommended config defaults:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+      model: "bear-1.2",
+      aggressiveness: 0.3,
+      protectJson: true,
+    },
+  },
+});
+```
+
+If you prefer to reference the env var directly in `docs.config.tsx`, that works too:
+
+```tsx title="docs.config.tsx"
+export default defineDocs({
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKey: process.env.TOKEN_COMPANY_API_KEY,
+    },
+  },
+});
+```
+
+The command loads `.env` and `.env.local` from the current project before it resolves the key, so
+the default `TOKEN_COMPANY_API_KEY` env var works without exporting it manually.
+
+Useful checks:
+
+```bash title="terminal"
+pnpm exec docs agent compact installation --dry-run
+pnpm exec docs agent compact installation
+curl "http://127.0.0.1:3000/docs/installation.md"
+```
+
+See [Configuration](/docs/configuration) for `agent.compact`, and [Token Efficiency](/docs/token-efficiency)
+for when you should use compaction instead of writing `agent.md` by hand.
 
 ## Init
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -205,17 +205,8 @@ ALGOLIA_SEARCH_API_KEY=your-search-key
 
 ### Compact page-level agent docs
 
-Use `agent compact` when you want to generate or refresh sibling `agent.md` files from your
-resolved docs pages.
-
-```bash title="terminal"
-pnpm exec docs agent compact installation configuration
-pnpm exec docs agent compact --all
-```
-
-The command writes compact machine-readable page docs without changing the visible HTML page. Those
-generated `agent.md` files then power `.md` routes, `GET /api/docs?format=markdown&path=<slug>`,
-and MCP `read_page()`.
+For commands, config, and how generated `agent.md` files affect `.md` routes, docs API markdown
+output, and MCP, see [Agent compact](#agent-compact) below.
 
 ## Agent compact
 

--- a/website/app/docs/configuration/agent.md
+++ b/website/app/docs/configuration/agent.md
@@ -12,6 +12,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
    - `theme`
    - `components`
    - `pageActions`
+   - `agent`
    - `search`
    - `ai`
    - `mcp`
@@ -30,6 +31,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
 - When they want to change default props for a built-in component like `HoverLink`, point them to `theme.ui.components`.
 - When they want AI-facing behavior, distinguish between:
   - `ai` for Ask AI / chat
+  - `agent.compact` for defaults used by `docs agent compact`
   - `mcp` for the built-in MCP server
   - `llmsTxt` for crawler-friendly site summaries
   - markdown routes for page-level machine-readable content
@@ -63,7 +65,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
 2. Verify `entry`, `contentDir`, `nav`, and `theme` before discussing advanced features.
 3. Move to `search`, `ai`, `mcp`, `pageActions`, or `llmsTxt` only after the base project shape is correct.
 4. Use customization and theme pages once routing and content structure are stable.
-5. Use markdown routes, MCP, and token-efficiency docs when the user is optimizing for agents or machine-readable access.
+5. Use markdown routes, `agent.compact`, MCP, and token-efficiency docs when the user is optimizing for agents or machine-readable access.
 
 ## Output style
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1007,6 +1007,68 @@ export async function POST(request: Request) {
 }
 ```
 
+## Agent Compaction
+
+Use `agent.compact` to set defaults for `docs agent compact`, which generates sibling `agent.md`
+files from resolved docs pages.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+      model: "bear-1.2",
+      aggressiveness: 0.3,
+      protectJson: true,
+    },
+  },
+});
+```
+
+If you want to reference the key directly from `docs.config.tsx`, this is supported too:
+
+```tsx title="docs.config.tsx"
+export default defineDocs({
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKey: process.env.TOKEN_COMPANY_API_KEY,
+    },
+  },
+});
+```
+
+Supported fields:
+
+- `apiKey`
+- `apiKeyEnv`
+- `baseUrl`
+- `model`
+- `aggressiveness`
+- `maxOutputTokens`
+- `minOutputTokens`
+- `protectJson`
+
+<Callout type="info" title="What changes after compaction">
+  `docs agent compact` creates missing `agent.md` files and overwrites existing ones. The written
+  `agent.md` becomes the machine-readable source for `.md` routes,
+  `GET /api/docs?format=markdown&path=<slug>`, and MCP `read_page()`. The human docs UI still
+  renders the normal page.
+</Callout>
+
+The CLI loads `.env` and `.env.local` before resolving the key, so `TOKEN_COMPANY_API_KEY` works
+out of the box. Use positional page args by default:
+
+```bash title="terminal"
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact installation --dry-run
+pnpm exec docs agent compact --all
+```
+
+See [CLI](/docs/cli) for the command surface and [Token Efficiency](/docs/token-efficiency) for
+when to use compaction instead of writing `agent.md` by hand.
+
 ## Agent Feedback Endpoints
 
 Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -22,6 +22,24 @@ Use this page when you need the page-level authoring contract for agent-facing d
 - Choose `Agent` when the human page should stay canonical and only needs extra machine context
 - Choose `agent.md` when agents need a shorter, stricter, or more operational document
 
+## Automation
+
+If the team wants to generate or refresh page-level `agent.md` files automatically, use
+`docs agent compact`.
+
+- it resolves the same page-level machine document with this order: `agent.md`, embedded `Agent`
+  blocks, then page markdown
+- it writes sibling `agent.md` files that become the new `.md`, docs API, and MCP source
+- it is useful when authors start with `<Agent>` blocks and later want a shorter, fully
+  machine-focused document
+
+Example:
+
+```bash
+pnpm exec docs agent compact customization/agent-primitive
+pnpm exec docs agent compact --all
+```
+
 ## Validation
 
 - Human page: `/docs/customization/agent-primitive`

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -124,6 +124,33 @@ This is the stronger option. Use it when agents need:
 - testing or validation steps
 - a shorter, more targeted page than the human docs should show
 
+## Generate `agent.md` From The CLI
+
+You do not have to hand-write every override. `docs agent compact` can take the resolved
+machine-readable page for one or more routes and write a sibling `agent.md` automatically.
+
+It uses the same resolution order as the runtime:
+
+- existing `agent.md`
+- hidden `Agent` blocks
+- normal page markdown
+
+That makes it a good fit when you want to start with additive `<Agent>` context and later freeze a
+shorter, more operational machine page.
+
+```bash title="terminal"
+pnpm exec docs agent compact customization/agent-primitive
+pnpm exec docs agent compact --all
+```
+
+Once the file is written:
+
+- `/docs/customization/agent-primitive.md` returns the generated `agent.md`
+- `GET /api/docs?format=markdown&path=customization/agent-primitive` returns the same file
+- MCP `read_page("/docs/customization/agent-primitive")` prefers that `agent.md`
+
+The visible UI page still renders `page.mdx`. Only the machine-readable surface changes.
+
 ## Point Agents At Feedback Endpoints
 
 Page primitives are also a good place to tell agents how to report whether the docs were enough to

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -39,7 +39,7 @@ spec.
 
 - **Zero boilerplate** — No layout files, no `[[...slug]]` wrappers except for fully fledged functionality like AI, Search and metadata to work. Just write Markdown or MDX.
 - **One config** — Everything in `docs.config.ts`: theme, colors, typography, icons, components, metadata.
-- **Token efficient** — Your entire docs framework surface is a single config file (~15 lines). AI tools like Cursor, Copilot, and Claude spend less time reading framework plumbing and more time working with your actual content. Built-in [llms.txt](/docs/customization/llms-txt) serves your docs in LLM-optimized format automatically. [Learn more →](/docs/token-efficiency)
+- **Token efficient** — Your entire docs framework surface is a single config file (~15 lines). AI tools like Cursor, Copilot, and Claude spend less time reading framework plumbing and more time working with your actual content. Built-in [llms.txt](/docs/customization/llms-txt) and `docs agent compact` keep the machine-readable layer lean too. [Learn more →](/docs/token-efficiency)
 - **Multiple frameworks** — First-class support for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt that just works.
 - **9 themes** — Default, Darksharp, Pixel Border, Colorful, Shiny, DarkBold, GreenTree, Hardline, and Concrete — or build your own with [`createTheme()`](/docs/themes/creating-themes).
 - **Built-in search** — Zero-config simple search by default, or upgrade to Typesense, Algolia, or a custom adapter.

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -140,6 +140,51 @@ When an AI agent needs to modify your docs setup — change a theme, enable AI c
 
 A declarative config file is hard to break. An AI can add `ai: { enabled: true }` or change `theme: darksharp()` without worrying about import paths, component hierarchies, or routing logic. The framework handles all of that internally.
 
+## Compact Page-Level Agent Docs
+
+The framework already gives agents clean page-level markdown through `.md` routes, hidden
+`<Agent>...</Agent>` blocks, and sibling `agent.md` files. When you want that machine-readable layer
+to be even tighter, use `docs agent compact`.
+
+The command resolves the same page contract the runtime already uses:
+
+- existing `agent.md`
+- embedded `Agent` blocks
+- normal page markdown
+
+Then it sends that resolved document to the Token Company compression API and writes a sibling
+`agent.md` file for the page.
+
+<Callout type="info" title="Compaction only changes the machine-readable layer">
+  The visible docs UI still renders `page.mdx` or `page.md`. The generated `agent.md` becomes the
+  page-level source for `.md` routes, `GET /api/docs?format=markdown&path=<slug>`, and MCP
+  `read_page()`.
+</Callout>
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+      model: "bear-1.2",
+      aggressiveness: 0.3,
+      protectJson: true,
+    },
+  },
+});
+```
+
+```bash title="terminal"
+pnpm exec docs agent compact installation configuration
+pnpm exec docs agent compact --all
+```
+
+The CLI also loads `.env` and `.env.local`, so `TOKEN_COMPANY_API_KEY` can stay out of checked-in
+config. Use `--dry-run` when you want to preview the compression call without writing files. For the
+full command surface, see the [CLI page](/docs/cli). For the `agent.compact` config shape, see
+[Configuration](/docs/configuration).
+
 ## Built-in AI Features
 
 Beyond being token-efficient to work with, `@farming-labs/docs` includes features designed for AI consumption:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expands docs and config for compacting page-level machine docs via `docs agent compact`, generating sibling `agent.md` files without changing visible pages. Also types `withDocs` to return `NextConfig` in the `next` integration.

- **New Features**
  - Documents `agent compact` across CLI, configuration, customization/agent-primitive, token-efficiency, and Skills README, with examples (`--all`, `--dry-run`, positional args), env loading, and cross-links.
  - New `agent.compact` config defaults in `docs.config.ts(x)` (`apiKey`/`apiKeyEnv`, `baseUrl`, `model`, `aggressiveness`, `maxOutputTokens`, `minOutputTokens`, `protectJson`), with `.env` loading.
  - Clarifies that generated `agent.md` powers `.md` routes, `GET /api/docs?format=markdown&path=...`, and MCP `read_page()`.

- **Refactors**
  - Narrowed `withDocs(nextConfig)` to `NextConfig` and typed return as `NextConfig`.

<sup>Written for commit 3cc1c76fae34dc680434238015d1fd3b60e2cf14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

