### PR TITLE
feat: framework agnostic reading time per docs

### DIFF
--- a/examples/astro/src/lib/docs.config.ts
+++ b/examples/astro/src/lib/docs.config.ts
@@ -60,6 +60,7 @@ export default defineDocs({
     url: "/docs",
   },
   sidebar: { flat: false, collapsible: true },
+  readingTime: { enabled: true, wordsPerMinute: 220 },
   pageActions: {
     alignment: "right",
     copyMarkdown: { enabled: true },

--- a/examples/nuxt/docs.config.ts
+++ b/examples/nuxt/docs.config.ts
@@ -29,6 +29,7 @@ export default defineDocs({
     title: "Example Docs",
     url: "/docs",
   },
+  readingTime: { enabled: true, wordsPerMinute: 220 },
   ai: {
     enabled: true,
     model: {

--- a/examples/sveltekit/src/lib/docs.config.ts
+++ b/examples/sveltekit/src/lib/docs.config.ts
@@ -58,6 +58,7 @@ export default defineDocs({
     title: "Example Docs",
     url: "/docs",
   },
+  readingTime: { enabled: true, wordsPerMinute: 220 },
   themeToggle: { enabled: true, default: "dark" },
   breadcrumb: { enabled: true },
   metadata: {

--- a/examples/tanstack-start/docs.config.tsx
+++ b/examples/tanstack-start/docs.config.tsx
@@ -51,6 +51,7 @@ export default defineDocs({
   },
   sidebar: { flat: true },
   breadcrumb: { enabled: true },
+  readingTime: { enabled: true, wordsPerMinute: 220 },
   lastUpdated: { position: "below-title" },
   pageActions: {
     alignment: "right",

--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -1,4 +1,5 @@
 ---
+import { resolveReadingTimeOptions } from "@farming-labs/docs";
 import DocsPage from "./DocsPage.astro";
 
 const { data, config = null } = Astro.props;
@@ -100,14 +101,7 @@ const lastUpdatedConfig = (() => {
 
 const showLastUpdatedInFooter = !!data.lastModified && lastUpdatedConfig.enabled && lastUpdatedConfig.position === "footer";
 const showLastUpdatedBelowTitle = !!data.lastModified && lastUpdatedConfig.enabled && lastUpdatedConfig.position === "below-title";
-const readingTimeConfig = (() => {
-  const rt = config?.readingTime;
-  if (rt === false || rt === undefined) return { enabled: false };
-  if (rt === true) return { enabled: true };
-  return {
-    enabled: (rt as { enabled?: boolean }).enabled !== false,
-  };
-})();
+const readingTimeConfig = resolveReadingTimeOptions(config?.readingTime as never);
 const readingTimeValue =
   readingTimeConfig.enabled && typeof data.readingTime === "number"
     ? Math.max(1, Math.ceil(data.readingTime))

--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -84,6 +84,9 @@ const pageActionsAlignment = (() => {
   if (typeof pa === "object" && pa !== null && pa.alignment) return pa.alignment;
   return "left";
 })();
+const showPageActions = copyMarkdownEnabled || openDocsEnabled;
+const showActionsAbove = pageActionsPosition === "above-title" && showPageActions;
+const showActionsBelow = pageActionsPosition === "below-title" && showPageActions;
 
 const lastUpdatedConfig = (() => {
   const lu = config?.lastUpdated;
@@ -97,6 +100,25 @@ const lastUpdatedConfig = (() => {
 
 const showLastUpdatedInFooter = !!data.lastModified && lastUpdatedConfig.enabled && lastUpdatedConfig.position === "footer";
 const showLastUpdatedBelowTitle = !!data.lastModified && lastUpdatedConfig.enabled && lastUpdatedConfig.position === "below-title";
+const readingTimeConfig = (() => {
+  const rt = config?.readingTime;
+  if (rt === false || rt === undefined) return { enabled: false };
+  if (rt === true) return { enabled: true };
+  return {
+    enabled: (rt as { enabled?: boolean }).enabled !== false,
+  };
+})();
+const readingTimeValue =
+  readingTimeConfig.enabled && typeof data.readingTime === "number"
+    ? Math.max(1, Math.ceil(data.readingTime))
+    : null;
+const readingTimeLabel = readingTimeValue ? `${readingTimeValue} min read` : null;
+const showReadingTimeAbove = !!readingTimeLabel && showActionsAbove;
+const showReadingTimeBelow =
+  !!readingTimeLabel &&
+  !showReadingTimeAbove &&
+  (showActionsBelow || showLastUpdatedBelowTitle || (!showPageActions && pageActionsPosition === "below-title"));
+const showReadingTimeStandalone = !!readingTimeLabel && !showReadingTimeAbove && !showReadingTimeBelow;
 const feedbackConfig = (() => {
   const defaults = {
     enabled: false,
@@ -188,10 +210,28 @@ const htmlWithoutFirstH1 = (data.html || "").replace(/<h1[^>]*>[\s\S]*?<\/h1>\s*
       )}
     </div>
   )}
+  {showReadingTimeAbove && (
+    <div class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{readingTimeLabel}</span>
+    </div>
+  )}
+  {showReadingTimeStandalone && (
+    <div class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{readingTimeLabel}</span>
+    </div>
+  )}
   <h1 class="fd-page-title">{data.title}</h1>
   {data.description && <p class="fd-page-description">{data.description}</p>}
   {showLastUpdatedBelowTitle && data.lastModified && (
     <p class="fd-last-modified fd-last-modified-below-title">Last updated: {data.lastModified}</p>
+  )}
+  {showReadingTimeBelow && !showActionsBelow && (
+    <div class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{readingTimeLabel}</span>
+    </div>
   )}
   {pageActionsPosition === "below-title" && (copyMarkdownEnabled || openDocsEnabled) && (
     <>
@@ -241,6 +281,12 @@ const htmlWithoutFirstH1 = (data.html || "").replace(/<h1[^>]*>[\s\S]*?<\/h1>\s*
           </div>
         )}
       </div>
+      {showReadingTimeBelow && (
+        <div class="fd-page-meta">
+          <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+          <span class="fd-page-meta-item">{readingTimeLabel}</span>
+        </div>
+      )}
     </>
   )}
   <Fragment set:html={htmlWithoutFirstH1} />

--- a/packages/astro-theme/styles/docs.css
+++ b/packages/astro-theme/styles/docs.css
@@ -1641,6 +1641,33 @@ html.dark pre.shiki {
   margin-bottom: 1rem;
 }
 
+.fd-page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.fd-page-meta-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.8rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--color-fd-muted-foreground) 78%, transparent);
+}
+
+.fd-page-meta-item {
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
 .fd-feedback {
   margin-top: 2rem;
   margin-bottom: 1.25rem;

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -47,6 +47,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveReadingTimeFromSource,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -128,6 +129,7 @@ export interface DocsServer {
     description?: string;
     html: string;
     rawMarkdown?: string;
+    readingTime?: number | null;
     entry?: string;
     locale?: string;
     slug?: string;
@@ -482,6 +484,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
+  const readingTimeConfig = config.readingTime;
+  const readingTimeWordsPerMinute =
+    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
 
   const preloaded = config._preloadedContent as ContentFileMap | undefined;
 
@@ -633,6 +638,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
@@ -658,6 +664,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       description: data.description as string | undefined,
       html,
       rawMarkdown: humanRawContent,
+      readingTime,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -47,7 +47,8 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
-  resolveReadingTimeFromSource,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeOptions,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -484,9 +485,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
-  const readingTimeConfig = config.readingTime;
-  const readingTimeWordsPerMinute =
-    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
 
   const preloaded = config._preloadedContent as ContentFileMap | undefined;
 
@@ -638,7 +637,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
+    const readingTime = readingTimeOptions.enabled
+      ? resolveReadingTimeFromContent(data, humanRawContent, readingTimeOptions.wordsPerMinute)
+      : null;
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -15,6 +15,7 @@ export { deepMerge } from "./utils.js";
 export { createTheme, extendTheme } from "./create-theme.js";
 export { resolveDocsI18n, resolveDocsLocale, resolveDocsPath } from "./i18n.js";
 export { resolveTitle, resolveOGImage, buildPageOpenGraph, buildPageTwitter } from "./metadata.js";
+export { estimateReadingTimeMinutes, resolveReadingTimeFromSource } from "./reading-time.js";
 export { normalizeDocsRelated, renderDocsRelatedMarkdownLines } from "./related.js";
 export {
   DEFAULT_AGENT_FEEDBACK_ROUTE,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -15,7 +15,12 @@ export { deepMerge } from "./utils.js";
 export { createTheme, extendTheme } from "./create-theme.js";
 export { resolveDocsI18n, resolveDocsLocale, resolveDocsPath } from "./i18n.js";
 export { resolveTitle, resolveOGImage, buildPageOpenGraph, buildPageTwitter } from "./metadata.js";
-export { estimateReadingTimeMinutes, resolveReadingTimeFromSource } from "./reading-time.js";
+export {
+  estimateReadingTimeMinutes,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeFromSource,
+  resolveReadingTimeOptions,
+} from "./reading-time.js";
 export { normalizeDocsRelated, renderDocsRelatedMarkdownLines } from "./related.js";
 export {
   DEFAULT_AGENT_FEEDBACK_ROUTE,

--- a/packages/docs/src/reading-time.test.ts
+++ b/packages/docs/src/reading-time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { estimateReadingTimeMinutes, resolveReadingTimeFromSource } from "./reading-time.js";
+import {
+  estimateReadingTimeMinutes,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeFromSource,
+  resolveReadingTimeOptions,
+} from "./reading-time.js";
 
 describe("reading time helpers", () => {
   it("ignores code blocks and links when estimating", () => {
@@ -36,5 +41,31 @@ describe("reading time helpers", () => {
         ["---", "readingTime: false", "---", "", "# Hello", "", "Short page."].join("\n"),
       ),
     ).toBeNull();
+  });
+
+  it("treats null config as disabled", () => {
+    expect(resolveReadingTimeOptions(null)).toEqual({ enabled: false });
+  });
+
+  it("ignores four-backtick fenced code blocks", () => {
+    const minutes = resolveReadingTimeFromContent(
+      {},
+      [
+        "# Guide",
+        "",
+        "This prose should count.",
+        "",
+        "````md",
+        "```ts",
+        "const hidden = true;",
+        "```",
+        "````",
+        "",
+        "This prose should count too.",
+      ].join("\n"),
+      4,
+    );
+
+    expect(minutes).toBe(3);
   });
 });

--- a/packages/docs/src/reading-time.test.ts
+++ b/packages/docs/src/reading-time.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { estimateReadingTimeMinutes, resolveReadingTimeFromSource } from "./reading-time.js";
+
+describe("reading time helpers", () => {
+  it("ignores code blocks and links when estimating", () => {
+    const minutes = estimateReadingTimeMinutes(
+      [
+        "# Install",
+        "",
+        "Read these words carefully before setup.",
+        "",
+        "```bash",
+        "pnpm install",
+        "pnpm dev",
+        "```",
+        "",
+        "Visit [Configuration](/docs/configuration) for more details.",
+      ].join("\n"),
+      3,
+    );
+
+    expect(minutes).toBe(4);
+  });
+
+  it("respects per-page numeric overrides", () => {
+    expect(
+      resolveReadingTimeFromSource(
+        ["---", "readingTime: 8", "---", "", "# Hello", "", "Short page."].join("\n"),
+      ),
+    ).toBe(8);
+  });
+
+  it("respects per-page disabled overrides", () => {
+    expect(
+      resolveReadingTimeFromSource(
+        ["---", "readingTime: false", "---", "", "# Hello", "", "Short page."].join("\n"),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/docs/src/reading-time.ts
+++ b/packages/docs/src/reading-time.ts
@@ -43,8 +43,7 @@ export function resolveReadingTimeOptions(
   return {
     enabled: readingTime.enabled !== false,
     wordsPerMinute:
-      typeof readingTime.wordsPerMinute === "number" &&
-      Number.isFinite(readingTime.wordsPerMinute)
+      typeof readingTime.wordsPerMinute === "number" && Number.isFinite(readingTime.wordsPerMinute)
         ? readingTime.wordsPerMinute
         : undefined,
   };

--- a/packages/docs/src/reading-time.ts
+++ b/packages/docs/src/reading-time.ts
@@ -1,0 +1,43 @@
+import matter from "gray-matter";
+import type { PageFrontmatter } from "./types.js";
+
+function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
+  if (typeof wordsPerMinute !== "number" || !Number.isFinite(wordsPerMinute)) return 220;
+  return Math.max(1, Math.floor(wordsPerMinute));
+}
+
+function stripNonReadingContent(content: string): string {
+  return content
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/`[^`\n]+`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, " $1 ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\{[^{}]*\}/g, " ")
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[#>*_~|]/g, " ");
+}
+
+export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: number): number {
+  const cleaned = stripNonReadingContent(content);
+  const wordCount = cleaned.match(/\b[\p{L}\p{N}][\p{L}\p{N}'’-]*\b/gu)?.length ?? 0;
+
+  return Math.max(1, Math.ceil(wordCount / normalizeWordsPerMinute(wordsPerMinute)));
+}
+
+export function resolveReadingTimeFromSource(
+  source: string,
+  wordsPerMinute?: number,
+): number | null {
+  const { data, content } = matter(source);
+  const pageData = data as PageFrontmatter;
+
+  if (pageData.readingTime === false) return null;
+
+  if (typeof pageData.readingTime === "number" && Number.isFinite(pageData.readingTime)) {
+    return Math.max(1, Math.ceil(pageData.readingTime));
+  }
+
+  return estimateReadingTimeMinutes(content, wordsPerMinute);
+}

--- a/packages/docs/src/reading-time.ts
+++ b/packages/docs/src/reading-time.ts
@@ -1,5 +1,10 @@
 import matter from "gray-matter";
-import type { PageFrontmatter } from "./types.js";
+import type { PageFrontmatter, ReadingTimeConfig } from "./types.js";
+
+export interface ResolvedReadingTimeOptions {
+  enabled: boolean;
+  wordsPerMinute?: number;
+}
 
 function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
   if (typeof wordsPerMinute !== "number" || !Number.isFinite(wordsPerMinute)) return 220;
@@ -8,8 +13,8 @@ function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
 
 function stripNonReadingContent(content: string): string {
   return content
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/(`{3,})[^\n]*\n[\s\S]*?\1/g, " ")
+    .replace(/(~{3,})[^\n]*\n[\s\S]*?\1/g, " ")
     .replace(/`[^`\n]+`/g, " ")
     .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, " $1 ")
@@ -26,12 +31,31 @@ export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: num
   return Math.max(1, Math.ceil(wordCount / normalizeWordsPerMinute(wordsPerMinute)));
 }
 
-export function resolveReadingTimeFromSource(
-  source: string,
+export function resolveReadingTimeOptions(
+  readingTime: boolean | ReadingTimeConfig | null | undefined,
+): ResolvedReadingTimeOptions {
+  if (readingTime === true) return { enabled: true };
+  if (readingTime === false || readingTime === undefined || readingTime === null) {
+    return { enabled: false };
+  }
+  if (typeof readingTime !== "object") return { enabled: false };
+
+  return {
+    enabled: readingTime.enabled !== false,
+    wordsPerMinute:
+      typeof readingTime.wordsPerMinute === "number" &&
+      Number.isFinite(readingTime.wordsPerMinute)
+        ? readingTime.wordsPerMinute
+        : undefined,
+  };
+}
+
+export function resolveReadingTimeFromContent(
+  frontmatter: Partial<PageFrontmatter> | undefined,
+  content: string,
   wordsPerMinute?: number,
 ): number | null {
-  const { data, content } = matter(source);
-  const pageData = data as PageFrontmatter;
+  const pageData = frontmatter ?? {};
 
   if (pageData.readingTime === false) return null;
 
@@ -40,4 +64,12 @@ export function resolveReadingTimeFromSource(
   }
 
   return estimateReadingTimeMinutes(content, wordsPerMinute);
+}
+
+export function resolveReadingTimeFromSource(
+  source: string,
+  wordsPerMinute?: number,
+): number | null {
+  const { data, content } = matter(source);
+  return resolveReadingTimeFromContent(data as PageFrontmatter, content, wordsPerMinute);
 }

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -192,6 +192,22 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.readingTimeMap).toEqual({});
   });
 
+  it("keeps reading time disabled when the config is nullish at runtime", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      readingTime: null as never,
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.readingTimeEnabled).toBe(false);
+    expect(props?.readingTimeMap).toEqual({});
+  });
+
   it("passes computed reading time through to DocsPageClient when enabled", () => {
     mkdirSync(join(tmpDir, "app", "docs", "installation"), { recursive: true });
     writeFileSync(
@@ -223,6 +239,42 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.readingTimeMap).toMatchObject({
       "/docs": 1,
       "/docs/installation": 1,
+    });
+  });
+
+  it("ignores Agent-only content when computing reading time", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "agent-safe"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "agent-safe", "page.mdx"),
+      [
+        "---",
+        "title: Agent Safe",
+        "---",
+        "",
+        "# Agent Safe",
+        "",
+        "Short human summary.",
+        "",
+        "<Agent>",
+        "These extra machine-only instructions should not count toward visible reading time even if they are verbose and packed with many additional words for testing purposes.",
+        "</Agent>",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({
+      entry: "docs",
+      readingTime: { enabled: true, wordsPerMinute: 10 },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.readingTimeMap).toMatchObject({
+      "/docs/agent-safe": 1,
     });
   });
 

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -4,7 +4,12 @@ import matter from "gray-matter";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { Suspense, type ReactNode } from "react";
 import { serializeIcon } from "./serialize-icon.js";
-import { buildPageOpenGraph, buildPageTwitter, resolveChangelogConfig } from "@farming-labs/docs";
+import {
+  buildPageOpenGraph,
+  buildPageTwitter,
+  resolveChangelogConfig,
+  resolveDocsAgentMdxContent,
+} from "@farming-labs/docs";
 import type {
   DocsConfig,
   ThemeToggleConfig,
@@ -18,7 +23,10 @@ import type {
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
-import { resolveReadingTimeFromSource } from "./reading-time.js";
+import {
+  resolveReadingTimeFromContent,
+  resolveReadingTimeOptions,
+} from "./reading-time.js";
 import { SidebarSearchWithAI } from "./sidebar-search-ai.js";
 import { LocaleThemeControl } from "./locale-theme-control.js";
 import { withLangInUrl } from "./i18n.js";
@@ -497,7 +505,9 @@ function buildReadingTimeMap(
     const pagePath = path.join(dir, "page.mdx");
     if (fs.existsSync(pagePath)) {
       const source = fs.readFileSync(pagePath, "utf-8");
-      const minutes = resolveReadingTimeFromSource(source, wordsPerMinute);
+      const { data, content } = matter(source);
+      const humanContent = resolveDocsAgentMdxContent(content, "human");
+      const minutes = resolveReadingTimeFromContent(data as PageFrontmatter, humanContent, wordsPerMinute);
 
       if (minutes !== null) {
         const url =
@@ -827,13 +837,9 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
-  const readingTimeRaw = config.readingTime;
-  const readingTimeEnabled =
-    readingTimeRaw !== undefined &&
-    readingTimeRaw !== false &&
-    (typeof readingTimeRaw !== "object" || readingTimeRaw.enabled !== false);
-  const readingTimeWordsPerMinute =
-    typeof readingTimeRaw === "object" ? (readingTimeRaw.wordsPerMinute ?? 220) : 220;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
+  const readingTimeEnabled = readingTimeOptions.enabled;
+  const readingTimeWordsPerMinute = readingTimeOptions.wordsPerMinute ?? 220;
 
   // llms.txt config
   const llmsTxtEnabled = resolveBool(config.llmsTxt);

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -23,10 +23,7 @@ import type {
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
-import {
-  resolveReadingTimeFromContent,
-  resolveReadingTimeOptions,
-} from "./reading-time.js";
+import { resolveReadingTimeFromContent, resolveReadingTimeOptions } from "./reading-time.js";
 import { SidebarSearchWithAI } from "./sidebar-search-ai.js";
 import { LocaleThemeControl } from "./locale-theme-control.js";
 import { withLangInUrl } from "./i18n.js";
@@ -507,7 +504,11 @@ function buildReadingTimeMap(
       const source = fs.readFileSync(pagePath, "utf-8");
       const { data, content } = matter(source);
       const humanContent = resolveDocsAgentMdxContent(content, "human");
-      const minutes = resolveReadingTimeFromContent(data as PageFrontmatter, humanContent, wordsPerMinute);
+      const minutes = resolveReadingTimeFromContent(
+        data as PageFrontmatter,
+        humanContent,
+        wordsPerMinute,
+      );
 
       if (minutes !== null) {
         const url =

--- a/packages/fumadocs/src/reading-time.ts
+++ b/packages/fumadocs/src/reading-time.ts
@@ -43,8 +43,7 @@ export function resolveReadingTimeOptions(
   return {
     enabled: readingTime.enabled !== false,
     wordsPerMinute:
-      typeof readingTime.wordsPerMinute === "number" &&
-      Number.isFinite(readingTime.wordsPerMinute)
+      typeof readingTime.wordsPerMinute === "number" && Number.isFinite(readingTime.wordsPerMinute)
         ? readingTime.wordsPerMinute
         : undefined,
   };

--- a/packages/fumadocs/src/reading-time.ts
+++ b/packages/fumadocs/src/reading-time.ts
@@ -1,5 +1,10 @@
 import matter from "gray-matter";
-import type { PageFrontmatter } from "@farming-labs/docs";
+import type { PageFrontmatter, ReadingTimeConfig } from "@farming-labs/docs";
+
+export interface ResolvedReadingTimeOptions {
+  enabled: boolean;
+  wordsPerMinute?: number;
+}
 
 function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
   if (typeof wordsPerMinute !== "number" || !Number.isFinite(wordsPerMinute)) return 220;
@@ -8,8 +13,8 @@ function normalizeWordsPerMinute(wordsPerMinute: number | undefined): number {
 
 function stripNonReadingContent(content: string): string {
   return content
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/(`{3,})[^\n]*\n[\s\S]*?\1/g, " ")
+    .replace(/(~{3,})[^\n]*\n[\s\S]*?\1/g, " ")
     .replace(/`[^`\n]+`/g, " ")
     .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, " $1 ")
@@ -26,12 +31,31 @@ export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: num
   return Math.max(1, Math.ceil(wordCount / normalizeWordsPerMinute(wordsPerMinute)));
 }
 
-export function resolveReadingTimeFromSource(
-  source: string,
+export function resolveReadingTimeOptions(
+  readingTime: boolean | ReadingTimeConfig | null | undefined,
+): ResolvedReadingTimeOptions {
+  if (readingTime === true) return { enabled: true };
+  if (readingTime === false || readingTime === undefined || readingTime === null) {
+    return { enabled: false };
+  }
+  if (typeof readingTime !== "object") return { enabled: false };
+
+  return {
+    enabled: readingTime.enabled !== false,
+    wordsPerMinute:
+      typeof readingTime.wordsPerMinute === "number" &&
+      Number.isFinite(readingTime.wordsPerMinute)
+        ? readingTime.wordsPerMinute
+        : undefined,
+  };
+}
+
+export function resolveReadingTimeFromContent(
+  frontmatter: Partial<PageFrontmatter> | undefined,
+  content: string,
   wordsPerMinute?: number,
 ): number | null {
-  const { data, content } = matter(source);
-  const pageData = data as PageFrontmatter;
+  const pageData = frontmatter ?? {};
 
   if (pageData.readingTime === false) return null;
 
@@ -40,4 +64,12 @@ export function resolveReadingTimeFromSource(
   }
 
   return estimateReadingTimeMinutes(content, wordsPerMinute);
+}
+
+export function resolveReadingTimeFromSource(
+  source: string,
+  wordsPerMinute?: number,
+): number | null {
+  const { data, content } = matter(source);
+  return resolveReadingTimeFromContent(data as PageFrontmatter, content, wordsPerMinute);
 }

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -91,6 +91,7 @@ export interface TanstackDocsLayoutProps {
   tree: TreeRoot;
   locale?: string;
   description?: string;
+  readingTime?: number | null;
   lastModified?: string;
   editOnGithubUrl?: string;
   children: ReactNode;
@@ -314,6 +315,7 @@ export function TanstackDocsLayout({
   tree,
   locale,
   description,
+  readingTime,
   lastModified,
   editOnGithubUrl,
   children,
@@ -361,6 +363,11 @@ export function TanstackDocsLayout({
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
+  const readingTimeRaw = config.readingTime;
+  const readingTimeEnabled =
+    readingTimeRaw !== undefined &&
+    readingTimeRaw !== false &&
+    (typeof readingTimeRaw !== "object" || readingTimeRaw.enabled !== false);
 
   const llmsTxtEnabled = resolveBool(config.llmsTxt);
   const feedbackConfig = resolveFeedbackConfig(config.feedback);
@@ -489,6 +496,8 @@ export function TanstackDocsLayout({
             lastUpdatedEnabled={lastUpdatedEnabled}
             lastUpdatedPosition={lastUpdatedPosition}
             lastModified={lastModified}
+            readingTimeEnabled={readingTimeEnabled}
+            readingTime={typeof readingTime === "number" ? readingTime : undefined}
             llmsTxtEnabled={llmsTxtEnabled}
             description={description}
             feedbackEnabled={feedbackConfig.enabled}

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -11,6 +11,7 @@ import type {
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
+import { resolveReadingTimeOptions } from "./reading-time.js";
 import { SidebarSearchWithAI } from "./sidebar-search-ai.js";
 import { LocaleThemeControl } from "./locale-theme-control.js";
 import { withLangInUrl } from "./i18n.js";
@@ -363,11 +364,7 @@ export function TanstackDocsLayout({
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
-  const readingTimeRaw = config.readingTime;
-  const readingTimeEnabled =
-    readingTimeRaw !== undefined &&
-    readingTimeRaw !== false &&
-    (typeof readingTimeRaw !== "object" || readingTimeRaw.enabled !== false);
+  const readingTimeEnabled = resolveReadingTimeOptions(config.readingTime).enabled;
 
   const llmsTxtEnabled = resolveBool(config.llmsTxt);
   const feedbackConfig = resolveFeedbackConfig(config.feedback);

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
     description?: string;
     html: string;
     rawMarkdown?: string;
+    readingTime?: number | null;
     previousPage?: { name: string; url: string } | null;
     nextPage?: { name: string; url: string } | null;
     editOnGithub?: string;
@@ -168,6 +169,34 @@ const showPageActions = computed(
 );
 const showActionsAbove = computed(() => pageActionsPosition.value === "above-title" && showPageActions.value);
 const showActionsBelow = computed(() => pageActionsPosition.value === "below-title" && showPageActions.value);
+const readingTimeConfig = computed(() => {
+  const rt = props.config?.readingTime;
+  if (rt === false || rt === undefined) return { enabled: false };
+  if (rt === true) return { enabled: true };
+  return {
+    enabled: (rt as { enabled?: boolean }).enabled !== false,
+  };
+});
+const readingTimeValue = computed(() =>
+  readingTimeConfig.value.enabled && typeof props.data.readingTime === "number"
+    ? Math.max(1, Math.ceil(props.data.readingTime))
+    : null,
+);
+const readingTimeLabel = computed(() =>
+  readingTimeValue.value ? `${readingTimeValue.value} min read` : null,
+);
+const showReadingTimeAbove = computed(() => !!readingTimeLabel.value && showActionsAbove.value);
+const showReadingTimeBelow = computed(
+  () =>
+    !!readingTimeLabel.value &&
+    !showReadingTimeAbove.value &&
+    (showActionsBelow.value ||
+      showLastUpdatedBelowTitle.value ||
+      (!showPageActions.value && pageActionsPosition.value === "below-title")),
+);
+const showReadingTimeStandalone = computed(
+  () => !!readingTimeLabel.value && !showReadingTimeAbove.value && !showReadingTimeBelow.value,
+);
 const feedbackConfig = computed(() => {
   const defaults = {
     enabled: false,
@@ -415,12 +444,24 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+    <div v-if="showReadingTimeAbove" class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{{ readingTimeLabel }}</span>
+    </div>
+    <div v-if="showReadingTimeStandalone" class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{{ readingTimeLabel }}</span>
+    </div>
 
     <h1 class="fd-page-title">{{ data.title }}</h1>
     <p v-if="data.description" class="fd-page-description">{{ data.description }}</p>
     <p v-if="showLastUpdatedBelowTitle && data.lastModified" class="fd-last-modified fd-last-modified-below-title">
       Last updated: {{ data.lastModified }}
     </p>
+    <div v-if="showReadingTimeBelow && !showActionsBelow" class="fd-page-meta">
+      <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+      <span class="fd-page-meta-item">{{ readingTimeLabel }}</span>
+    </div>
 
     <!-- Below-title actions -->
     <template v-if="showActionsBelow">
@@ -479,6 +520,10 @@ onUnmounted(() => {
             </a>
           </div>
         </div>
+      </div>
+      <div v-if="showReadingTimeBelow" class="fd-page-meta">
+        <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+        <span class="fd-page-meta-item">{{ readingTimeLabel }}</span>
       </div>
     </template>
 

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { resolveReadingTimeOptions } from "@farming-labs/docs";
 import { computed, ref, onMounted, onUnmounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useHead } from "#app";
@@ -169,14 +170,9 @@ const showPageActions = computed(
 );
 const showActionsAbove = computed(() => pageActionsPosition.value === "above-title" && showPageActions.value);
 const showActionsBelow = computed(() => pageActionsPosition.value === "below-title" && showPageActions.value);
-const readingTimeConfig = computed(() => {
-  const rt = props.config?.readingTime;
-  if (rt === false || rt === undefined) return { enabled: false };
-  if (rt === true) return { enabled: true };
-  return {
-    enabled: (rt as { enabled?: boolean }).enabled !== false,
-  };
-});
+const readingTimeConfig = computed(() =>
+  resolveReadingTimeOptions(props.config?.readingTime as never),
+);
 const readingTimeValue = computed(() =>
   readingTimeConfig.value.enabled && typeof props.data.readingTime === "number"
     ? Math.max(1, Math.ceil(props.data.readingTime))

--- a/packages/nuxt-theme/styles/docs.css
+++ b/packages/nuxt-theme/styles/docs.css
@@ -750,6 +750,33 @@ samp {
   margin-bottom: 1rem;
 }
 
+.fd-page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.fd-page-meta-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.8rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--color-fd-muted-foreground) 78%, transparent);
+}
+
+.fd-page-meta-item {
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
 .fd-feedback {
   margin-top: 2rem;
   margin-bottom: 1.25rem;

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -36,6 +36,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveReadingTimeFromSource,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -115,6 +116,7 @@ export interface DocsServer {
     title: string;
     description?: string;
     html: string;
+    readingTime?: number | null;
     entry?: string;
     locale?: string;
     slug?: string;
@@ -469,6 +471,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
+  const readingTimeConfig = config.readingTime;
+  const readingTimeWordsPerMinute =
+    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
 
   const preloaded = config._preloadedContent as ContentFileMap | undefined;
 
@@ -623,6 +628,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
@@ -647,6 +653,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,
+      readingTime,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -36,7 +36,8 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
-  resolveReadingTimeFromSource,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeOptions,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -471,9 +472,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
-  const readingTimeConfig = config.readingTime;
-  const readingTimeWordsPerMinute =
-    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
 
   const preloaded = config._preloadedContent as ContentFileMap | undefined;
 
@@ -628,7 +627,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
+    const readingTime = readingTimeOptions.enabled
+      ? resolveReadingTimeFromContent(data, humanRawContent, readingTimeOptions.wordsPerMinute)
+      : null;
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -124,6 +124,31 @@
   );
   let showActionsAbove = $derived(pageActionsPosition === "above-title" && showPageActions);
   let showActionsBelow = $derived(pageActionsPosition === "below-title" && showPageActions);
+  let readingTimeConfig = $derived.by(() => {
+    const rt = config?.readingTime;
+    if (rt === false || rt === undefined) return { enabled: false };
+    if (rt === true) return { enabled: true };
+    return {
+      enabled: rt.enabled !== false,
+    };
+  });
+  let readingTimeValue = $derived(
+    readingTimeConfig.enabled && typeof data.readingTime === "number"
+      ? Math.max(1, Math.ceil(data.readingTime))
+      : null
+  );
+  let readingTimeLabel = $derived(readingTimeValue ? `${readingTimeValue} min read` : null);
+  let showReadingTimeAbove = $derived(!!readingTimeLabel && showActionsAbove);
+  let showReadingTimeBelow = $derived(
+    !!readingTimeLabel &&
+      !showReadingTimeAbove &&
+      (showActionsBelow ||
+        showLastUpdatedBelowTitle ||
+        (!showPageActions && pageActionsPosition === "below-title"))
+  );
+  let showReadingTimeStandalone = $derived(
+    !!readingTimeLabel && !showReadingTimeAbove && !showReadingTimeBelow
+  );
   let feedbackPathKey = $derived(
     `${data.locale ?? ""}:${data.entry ?? config?.entry ?? "docs"}:${data.slug ?? ""}`
   );
@@ -373,6 +398,18 @@
           {/if}
         </div>
       {/if}
+      {#if showReadingTimeAbove}
+        <div class="fd-page-meta">
+          <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+          <span class="fd-page-meta-item">{readingTimeLabel}</span>
+        </div>
+      {/if}
+      {#if showReadingTimeStandalone}
+        <div class="fd-page-meta">
+          <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+          <span class="fd-page-meta-item">{readingTimeLabel}</span>
+        </div>
+      {/if}
 
       <h1 class="fd-page-title">{data.title}</h1>
       {#if data.description}
@@ -382,6 +419,12 @@
         <p class="fd-last-modified fd-last-modified-below-title">
           Last updated: {data.lastModified}
         </p>
+      {/if}
+      {#if showReadingTimeBelow && !showActionsBelow}
+        <div class="fd-page-meta">
+          <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+          <span class="fd-page-meta-item">{readingTimeLabel}</span>
+        </div>
       {/if}
 
       {#if showActionsBelow}
@@ -444,6 +487,12 @@
             </div>
           {/if}
         </div>
+        {#if showReadingTimeBelow}
+          <div class="fd-page-meta">
+            <span class="fd-page-meta-dot" aria-hidden="true">·</span>
+            <span class="fd-page-meta-item">{readingTimeLabel}</span>
+          </div>
+        {/if}
       {/if}
 
       {@html htmlWithoutFirstH1}

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { resolveReadingTimeOptions } from "@farming-labs/docs";
   import DocsPage from "./DocsPage.svelte";
   import { onMount, onDestroy } from "svelte";
 
@@ -125,12 +126,7 @@
   let showActionsAbove = $derived(pageActionsPosition === "above-title" && showPageActions);
   let showActionsBelow = $derived(pageActionsPosition === "below-title" && showPageActions);
   let readingTimeConfig = $derived.by(() => {
-    const rt = config?.readingTime;
-    if (rt === false || rt === undefined) return { enabled: false };
-    if (rt === true) return { enabled: true };
-    return {
-      enabled: rt.enabled !== false,
-    };
+    return resolveReadingTimeOptions(config?.readingTime);
   });
   let readingTimeValue = $derived(
     readingTimeConfig.enabled && typeof data.readingTime === "number"

--- a/packages/svelte-theme/styles/docs.css
+++ b/packages/svelte-theme/styles/docs.css
@@ -745,6 +745,33 @@ samp {
   margin-bottom: 1rem;
 }
 
+.fd-page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.fd-page-meta-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.8rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--color-fd-muted-foreground) 78%, transparent);
+}
+
+.fd-page-meta-item {
+  font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--color-fd-muted-foreground);
+}
+
 .fd-feedback {
   margin-top: 2rem;
   margin-bottom: 1.25rem;

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -47,7 +47,8 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
-  resolveReadingTimeFromSource,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeOptions,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -493,9 +494,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
-  const readingTimeConfig = config.readingTime;
-  const readingTimeWordsPerMinute =
-    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
 
   const rawPreloaded = config._preloadedContent as ContentFileMap | undefined;
   // Normalize keys: Vite's import.meta.glob may return paths without leading slash (e.g. "docs/...")
@@ -648,7 +647,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
+    const readingTime = readingTimeOptions.enabled
+      ? resolveReadingTimeFromContent(data, humanRawContent, readingTimeOptions.wordsPerMinute)
+      : null;
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -47,6 +47,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveReadingTimeFromSource,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -136,6 +137,7 @@ export interface DocsServer {
     title: string;
     description?: string;
     html: string;
+    readingTime?: number | null;
     entry?: string;
     locale?: string;
     slug?: string;
@@ -491,6 +493,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const githubRepo = github?.url;
   const githubBranch = github?.branch ?? "main";
   const githubContentPath = github?.directory;
+  const readingTimeConfig = config.readingTime;
+  const readingTimeWordsPerMinute =
+    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
 
   const rawPreloaded = config._preloadedContent as ContentFileMap | undefined;
   // Normalize keys: Vite's import.meta.glob may return paths without leading slash (e.g. "docs/...")
@@ -643,6 +648,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
     const html = await renderMarkdown(humanRawContent, { theme: config.theme });
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
@@ -667,6 +673,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,
+      readingTime,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/tanstack-start/src/react.tsx
+++ b/packages/tanstack-start/src/react.tsx
@@ -58,6 +58,7 @@ export function TanstackDocsPage({
         tree={data.tree}
         locale={data.locale}
         description={data.description}
+        readingTime={data.readingTime}
         lastModified={data.lastModified}
         editOnGithubUrl={data.editOnGithub}
       >

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -17,6 +17,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
+  resolveReadingTimeFromSource,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -92,6 +93,7 @@ export interface DocsServerLoadResult {
   title: string;
   description?: string;
   rawContent: string;
+  readingTime?: number | null;
   sourcePath: string;
   entry?: string;
   locale?: string;
@@ -475,6 +477,9 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   const githubBranch = typeof githubRaw === "object" ? (githubRaw.branch ?? "main") : "main";
   const githubContentPath =
     typeof githubRaw === "object" ? githubRaw.directory?.replace(/^\/|\/$/g, "") : undefined;
+  const readingTimeConfig = config.readingTime;
+  const readingTimeWordsPerMinute =
+    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
 
   const aiConfig: AIConfigObj = { enabled: false, ...config.ai };
   if (config.apiKey && !aiConfig.apiKey) {
@@ -622,6 +627,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     }
 
     const { data, content } = matter(raw);
+    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
     const currentIndex = flatPages.findIndex((page) => page.url === currentUrl);
@@ -645,6 +651,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       rawContent: content,
+      readingTime,
       sourcePath: toSourcePath(ctx.contentDirRel, relPath, rootDir),
       entry,
       locale: ctx.locale,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -17,7 +17,8 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsPath,
-  resolveReadingTimeFromSource,
+  resolveReadingTimeFromContent,
+  resolveReadingTimeOptions,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
@@ -477,9 +478,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   const githubBranch = typeof githubRaw === "object" ? (githubRaw.branch ?? "main") : "main";
   const githubContentPath =
     typeof githubRaw === "object" ? githubRaw.directory?.replace(/^\/|\/$/g, "") : undefined;
-  const readingTimeConfig = config.readingTime;
-  const readingTimeWordsPerMinute =
-    typeof readingTimeConfig === "object" ? readingTimeConfig.wordsPerMinute : undefined;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
 
   const aiConfig: AIConfigObj = { enabled: false, ...config.ai };
   if (config.apiKey && !aiConfig.apiKey) {
@@ -627,7 +626,10 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const readingTime = resolveReadingTimeFromSource(raw, readingTimeWordsPerMinute);
+    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const readingTime = readingTimeOptions.enabled
+      ? resolveReadingTimeFromContent(data, humanRawContent, readingTimeOptions.wordsPerMinute)
+      : null;
 
     const currentUrl = isIndex ? `/${entry}` : `/${entry}/${slug}`;
     const currentIndex = flatPages.findIndex((page) => page.url === currentUrl);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add framework-agnostic reading time to docs pages with server-side estimation, config toggles, and UI across Astro, Nuxt, Svelte, and TanStack Start. Excludes code, links, and <Agent> blocks, and shows “X min read” near the title with layout-aware placement.

- New Features
  - Core (`@farming-labs/docs`): export `estimateReadingTimeMinutes`, `resolveReadingTimeFromContent`, `resolveReadingTimeFromSource`, and `resolveReadingTimeOptions`. Strips code fences (incl. 4‑backticks), inline code, links; default 220 WPM; supports `readingTime: <number|false>` in frontmatter.
  - Servers (Astro/Nuxt/Svelte/TanStack Start): compute `readingTime` from human-only content; add `readingTime` to response types; accept `readingTime` config (boolean or object) with `wordsPerMinute`, resolved via `resolveReadingTimeOptions`.
  - UI: show reading time in `DocsContent` (Astro/Nuxt/Svelte) and TanStack layout; placement respects `pageActions`/`lastUpdated`; new `.fd-page-meta` styles.
  - Examples: enabled `readingTime: { enabled: true, wordsPerMinute: 220 }`.
  - Tests: add cases for estimation, frontmatter overrides, null config, <Agent> exclusion, and 4‑backtick fences.

- Migration
  - Enable in docs config: `readingTime: { enabled: true, wordsPerMinute?: number }` (off by default).
  - Per-page overrides: `readingTime: false` to hide, or `readingTime: <number>` to set a value.
  - Placement follows `pageActions.position` and `lastUpdated.position`; no other changes needed.

<sup>Written for commit 5f85e52c148b4a98537f186c174df4084b3be7a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

