### PR TITLE
feat: reading time per docs

### DIFF
--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -22,6 +22,7 @@ export function defineDocs(config: DocsConfig): DocsConfig {
     icons: config.icons,
     pageActions: config.pageActions,
     lastUpdated: config.lastUpdated,
+    readingTime: config.readingTime,
     llmsTxt: config.llmsTxt,
     ai: config.ai,
     ordering: config.ordering,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -94,6 +94,7 @@ export type {
   AIConfig,
   OrderingItem,
   LastUpdatedConfig,
+  ReadingTimeConfig,
   LlmsTxtConfig,
   CodeBlockCopyData,
   DocsFeedbackValue,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1860,6 +1860,7 @@ export interface DocsConfig {
   /**
    * Estimated reading time shown at the top of docs pages.
    *
+   * - `undefined` → disabled by default
    * - `true` or `{ enabled: true }` → show a computed "{n} min read" label
    * - `false` → hide it entirely
    *

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -278,6 +278,8 @@ export interface PageFrontmatter {
   description?: string;
   /** Related doc URLs rendered into machine-readable markdown routes and MCP page output. */
   related?: DocsRelatedItem[];
+  /** Override or disable the estimated reading time for this page. */
+  readingTime?: boolean | number;
   tags?: string[];
   icon?: string;
   /** Path to custom OG image for this page (shorthand). Ignored if `openGraph` is set. */
@@ -846,6 +848,27 @@ export interface LastUpdatedConfig {
    * @default "footer"
    */
   position?: "footer" | "below-title";
+}
+
+/**
+ * Configuration for estimated page reading time.
+ *
+ * @example
+ * ```ts
+ * readingTime: { enabled: true, wordsPerMinute: 220 }
+ * ```
+ */
+export interface ReadingTimeConfig {
+  /**
+   * Whether to show the estimated reading time.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Words-per-minute rate used for the estimate.
+   * @default 220
+   */
+  wordsPerMinute?: number;
 }
 
 /**
@@ -1832,8 +1855,20 @@ export interface DocsConfig {
    * // Hide entirely
    * lastUpdated: false
    * ```
-   */
+  */
   lastUpdated?: boolean | LastUpdatedConfig;
+  /**
+   * Estimated reading time shown at the top of docs pages.
+   *
+   * - `true` or `{ enabled: true }` → show a computed "{n} min read" label
+   * - `false` → hide it entirely
+   *
+   * @example
+   * ```ts
+   * readingTime: { enabled: true, wordsPerMinute: 220 }
+   * ```
+   */
+  readingTime?: boolean | ReadingTimeConfig;
   /**
    * AI-powered "Ask AI" chat for documentation.
    *

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1855,7 +1855,7 @@ export interface DocsConfig {
    * // Hide entirely
    * lastUpdated: false
    * ```
-  */
+   */
   lastUpdated?: boolean | LastUpdatedConfig;
   /**
    * Estimated reading time shown at the top of docs pages.

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -177,6 +177,40 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.openDocs).toBe(false);
   });
 
+  it("passes computed reading time through to DocsPageClient when enabled", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      [
+        "---",
+        "title: Installation",
+        "---",
+        "",
+        "# Installation",
+        "",
+        "This page explains how to install the framework in an existing app.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({
+      entry: "docs",
+      readingTime: { enabled: true, wordsPerMinute: 200 },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.readingTimeEnabled).toBe(true);
+    expect(props?.readingTimeMap).toMatchObject({
+      "/docs": 1,
+      "/docs/installation": 1,
+    });
+  });
+
   it("adds changelog entries as a dedicated sidebar section under the docs route with a separator above it", () => {
     mkdirSync(join(tmpDir, "app", "docs", "changelog", "2026-04-15"), { recursive: true });
     mkdirSync(join(tmpDir, "app", "docs", "changelog", "2026-04-03"), { recursive: true });

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -177,6 +177,21 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.openDocs).toBe(false);
   });
 
+  it("keeps reading time disabled when the config is unconfigured", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.readingTimeEnabled).toBe(false);
+    expect(props?.readingTimeMap).toEqual({});
+  });
+
   it("passes computed reading time through to DocsPageClient when enabled", () => {
     mkdirSync(join(tmpDir, "app", "docs", "installation"), { recursive: true });
     writeFileSync(

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -829,6 +829,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
   const readingTimeRaw = config.readingTime;
   const readingTimeEnabled =
+    readingTimeRaw !== undefined &&
     readingTimeRaw !== false &&
     (typeof readingTimeRaw !== "object" || readingTimeRaw.enabled !== false);
   const readingTimeWordsPerMinute =

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -18,6 +18,7 @@ import type {
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
+import { resolveReadingTimeFromSource } from "./reading-time.js";
 import { SidebarSearchWithAI } from "./sidebar-search-ai.js";
 import { LocaleThemeControl } from "./locale-theme-control.js";
 import { withLangInUrl } from "./i18n.js";
@@ -480,6 +481,43 @@ function buildDescriptionMap(config: DocsConfig, ctx: DocsLocaleContext): Record
   return map;
 }
 
+function buildReadingTimeMap(
+  config: DocsConfig,
+  ctx: DocsLocaleContext,
+  wordsPerMinute: number,
+): Record<string, number> {
+  const docsDir = ctx.docsDir;
+  const map: Record<string, number> = {};
+  const excludedDirs = getExcludedDocsDirs(config, ctx);
+
+  function scan(dir: string, slugParts: string[]) {
+    if (!fs.existsSync(dir)) return;
+    if (isExcludedDir(dir, excludedDirs)) return;
+
+    const pagePath = path.join(dir, "page.mdx");
+    if (fs.existsSync(pagePath)) {
+      const source = fs.readFileSync(pagePath, "utf-8");
+      const minutes = resolveReadingTimeFromSource(source, wordsPerMinute);
+
+      if (minutes !== null) {
+        const url =
+          slugParts.length === 0 ? `/${ctx.entryPath}` : `/${ctx.entryPath}/${slugParts.join("/")}`;
+        map[url] = minutes;
+      }
+    }
+
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      if (fs.statSync(full).isDirectory()) {
+        scan(full, [...slugParts, name]);
+      }
+    }
+  }
+
+  scan(docsDir, []);
+  return map;
+}
+
 // ─── createDocsMetadata ──────────────────────────────────────────────
 
 /**
@@ -789,6 +827,12 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
+  const readingTimeRaw = config.readingTime;
+  const readingTimeEnabled =
+    readingTimeRaw !== false &&
+    (typeof readingTimeRaw !== "object" || readingTimeRaw.enabled !== false);
+  const readingTimeWordsPerMinute =
+    typeof readingTimeRaw === "object" ? (readingTimeRaw.wordsPerMinute ?? 220) : 220;
 
   // llms.txt config
   const llmsTxtEnabled = resolveBool(config.llmsTxt);
@@ -865,6 +909,9 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
 
   // Build description map from frontmatter
   const descriptionMap = buildDescriptionMap(config, localeContext);
+  const readingTimeMap = readingTimeEnabled
+    ? buildReadingTimeMap(config, localeContext, readingTimeWordsPerMinute)
+    : {};
 
   return function DocsLayoutWrapper({ children }: { children: ReactNode }) {
     const tree = buildTree(config, localeContext, !!sidebarFlat);
@@ -958,6 +1005,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
               lastModifiedMap={lastModifiedMap}
               lastUpdatedEnabled={lastUpdatedEnabled}
               lastUpdatedPosition={lastUpdatedPosition}
+              readingTimeEnabled={readingTimeEnabled}
+              readingTimeMap={readingTimeMap}
               llmsTxtEnabled={llmsTxtEnabled}
               descriptionMap={descriptionMap}
               feedbackEnabled={feedbackConfig.enabled}

--- a/packages/fumadocs/src/docs-page-client.test.ts
+++ b/packages/fumadocs/src/docs-page-client.test.ts
@@ -7,6 +7,10 @@ vi.mock("fumadocs-core/framework", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+vi.mock("./page-actions.js", () => ({
+  PageActions: () => React.createElement("div", null, "Mock Actions"),
+}));
+
 vi.mock("fumadocs-ui/layouts/docs/page", async () => {
   const ReactModule = await import("react");
 
@@ -37,5 +41,69 @@ describe("DocsPageClient llms.txt footer links", () => {
     expect(html).toContain('href="/llms.txt?lang=en"');
     expect(html).toContain('href="/llms-full.txt?lang=en"');
     expect(html).not.toContain("/api/docs?format=llms");
+  });
+});
+
+describe("DocsPageClient reading time", () => {
+  it("renders the reading-time row when enabled", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        readingTimeEnabled: true,
+        readingTime: 5,
+        children: React.createElement(
+          "article",
+          null,
+          React.createElement("h1", null, "Installation"),
+          React.createElement("p", null, "Docs"),
+        ),
+      }),
+    );
+
+    expect(html).toContain("5 min read");
+  });
+
+  it("renders reading time below below-title page actions", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        copyMarkdown: true,
+        pageActionsPosition: "below-title",
+        readingTimeEnabled: true,
+        readingTime: 5,
+        children: React.createElement(
+          "article",
+          null,
+          React.createElement("h1", null, "Installation"),
+          React.createElement("p", null, "Docs"),
+        ),
+      }),
+    );
+
+    expect(html.indexOf("Mock Actions")).toBeLessThan(html.indexOf("5 min read"));
+  });
+
+  it("renders reading time below above-title page actions and above the page title", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        copyMarkdown: true,
+        pageActionsPosition: "above-title",
+        readingTimeEnabled: true,
+        readingTime: 5,
+        children: React.createElement(
+          "article",
+          null,
+          React.createElement("h1", null, "Installation"),
+          React.createElement("p", null, "Docs"),
+        ),
+      }),
+    );
+
+    expect(html.indexOf("Mock Actions")).toBeLessThan(html.indexOf("5 min read"));
+    expect(html.indexOf("5 min read")).toBeLessThan(html.indexOf("Installation"));
   });
 });

--- a/packages/fumadocs/src/docs-page-client.test.ts
+++ b/packages/fumadocs/src/docs-page-client.test.ts
@@ -82,7 +82,12 @@ describe("DocsPageClient reading time", () => {
       }),
     );
 
-    expect(html.indexOf("Mock Actions")).toBeLessThan(html.indexOf("5 min read"));
+    const actionsIndex = html.indexOf("Mock Actions");
+    const readingTimeIndex = html.indexOf("5 min read");
+
+    expect(actionsIndex).toBeGreaterThanOrEqual(0);
+    expect(readingTimeIndex).toBeGreaterThanOrEqual(0);
+    expect(actionsIndex).toBeLessThan(readingTimeIndex);
   });
 
   it("renders reading time below above-title page actions and above the page title", () => {
@@ -103,7 +108,69 @@ describe("DocsPageClient reading time", () => {
       }),
     );
 
-    expect(html.indexOf("Mock Actions")).toBeLessThan(html.indexOf("5 min read"));
-    expect(html.indexOf("5 min read")).toBeLessThan(html.indexOf("Installation"));
+    const actionsIndex = html.indexOf("Mock Actions");
+    const readingTimeIndex = html.indexOf("5 min read");
+    const titleIndex = html.indexOf("Installation");
+
+    expect(actionsIndex).toBeGreaterThanOrEqual(0);
+    expect(readingTimeIndex).toBeGreaterThanOrEqual(0);
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(actionsIndex).toBeLessThan(readingTimeIndex);
+    expect(readingTimeIndex).toBeLessThan(titleIndex);
+  });
+
+  it("renders reading time below the title when page actions are disabled and position is below-title", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        pageActionsPosition: "below-title",
+        readingTimeEnabled: true,
+        readingTime: 5,
+        children: React.createElement(
+          "article",
+          null,
+          React.createElement("h1", null, "Installation"),
+          React.createElement("p", null, "Docs"),
+        ),
+      }),
+    );
+
+    const titleIndex = html.indexOf("Installation");
+    const readingTimeIndex = html.indexOf("5 min read");
+
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(readingTimeIndex).toBeGreaterThanOrEqual(0);
+    expect(titleIndex).toBeLessThan(readingTimeIndex);
+  });
+
+  it("keeps reading time grouped with last updated when last updated is below-title", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        lastUpdatedEnabled: true,
+        lastUpdatedPosition: "below-title",
+        lastModified: "April 25, 2026",
+        readingTimeEnabled: true,
+        readingTime: 5,
+        children: React.createElement(
+          "article",
+          null,
+          React.createElement("h1", null, "Installation"),
+          React.createElement("p", null, "Docs"),
+        ),
+      }),
+    );
+
+    const titleIndex = html.indexOf("Installation");
+    const lastUpdatedIndex = html.indexOf("Last updated April 25, 2026");
+    const readingTimeIndex = html.indexOf("5 min read");
+
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(lastUpdatedIndex).toBeGreaterThanOrEqual(0);
+    expect(readingTimeIndex).toBeGreaterThanOrEqual(0);
+    expect(titleIndex).toBeLessThan(lastUpdatedIndex);
+    expect(lastUpdatedIndex).toBeLessThan(readingTimeIndex);
   });
 });

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -496,7 +496,9 @@ export function DocsPageClient({
   const showReadingTimeBelowTitle =
     !!readingTimeBlock &&
     !showReadingTimeAboveTitle &&
-    (showActionsBelowTitle || showLastUpdatedBelowTitle || (!showActions && pageActionsPosition === "below-title"));
+    (showActionsBelowTitle ||
+      showLastUpdatedBelowTitle ||
+      (!showActions && pageActionsPosition === "below-title"));
 
   const belowTitleBlock =
     showLastUpdatedBelowTitle || showActionsBelowTitle || showReadingTimeBelowTitle ? (

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -244,7 +244,7 @@ function injectTitleDecorations(
 
   let inserted = false;
 
-  const extras = [description, belowTitle].filter(Boolean);
+  const extras = Children.toArray([description, belowTitle].filter(Boolean));
   if (extras.length === 0) return { node, inserted: false };
 
   function visit(current: ReactNode): ReactNode {
@@ -262,7 +262,7 @@ function injectTitleDecorations(
 
     if (typeof current.type === "string" && current.type === "h1") {
       inserted = true;
-      return [current, ...extras];
+      return Children.toArray([current, ...extras]);
     }
 
     const childProps = (current.props as { children?: ReactNode } | null) ?? null;
@@ -303,12 +303,7 @@ function TitleDecorations({
 }) {
   if (!description && !belowTitle) return null;
 
-  return (
-    <>
-      {description}
-      {belowTitle}
-    </>
-  );
+  return <>{Children.toArray([description, belowTitle].filter(Boolean))}</>;
 }
 
 export function DocsPageClient({
@@ -497,8 +492,14 @@ export function DocsPageClient({
     <p className="fd-page-description">{pageDescription}</p>
   ) : undefined;
 
+  const showReadingTimeAboveTitle = !!readingTimeBlock && showActionsAboveTitle;
+  const showReadingTimeBelowTitle =
+    !!readingTimeBlock &&
+    !showReadingTimeAboveTitle &&
+    (showActionsBelowTitle || showLastUpdatedBelowTitle || (!showActions && pageActionsPosition === "below-title"));
+
   const belowTitleBlock =
-    showLastUpdatedBelowTitle || showActionsBelowTitle ? (
+    showLastUpdatedBelowTitle || showActionsBelowTitle || showReadingTimeBelowTitle ? (
       <div className="fd-below-title-block not-prose">
         {showLastUpdatedBelowTitle && (
           <p className="fd-last-updated-inline">Last updated {lastModified}</p>
@@ -515,7 +516,7 @@ export function DocsPageClient({
             />
           </div>
         )}
-        {showActionsBelowTitle && readingTimeBlock}
+        {showReadingTimeBelowTitle && readingTimeBlock}
       </div>
     ) : undefined;
 
@@ -587,7 +588,7 @@ export function DocsPageClient({
           {readingTimeBlock}
         </div>
       )}
-      {showActions ? null : readingTimeBlock}
+      {!showReadingTimeAboveTitle && !showReadingTimeBelowTitle ? readingTimeBlock : null}
       <DocsBody style={{ display: "flex", flexDirection: "column" }}>
         <div style={{ flex: 1 }}>{decoratedChildren}</div>
         {titleDecorationsPortal}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -58,6 +58,12 @@ interface DocsPageClientProps {
   lastModifiedMap?: Record<string, string>;
   /** Direct last-modified value override for the current page. */
   lastModified?: string;
+  /** Map of pathname → reading time in minutes */
+  readingTimeMap?: Record<string, number>;
+  /** Direct reading-time override for the current page. */
+  readingTime?: number;
+  /** Whether to show estimated reading time at the top of the page. */
+  readingTimeEnabled?: boolean;
   /** Whether to show "Last updated" at all */
   lastUpdatedEnabled?: boolean;
   /** Where to show the "Last updated" date: "footer" (next to Edit on GitHub) or "below-title" */
@@ -202,6 +208,11 @@ function decodeHashTarget(hash: string): string {
   }
 }
 
+function formatReadingTimeLabel(minutes: number): string {
+  const normalized = Math.max(1, Math.ceil(minutes));
+  return `${normalized} min read`;
+}
+
 function escapeIdSelector(value: string): string {
   if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
     return CSS.escape(value);
@@ -319,6 +330,9 @@ export function DocsPageClient({
   editOnGithubUrl,
   lastModifiedMap,
   lastModified: lastModifiedProp,
+  readingTimeMap,
+  readingTime: readingTimeProp,
+  readingTimeEnabled = false,
   lastUpdatedEnabled = true,
   lastUpdatedPosition = "footer",
   llmsTxtEnabled = false,
@@ -348,6 +362,10 @@ export function DocsPageClient({
     changelogBasePath &&
     (normalizedPath === changelogBasePath || normalizedPath.startsWith(`${changelogBasePath}/`))
   );
+  const resolvedReadingTime =
+    !isChangelogRoute && readingTimeEnabled
+      ? (readingTimeProp ?? readingTimeMap?.[normalizedPath])
+      : undefined;
   const effectiveTocEnabled = isChangelogRoute ? false : tocEnabled;
   const effectiveBreadcrumbEnabled = isChangelogRoute ? false : breadcrumbEnabled;
 
@@ -465,6 +483,12 @@ export function DocsPageClient({
   const showLastUpdatedInFooter = !!lastModified && lastUpdatedPosition === "footer";
   const showFooter =
     !isChangelogRoute && (!!githubFileUrl || showLastUpdatedInFooter || llmsTxtEnabled);
+  const readingTimeBlock =
+    typeof resolvedReadingTime === "number" ? (
+      <div className="fd-page-meta not-prose">
+        <span className="fd-page-meta-item">{formatReadingTimeLabel(resolvedReadingTime)}</span>
+      </div>
+    ) : undefined;
 
   const titleDescription = pageDescription ? (
     <p className="fd-page-description">{pageDescription}</p>
@@ -488,6 +512,7 @@ export function DocsPageClient({
             />
           </div>
         )}
+        {showActionsBelowTitle && readingTimeBlock}
       </div>
     ) : undefined;
 
@@ -556,8 +581,10 @@ export function DocsPageClient({
               githubFileUrl={githubFileUrl}
             />
           </div>
+          {readingTimeBlock}
         </div>
       )}
+      {showActions ? null : readingTimeBlock}
       <DocsBody style={{ display: "flex", flexDirection: "column" }}>
         <div style={{ flex: 1 }}>{decoratedChildren}</div>
         {titleDecorationsPortal}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -486,6 +486,9 @@ export function DocsPageClient({
   const readingTimeBlock =
     typeof resolvedReadingTime === "number" ? (
       <div className="fd-page-meta not-prose">
+        <span className="fd-page-meta-dot" aria-hidden="true">
+          ·
+        </span>
         <span className="fd-page-meta-item">{formatReadingTimeLabel(resolvedReadingTime)}</span>
       </div>
     ) : undefined;

--- a/packages/fumadocs/src/reading-time.ts
+++ b/packages/fumadocs/src/reading-time.ts
@@ -1,0 +1,43 @@
+import matter from "gray-matter";
+import type { PageFrontmatter } from "@farming-labs/docs";
+
+function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
+  if (typeof wordsPerMinute !== "number" || !Number.isFinite(wordsPerMinute)) return 220;
+  return Math.max(1, Math.floor(wordsPerMinute));
+}
+
+function stripNonReadingContent(content: string): string {
+  return content
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/`[^`\n]+`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, " $1 ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\{[^{}]*\}/g, " ")
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[#>*_~|]/g, " ");
+}
+
+export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: number): number {
+  const cleaned = stripNonReadingContent(content);
+  const wordCount = cleaned.match(/\b[\p{L}\p{N}][\p{L}\p{N}'’-]*\b/gu)?.length ?? 0;
+
+  return Math.max(1, Math.ceil(wordCount / normalizeWordsPerMinute(wordsPerMinute)));
+}
+
+export function resolveReadingTimeFromSource(
+  source: string,
+  wordsPerMinute?: number,
+): number | null {
+  const { data, content } = matter(source);
+  const pageData = data as PageFrontmatter;
+
+  if (pageData.readingTime === false) return null;
+
+  if (typeof pageData.readingTime === "number" && Number.isFinite(pageData.readingTime)) {
+    return Math.max(1, Math.ceil(pageData.readingTime));
+  }
+
+  return estimateReadingTimeMinutes(content, wordsPerMinute);
+}

--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -175,8 +175,26 @@ figure.shiki:has(figcaption) figcaption {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
   margin-bottom: 0.75rem;
+}
+
+.fd-page-meta-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(
+    --fd-font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace
+  );
+  font-size: 0.8rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--color-fd-muted-foreground) 78%, transparent);
 }
 
 .fd-page-meta-item {

--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -171,6 +171,31 @@ figure.shiki:has(figcaption) figcaption {
 
 /* ─── Page description (frontmatter) ─────────────────────────────────── */
 
+.fd-page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.fd-page-meta-item {
+  font-family: var(
+    --fd-font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace
+  );
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
 .fd-page-description {
   margin-bottom: 1rem;
   font-size: 1.125rem;

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -23,10 +23,6 @@ order: 1
     <span aria-hidden="true" className="mx-2 text-black/30 dark:text-white/28">
       {"·"}
     </span>
-    <span>{"12 min read"}</span>
-    <span aria-hidden="true" className="mx-2 text-black/30 dark:text-white/28">
-      {"·"}
-    </span>
     <span>{"@farming-labs/docs"}</span>
   </div>
   <p className="mt-4 max-w-3xl text-pretty text-[1.04rem] leading-8 text-black/68 dark:text-white/58">

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -124,6 +124,10 @@ export default defineDocs({
   },
 
   breadcrumb: { enabled: true },
+  readingTime: {
+    enabled: true,
+    wordsPerMinute: 220,
+  },
 
   pageActions: {
     copyMarkdown: { enabled: true },


### PR DESCRIPTION
- **feat: reading time per docs**
- **chore: lint**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds estimated reading time to docs pages. It’s computed per page and shown near the title, with global opt-in and per-page overrides.

- **New Features**
  - Global `readingTime` in `DocsConfig` (opt-in; disabled by default). Use `true` or `{ enabled: true, wordsPerMinute }` (default 220); `false` disables.
  - Per-page frontmatter `readingTime` (boolean or number) to hide or override minutes.
  - Estimation strips code blocks, inline code, links, images, HTML, URLs, and MDX markup before counting words.
  - Placement respects `pageActionsPosition`, groups with “Last updated” when below-title, and hides on changelog routes.
  - Computes a server-side `readingTimeMap` from MDX and passes it to `DocsPageClient`; exposes `ReadingTimeConfig` from `@farming-labs/docs` and wires through `defineDocs`, layout, and client.
  - Added styles (`.fd-page-meta*`) and tests; removed the hardcoded label from the guides page.

<sup>Written for commit 3fdf6b75dacdd516829ad51ab70737c773e8beef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

