### PR TITLE
feat: agent compat for changed git diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ resolved docs pages.
 
 ```bash
 pnpm exec docs agent compact installation
+pnpm exec docs agent compact --changed
 pnpm exec docs agent compact --stale
 pnpm exec docs agent compact --stale --include-missing
 ```
@@ -156,6 +157,8 @@ writes a new sibling `agent.md`.
 
 Generated files carry hidden provenance metadata so the CLI can detect drift later:
 
+- `docs agent compact --changed` compacts only docs pages whose source files changed in the current
+  git working tree, including staged, unstaged, and untracked docs changes
 - `docs agent compact --stale` refreshes only stale generated `agent.md` files
 - `docs agent compact --stale --include-missing` also creates missing `agent.md` files for
   explicitly requested pages or pages that define `agent.tokenBudget`

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "node:http";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -74,6 +75,13 @@ describe("parseAgentCompactArgs", () => {
     expect(parseAgentCompactArgs(["--stale", "--include-missing", "installation"])).toEqual({
       stale: true,
       includeMissing: true,
+      pages: ["installation"],
+    });
+  });
+
+  it("parses changed compaction flags", () => {
+    expect(parseAgentCompactArgs(["--changed", "installation"])).toEqual({
+      changed: true,
       pages: ["installation"],
     });
   });
@@ -1145,6 +1153,201 @@ Body.
       "resolved-page",
     );
   });
+
+  it("uses --changed to compact only docs sources changed in the current git working tree", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs" };`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    mkdirSync(path.join(tmpDir, "app", "docs", "handwritten"), { recursive: true });
+    mkdirSync(path.join(tmpDir, "app", "docs", "generated"), { recursive: true });
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+First body.
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "handwritten", "page.mdx"),
+      `---
+title: "Handwritten"
+description: "Custom machine page"
+---
+
+# Handwritten
+
+Body.
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "handwritten", "agent.md"),
+      `Handwritten source.
+`,
+      "utf-8",
+    );
+
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "generated", "page.mdx"),
+      `---
+title: "Generated"
+description: "Generated agent file"
+---
+
+# Generated
+
+Body.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    initializeGitRepo(tmpDir);
+
+    const seenInputs: string[] = [];
+    let generatedPass = false;
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as { input: string };
+      seenInputs.push(payload.input);
+
+      let output = "Compacted";
+      if (payload.input.includes("URL: /docs/generated")) {
+        generatedPass = true;
+        output = "Generated compacted";
+      } else if (payload.input.includes("URL: /docs/installation")) {
+        output = "Installation changed compacted";
+      } else if (payload.input.includes("Handwritten source updated.")) {
+        output = "Handwritten changed compacted";
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          output,
+          original_input_tokens: 100,
+          output_tokens: 25,
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await compactAgentDocs({
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${port}`,
+        pages: ["generated"],
+      });
+
+      expect(generatedPass).toBe(true);
+      commitAllGitChanges(tmpDir, "initial");
+      seenInputs.length = 0;
+      generatedPass = false;
+
+      writeFileSync(
+        path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+        `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Updated body.
+`,
+        "utf-8",
+      );
+
+      writeFileSync(
+        path.join(tmpDir, "app", "docs", "handwritten", "agent.md"),
+        `Handwritten source updated.
+`,
+        "utf-8",
+      );
+
+      await compactAgentDocs({
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${port}`,
+        changed: true,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    expect(seenInputs).toHaveLength(2);
+    expect(seenInputs.some((input) => input.includes("URL: /docs/installation"))).toBe(true);
+    expect(seenInputs.some((input) => input.includes("Handwritten source updated."))).toBe(true);
+    expect(
+      seenInputs.some(
+        (input) =>
+          input.includes("Handwritten source updated.") && !input.includes("URL: /docs/handwritten"),
+      ),
+    ).toBe(true);
+    expect(seenInputs.some((input) => input.includes("URL: /docs/generated"))).toBe(false);
+    expectGeneratedAgentFile(
+      path.join(tmpDir, "app", "docs", "installation", "agent.md"),
+      "Installation changed compacted",
+      "resolved-page",
+    );
+    expectGeneratedAgentFile(
+      path.join(tmpDir, "app", "docs", "handwritten", "agent.md"),
+      "Handwritten changed compacted",
+      "agent-md",
+    );
+  });
+
+  it("prints a friendly message when --changed finds no changed docs sources", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs" };`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Body.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    initializeGitRepo(tmpDir);
+
+    await compactAgentDocs({
+      changed: true,
+    });
+
+    expect(logs.some((line) => line.includes("No changed docs pages needed compaction."))).toBe(true);
+  });
 });
 
 function existsAtPath(value: string): boolean {
@@ -1154,6 +1357,26 @@ function existsAtPath(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function runGit(rootDir: string, args: string[]) {
+  return execFileSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf-8",
+  });
+}
+
+function initializeGitRepo(rootDir: string) {
+  runGit(rootDir, ["init"]);
+  runGit(rootDir, ["config", "user.name", "Docs Test"]);
+  runGit(rootDir, ["config", "user.email", "docs@example.com"]);
+  runGit(rootDir, ["add", "."]);
+  runGit(rootDir, ["commit", "-m", "initial"]);
+}
+
+function commitAllGitChanges(rootDir: string, message: string) {
+  runGit(rootDir, ["add", "."]);
+  runGit(rootDir, ["commit", "-m", message]);
 }
 
 function expectGeneratedAgentFile(

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -1351,6 +1351,84 @@ Body.
       true,
     );
   });
+
+  it("supports --changed when contentDir points at the repository root", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "",
+  contentDir: ".",
+};`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "installation"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Body.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    initializeGitRepo(tmpDir);
+
+    writeFileSync(
+      path.join(tmpDir, "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Updated body.
+`,
+      "utf-8",
+    );
+
+    let requestCount = 0;
+    const server = createServer(async (_req, res) => {
+      requestCount += 1;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          output: "Root compacted",
+          original_input_tokens: 100,
+          output_tokens: 25,
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await compactAgentDocs({
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${port}`,
+        changed: true,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    expect(requestCount).toBe(1);
+    expectGeneratedAgentFile(
+      path.join(tmpDir, "installation", "agent.md"),
+      "Root compacted",
+      "resolved-page",
+    );
+  });
 });
 
 function existsAtPath(value: string): boolean {

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -1301,7 +1301,8 @@ Updated body.
     expect(
       seenInputs.some(
         (input) =>
-          input.includes("Handwritten source updated.") && !input.includes("URL: /docs/handwritten"),
+          input.includes("Handwritten source updated.") &&
+          !input.includes("URL: /docs/handwritten"),
       ),
     ).toBe(true);
     expect(seenInputs.some((input) => input.includes("URL: /docs/generated"))).toBe(false);
@@ -1346,7 +1347,9 @@ Body.
       changed: true,
     });
 
-    expect(logs.some((line) => line.includes("No changed docs pages needed compaction."))).toBe(true);
+    expect(logs.some((line) => line.includes("No changed docs pages needed compaction."))).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import matter from "gray-matter";
 import pc from "picocolors";
@@ -45,6 +46,7 @@ export interface AgentCompactOptions {
   protectJson?: boolean;
   all?: boolean;
   pages?: string[];
+  changed?: boolean;
   stale?: boolean;
   includeMissing?: boolean;
   dryRun?: boolean;
@@ -128,6 +130,11 @@ export function parseAgentCompactArgs(argv: string[]): ParsedAgentCompactArgs {
 
     if (arg === "--dry-run") {
       parsed.dryRun = true;
+      continue;
+    }
+
+    if (arg === "--changed") {
+      parsed.changed = true;
       continue;
     }
 
@@ -308,6 +315,58 @@ function resolveCompressionEndpoint(rawBaseUrl?: string): string {
   return `${baseUrl.replace(/\/+$/, "")}/v1/compress`;
 }
 
+function runGitCommand(rootDir: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf-8",
+  }).trim();
+}
+
+function normalizeGitRelativePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^\/+/, "");
+}
+
+function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
+  let gitRoot: string;
+  try {
+    gitRoot = runGitCommand(rootDir, ["rev-parse", "--show-toplevel"]);
+  } catch {
+    throw new Error("Use --changed inside a git repository.");
+  }
+
+  const contentDirAbs = path.resolve(rootDir, contentDir);
+  const relativeContentDir = normalizeGitRelativePath(path.relative(gitRoot, contentDirAbs));
+
+  if (!relativeContentDir || relativeContentDir.startsWith("../")) {
+    throw new Error("Configured contentDir must live inside the current git repository for --changed.");
+  }
+
+  const changedFiles = new Set<string>();
+  const commands = [
+    ["diff", "--name-only", "--", relativeContentDir],
+    ["diff", "--name-only", "--cached", "--", relativeContentDir],
+    ["ls-files", "--others", "--exclude-standard", "--", relativeContentDir],
+  ];
+
+  for (const args of commands) {
+    const output = runGitCommand(gitRoot, args);
+    if (!output) continue;
+
+    for (const line of output.split("\n")) {
+      const normalized = normalizeGitRelativePath(line.trim());
+      if (!normalized) continue;
+
+      const absolutePath = path.resolve(gitRoot, normalized);
+      const relativeToRoot = normalizeGitRelativePath(path.relative(rootDir, absolutePath));
+      if (relativeToRoot && !relativeToRoot.startsWith("../")) {
+        changedFiles.add(relativeToRoot);
+      }
+    }
+  }
+
+  return changedFiles;
+}
+
 function resolveCompressionApiKey(explicitApiKey?: string, explicitApiKeyEnv?: string): string {
   const candidateKeys = [
     explicitApiKeyEnv,
@@ -436,6 +495,14 @@ function readCurrentAgentDocument(target: DocsPageTarget) {
   if (!target.hasAgentFile || !existsSync(target.agentPath)) return undefined;
   const raw = readFileSync(target.agentPath, "utf-8");
   return parseGeneratedAgentDocument(raw);
+}
+
+function shouldCompactChangedAgentFile(target: DocsPageTarget): boolean {
+  const currentDocument = readCurrentAgentDocument(target);
+  if (!currentDocument) return false;
+  if (!currentDocument.provenance) return true;
+  if (currentDocument.provenance.sourceKind !== "agent-md") return false;
+  return hashGeneratedAgentContent(currentDocument.content) !== currentDocument.provenance.outputHash;
 }
 
 function resolveSourceKindForCompaction(
@@ -670,6 +737,22 @@ function resolveSelectedPages(
   return resolved;
 }
 
+function filterChangedPages(
+  rootDir: string,
+  contentDir: string,
+  selectedPages: Array<{ page: DocsMcpPage; target: DocsPageTarget }>,
+): Array<{ page: DocsMcpPage; target: DocsPageTarget }> {
+  const changedFiles = listGitChangedFiles(rootDir, contentDir);
+
+  return selectedPages.filter(({ target }) => {
+    const relativePagePath = normalizeGitRelativePath(path.relative(rootDir, target.pagePath));
+    if (changedFiles.has(relativePagePath)) return true;
+
+    const relativeAgentPath = normalizeGitRelativePath(path.relative(rootDir, target.agentPath));
+    return changedFiles.has(relativeAgentPath) && shouldCompactChangedAgentFile(target);
+  });
+}
+
 export async function compactAgentDocs(options: AgentCompactOptions = {}): Promise<void> {
   const rootDir = process.cwd();
   const loadedEnv = loadProjectEnv(rootDir);
@@ -711,8 +794,8 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   }
 
   const requestedPages = resolvedOptions.pages?.filter((value) => value.trim().length > 0) ?? [];
-  if (!resolvedOptions.all && requestedPages.length === 0 && !resolvedOptions.stale) {
-    throw new Error("Pass --all, --stale, or at least one docs page slug/path to compact.");
+  if (!resolvedOptions.all && requestedPages.length === 0 && !resolvedOptions.stale && !resolvedOptions.changed) {
+    throw new Error("Pass --all, --changed, --stale, or at least one docs page slug/path to compact.");
   }
 
   const source = createFilesystemDocsMcpSource({
@@ -729,10 +812,19 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
 
   const targets = scanDocsPageTargets(rootDir, contentDir, entry);
   const selectAll =
-    resolvedOptions.all === true || (resolvedOptions.stale === true && requestedPages.length === 0);
+    resolvedOptions.all === true ||
+    (resolvedOptions.stale === true && requestedPages.length === 0) ||
+    (resolvedOptions.changed === true && requestedPages.length === 0);
   const selectedPages = resolveSelectedPages(pages, targets, entry, requestedPages, selectAll);
+  const filteredPages = resolvedOptions.changed
+    ? filterChangedPages(rootDir, contentDir, selectedPages)
+    : selectedPages;
 
-  if (selectedPages.length === 0) {
+  if (filteredPages.length === 0) {
+    if (resolvedOptions.changed) {
+      console.log(pc.green("No changed docs pages needed compaction."));
+      return;
+    }
     throw new Error("No compactable docs pages matched the request.");
   }
 
@@ -745,7 +837,7 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   let skippedMissing = 0;
   const requestedExplicitPages = requestedPages.length > 0;
 
-  for (const { page, target } of selectedPages) {
+  for (const { page, target } of filteredPages) {
     const state = inspectAgentCompactionState(page, target, resolvedOptions);
 
     if (resolvedOptions.stale) {
@@ -765,7 +857,7 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
       }
 
       if (state.status === "missing") {
-        const shouldCreateMissing =
+      const shouldCreateMissing =
           resolvedOptions.includeMissing === true &&
           (requestedExplicitPages || state.tokenBudget !== undefined);
 
@@ -806,7 +898,7 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
 
   if (resolvedOptions.dryRun) {
     processed =
-      selectedPages.length - skippedFresh - skippedModified - skippedUnknown - skippedMissing;
+      filteredPages.length - skippedFresh - skippedModified - skippedUnknown - skippedMissing;
   }
 
   if (resolvedOptions.stale && processed === 0) {
@@ -850,6 +942,7 @@ ${pc.dim("Examples:")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact /docs/installation")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --page installation --page configuration")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --all")}
+  ${pc.cyan("npx @farming-labs/docs@latest agent compact --changed")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --stale")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --stale --include-missing")}
 
@@ -859,6 +952,7 @@ ${pc.dim("Per-page override:")}
 ${pc.dim("Options:")}
   ${pc.cyan("--all")}                    Compact every folder-based docs page under the configured contentDir
   ${pc.cyan("--page <slug|path>")}       Add a page explicitly (repeatable); positional page args work too
+  ${pc.cyan("--changed")}                Compact only docs pages changed in the current git working tree
   ${pc.cyan("--stale")}                  Re-compact only stale generated agent.md files
   ${pc.cyan("--include-missing")}        With ${pc.cyan("--stale")}, also create missing agent.md files for explicit pages or pages that define ${pc.cyan("agent.tokenBudget")}
   ${pc.cyan("--config <path>")}          Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -323,7 +323,10 @@ function runGitCommand(rootDir: string, args: string[]): string {
 }
 
 function normalizeGitRelativePath(value: string): string {
-  return value.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^\/+/, "");
+  return value
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "")
+    .replace(/^\/+/, "");
 }
 
 function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
@@ -338,7 +341,9 @@ function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
   const relativeContentDir = normalizeGitRelativePath(path.relative(gitRoot, contentDirAbs));
 
   if (!relativeContentDir || relativeContentDir.startsWith("../")) {
-    throw new Error("Configured contentDir must live inside the current git repository for --changed.");
+    throw new Error(
+      "Configured contentDir must live inside the current git repository for --changed.",
+    );
   }
 
   const changedFiles = new Set<string>();
@@ -502,7 +507,9 @@ function shouldCompactChangedAgentFile(target: DocsPageTarget): boolean {
   if (!currentDocument) return false;
   if (!currentDocument.provenance) return true;
   if (currentDocument.provenance.sourceKind !== "agent-md") return false;
-  return hashGeneratedAgentContent(currentDocument.content) !== currentDocument.provenance.outputHash;
+  return (
+    hashGeneratedAgentContent(currentDocument.content) !== currentDocument.provenance.outputHash
+  );
 }
 
 function resolveSourceKindForCompaction(
@@ -794,8 +801,15 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   }
 
   const requestedPages = resolvedOptions.pages?.filter((value) => value.trim().length > 0) ?? [];
-  if (!resolvedOptions.all && requestedPages.length === 0 && !resolvedOptions.stale && !resolvedOptions.changed) {
-    throw new Error("Pass --all, --changed, --stale, or at least one docs page slug/path to compact.");
+  if (
+    !resolvedOptions.all &&
+    requestedPages.length === 0 &&
+    !resolvedOptions.stale &&
+    !resolvedOptions.changed
+  ) {
+    throw new Error(
+      "Pass --all, --changed, --stale, or at least one docs page slug/path to compact.",
+    );
   }
 
   const source = createFilesystemDocsMcpSource({
@@ -857,7 +871,7 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
       }
 
       if (state.status === "missing") {
-      const shouldCreateMissing =
+        const shouldCreateMissing =
           resolvedOptions.includeMissing === true &&
           (requestedExplicitPages || state.tokenBudget !== undefined);
 

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -340,17 +340,19 @@ function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
   const contentDirAbs = path.resolve(rootDir, contentDir);
   const relativeContentDir = normalizeGitRelativePath(path.relative(gitRoot, contentDirAbs));
 
-  if (!relativeContentDir || relativeContentDir.startsWith("../")) {
+  if (relativeContentDir.startsWith("../")) {
     throw new Error(
       "Configured contentDir must live inside the current git repository for --changed.",
     );
   }
 
+  const pathspec = relativeContentDir || ".";
+
   const changedFiles = new Set<string>();
   const commands = [
-    ["diff", "--name-only", "--", relativeContentDir],
-    ["diff", "--name-only", "--cached", "--", relativeContentDir],
-    ["ls-files", "--others", "--exclude-standard", "--", relativeContentDir],
+    ["diff", "--name-only", "--", pathspec],
+    ["diff", "--name-only", "--cached", "--", pathspec],
+    ["ls-files", "--others", "--exclude-standard", "--", pathspec],
   ];
 
   for (const args of commands) {

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -179,6 +179,7 @@ ${pc.dim("Options for mcp:")}
 ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact <page...>")}             Compact pages and write sibling ${pc.dim("agent.md")} files
   ${pc.cyan("agent compact --all")}                 Compact every folder-based docs page
+  ${pc.cyan("agent compact --changed")}             Compact only docs pages changed in the current git working tree
   ${pc.cyan("agent compact --stale")}               Refresh only stale generated ${pc.dim("agent.md")} files
   ${pc.cyan("--page <slug|path>")}                  Repeatable explicit page flag; positional page args work too
   ${pc.cyan("--include-missing")}                   With ${pc.cyan("--stale")}, also create explicit or token-budget pages missing ${pc.dim("agent.md")}

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -239,6 +239,7 @@ pnpm exec docs agent compact https://docs.example.com/docs/installation
 pnpm exec docs agent compact . --dry-run
 pnpm exec docs agent compact --page installation --page configuration
 pnpm exec docs agent compact --all
+pnpm exec docs agent compact --changed
 pnpm exec docs agent compact --stale
 pnpm exec docs agent compact --stale --include-missing
 ```
@@ -250,6 +251,8 @@ Behavior:
   page
 - the command loads `.env` and `.env.local`
 - defaults can come from `agent.compact` in `docs.config.ts` or `docs.config.tsx`
+- `--changed` compacts only docs pages changed in the current git working tree, including staged,
+  unstaged, and untracked docs changes plus handwritten `agent.md` sources
 - `--stale` refreshes only generated `agent.md` files whose page source or compaction settings
   changed
 - `--include-missing` only works with `--stale`, and creates missing `agent.md` files for explicit

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -187,6 +187,8 @@ Notes:
 - page frontmatter `agent.tokenBudget` overrides `maxOutputTokens` for that page
 - if no sibling `agent.md` exists, the command compacts the generated machine-readable page output
   first and then writes a new `agent.md`
+- `docs agent compact --changed` only processes docs pages changed in the current git working
+  tree, including staged, unstaged, and untracked docs changes
 - if inherited `minOutputTokens` is greater than the page budget, the CLI clamps it down to the
   page budget before calling the compression API
 
@@ -196,6 +198,7 @@ Common commands:
 pnpm exec docs agent compact installation configuration
 pnpm exec docs agent compact installation --dry-run
 pnpm exec docs agent compact --all
+pnpm exec docs agent compact --changed
 ```
 
 Per-page override example:

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -232,6 +232,7 @@ pnpm exec docs agent compact https://docs.example.com/docs/installation
 pnpm exec docs agent compact . --dry-run
 pnpm exec docs agent compact --page installation --page configuration
 pnpm exec docs agent compact --all
+pnpm exec docs agent compact --changed
 pnpm exec docs agent compact --stale
 pnpm exec docs agent compact --stale --include-missing
 ```
@@ -242,6 +243,8 @@ Selection notes:
 - page identifiers can be a slug, docs path, `.md` path, full docs URL, or `.` for the root docs
   page
 - `--all` compacts every folder-based docs page under the configured `contentDir`
+- `--changed` compacts only docs pages changed in the current git working tree, including staged,
+  unstaged, and untracked docs changes plus handwritten `agent.md` sources
 - `--stale` only refreshes generated `agent.md` files whose source content or compaction settings
   drifted
 - `--include-missing` only works with `--stale`, and creates missing `agent.md` files for explicit
@@ -316,6 +319,7 @@ Useful checks:
 
 ```bash title="terminal"
 pnpm exec docs agent compact installation --dry-run
+pnpm exec docs agent compact --changed
 pnpm exec docs agent compact installation
 curl "http://127.0.0.1:3000/docs/installation.md"
 ```

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1066,6 +1066,7 @@ out of the box. Use positional page args by default:
 pnpm exec docs agent compact installation configuration
 pnpm exec docs agent compact installation --dry-run
 pnpm exec docs agent compact --all
+pnpm exec docs agent compact --changed
 ```
 
 Per-page compaction budgets live in frontmatter:
@@ -1086,6 +1087,8 @@ Notes:
 - if a sibling `agent.md` already exists, `docs agent compact` compacts that file
 - if no `agent.md` exists, the command compacts the generated machine-readable page output and then
   writes a new sibling `agent.md`
+- `docs agent compact --changed` only processes docs pages changed in the current git working
+  tree, including staged, unstaged, and untracked docs changes
 - `docs agent compact --stale --include-missing` will also create missing `agent.md` files for
   pages that define `agent.tokenBudget`
 - if inherited `minOutputTokens` would be greater than the page budget, the CLI clamps it down to

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1274,6 +1274,8 @@ Notes:
 - if the page already has a sibling `agent.md`, `docs agent compact` compacts that file
 - if the page does not have `agent.md`, the command compacts the generated machine-readable page
   output and writes a new sibling `agent.md`
+- `docs agent compact --changed` only processes docs pages changed in the current git working
+  tree, including staged, unstaged, and untracked docs changes
 - `docs agent compact --stale --include-missing` will also create missing `agent.md` files for
   pages that define `agent.tokenBudget`
 - inherited `minOutputTokens` is clamped down to `tokenBudget` when needed so the compression API


### PR DESCRIPTION
- **feat: agnt compat for changed git diff**
- **chore: fmt**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `--changed` mode to `docs agent compact` that only re-compacts docs pages changed in the current git working tree, cutting run time and API usage. Updates CLI help, README, tests, and site docs.

- **New Features**
  - `--changed` selects pages with modified `page.mdx` or updated handwritten `agent.md` (staged, unstaged, untracked).
  - Uses provenance hash to detect handwritten `agent.md` edits and avoid unnecessary work.
  - Works alone or with explicit pages; prints “No changed docs pages needed compaction.” when none.
  - Validates git state and `contentDir` location (supports `contentDir: "."`; errors if not in git or outside the repo).
  - CLI error/help updated to include `--changed`; examples added across README, skills, and website docs.
  - Tests cover arg parsing, git change detection, repo-root `contentDir`, selective compaction, and empty-state messaging.

<sup>Written for commit 720b41d5cdbb2960847e97cccf7322779a443a04. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

