### PR TITLE
feat: token budget for agent frontmatter

### DIFF
--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -248,6 +248,7 @@ Keep this focused.
         agent: {
           compact: {
             maxOutputTokens: 900,
+            minOutputTokens: 500,
           },
         },
       });`,
@@ -317,7 +318,11 @@ Body.
       "utf-8",
     );
 
-    const seenRequests: Array<{ input: string; maxOutputTokens?: number }> = [];
+    const seenRequests: Array<{
+      input: string;
+      maxOutputTokens?: number;
+      minOutputTokens?: number;
+    }> = [];
     const server = createServer(async (req, res) => {
       const chunks: Buffer[] = [];
       for await (const chunk of req) {
@@ -328,12 +333,14 @@ Body.
         input: string;
         compression_settings?: {
           max_output_tokens?: number;
+          min_output_tokens?: number;
         };
       };
 
       seenRequests.push({
         input: payload.input,
         maxOutputTokens: payload.compression_settings?.max_output_tokens,
+        minOutputTokens: payload.compression_settings?.min_output_tokens,
       });
 
       let output = "Compacted output";
@@ -376,17 +383,20 @@ Body.
     expect(seenRequests).toHaveLength(3);
     expect(seenRequests[0]).toMatchObject({
       maxOutputTokens: 777,
+      minOutputTokens: 500,
     });
     expect(seenRequests[0].input).toContain("URL: /docs/installation");
 
     expect(seenRequests[1]).toMatchObject({
       maxOutputTokens: 333,
+      minOutputTokens: 333,
     });
     expect(seenRequests[1].input).toContain("Existing agent-only instructions.");
     expect(seenRequests[1].input).not.toContain("URL: /docs/existing");
 
     expect(seenRequests[2]).toMatchObject({
       maxOutputTokens: 1200,
+      minOutputTokens: 500,
     });
     expect(seenRequests[2].input).toContain("URL: /docs/quickstart");
 

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -240,6 +240,167 @@ Keep this focused.
     ).toBe(true);
   });
 
+  it("uses per-page agent.tokenBudget for pages with and without agent.md", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default defineDocs({
+        entry: "docs",
+        agent: {
+          compact: {
+            maxOutputTokens: 900,
+          },
+        },
+      });`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    mkdirSync(path.join(tmpDir, "app", "docs", "existing"), { recursive: true });
+    mkdirSync(path.join(tmpDir, "app", "docs", "quickstart"), { recursive: true });
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install the framework"
+agent:
+  tokenBudget: 777
+---
+
+# Installation
+
+Run this:
+
+\`\`\`bash
+pnpm add @farming-labs/docs
+\`\`\`
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "existing", "page.mdx"),
+      `---
+title: "Existing"
+description: "This page already has an agent file"
+agent:
+  tokenBudget: 333
+---
+
+# Existing
+
+Human page body.
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "existing", "agent.md"),
+      `Existing agent-only instructions.
+
+Keep this focused.
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "quickstart", "page.mdx"),
+      `---
+title: "Quickstart"
+description: "No page override"
+---
+
+# Quickstart
+
+Body.
+`,
+      "utf-8",
+    );
+
+    const seenRequests: Array<{ input: string; maxOutputTokens?: number }> = [];
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
+        input: string;
+        compression_settings?: {
+          max_output_tokens?: number;
+        };
+      };
+
+      seenRequests.push({
+        input: payload.input,
+        maxOutputTokens: payload.compression_settings?.max_output_tokens,
+      });
+
+      let output = "Compacted output";
+      if (payload.input.includes("URL: /docs/installation")) {
+        output = "Installation compacted";
+      } else if (payload.input.includes("Existing agent-only instructions.")) {
+        output = "Existing compacted";
+      } else if (payload.input.includes("URL: /docs/quickstart")) {
+        output = "Quickstart compacted";
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          output,
+          original_input_tokens: 120,
+          output_tokens: 35,
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      process.chdir(tmpDir);
+
+      await compactAgentDocs({
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${port}`,
+        maxOutputTokens: 1200,
+        pages: ["installation", "existing", "quickstart"],
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    expect(seenRequests).toHaveLength(3);
+    expect(seenRequests[0]).toMatchObject({
+      maxOutputTokens: 777,
+    });
+    expect(seenRequests[0].input).toContain("URL: /docs/installation");
+
+    expect(seenRequests[1]).toMatchObject({
+      maxOutputTokens: 333,
+    });
+    expect(seenRequests[1].input).toContain("Existing agent-only instructions.");
+    expect(seenRequests[1].input).not.toContain("URL: /docs/existing");
+
+    expect(seenRequests[2]).toMatchObject({
+      maxOutputTokens: 1200,
+    });
+    expect(seenRequests[2].input).toContain("URL: /docs/quickstart");
+
+    expect(
+      readFileSync(path.join(tmpDir, "app", "docs", "installation", "agent.md"), "utf-8"),
+    ).toBe("Installation compacted\n");
+    expect(readFileSync(path.join(tmpDir, "app", "docs", "existing", "agent.md"), "utf-8")).toBe(
+      "Existing compacted\n",
+    );
+    expect(
+      readFileSync(path.join(tmpDir, "app", "docs", "quickstart", "agent.md"), "utf-8"),
+    ).toBe("Quickstart compacted\n");
+  });
+
   it("supports --all with dry-run without writing files", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -396,9 +396,9 @@ Body.
     expect(readFileSync(path.join(tmpDir, "app", "docs", "existing", "agent.md"), "utf-8")).toBe(
       "Existing compacted\n",
     );
-    expect(
-      readFileSync(path.join(tmpDir, "app", "docs", "quickstart", "agent.md"), "utf-8"),
-    ).toBe("Quickstart compacted\n");
+    expect(readFileSync(path.join(tmpDir, "app", "docs", "quickstart", "agent.md"), "utf-8")).toBe(
+      "Quickstart compacted\n",
+    );
   });
 
   it("supports --all with dry-run without writing files", async () => {

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import matter from "gray-matter";
 import pc from "picocolors";
 import { findDocsMarkdownPage, renderDocsMarkdownDocument } from "../index.js";
 import { createFilesystemDocsMcpSource } from "../server.js";
@@ -17,7 +18,7 @@ import {
   resolveDocsConfigPath,
   resolveDocsContentDir,
 } from "./config.js";
-import type { DocsConfig } from "../types.js";
+import type { DocsConfig, PageFrontmatter } from "../types.js";
 
 const DEFAULT_TTC_BASE_URL = "https://api.thetokencompany.com";
 const DEFAULT_TTC_MODEL = "bear-1.2";
@@ -332,6 +333,17 @@ function mergeAgentCompactOptions(
   };
 }
 
+function normalizeTokenBudget(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(1, Math.ceil(value));
+}
+
+function readPageTokenBudget(pagePath: string): number | undefined {
+  const source = readFileSync(pagePath, "utf-8");
+  const { data } = matter(source);
+  return normalizeTokenBudget((data as PageFrontmatter).agent?.tokenBudget);
+}
+
 function protectForCompression(input: string): string {
   const segments: string[] = [];
   const stash = (value: string) => {
@@ -531,7 +543,10 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
 
   for (const { page, target } of selectedPages) {
     const sourceDocument = renderDocsMarkdownDocument(page);
-    const compressed = await compressDocument(sourceDocument, resolvedOptions);
+    const pageOptions = mergeAgentCompactOptions(resolvedOptions, {
+      maxOutputTokens: readPageTokenBudget(target.pagePath),
+    });
+    const compressed = await compressDocument(sourceDocument, pageOptions);
     const nextContent = compressed.output.trimEnd();
 
     console.log(
@@ -570,6 +585,9 @@ ${pc.dim("Examples:")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact /docs/installation")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --page installation --page configuration")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --all")}
+
+${pc.dim("Per-page override:")}
+  Add ${pc.cyan("agent.tokenBudget")} to a page frontmatter block to override the compact output target for that page.
 
 ${pc.dim("Options:")}
   ${pc.cyan("--all")}                    Compact every folder-based docs page under the configured contentDir

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -546,6 +546,13 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
     const pageOptions = mergeAgentCompactOptions(resolvedOptions, {
       maxOutputTokens: readPageTokenBudget(target.pagePath),
     });
+    if (
+      pageOptions.minOutputTokens !== undefined &&
+      pageOptions.maxOutputTokens !== undefined &&
+      pageOptions.minOutputTokens > pageOptions.maxOutputTokens
+    ) {
+      pageOptions.minOutputTokens = pageOptions.maxOutputTokens;
+    }
     const compressed = await compressDocument(sourceDocument, pageOptions);
     const nextContent = compressed.output.trimEnd();
 

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -273,11 +273,21 @@ export interface ResolvedDocsRelatedLink {
   href: string;
 }
 
+export interface PageAgentFrontmatter {
+  /**
+   * Approximate output token target for machine-readable compaction on this page.
+   * Used by `docs agent compact` as a per-page override.
+   */
+  tokenBudget?: number;
+}
+
 export interface PageFrontmatter {
   title: string;
   description?: string;
   /** Related doc URLs rendered into machine-readable markdown routes and MCP page output. */
   related?: DocsRelatedItem[];
+  /** Per-page agent-oriented metadata used by machine-readable docs features. */
+  agent?: PageAgentFrontmatter;
   /** Override or disable the estimated reading time for this page. */
   readingTime?: boolean | number;
   tags?: string[];


### PR DESCRIPTION
- **feat: token budget for agent**
- **chore: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-page token budget overrides for `docs agent compact` via `agent.tokenBudget` in page frontmatter. This lets each page control its compact output size while keeping a global default.

- **New Features**
  - Read and normalize `agent.tokenBudget` from page frontmatter (via `gray-matter`) and use it as per-page `maxOutputTokens` (works with or without an existing `agent.md`).
  - Clamp `minOutputTokens` to not exceed the per-page `maxOutputTokens`; fall back to global defaults when unset. Adds `agent.tokenBudget` to `PageFrontmatter` types and updates CLI help.

<sup>Written for commit 75b5a475d7e83e04d31a18129782a2cfc2c030bd. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/132?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

