### PR TITLE
fix: content layout on spider monkey browser engine

### DIFF
--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -112,7 +112,9 @@ describe("createDocsLayout pageActions", () => {
     expect(React.isValidElement(tree)).toBe(true);
     expect(tree.type).not.toBe("div");
     expect((tree.props as { id?: string; style?: { display?: string } }).id).toBeUndefined();
-    expect((tree.props as { id?: string; style?: { display?: string } }).style?.display).toBeUndefined();
+    expect(
+      (tree.props as { id?: string; style?: { display?: string } }).style?.display,
+    ).toBeUndefined();
   });
 
   it("supports boolean shorthand, custom providers, and above-title placement", () => {

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -100,6 +100,21 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.pageActionsPosition).toBe("below-title");
   });
 
+  it("does not add an extra display: contents wrapper above the docs layout root", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+
+    expect(React.isValidElement(tree)).toBe(true);
+    expect(tree.type).not.toBe("div");
+    expect((tree.props as { id?: string; style?: { display?: string } }).id).toBeUndefined();
+    expect((tree.props as { id?: string; style?: { display?: string } }).style?.display).toBeUndefined();
+  });
+
   it("supports boolean shorthand, custom providers, and above-title placement", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -955,81 +955,79 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
     }
 
     return (
-      <div id="nd-docs-layout" style={{ display: "contents" }}>
-        <DocsLayout
-          tree={localizedTree}
-          nav={{ title: navTitle, url: navUrl }}
-          themeSwitch={i18n ? { ...themeSwitch, enabled: false } : themeSwitch}
-          sidebar={finalSidebarProps}
-          {...(aiMode === "sidebar-icon" && aiEnabled
-            ? {
-                searchToggle: { components: { lg: <SidebarSearchWithAI /> } },
-              }
-            : {})}
-        >
-          <ColorStyle colors={colors} />
-          <TypographyStyle typography={typography} />
-          <LayoutStyle layout={layoutDimensions} />
-          {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
-          {!staticExport && (
-            <Suspense fallback={null}>
-              <DocsCommandSearch api={docsApiUrl} locale={activeLocale} />
-            </Suspense>
-          )}
-          {aiEnabled && (
-            <Suspense fallback={null}>
-              <DocsAIFeatures
-                mode={aiMode}
-                api={docsApiUrl}
-                locale={activeLocale}
-                position={aiPosition}
-                floatingStyle={aiFloatingStyle}
-                triggerComponentHtml={aiTriggerComponentHtml}
-                suggestedQuestions={aiSuggestedQuestions}
-                aiLabel={aiLabel}
-                loaderVariant={aiLoaderVariant}
-                loadingComponentHtml={aiLoadingComponentHtml}
-                models={aiModels}
-                defaultModelId={aiDefaultModelId}
-              />
-            </Suspense>
-          )}
-          <Suspense fallback={children}>
-            <DocsPageClient
-              tocEnabled={tocEnabled}
-              tocStyle={tocStyle}
-              breadcrumbEnabled={breadcrumbEnabled}
-              changelogBasePath={changelogBasePath}
-              entry={localeContext.entryPath}
-              locale={activeLocale}
-              copyMarkdown={copyMarkdownEnabled}
-              openDocs={openDocsEnabled}
-              openDocsProviders={openDocsProviders as any}
-              pageActionsPosition={pageActionsPosition}
-              pageActionsAlignment={pageActionsAlignment}
-              githubUrl={githubUrl}
-              contentDir={contentDir}
-              githubBranch={githubBranch}
-              githubDirectory={githubDirectory}
-              lastModifiedMap={lastModifiedMap}
-              lastUpdatedEnabled={lastUpdatedEnabled}
-              lastUpdatedPosition={lastUpdatedPosition}
-              readingTimeEnabled={readingTimeEnabled}
-              readingTimeMap={readingTimeMap}
-              llmsTxtEnabled={llmsTxtEnabled}
-              descriptionMap={descriptionMap}
-              feedbackEnabled={feedbackConfig.enabled}
-              feedbackQuestion={feedbackConfig.question}
-              feedbackPlaceholder={feedbackConfig.placeholder}
-              feedbackPositiveLabel={feedbackConfig.positiveLabel}
-              feedbackNegativeLabel={feedbackConfig.negativeLabel}
-              feedbackSubmitLabel={feedbackConfig.submitLabel}
-            >
-              {children}
-            </DocsPageClient>
+      <DocsLayout
+        tree={localizedTree}
+        nav={{ title: navTitle, url: navUrl }}
+        themeSwitch={i18n ? { ...themeSwitch, enabled: false } : themeSwitch}
+        sidebar={finalSidebarProps}
+        {...(aiMode === "sidebar-icon" && aiEnabled
+          ? {
+              searchToggle: { components: { lg: <SidebarSearchWithAI /> } },
+            }
+          : {})}
+      >
+        <ColorStyle colors={colors} />
+        <TypographyStyle typography={typography} />
+        <LayoutStyle layout={layoutDimensions} />
+        {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
+        {!staticExport && (
+          <Suspense fallback={null}>
+            <DocsCommandSearch api={docsApiUrl} locale={activeLocale} />
           </Suspense>
-        </DocsLayout>
-      </div>
+        )}
+        {aiEnabled && (
+          <Suspense fallback={null}>
+            <DocsAIFeatures
+              mode={aiMode}
+              api={docsApiUrl}
+              locale={activeLocale}
+              position={aiPosition}
+              floatingStyle={aiFloatingStyle}
+              triggerComponentHtml={aiTriggerComponentHtml}
+              suggestedQuestions={aiSuggestedQuestions}
+              aiLabel={aiLabel}
+              loaderVariant={aiLoaderVariant}
+              loadingComponentHtml={aiLoadingComponentHtml}
+              models={aiModels}
+              defaultModelId={aiDefaultModelId}
+            />
+          </Suspense>
+        )}
+        <Suspense fallback={children}>
+          <DocsPageClient
+            tocEnabled={tocEnabled}
+            tocStyle={tocStyle}
+            breadcrumbEnabled={breadcrumbEnabled}
+            changelogBasePath={changelogBasePath}
+            entry={localeContext.entryPath}
+            locale={activeLocale}
+            copyMarkdown={copyMarkdownEnabled}
+            openDocs={openDocsEnabled}
+            openDocsProviders={openDocsProviders as any}
+            pageActionsPosition={pageActionsPosition}
+            pageActionsAlignment={pageActionsAlignment}
+            githubUrl={githubUrl}
+            contentDir={contentDir}
+            githubBranch={githubBranch}
+            githubDirectory={githubDirectory}
+            lastModifiedMap={lastModifiedMap}
+            lastUpdatedEnabled={lastUpdatedEnabled}
+            lastUpdatedPosition={lastUpdatedPosition}
+            readingTimeEnabled={readingTimeEnabled}
+            readingTimeMap={readingTimeMap}
+            llmsTxtEnabled={llmsTxtEnabled}
+            descriptionMap={descriptionMap}
+            feedbackEnabled={feedbackConfig.enabled}
+            feedbackQuestion={feedbackConfig.question}
+            feedbackPlaceholder={feedbackConfig.placeholder}
+            feedbackPositiveLabel={feedbackConfig.positiveLabel}
+            feedbackNegativeLabel={feedbackConfig.negativeLabel}
+            feedbackSubmitLabel={feedbackConfig.submitLabel}
+          >
+            {children}
+          </DocsPageClient>
+        </Suspense>
+      </DocsLayout>
     );
   };
 }

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -18,6 +18,8 @@ describe("TanstackDocsLayout", () => {
     expect(React.isValidElement(tree)).toBe(true);
     expect(tree.type).not.toBe("div");
     expect((tree.props as { id?: string; style?: { display?: string } }).id).toBeUndefined();
-    expect((tree.props as { id?: string; style?: { display?: string } }).style?.display).toBeUndefined();
+    expect(
+      (tree.props as { id?: string; style?: { display?: string } }).style?.display,
+    ).toBeUndefined();
   });
 });

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { TanstackDocsLayout } from "./tanstack-layout.js";
+
+describe("TanstackDocsLayout", () => {
+  it("does not add an extra display: contents wrapper above the docs layout root", () => {
+    const tree = TanstackDocsLayout({
+      config: {
+        entry: "docs",
+      },
+      tree: {
+        name: "Docs",
+        children: [],
+      },
+      children: React.createElement("div", null, "child"),
+    });
+
+    expect(React.isValidElement(tree)).toBe(true);
+    expect(tree.type).not.toBe("div");
+    expect((tree.props as { id?: string; style?: { display?: string } }).id).toBeUndefined();
+    expect((tree.props as { id?: string; style?: { display?: string } }).style?.display).toBeUndefined();
+  });
+});

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -440,74 +440,72 @@ export function TanstackDocsLayout({
   }
 
   return (
-    <div id="nd-docs-layout" style={{ display: "contents" }}>
-      <DocsLayout
-        tree={resolvedTree}
-        nav={{ title: navTitle, url: navUrl }}
-        themeSwitch={locale && i18n?.locales ? { ...themeSwitch, enabled: false } : themeSwitch}
-        sidebar={finalSidebarProps}
-        {...(aiMode === "sidebar-icon" && aiEnabled
-          ? {
-              searchToggle: { components: { lg: <SidebarSearchWithAI /> } },
-            }
-          : {})}
-      >
-        <ColorStyle colors={colors} />
-        <TypographyStyle typography={typography} />
-        <LayoutStyle layout={layoutDimensions} />
-        {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
-        {!staticExport && (
-          <Suspense fallback={null}>
-            <DocsCommandSearch api={docsApiUrl} locale={locale} />
-          </Suspense>
-        )}
-        {aiEnabled && (
-          <Suspense fallback={null}>
-            <DocsAIFeatures
-              mode={aiMode}
-              api={docsApiUrl}
-              locale={locale}
-              position={aiPosition}
-              floatingStyle={aiFloatingStyle}
-              suggestedQuestions={aiSuggestedQuestions}
-              aiLabel={aiLabel}
-              loaderVariant={aiLoaderVariant}
-              models={aiModels}
-              defaultModelId={aiDefaultModelId}
-            />
-          </Suspense>
-        )}
-        <Suspense fallback={children}>
-          <DocsPageClient
-            tocEnabled={tocEnabled}
-            tocStyle={tocStyle}
-            breadcrumbEnabled={breadcrumbEnabled}
-            entry={config.entry ?? "docs"}
-            locale={locale}
-            copyMarkdown={copyMarkdownEnabled}
-            openDocs={openDocsEnabled}
-            openDocsProviders={openDocsProviders}
-            pageActionsPosition={pageActionsPosition}
-            pageActionsAlignment={pageActionsAlignment}
-            editOnGithubUrl={editOnGithubUrl}
-            lastUpdatedEnabled={lastUpdatedEnabled}
-            lastUpdatedPosition={lastUpdatedPosition}
-            lastModified={lastModified}
-            readingTimeEnabled={readingTimeEnabled}
-            readingTime={typeof readingTime === "number" ? readingTime : undefined}
-            llmsTxtEnabled={llmsTxtEnabled}
-            description={description}
-            feedbackEnabled={feedbackConfig.enabled}
-            feedbackQuestion={feedbackConfig.question}
-            feedbackPlaceholder={feedbackConfig.placeholder}
-            feedbackPositiveLabel={feedbackConfig.positiveLabel}
-            feedbackNegativeLabel={feedbackConfig.negativeLabel}
-            feedbackSubmitLabel={feedbackConfig.submitLabel}
-          >
-            {children}
-          </DocsPageClient>
+    <DocsLayout
+      tree={resolvedTree}
+      nav={{ title: navTitle, url: navUrl }}
+      themeSwitch={locale && i18n?.locales ? { ...themeSwitch, enabled: false } : themeSwitch}
+      sidebar={finalSidebarProps}
+      {...(aiMode === "sidebar-icon" && aiEnabled
+        ? {
+            searchToggle: { components: { lg: <SidebarSearchWithAI /> } },
+          }
+        : {})}
+    >
+      <ColorStyle colors={colors} />
+      <TypographyStyle typography={typography} />
+      <LayoutStyle layout={layoutDimensions} />
+      {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
+      {!staticExport && (
+        <Suspense fallback={null}>
+          <DocsCommandSearch api={docsApiUrl} locale={locale} />
         </Suspense>
-      </DocsLayout>
-    </div>
+      )}
+      {aiEnabled && (
+        <Suspense fallback={null}>
+          <DocsAIFeatures
+            mode={aiMode}
+            api={docsApiUrl}
+            locale={locale}
+            position={aiPosition}
+            floatingStyle={aiFloatingStyle}
+            suggestedQuestions={aiSuggestedQuestions}
+            aiLabel={aiLabel}
+            loaderVariant={aiLoaderVariant}
+            models={aiModels}
+            defaultModelId={aiDefaultModelId}
+          />
+        </Suspense>
+      )}
+      <Suspense fallback={children}>
+        <DocsPageClient
+          tocEnabled={tocEnabled}
+          tocStyle={tocStyle}
+          breadcrumbEnabled={breadcrumbEnabled}
+          entry={config.entry ?? "docs"}
+          locale={locale}
+          copyMarkdown={copyMarkdownEnabled}
+          openDocs={openDocsEnabled}
+          openDocsProviders={openDocsProviders}
+          pageActionsPosition={pageActionsPosition}
+          pageActionsAlignment={pageActionsAlignment}
+          editOnGithubUrl={editOnGithubUrl}
+          lastUpdatedEnabled={lastUpdatedEnabled}
+          lastUpdatedPosition={lastUpdatedPosition}
+          lastModified={lastModified}
+          readingTimeEnabled={readingTimeEnabled}
+          readingTime={typeof readingTime === "number" ? readingTime : undefined}
+          llmsTxtEnabled={llmsTxtEnabled}
+          description={description}
+          feedbackEnabled={feedbackConfig.enabled}
+          feedbackQuestion={feedbackConfig.question}
+          feedbackPlaceholder={feedbackConfig.placeholder}
+          feedbackPositiveLabel={feedbackConfig.positiveLabel}
+          feedbackNegativeLabel={feedbackConfig.negativeLabel}
+          feedbackSubmitLabel={feedbackConfig.submitLabel}
+        >
+          {children}
+        </DocsPageClient>
+      </Suspense>
+    </DocsLayout>
   );
 }


### PR DESCRIPTION
- **fix: content layout on spider monkey browser engine**
- **chore: format**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the extra display: contents wrapper around the docs layout root to fix layout issues on SpiderMonkey/Firefox. Rendering is now stable across browsers with no API changes.

- **Bug Fixes**
  - In `createDocsLayout` and `TanstackDocsLayout`, removed the outer `<div id="nd-docs-layout" style="display: contents">` and render `DocsLayout` as the root.
  - Added tests to ensure no extra wrapper or inline display style is introduced.

<sup>Written for commit 74f9c473a872ab6f776b9098a3f9d53aff6ddd18. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

