### PR TITLE
feat: page level sidebar override behaviour

### DIFF
--- a/examples/next/app/docs/changelogs/[slug]/page.tsx
+++ b/examples/next/app/docs/changelogs/[slug]/page.tsx
@@ -18,7 +18,16 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-15",
     sourcePath: "app/docs/changelog/2026-04-15/page.mdx",
     Component: ChangelogEntry1,
-    metadata: {"title":"API Reference: OpenAPI mode is now the default","description":"The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.","image":"/images/changelog/fumadocs-openapi-mode.png","authors":["Farming Labs"],"version":"v0.1.13","tags":["api-reference","next"],"pinned":true},
+    metadata: {
+      title: "API Reference: OpenAPI mode is now the default",
+      description:
+        "The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.",
+      image: "/images/changelog/fumadocs-openapi-mode.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.13",
+      tags: ["api-reference", "next"],
+      pinned: true,
+    },
   },
   {
     slug: "2026-04-03",
@@ -26,7 +35,15 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-03",
     sourcePath: "app/docs/changelog/2026-04-03/page.mdx",
     Component: ChangelogEntry2,
-    metadata: {"title":"Colorful theme cleanup across docs and API routes","description":"We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.","image":"/images/changelog/colorful-theme-cleanup.png","authors":["Farming Labs"],"version":"v0.1.12","tags":["themes","colorful"]},
+    metadata: {
+      title: "Colorful theme cleanup across docs and API routes",
+      description:
+        "We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.",
+      image: "/images/changelog/colorful-theme-cleanup.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.12",
+      tags: ["themes", "colorful"],
+    },
   },
   {
     slug: "2026-03-18",
@@ -34,10 +51,17 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-03-18",
     sourcePath: "app/docs/changelog/2026-03-18/page.mdx",
     Component: ChangelogEntry3,
-    metadata: {"title":"Cloud page motion pass","description":"The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.","image":"/images/changelog/cloud-motion-pass.png","authors":["Farming Labs"],"version":"v0.1.11","tags":["cloud","website"]},
-  }
+    metadata: {
+      title: "Cloud page motion pass",
+      description:
+        "The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.",
+      image: "/images/changelog/cloud-motion-pass.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.11",
+      tags: ["cloud", "website"],
+    },
+  },
 ];
-
 
 export const generateStaticParams = createNextChangelogStaticParams(changelogEntries);
 export const generateMetadata = createNextChangelogEntryMetadata(docsConfig, changelogEntries);

--- a/examples/next/app/docs/changelogs/[slug]/page.tsx
+++ b/examples/next/app/docs/changelogs/[slug]/page.tsx
@@ -18,16 +18,7 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-15",
     sourcePath: "app/docs/changelog/2026-04-15/page.mdx",
     Component: ChangelogEntry1,
-    metadata: {
-      title: "API Reference: OpenAPI mode is now the default",
-      description:
-        "The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.",
-      image: "/images/changelog/fumadocs-openapi-mode.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.13",
-      tags: ["api-reference", "next"],
-      pinned: true,
-    },
+    metadata: {"title":"API Reference: OpenAPI mode is now the default","description":"The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.","image":"/images/changelog/fumadocs-openapi-mode.png","authors":["Farming Labs"],"version":"v0.1.13","tags":["api-reference","next"],"pinned":true},
   },
   {
     slug: "2026-04-03",
@@ -35,15 +26,7 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-03",
     sourcePath: "app/docs/changelog/2026-04-03/page.mdx",
     Component: ChangelogEntry2,
-    metadata: {
-      title: "Colorful theme cleanup across docs and API routes",
-      description:
-        "We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.",
-      image: "/images/changelog/colorful-theme-cleanup.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.12",
-      tags: ["themes", "colorful"],
-    },
+    metadata: {"title":"Colorful theme cleanup across docs and API routes","description":"We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.","image":"/images/changelog/colorful-theme-cleanup.png","authors":["Farming Labs"],"version":"v0.1.12","tags":["themes","colorful"]},
   },
   {
     slug: "2026-03-18",
@@ -51,17 +34,10 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-03-18",
     sourcePath: "app/docs/changelog/2026-03-18/page.mdx",
     Component: ChangelogEntry3,
-    metadata: {
-      title: "Cloud page motion pass",
-      description:
-        "The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.",
-      image: "/images/changelog/cloud-motion-pass.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.11",
-      tags: ["cloud", "website"],
-    },
-  },
+    metadata: {"title":"Cloud page motion pass","description":"The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.","image":"/images/changelog/cloud-motion-pass.png","authors":["Farming Labs"],"version":"v0.1.11","tags":["cloud","website"]},
+  }
 ];
+
 
 export const generateStaticParams = createNextChangelogStaticParams(changelogEntries);
 export const generateMetadata = createNextChangelogEntryMetadata(docsConfig, changelogEntries);

--- a/examples/next/app/docs/changelogs/page.tsx
+++ b/examples/next/app/docs/changelogs/page.tsx
@@ -17,16 +17,7 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-15",
     sourcePath: "app/docs/changelog/2026-04-15/page.mdx",
     Component: ChangelogEntry1,
-    metadata: {
-      title: "API Reference: OpenAPI mode is now the default",
-      description:
-        "The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.",
-      image: "/images/changelog/fumadocs-openapi-mode.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.13",
-      tags: ["api-reference", "next"],
-      pinned: true,
-    },
+    metadata: {"title":"API Reference: OpenAPI mode is now the default","description":"The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.","image":"/images/changelog/fumadocs-openapi-mode.png","authors":["Farming Labs"],"version":"v0.1.13","tags":["api-reference","next"],"pinned":true},
   },
   {
     slug: "2026-04-03",
@@ -34,15 +25,7 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-03",
     sourcePath: "app/docs/changelog/2026-04-03/page.mdx",
     Component: ChangelogEntry2,
-    metadata: {
-      title: "Colorful theme cleanup across docs and API routes",
-      description:
-        "We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.",
-      image: "/images/changelog/colorful-theme-cleanup.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.12",
-      tags: ["themes", "colorful"],
-    },
+    metadata: {"title":"Colorful theme cleanup across docs and API routes","description":"We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.","image":"/images/changelog/colorful-theme-cleanup.png","authors":["Farming Labs"],"version":"v0.1.12","tags":["themes","colorful"]},
   },
   {
     slug: "2026-03-18",
@@ -50,17 +33,10 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-03-18",
     sourcePath: "app/docs/changelog/2026-03-18/page.mdx",
     Component: ChangelogEntry3,
-    metadata: {
-      title: "Cloud page motion pass",
-      description:
-        "The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.",
-      image: "/images/changelog/cloud-motion-pass.png",
-      authors: ["Farming Labs"],
-      version: "v0.1.11",
-      tags: ["cloud", "website"],
-    },
-  },
+    metadata: {"title":"Cloud page motion pass","description":"The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.","image":"/images/changelog/cloud-motion-pass.png","authors":["Farming Labs"],"version":"v0.1.11","tags":["cloud","website"]},
+  }
 ];
+
 
 export const metadata = createNextChangelogIndexMetadata(docsConfig);
 

--- a/examples/next/app/docs/changelogs/page.tsx
+++ b/examples/next/app/docs/changelogs/page.tsx
@@ -17,7 +17,16 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-15",
     sourcePath: "app/docs/changelog/2026-04-15/page.mdx",
     Component: ChangelogEntry1,
-    metadata: {"title":"API Reference: OpenAPI mode is now the default","description":"The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.","image":"/images/changelog/fumadocs-openapi-mode.png","authors":["Farming Labs"],"version":"v0.1.13","tags":["api-reference","next"],"pinned":true},
+    metadata: {
+      title: "API Reference: OpenAPI mode is now the default",
+      description:
+        "The Next example now ships with the faster OpenAPI experience, plus a tighter docs/API switcher.",
+      image: "/images/changelog/fumadocs-openapi-mode.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.13",
+      tags: ["api-reference", "next"],
+      pinned: true,
+    },
   },
   {
     slug: "2026-04-03",
@@ -25,7 +34,15 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-04-03",
     sourcePath: "app/docs/changelog/2026-04-03/page.mdx",
     Component: ChangelogEntry2,
-    metadata: {"title":"Colorful theme cleanup across docs and API routes","description":"We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.","image":"/images/changelog/colorful-theme-cleanup.png","authors":["Farming Labs"],"version":"v0.1.12","tags":["themes","colorful"]},
+    metadata: {
+      title: "Colorful theme cleanup across docs and API routes",
+      description:
+        "We tightened the theme handoff so the colorful preset keeps its own identity when moving between docs and API reference.",
+      image: "/images/changelog/colorful-theme-cleanup.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.12",
+      tags: ["themes", "colorful"],
+    },
   },
   {
     slug: "2026-03-18",
@@ -33,10 +50,17 @@ export const changelogEntries: GeneratedChangelogEntry[] = [
     url: "/docs/changelogs/2026-03-18",
     sourcePath: "app/docs/changelog/2026-03-18/page.mdx",
     Component: ChangelogEntry3,
-    metadata: {"title":"Cloud page motion pass","description":"The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.","image":"/images/changelog/cloud-motion-pass.png","authors":["Farming Labs"],"version":"v0.1.11","tags":["cloud","website"]},
-  }
+    metadata: {
+      title: "Cloud page motion pass",
+      description:
+        "The cloud landing page picked up smoother looping motion, better path-based SVG behavior, and more stable theme controls.",
+      image: "/images/changelog/cloud-motion-pass.png",
+      authors: ["Farming Labs"],
+      version: "v0.1.11",
+      tags: ["cloud", "website"],
+    },
+  },
 ];
-
 
 export const metadata = createNextChangelogIndexMetadata(docsConfig);
 

--- a/packages/astro/src/content.ts
+++ b/packages/astro/src/content.ts
@@ -12,8 +12,10 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type ResolvedDocsRelatedLink,
+  type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 
 export interface PageNode {
@@ -29,6 +31,7 @@ export interface FolderNode {
   name: string;
   icon?: string;
   index?: PageNode;
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
   children: NavNode[];
 }
 
@@ -194,6 +197,7 @@ function buildNavNode(
       name: displayName,
       icon,
       index: { type: "page", name: displayName, url, icon },
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       children: scanDir(full, slug, entry, ordering, childSlugOrder),
     };
   }

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -43,6 +43,7 @@ import {
   renderDocsSkillDocument,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -224,6 +225,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
+    folderIndexBehavior?: "link" | "toggle";
     order: number;
   }
 
@@ -252,6 +254,7 @@ function navTreeFromMap(
       title: (data.title as string) ?? fallbackTitle,
       url,
       icon: data.icon as string | undefined,
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       order: typeof data.order === "number" ? data.order : Infinity,
     });
   }
@@ -320,6 +323,7 @@ function navTreeFromMap(
             name: child.title,
             icon: child.icon,
             index: { type: "page", name: child.title, url: child.url, icon: child.icon },
+            folderIndexBehavior: child.folderIndexBehavior,
             children: buildLevel(child.parts),
           });
         } else {
@@ -355,6 +359,7 @@ function navTreeFromMap(
             url: child.url,
             icon: child.icon,
           },
+          folderIndexBehavior: child.folderIndexBehavior,
           children: buildLevel(child.parts),
         });
       } else {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -25,6 +25,7 @@ export {
 export { normalizeDocsRelated, renderDocsRelatedMarkdownLines } from "./related.js";
 export {
   applySidebarFolderIndexBehavior,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehaviorForPath,
 } from "./sidebar.js";
@@ -100,6 +101,7 @@ export type {
   FontStyle,
   TypographyConfig,
   PageFrontmatter,
+  PageSidebarFrontmatter,
   ThemeToggleConfig,
   BreadcrumbConfig,
   SidebarConfig,

--- a/packages/docs/src/sidebar.test.ts
+++ b/packages/docs/src/sidebar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applySidebarFolderIndexBehavior,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehaviorForPath,
 } from "./sidebar.js";
@@ -48,6 +49,25 @@ describe("resolveSidebarFolderIndexBehaviorForPath", () => {
         "/docs/components",
       ),
     ).toBe("toggle");
+  });
+});
+
+describe("resolvePageSidebarFolderIndexBehavior", () => {
+  it("reads folderIndexBehavior from page frontmatter sidebar config", () => {
+    expect(
+      resolvePageSidebarFolderIndexBehavior({
+        folderIndexBehavior: "toggle",
+      }),
+    ).toBe("toggle");
+  });
+
+  it("ignores invalid sidebar frontmatter values", () => {
+    expect(resolvePageSidebarFolderIndexBehavior("toggle")).toBeUndefined();
+    expect(
+      resolvePageSidebarFolderIndexBehavior({
+        folderIndexBehavior: "sideways",
+      }),
+    ).toBeUndefined();
   });
 });
 
@@ -168,6 +188,91 @@ describe("applySidebarFolderIndexBehavior", () => {
           index: { type: "page", name: "Guides", url: "/docs/guides" },
           children: [{ type: "page", name: "Writing", url: "/docs/guides/writing" }],
         },
+      ],
+    });
+  });
+
+  it("prefers explicit folder behavior on the node over config overrides", () => {
+    const tree = {
+      name: "Docs",
+      children: [
+        {
+          type: "folder",
+          name: "Components",
+          folderIndexBehavior: "toggle",
+          url: "/docs/components",
+          index: { type: "page", name: "Components", url: "/docs/components" },
+          children: [{ type: "page", name: "Button", url: "/docs/components/button" }],
+        },
+      ],
+    };
+
+    expect(
+      applySidebarFolderIndexBehavior(tree, {
+        sidebar: {
+          folderIndexBehavior: "link",
+          folderIndexBehaviorOverrides: {
+            "/docs/components": "link",
+          },
+        },
+      }),
+    ).toEqual({
+      name: "Docs",
+      children: [
+        {
+          type: "folder",
+          index: undefined,
+          url: undefined,
+          name: "Components",
+          children: [
+            { type: "page", name: "Components", url: "/docs/components" },
+            { type: "page", name: "Button", url: "/docs/components/button" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("preserves the folder row position among siblings when toggle behavior is applied", () => {
+    const tree = {
+      name: "Docs",
+      children: [
+        { type: "page", name: "Overview", url: "/docs/overview" },
+        {
+          type: "folder",
+          name: "Components",
+          folderIndexBehavior: "toggle",
+          url: "/docs/components",
+          index: { type: "page", name: "Components", url: "/docs/components" },
+          children: [{ type: "page", name: "Button", url: "/docs/components/button" }],
+        },
+        { type: "page", name: "Guides", url: "/docs/guides" },
+      ],
+    };
+
+    const result = applySidebarFolderIndexBehavior(tree, {
+      sidebar: {
+        folderIndexBehavior: "link",
+      },
+    });
+
+    expect(result.children.map((node) => (node as { name?: string }).name)).toEqual([
+      "Overview",
+      "Components",
+      "Guides",
+    ]);
+    expect(result.children[1]).toMatchObject({
+      type: "folder",
+      index: undefined,
+      children: [
+        expect.objectContaining({
+          name: "Components",
+          url: "/docs/components",
+        }),
+        expect.objectContaining({
+          name: "Button",
+          url: "/docs/components/button",
+        }),
       ],
     });
   });

--- a/packages/docs/src/sidebar.ts
+++ b/packages/docs/src/sidebar.ts
@@ -5,6 +5,15 @@ export interface SidebarFolderIndexBehaviorOptions {
   defaultBehavior?: SidebarFolderIndexBehavior;
 }
 
+export function resolvePageSidebarFolderIndexBehavior(
+  sidebar: unknown,
+): SidebarFolderIndexBehavior | undefined {
+  if (!sidebar || typeof sidebar !== "object") return undefined;
+
+  const value = (sidebar as { folderIndexBehavior?: unknown }).folderIndexBehavior;
+  return value === "link" || value === "toggle" ? value : undefined;
+}
+
 function normalizeSidebarFolderBehaviorPath(path: string | undefined): string | undefined {
   if (!path) return undefined;
 
@@ -80,6 +89,7 @@ export function applySidebarFolderIndexBehavior<TTree extends { children: unknow
       index?: unknown;
       children?: unknown[];
       url?: unknown;
+      folderIndexBehavior?: unknown;
     };
 
     if (candidate.type !== "folder" || !Array.isArray(candidate.children)) {
@@ -97,11 +107,16 @@ export function applySidebarFolderIndexBehavior<TTree extends { children: unknow
       typeof (candidate.index as { url?: unknown }).url === "string"
         ? ((candidate.index as { url?: string }).url ?? undefined)
         : undefined);
-    const behavior = resolveBehavior(folderPath);
+    const explicitBehavior =
+      candidate.folderIndexBehavior === "link" || candidate.folderIndexBehavior === "toggle"
+        ? candidate.folderIndexBehavior
+        : undefined;
+    const behavior = explicitBehavior ?? resolveBehavior(folderPath);
 
     if (behavior !== "toggle") {
       return {
         ...candidate,
+        folderIndexBehavior: undefined,
         index,
         children,
       };
@@ -109,6 +124,7 @@ export function applySidebarFolderIndexBehavior<TTree extends { children: unknow
 
     return {
       ...candidate,
+      folderIndexBehavior: undefined,
       index: undefined,
       url: undefined,
       children: index ? [index, ...children] : children,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -281,6 +281,15 @@ export interface PageAgentFrontmatter {
   tokenBudget?: number;
 }
 
+export interface PageSidebarFrontmatter {
+  /**
+   * Override how this folder page behaves in the default sidebar when it has children.
+   *
+   * This is only read from folder landing pages such as `page.mdx` / `index.md`.
+   */
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
+}
+
 export interface PageFrontmatter {
   title: string;
   description?: string;
@@ -288,6 +297,8 @@ export interface PageFrontmatter {
   related?: DocsRelatedItem[];
   /** Per-page agent-oriented metadata used by machine-readable docs features. */
   agent?: PageAgentFrontmatter;
+  /** Per-page sidebar metadata used when building the docs navigation tree. */
+  sidebar?: PageSidebarFrontmatter;
   /** Override or disable the estimated reading time for this page. */
   readingTime?: boolean | number;
   tags?: string[];
@@ -389,6 +400,11 @@ export interface SidebarFolderNode {
   icon?: unknown;
   /** Index page for this folder (the folder's own landing page). */
   index?: SidebarPageNode;
+  /**
+   * Optional per-folder override read from the folder page frontmatter before the
+   * tree is normalized for the default sidebar.
+   */
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
   /** Child pages and sub-folders. */
   children: SidebarNode[];
   /** Whether this folder section is collapsible. */
@@ -513,6 +529,16 @@ export interface SidebarConfig {
    * - `"toggle"` — clicking the parent row only expands/collapses children, and the
    *   folder landing page appears as the first child item instead
    *
+   * This is the global default. Individual folder pages can still override it with
+   * page frontmatter:
+   *
+   * ```mdx
+   * ---
+   * sidebar:
+   *   folderIndexBehavior: "toggle"
+   * ---
+   * ```
+   *
    * When omitted, each adapter keeps its existing folder-parent behavior. Set this
    * explicitly if you want the same sidebar interaction across frameworks.
    */
@@ -520,6 +546,7 @@ export interface SidebarConfig {
 
   /**
    * Selective per-folder overrides keyed by the folder landing-page URL.
+   * Folder page frontmatter still wins when both are present.
    *
    * ```ts
    * sidebar: {

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -440,6 +440,64 @@ describe("createDocsLayout pageActions", () => {
     });
   });
 
+  it("lets folder page frontmatter override sidebar.folderIndexBehavior config", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "components", "button"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "components", "page.mdx"),
+      [
+        "---",
+        'title: "Components"',
+        "sidebar:",
+        '  folderIndexBehavior: "toggle"',
+        "---",
+        "",
+        "# Components",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "components", "button", "page.mdx"),
+      "---\ntitle: Button\n---\n\n# Button\n",
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({
+      entry: "docs",
+      sidebar: {
+        folderIndexBehavior: "link",
+        folderIndexBehaviorOverrides: {
+          "/docs/components": "link",
+        },
+      },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const sidebarTree = findDocsLayoutTree(tree);
+    const componentsNode = (sidebarTree?.children as Array<Record<string, unknown>>).find(
+      (entry) => entry.name === "Components",
+    );
+
+    expect(componentsNode).toMatchObject({
+      type: "folder",
+      index: undefined,
+      children: [
+        expect.objectContaining({
+          type: "page",
+          name: "Components",
+          url: "/docs/components",
+        }),
+        expect.objectContaining({
+          type: "page",
+          name: "Button",
+          url: "/docs/components/button",
+        }),
+      ],
+    });
+  });
+
   it("adds changelog entries as a dedicated sidebar section under the docs route with a separator above it", () => {
     mkdirSync(join(tmpDir, "app", "docs", "changelog", "2026-04-15"), { recursive: true });
     mkdirSync(join(tmpDir, "app", "docs", "changelog", "2026-04-03"), { recursive: true });

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -10,6 +10,7 @@ import {
   buildPageTwitter,
   resolveChangelogConfig,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 import type {
   DocsConfig,
@@ -40,6 +41,7 @@ interface FolderNode {
   name: string;
   icon?: ReactNode;
   index?: PageNode;
+  folderIndexBehavior?: "link" | "toggle";
   children: TreeNode[];
   collapsible?: boolean;
   defaultOpen?: boolean;
@@ -302,6 +304,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
         name: displayName,
         icon,
         index: { type: "page", name: displayName, url, icon },
+        folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
         children: folderChildren,
         ...(flat ? { collapsible: false, defaultOpen: true } : {}),
       };

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -129,4 +129,50 @@ describe("TanstackDocsLayout", () => {
       ],
     });
   });
+
+  it("prefers explicit folder behavior on the provided tree", () => {
+    const tree = TanstackDocsLayout({
+      config: {
+        entry: "docs",
+        sidebar: {
+          folderIndexBehavior: "link",
+          folderIndexBehaviorOverrides: {
+            "/docs/components": "link",
+          },
+        },
+      },
+      tree: {
+        name: "Docs",
+        children: [
+          {
+            type: "folder",
+            name: "Components",
+            folderIndexBehavior: "toggle",
+            index: { type: "page", name: "Components", url: "/docs/components" },
+            children: [{ type: "page", name: "Button", url: "/docs/components/button" }],
+          },
+        ],
+      },
+      children: React.createElement("div", null, "child"),
+    });
+
+    const resolvedTree = (tree.props as { tree: { children: Array<Record<string, unknown>> } })
+      .tree;
+    expect(resolvedTree.children[0]).toMatchObject({
+      type: "folder",
+      index: undefined,
+      children: [
+        expect.objectContaining({
+          type: "page",
+          name: "Components",
+          url: "/docs/components",
+        }),
+        expect.objectContaining({
+          type: "page",
+          name: "Button",
+          url: "/docs/components/button",
+        }),
+      ],
+    });
+  });
 });

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -29,6 +29,7 @@ interface FolderNode {
   name: string;
   icon?: ReactNode;
   index?: PageNode;
+  folderIndexBehavior?: "link" | "toggle";
   children: (PageNode | FolderNode)[];
   collapsible?: boolean;
   defaultOpen?: boolean;

--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -26,6 +26,24 @@ body {
   font-family: var(--fd-font-sans, var(--font-geist-sans, ui-sans-serif, system-ui, sans-serif));
 }
 
+/*
+ * Sidebar folder rows can render as either links or toggle buttons depending on
+ * folderIndexBehavior. Reset the button chrome so both variants can share the
+ * same layout metrics once theme styles are applied.
+ */
+:where(.fd-sidebar, aside#nd-sidebar, aside#nd-sidebar-mobile)
+  button[aria-controls][aria-expanded] {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  text-transform: inherit;
+}
+
 code,
 kbd,
 pre,

--- a/packages/fumadocs/styles/concrete.css
+++ b/packages/fumadocs/styles/concrete.css
@@ -50,7 +50,8 @@
     linear-gradient(180deg, color-mix(in srgb, var(--color-fd-primary) 10%, var(--color-fd-background)), var(--color-fd-background));
 }
 
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   text-transform: uppercase;
   letter-spacing: 0.045em;
   font-size: 0.79rem;

--- a/packages/fumadocs/styles/darkbold.css
+++ b/packages/fumadocs/styles/darkbold.css
@@ -105,9 +105,12 @@ aside a[data-active],
 aside button[aria-controls][aria-expanded] {
   font-size: 0.875rem;
   line-height: 1.5;
-  font-weight: 400;
   padding: 6px 8px;
   border-radius: 6px;
+}
+
+aside a[data-active] {
+  font-weight: 400;
   color: var(--color-fd-muted-foreground);
   transition: color 150ms;
 }

--- a/packages/fumadocs/styles/darkbold.css
+++ b/packages/fumadocs/styles/darkbold.css
@@ -101,7 +101,8 @@ aside a > img:first-child {
 }
 
 /* ── Sidebar links — match DarkBold: 14px, 400 weight, minimal pad ─ */
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   font-size: 0.875rem;
   line-height: 1.5;
   font-weight: 400;

--- a/packages/fumadocs/styles/darksharp.css
+++ b/packages/fumadocs/styles/darksharp.css
@@ -253,7 +253,8 @@ article a[class*="text-fd-muted-foreground"] {
   border-color: hsl(0 0% 12%);
 }
 
-.dark aside a[data-active] {
+.dark aside a[data-active],
+.dark aside button[aria-controls][aria-expanded] {
   border-radius: 0.2rem !important;
   padding: 0.4rem 0.5rem;
   font-size: 0.8125rem;

--- a/packages/fumadocs/styles/greentree.css
+++ b/packages/fumadocs/styles/greentree.css
@@ -86,7 +86,8 @@ aside#nd-sidebar,
   background: var(--color-fd-background);
 }
 
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   font-size: 0.875rem;
   line-height: 1.5;
   font-weight: 500;

--- a/packages/fumadocs/styles/hardline.css
+++ b/packages/fumadocs/styles/hardline.css
@@ -80,11 +80,14 @@ aside#nd-sidebar,
 /* Sidebar links and categories */
 aside a[data-active],
 aside button[aria-controls][aria-expanded] {
-  font-weight: 600;
   font-size: 0.92rem;
-  letter-spacing: 0.01em;
   padding: 0.5rem 0.625rem;
   border: 1px solid transparent;
+}
+
+aside a[data-active] {
+  font-weight: 600;
+  letter-spacing: 0.01em;
   color: var(--color-fd-foreground);
 }
 

--- a/packages/fumadocs/styles/hardline.css
+++ b/packages/fumadocs/styles/hardline.css
@@ -78,7 +78,8 @@ aside#nd-sidebar,
 }
 
 /* Sidebar links and categories */
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   font-weight: 600;
   font-size: 0.92rem;
   letter-spacing: 0.01em;

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -237,7 +237,8 @@ aside .overscroll-contain > div > div:last-child {
 
 /* ── Sidebar links (all levels) ──────────────────────────────────── */
 
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   font-size: 0.875rem;
   line-height: 1.6;
   border-radius: 0 !important;

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -244,10 +244,13 @@ aside button[aria-controls][aria-expanded] {
   border-radius: 0 !important;
   padding: 0.5rem 0.625rem !important;
   transition: color 0.15s ease;
-  color: var(--color-fd-muted-foreground);
-  font-weight: 400;
   overflow: hidden;
   background-color: transparent !important;
+}
+
+aside a[data-active] {
+  color: var(--color-fd-muted-foreground);
+  font-weight: 400;
 }
 
 aside a[data-active="true"],

--- a/packages/nuxt/src/content.ts
+++ b/packages/nuxt/src/content.ts
@@ -12,8 +12,10 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type ResolvedDocsRelatedLink,
+  type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 
 export interface PageNode {
@@ -29,6 +31,7 @@ export interface FolderNode {
   name: string;
   icon?: string;
   index?: PageNode;
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
   children: NavNode[];
 }
 
@@ -194,6 +197,7 @@ function buildNavNode(
       name: displayName,
       icon,
       index: { type: "page", name: displayName, url, icon },
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       children: scanDir(full, slug, entry, ordering, childSlugOrder),
     };
   }

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -32,6 +32,7 @@ import {
   renderDocsSkillDocument,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -211,6 +212,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
+    folderIndexBehavior?: "link" | "toggle";
     order: number;
   }
 
@@ -239,6 +241,7 @@ function navTreeFromMap(
       title: (data.title as string) ?? fallbackTitle,
       url,
       icon: data.icon as string | undefined,
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       order: typeof data.order === "number" ? data.order : Infinity,
     });
   }
@@ -307,6 +310,7 @@ function navTreeFromMap(
             name: child.title,
             icon: child.icon,
             index: { type: "page", name: child.title, url: child.url, icon: child.icon },
+            folderIndexBehavior: child.folderIndexBehavior,
             children: buildLevel(child.parts),
           });
         } else {
@@ -342,6 +346,7 @@ function navTreeFromMap(
             url: child.url,
             icon: child.icon,
           },
+          folderIndexBehavior: child.folderIndexBehavior,
           children: buildLevel(child.parts),
         });
       } else {

--- a/packages/svelte/src/content.ts
+++ b/packages/svelte/src/content.ts
@@ -12,8 +12,10 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type ResolvedDocsRelatedLink,
+  type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 
 export interface PageNode {
@@ -29,6 +31,7 @@ export interface FolderNode {
   name: string;
   icon?: string;
   index?: PageNode;
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
   children: NavNode[];
 }
 
@@ -194,6 +197,7 @@ function buildNavNode(
       name: displayName,
       icon,
       index: { type: "page", name: displayName, url, icon },
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       children: scanDir(full, slug, entry, ordering, childSlugOrder),
     };
   }

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -43,6 +43,7 @@ import {
   renderDocsSkillDocument,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -232,6 +233,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
+    folderIndexBehavior?: "link" | "toggle";
     order: number;
   }
 
@@ -260,6 +262,7 @@ function navTreeFromMap(
       title: (data.title as string) ?? fallbackTitle,
       url,
       icon: data.icon as string | undefined,
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       order: typeof data.order === "number" ? data.order : Infinity,
     });
   }
@@ -329,6 +332,7 @@ function navTreeFromMap(
             name: child.title,
             icon: child.icon,
             index: { type: "page", name: child.title, url: child.url, icon: child.icon },
+            folderIndexBehavior: child.folderIndexBehavior,
             children: buildLevel(child.parts),
           });
         } else {
@@ -364,6 +368,7 @@ function navTreeFromMap(
             url: child.url,
             icon: child.icon,
           },
+          folderIndexBehavior: child.folderIndexBehavior,
           children: buildLevel(child.parts),
         });
       } else {

--- a/packages/tanstack-start/src/content.ts
+++ b/packages/tanstack-start/src/content.ts
@@ -12,8 +12,10 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type ResolvedDocsRelatedLink,
+  type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 
 export interface PageNode {
@@ -29,6 +31,7 @@ export interface FolderNode {
   name: string;
   icon?: string;
   index?: PageNode;
+  folderIndexBehavior?: SidebarFolderIndexBehavior;
   children: NavNode[];
 }
 
@@ -184,6 +187,7 @@ function buildNavNode(
       name: displayName,
       icon,
       index: { type: "page", name: displayName, url, icon },
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       children: scanDir(full, slug, entry, ordering, childSlugOrder),
     };
   }

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -13,6 +13,7 @@ import {
   renderDocsSkillDocument,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolvePageSidebarFolderIndexBehavior,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -203,6 +204,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
+    folderIndexBehavior?: "link" | "toggle";
     order: number;
   }
 
@@ -233,6 +235,7 @@ function navTreeFromMap(
       title: (data.title as string) ?? fallbackTitle,
       url,
       icon: data.icon as string | undefined,
+      folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
       order: typeof data.order === "number" ? data.order : Infinity,
     });
   }
@@ -302,6 +305,7 @@ function navTreeFromMap(
             name: child.title,
             icon: child.icon,
             index: { type: "page", name: child.title, url: child.url, icon: child.icon },
+            folderIndexBehavior: child.folderIndexBehavior,
             children: buildLevel(child.parts),
           } satisfies NavNode;
         }
@@ -331,6 +335,7 @@ function navTreeFromMap(
           name: child.title,
           icon: child.icon,
           index: { type: "page", name: child.title, url: child.url, icon: child.icon },
+          folderIndexBehavior: child.folderIndexBehavior,
           children: buildLevel(child.parts),
         } satisfies NavNode;
       }

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -610,7 +610,13 @@ Set `enabled: false` to hide the toggle or force a single mode.
 
 ## Sidebar and breadcrumb
 
-- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`.
+- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`. A folder landing page can also override both with frontmatter:
+  ```mdx
+  ---
+  sidebar:
+    folderIndexBehavior: "toggle"
+  ---
+  ```
 - **breadcrumb:** `true` (default) or `BreadcrumbConfig` to show/hide or configure breadcrumb.
 
 ---

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -143,7 +143,14 @@ All configuration lives in a single `docs.config.ts` file.
 For sidebar folder parents that have their own landing page, use
 `sidebar.folderIndexBehavior: "toggle"` if you want parent rows to only open and close their
 children instead of navigating. Use `sidebar.folderIndexBehaviorOverrides` when only selected
-sections should behave that way.
+sections should behave that way. A folder landing page can also override both with frontmatter:
+
+```mdx title="page.mdx"
+---
+sidebar:
+  folderIndexBehavior: "toggle"
+---
+```
 
 ## Machine-readable markdown routes
 

--- a/website/app/docs/customization/sidebar/page.mdx
+++ b/website/app/docs/customization/sidebar/page.mdx
@@ -88,6 +88,17 @@ sidebar: {
 That lets one folder like `Components` stay toggle-only while other folders still navigate on
 parent click.
 
+You can also override the behavior from the folder landing page itself. This wins over the global
+config and over `folderIndexBehaviorOverrides`:
+
+```mdx title="app/docs/components/page.mdx"
+---
+title: "Components"
+sidebar:
+  folderIndexBehavior: "toggle"
+---
+```
+
 ## Flat Mode
 
 Render all sidebar items without collapsible sections (Mintlify-style):

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1293,6 +1293,13 @@ Notes:
   `--max-output-tokens` for that one page
 - if the page already has a sibling `agent.md`, `docs agent compact` compacts that file
 - if the page does not have `agent.md`, the command compacts the generated machine-readable page
+  output and writes a new sibling `agent.md`
+- `docs agent compact --changed` only processes docs pages changed in the current git working
+  tree, including staged, unstaged, and untracked docs changes
+- `docs agent compact --stale --include-missing` will also create missing `agent.md` files for
+  pages that define `agent.tokenBudget`
+- inherited `minOutputTokens` is clamped down to `tokenBudget` when needed so the compression API
+  never receives `min_output_tokens > max_output_tokens`
 
 ### `PageSidebarFrontmatter`
 
@@ -1315,13 +1322,6 @@ Notes:
 - this is only read from folder landing pages such as `page.mdx` / `index.md`
 - it overrides global `sidebar.folderIndexBehavior`
 - it also overrides `sidebar.folderIndexBehaviorOverrides` for that same folder
-  output and writes a new sibling `agent.md`
-- `docs agent compact --changed` only processes docs pages changed in the current git working
-  tree, including staged, unstaged, and untracked docs changes
-- `docs agent compact --stale --include-missing` will also create missing `agent.md` files for
-  pages that define `agent.tokenBudget`
-- inherited `minOutputTokens` is clamped down to `tokenBudget` when needed so the compression API
-  never receives `min_output_tokens > max_output_tokens`
 
 **Static OG example** — use `openGraph` and `twitter` in frontmatter to serve a static image instead of the dynamic OG endpoint:
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -851,6 +851,15 @@ Sidebar visibility and customization. See [Sidebar](/docs/customization/sidebar)
 | `folderIndexBehavior` | `"link" \| "toggle"`                    | adapter default | Whether folder parents with their own page navigate on click or only expand/collapse                         |
 | `folderIndexBehaviorOverrides` | `Record<string, "link" \| "toggle">` | — | Selective per-folder overrides keyed by the folder landing-page URL                                          |
 
+Folder landing pages can still override both of those with frontmatter:
+
+```mdx title="page.mdx"
+---
+sidebar:
+  folderIndexBehavior: "toggle"
+---
+```
+
 ### `SidebarComponentProps`
 
 Props passed to a custom sidebar component:
@@ -1251,6 +1260,7 @@ Each docs page (`.mdx` / `.md`) supports these frontmatter fields:
 | `description` | `string`    | Page description, used for meta tags and search                                    |
 | `related`     | `string[]`  | Related doc URLs rendered as a comma-separated metadata line in `.md` routes and MCP page output |
 | `agent`       | `PageAgentFrontmatter` | Per-page machine-docs metadata such as compaction token budgets |
+| `sidebar`     | `PageSidebarFrontmatter` | Per-folder sidebar metadata such as `folderIndexBehavior` overrides |
 | `readingTime` | `boolean \| number` | Disable the estimate for one page (`false`) or force an exact minute count |
 | `icon`        | `string`    | Icon key from the `icons` registry. Shows in sidebar.                              |
 | `order`       | `number`    | Sort order in the sidebar (only when `ordering: "numeric"`). Lower numbers first.   |
@@ -1283,6 +1293,28 @@ Notes:
   `--max-output-tokens` for that one page
 - if the page already has a sibling `agent.md`, `docs agent compact` compacts that file
 - if the page does not have `agent.md`, the command compacts the generated machine-readable page
+
+### `PageSidebarFrontmatter`
+
+Page-level sidebar metadata used while building the docs navigation tree.
+
+| Property              | Type                 | Description |
+| --------------------- | -------------------- | ----------- |
+| `folderIndexBehavior` | `"link" \| "toggle"` | Override how this folder page behaves in the default sidebar when it has child pages |
+
+```mdx title="app/docs/components/page.mdx"
+---
+title: "Components"
+sidebar:
+  folderIndexBehavior: "toggle"
+---
+```
+
+Notes:
+
+- this is only read from folder landing pages such as `page.mdx` / `index.md`
+- it overrides global `sidebar.folderIndexBehavior`
+- it also overrides `sidebar.folderIndexBehaviorOverrides` for that same folder
   output and writes a new sibling `agent.md`
 - `docs agent compact --changed` only processes docs pages changed in the current git working
   tree, including staged, unstaged, and untracked docs changes

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -154,11 +154,13 @@
     z-index: 1 !important;
   }
 
-  #nd-docs-layout aside .overscroll-contain > div > a[data-active] {
+  #nd-docs-layout aside .overscroll-contain > div > a[data-active],
+  #nd-docs-layout aside .overscroll-contain > div > div[data-state] > button[aria-controls][aria-expanded] {
     padding-right: calc(1rem + var(--fd-sidebar-item-inset)) !important;
   }
 
-  #nd-docs-layout aside a[data-active] {
+  #nd-docs-layout aside a[data-active],
+  #nd-docs-layout aside button[aria-controls][aria-expanded] {
     padding-left: calc(0.625rem + var(--fd-sidebar-item-inset)) !important;
     padding-right: calc(0.625rem + var(--fd-sidebar-item-inset)) !important;
   }

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -201,7 +201,8 @@ aside .overscroll-contain > div > div:last-child {
 
 /* ── Sidebar links (all levels) ──────────────────────────────────── */
 
-aside a[data-active] {
+aside a[data-active],
+aside button[aria-controls][aria-expanded] {
   font-size: 0.875rem !important;
   line-height: 1.6 !important;
   border-radius: 0 !important;

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -208,10 +208,13 @@ aside button[aria-controls][aria-expanded] {
   border-radius: 0 !important;
   padding: 0.5rem 0.625rem !important;
   transition: color 0.15s ease !important;
-  color: var(--color-fd-muted-foreground) !important;
-  font-weight: 400 !important;
   overflow: hidden !important;
   background-color: transparent !important;
+}
+
+aside a[data-active] {
+  color: var(--color-fd-muted-foreground) !important;
+  font-weight: 400 !important;
 }
 
 aside a[data-active="true"],


### PR DESCRIPTION
- **feat: page level sidebar override behaviour**
- **chore: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds page‑level control for sidebar folder parents via frontmatter. Folder landing pages can force "link" or "toggle", overriding global config and per-path overrides across all adapters.

- **New Features**
  - Frontmatter support: `sidebar.folderIndexBehavior: "link" | "toggle"` on folder landing pages (`page.mdx` / `index.md`).
  - Precedence: explicit node/frontmatter behavior wins over `sidebar.folderIndexBehavior` and `folderIndexBehaviorOverrides`.
  - API & types: export `resolvePageSidebarFolderIndexBehavior` from `@farming-labs/docs`; add `PageSidebarFrontmatter`, `PageFrontmatter.sidebar`, and transient `folderIndexBehavior` on `SidebarFolderNode`.
  - Adapters: propagated in `astro`, `nuxt`, `svelte`, `tanstack-start`, and `fumadocs` (layouts and server-side nav trees).
  - Behavior: `applySidebarFolderIndexBehavior` respects explicit node behavior, preserves folder row order when toggled, and moves the index page to the first child.
  - Styling & docs: reset toggle button chrome; theme and website CSS style `button[aria-controls][aria-expanded]` like links; docs updated with frontmatter examples; tests added for precedence, position, and adapter layouts.

<sup>Written for commit 3398ecb32ba809c689080b9de127583632fcd4e3. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

