### PR TITLE
feat: config schema for frameworkless or cloud workflow

### DIFF
--- a/website/app/docs/guides/docs-cloud-json/page.mdx
+++ b/website/app/docs/guides/docs-cloud-json/page.mdx
@@ -1,0 +1,197 @@
+---
+title: "Host a docs.cloud.json Schema"
+description: "Serve the public JSON Schema for docs.cloud.json from the website app that owns the docs domain."
+related:
+  - /docs/configuration
+  - /docs/reference
+  - /cloud
+  - /docs/guides/agent-friendly-docs
+icon: "lightbulb"
+order: 3.8
+---
+
+# Host a `docs.cloud.json` Schema
+
+If your public docs site lives in `website/`, the schema should be hosted by that same app.
+
+```txt
+website/public/schema/cloud.json
+```
+
+When the website deploys to `https://docs.farming-labs.dev`, that file is served at:
+
+```txt
+https://docs.farming-labs.dev/schema/cloud.json
+```
+
+Users reference that URL in their own `docs.cloud.json`:
+
+```json
+{
+  "$schema": "https://docs.farming-labs.dev/schema/cloud.json"
+}
+```
+
+## What this file is
+
+`/schema/cloud.json` does not return a sample config. It returns a JSON Schema document that
+describes the config format.
+
+That gives editors and tools:
+
+- Autocomplete for supported properties
+- Validation errors for wrong values
+- Hover text and defaults
+
+The schema document itself starts like this:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.farming-labs.dev/schema/cloud.json",
+  "title": "Docs Cloud Config",
+  "type": "object"
+}
+```
+
+## Supported sections
+
+The initial contract supports these top-level keys:
+
+- `$schema`
+- `version`
+- `docs`
+- `content`
+- `site`
+- `branding`
+- `theme`
+- `navigation`
+- `navbar`
+- `footer`
+- `links`
+- `search`
+- `extensions`
+- `preview`
+- `publish`
+
+The schema stays strict at the top level with `additionalProperties: false`.
+
+Custom framework or vendor fields should go under `extensions`:
+
+```json
+{
+  "extensions": {
+    "your-framework": {}
+  }
+}
+```
+
+In practice, the contract is split like this:
+
+- `docs`: framework and runtime root
+- `content`: docs roots and OpenAPI inputs
+- `site`, `branding`, `theme`: metadata and presentation
+- `navigation`, `navbar`, `footer`, `links`: docs structure and external links
+- `search`, `preview`, `publish`: runtime behavior
+- `extensions`: namespaced custom fields
+
+## Managed mode
+
+- `docs.framework = "managed"`
+- `docs.root = ".docs-cloud/site"`
+- `content.docsRoot = "docs"`
+- `content.apiReferenceRoot = "api-reference"`
+
+That means authored markdown lives in:
+
+```txt
+docs/
+api-reference/
+```
+
+and the generated runtime can live in:
+
+```txt
+.docs-cloud/site/
+```
+
+## Minimal example
+
+This is the typical starting config:
+
+```json
+{
+  "$schema": "https://docs.farming-labs.dev/schema/cloud.json",
+  "version": 1,
+  "docs": {
+    "framework": "managed",
+    "root": ".docs-cloud/site"
+  },
+  "content": {
+    "docsRoot": "docs",
+    "apiReferenceRoot": "api-reference"
+  },
+  "theme": {
+    "preset": "default",
+    "mode": "system"
+  },
+  "search": {
+    "enabled": true
+  },
+  "preview": {
+    "enabled": true
+  },
+  "publish": {
+    "mode": "draft-pr",
+    "baseBranch": "main"
+  }
+}
+```
+
+For the full field list, use the schema file itself:
+
+```txt
+website/public/schema/cloud.json
+```
+
+## Frameworkless project contract
+
+The goal is not to make end users build a docs app by hand.
+
+The goal is to let a project work with just:
+
+```txt
+docs.cloud.json
+docs/
+api-reference/
+```
+
+In managed mode, those three things are the source of truth.
+
+- `docs.cloud.json` defines config like theme, branding, navigation, search, preview, and publish behavior
+- `docs/` contains the main docs pages
+- `api-reference/` contains API reference pages and related generated content
+
+That means a user should be able to start with a repo like this:
+
+```txt
+my-project/
+  docs.cloud.json
+  docs/
+    index.mdx
+    quickstart.mdx
+  api-reference/
+    index.mdx
+```
+
+and not need to create a Next.js, Astro, Nuxt, or other framework docs app themselves.
+
+The managed system can then generate or deploy the runtime for them based on `docs.cloud.json`.
+
+For the frameworkless flow, the important rules are:
+
+1. Use `"$schema": "https://docs.farming-labs.dev/schema/cloud.json"` in `docs.cloud.json`.
+2. Treat `docs/` and `api-reference/` as the authored content source.
+3. Let `docs.cloud.json` drive the docs behavior and presentation.
+4. Keep the generated runtime hidden or managed, such as `.docs-cloud/site/`.
+5. Reject unknown top-level keys except through `extensions`.

--- a/website/app/docs/guides/docs-cloud-json/page.mdx
+++ b/website/app/docs/guides/docs-cloud-json/page.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Host a docs.cloud.json Schema"
-description: "Serve the public JSON Schema for docs.cloud.json from the website app that owns the docs domain."
+title: "Use the Shared docs.cloud.json Schema"
+description: "Point your docs.cloud.json to the shared schema URL for autocomplete and validation."
 related:
   - /docs/configuration
   - /docs/reference
@@ -10,21 +10,23 @@ icon: "lightbulb"
 order: 3.8
 ---
 
-# Host a `docs.cloud.json` Schema
+# Use the Shared `docs.cloud.json` Schema
 
-If your public docs site lives in `website/`, the schema should be hosted by that same app.
+Most users do not need to host anything.
 
-```txt
-website/public/schema/cloud.json
-```
+The normal setup is:
 
-When the website deploys to `https://docs.farming-labs.dev`, that file is served at:
+- this repo hosts one shared schema at `https://docs.farming-labs.dev/schema/cloud.json`
+- user projects point their own `docs.cloud.json` to that URL
+- editors use that schema for autocomplete and validation
+
+After the website deploys to `https://docs.farming-labs.dev`, that file is available at:
 
 ```txt
 https://docs.farming-labs.dev/schema/cloud.json
 ```
 
-Users reference that URL in their own `docs.cloud.json`:
+User projects can point their own `docs.cloud.json` to that URL:
 
 ```json
 {
@@ -32,10 +34,23 @@ Users reference that URL in their own `docs.cloud.json`:
 }
 ```
 
+Most projects should stop there. They do not need to host their own schema.
+
+## Do I need to host a schema?
+
+No.
+
+If you are using the standard `docs.cloud.json` contract, just reference the shared schema URL.
+
+You only need your own schema if you want custom validation for your own extra fields.
+
 ## What this file is
 
-`/schema/cloud.json` does not return a sample config. It returns a JSON Schema document that
-describes the config format.
+`/schema/cloud.json` is the rules file for `docs.cloud.json`.
+
+It is not a sample config.
+
+It tells tools which fields are allowed, what types they have, and which values are valid.
 
 That gives editors and tools:
 
@@ -43,7 +58,22 @@ That gives editors and tools:
 - Validation errors for wrong values
 - Hover text and defaults
 
-The schema document itself starts like this:
+That means a project can keep its own config file locally:
+
+```txt
+my-project/
+  docs.cloud.json
+```
+
+while still reusing the shared schema hosted by `docs.farming-labs.dev`.
+
+For maintainers of this repo, the shared schema is published from:
+
+```txt
+website/public/schema/cloud.json
+```
+
+The schema file itself starts like this:
 
 ```json
 {
@@ -56,7 +86,7 @@ The schema document itself starts like this:
 
 ## Supported sections
 
-The initial contract supports these top-level keys:
+These are the main top-level keys supported by `docs.cloud.json`:
 
 - `$schema`
 - `version`
@@ -74,7 +104,7 @@ The initial contract supports these top-level keys:
 - `preview`
 - `publish`
 
-The schema stays strict at the top level with `additionalProperties: false`.
+The schema stays strict at the top level. That means random top-level keys should not be accepted.
 
 Custom framework or vendor fields should go under `extensions`:
 
@@ -85,6 +115,12 @@ Custom framework or vendor fields should go under `extensions`:
   }
 }
 ```
+
+This is the important distinction:
+
+- users write their own `docs.cloud.json`
+- users normally reference the shared schema URL
+- users only need their own schema if they want custom validation for their own extra fields
 
 In practice, the contract is split like this:
 
@@ -195,3 +231,18 @@ For the frameworkless flow, the important rules are:
 3. Let `docs.cloud.json` drive the docs behavior and presentation.
 4. Keep the generated runtime hidden or managed, such as `.docs-cloud/site/`.
 5. Reject unknown top-level keys except through `extensions`.
+
+## When a project needs its own schema
+
+Most projects do not need this.
+
+A project should only host its own schema if it wants to extend the base contract with its own
+strictly validated custom fields.
+
+For example:
+
+- shared schema: validates the standard `docs`, `theme`, `navigation`, `publish`, and other built-in fields
+- project schema: adds exact validation for something like `extensions.acme`
+
+Without a project-specific schema, custom fields under `extensions` are still allowed, but they are
+not fully typed beyond being custom data.

--- a/website/app/docs/guides/page.mdx
+++ b/website/app/docs/guides/page.mdx
@@ -76,9 +76,9 @@ These are the longer, more opinionated walkthroughs in the docs. They sit on top
   href="/docs/guides/docs-cloud-json"
   label="Guide 02"
   metaItems={["Apr 2026", "10 min read"]}
-  title="How to Host a docs.cloud.json Schema"
-  description="A release-oriented contract for serving a public JSON Schema from the docs website so editors, agents, and Cloud tooling all agree on the same config format."
-  tags={["docs.cloud.json", "JSON Schema", "Managed mode", "Cloud", "Website host"]}
+  title="How to Use the Shared docs.cloud.json Schema"
+  description="Point a project’s docs.cloud.json at the shared schema URL so editors can autocomplete and validate the standard contract."
+  tags={["docs.cloud.json", "JSON Schema", "Managed mode", "Cloud", "Validation"]}
 />
 
 ## What These Guides Optimize For

--- a/website/app/docs/guides/page.mdx
+++ b/website/app/docs/guides/page.mdx
@@ -3,6 +3,7 @@ title: "Guides"
 description: "Long-form playbooks for building docs that work well for humans, IDEs, and agents"
 related:
   - /docs/guides/agent-friendly-docs
+  - /docs/guides/docs-cloud-json
   - /docs/customization/agent-primitive
   - /docs/customization/llms-txt
   - /docs/customization/mcp
@@ -71,6 +72,15 @@ These are the longer, more opinionated walkthroughs in the docs. They sit on top
   tags={["agent.md", "<Agent>", "llms.txt", "MCP", "Doctor"]}
 />
 
+<GuideCard
+  href="/docs/guides/docs-cloud-json"
+  label="Guide 02"
+  metaItems={["Apr 2026", "10 min read"]}
+  title="How to Host a docs.cloud.json Schema"
+  description="A release-oriented contract for serving a public JSON Schema from the docs website so editors, agents, and Cloud tooling all agree on the same config format."
+  tags={["docs.cloud.json", "JSON Schema", "Managed mode", "Cloud", "Website host"]}
+/>
+
 ## What These Guides Optimize For
 
 - **One source of truth** - the human page stays canonical unless a route truly needs a dedicated `agent.md`
@@ -86,6 +96,6 @@ These are the longer, more opinionated walkthroughs in the docs. They sit on top
 
 ## Coming Next
 
-- An implementation checklist for launching an agent-optimized docs site
+- A rollout guide for evolving the schema contract once breaking versions are needed
 - A page-level playbook for when to use `Agent` blocks versus sibling `agent.md`
 - A docs operations guide for `docs doctor --agent`, compaction, and ongoing audits

--- a/website/public/schema/cloud.json
+++ b/website/public/schema/cloud.json
@@ -1,0 +1,785 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.farming-labs.dev/schema/cloud.json",
+  "title": "Docs Cloud Config",
+  "description": "Schema for docs.cloud.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "$defs": {
+    "href": {
+      "type": "string",
+      "minLength": 1
+    },
+    "assetPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "link": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "href": {
+          "$ref": "#/$defs/href"
+        },
+        "external": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "label",
+        "href"
+      ]
+    },
+    "social": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": [
+            "github",
+            "gitlab",
+            "discord",
+            "slack",
+            "x",
+            "linkedin",
+            "youtube",
+            "website",
+            "custom"
+          ],
+          "default": "custom"
+        },
+        "href": {
+          "$ref": "#/$defs/href"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "href"
+      ]
+    },
+    "assetSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "light": {
+          "$ref": "#/$defs/assetPath"
+        },
+        "dark": {
+          "$ref": "#/$defs/assetPath"
+        },
+        "alt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "href": {
+          "$ref": "#/$defs/href"
+        }
+      }
+    },
+    "openapiSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "route": {
+          "type": "string",
+          "minLength": 1
+        },
+        "navigationLabel": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name",
+        "path"
+      ]
+    },
+    "navigationGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "string",
+          "minLength": 1
+        },
+        "icon": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pages": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "links": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        }
+      },
+      "required": [
+        "group"
+      ]
+    },
+    "footerColumn": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        }
+      },
+      "required": [
+        "title"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://docs.farming-labs.dev/schema/cloud.json",
+      "description": "Schema URL for docs.cloud.json."
+    },
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "default": 1,
+      "description": "Config schema version."
+    },
+    "docs": {
+      "description": "Docs runtime configuration. In managed mode, authored content stays in ./docs and ./api-reference while docs.root points at the generated runtime directory.",
+      "default": {
+        "framework": "nextjs",
+        "root": "apps/docs"
+      },
+      "oneOf": [
+        {
+          "title": "Managed Markdown Runtime",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "framework": {
+              "type": "string",
+              "const": "managed",
+              "default": "managed",
+              "description": "Markdown-first mode managed by Docs Cloud."
+            },
+            "root": {
+              "type": "string",
+              "default": ".docs-cloud/site",
+              "description": "Generated runtime root used by managed mode."
+            }
+          }
+        },
+        {
+          "title": "Framework Runtime",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "framework": {
+              "type": "string",
+              "enum": [
+                "nextjs",
+                "tanstack-start",
+                "sveltekit",
+                "astro",
+                "nuxt"
+              ],
+              "default": "nextjs",
+              "description": "Framework used by the docs runtime."
+            },
+            "root": {
+              "type": "string",
+              "default": "apps/docs",
+              "description": "Root directory of the framework-specific docs app."
+            }
+          }
+        }
+      ]
+    },
+    "content": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Content source roots and API reference specifications.",
+      "properties": {
+        "docsRoot": {
+          "type": "string",
+          "default": "docs",
+          "description": "Root folder for primary docs content."
+        },
+        "apiReferenceRoot": {
+          "type": "string",
+          "default": "api-reference",
+          "description": "Root folder for API reference content."
+        },
+        "openapi": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/openapiSpec"
+          }
+        }
+      }
+    },
+    "site": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "High-level site metadata.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "titleTemplate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "language": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 20,
+          "default": "en"
+        },
+        "favicon": {
+          "$ref": "#/$defs/assetPath"
+        },
+        "keywords": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "branding": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Brand and visual identity assets.",
+      "properties": {
+        "logo": {
+          "$ref": "#/$defs/assetSet"
+        },
+        "wordmark": {
+          "$ref": "#/$defs/assetSet"
+        },
+        "icon": {
+          "$ref": "#/$defs/assetPath"
+        },
+        "favicon": {
+          "$ref": "#/$defs/assetPath"
+        },
+        "ogImage": {
+          "$ref": "#/$defs/assetPath"
+        }
+      }
+    },
+    "theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Theme and presentation options similar to hosted docs products.",
+      "properties": {
+        "preset": {
+          "type": "string",
+          "minLength": 1,
+          "default": "default"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "light",
+            "dark",
+            "system"
+          ],
+          "default": "system"
+        },
+        "rounded": {
+          "type": "string",
+          "enum": [
+            "none",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "full"
+          ]
+        },
+        "colors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string",
+              "minLength": 1
+            },
+            "accent": {
+              "type": "string",
+              "minLength": 1
+            },
+            "background": {
+              "type": "string",
+              "minLength": 1
+            },
+            "surface": {
+              "type": "string",
+              "minLength": 1
+            },
+            "text": {
+              "type": "string",
+              "minLength": 1
+            },
+            "muted": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "fonts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "heading": {
+              "type": "string",
+              "minLength": 1
+            },
+            "body": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mono": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "codeBlock": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "light": {
+              "type": "string",
+              "minLength": 1
+            },
+            "dark": {
+              "type": "string",
+              "minLength": 1
+            },
+            "showLineNumbers": {
+              "type": "boolean"
+            }
+          }
+        },
+        "customCss": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "navigation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Navigation structure for tabs, anchors, and sidebar groups.",
+      "properties": {
+        "tabs": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        "anchors": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        "global": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        "sidebar": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/navigationGroup"
+          }
+        }
+      }
+    },
+    "navbar": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Top navigation and primary call-to-action.",
+      "properties": {
+        "links": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        "primary": {
+          "$ref": "#/$defs/link"
+        }
+      }
+    },
+    "footer": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Footer links, columns, and social destinations.",
+      "properties": {
+        "socials": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/social"
+          }
+        },
+        "links": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        "columns": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/footerColumn"
+          }
+        },
+        "copyright": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Common external product links.",
+      "properties": {
+        "website": {
+          "$ref": "#/$defs/href"
+        },
+        "documentation": {
+          "$ref": "#/$defs/href"
+        },
+        "github": {
+          "$ref": "#/$defs/href"
+        },
+        "discord": {
+          "$ref": "#/$defs/href"
+        },
+        "support": {
+          "$ref": "#/$defs/href"
+        },
+        "changelog": {
+          "$ref": "#/$defs/href"
+        },
+        "blog": {
+          "$ref": "#/$defs/href"
+        }
+      }
+    },
+    "search": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Search UI and provider configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "provider": {
+          "type": "string",
+          "enum": [
+            "local",
+            "algolia",
+            "custom"
+          ]
+        },
+        "placeholder": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Vendor-specific or project-specific extensions. Prefer namespaced keys such as your company or package name.",
+      "additionalProperties": true
+    },
+    "preview": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {
+        "enabled": true
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether Docs Cloud should request preview deployments."
+        }
+      }
+    },
+    "publish": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {
+        "mode": "draft-pr",
+        "baseBranch": "main"
+      },
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "draft-pr",
+            "direct-commit"
+          ],
+          "default": "draft-pr",
+          "description": "How Docs Cloud publishes generated documentation changes."
+        },
+        "baseBranch": {
+          "type": "string",
+          "minLength": 1,
+          "default": "main",
+          "description": "Repository branch that docs work should target."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "$schema": "https://docs.farming-labs.dev/schema/cloud.json",
+      "version": 1,
+      "docs": {
+        "framework": "managed",
+        "root": ".docs-cloud/site"
+      },
+      "content": {
+        "docsRoot": "docs",
+        "apiReferenceRoot": "api-reference",
+        "openapi": [
+          {
+            "name": "Core API",
+            "path": "api/openapi.json",
+            "route": "/api-reference/core",
+            "navigationLabel": "Core API"
+          }
+        ]
+      },
+      "site": {
+        "name": "Acme Docs",
+        "title": "Acme Documentation",
+        "description": "Developer docs for Acme.",
+        "titleTemplate": "%s | Acme Docs",
+        "url": "https://docs.acme.dev",
+        "language": "en",
+        "favicon": "/favicon.ico",
+        "keywords": [
+          "acme",
+          "api",
+          "docs"
+        ]
+      },
+      "branding": {
+        "logo": {
+          "light": "/logo-light.svg",
+          "dark": "/logo-dark.svg",
+          "alt": "Acme"
+        },
+        "icon": "/icon.svg",
+        "ogImage": "/og.png"
+      },
+      "theme": {
+        "preset": "default",
+        "mode": "system",
+        "rounded": "lg",
+        "colors": {
+          "primary": "#2563eb",
+          "accent": "#14b8a6",
+          "background": "#0b1020",
+          "surface": "#111827",
+          "text": "#f9fafb",
+          "muted": "#94a3b8"
+        },
+        "fonts": {
+          "heading": "Geist",
+          "body": "Geist",
+          "mono": "Geist Mono"
+        },
+        "codeBlock": {
+          "light": "github-light",
+          "dark": "github-dark",
+          "showLineNumbers": true
+        }
+      },
+      "navigation": {
+        "tabs": [
+          {
+            "label": "Docs",
+            "href": "/docs"
+          },
+          {
+            "label": "API",
+            "href": "/api-reference"
+          }
+        ],
+        "sidebar": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "docs/index.mdx",
+              "docs/quickstart.mdx"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "api-reference/index.mdx"
+            ]
+          }
+        ]
+      },
+      "navbar": {
+        "links": [
+          {
+            "label": "GitHub",
+            "href": "https://github.com/acme/docs",
+            "external": true
+          }
+        ],
+        "primary": {
+          "label": "Start Building",
+          "href": "https://acme.dev/signup",
+          "external": true
+        }
+      },
+      "footer": {
+        "socials": [
+          {
+            "platform": "github",
+            "href": "https://github.com/acme"
+          },
+          {
+            "platform": "discord",
+            "href": "https://discord.gg/acme"
+          }
+        ],
+        "columns": [
+          {
+            "title": "Resources",
+            "links": [
+              {
+                "label": "Support",
+                "href": "https://acme.dev/support",
+                "external": true
+              },
+              {
+                "label": "Changelog",
+                "href": "https://acme.dev/changelog",
+                "external": true
+              }
+            ]
+          }
+        ],
+        "copyright": "© Acme"
+      },
+      "links": {
+        "website": "https://acme.dev",
+        "github": "https://github.com/acme",
+        "support": "https://acme.dev/support",
+        "changelog": "https://acme.dev/changelog"
+      },
+      "extensions": {
+        "acme": {
+          "releaseChannels": [
+            "stable",
+            "beta"
+          ]
+        }
+      },
+      "search": {
+        "enabled": true,
+        "provider": "local",
+        "placeholder": "Search the docs"
+      },
+      "preview": {
+        "enabled": true
+      },
+      "publish": {
+        "mode": "draft-pr",
+        "baseBranch": "main"
+      }
+    },
+    {
+      "$schema": "https://docs.farming-labs.dev/schema/cloud.json",
+      "version": 1,
+      "docs": {
+        "framework": "nextjs",
+        "root": "apps/docs"
+      },
+      "preview": {
+        "enabled": true
+      },
+      "publish": {
+        "mode": "draft-pr",
+        "baseBranch": "main"
+      }
+    }
+  ]
+}

--- a/website/public/schema/cloud.json
+++ b/website/public/schema/cloud.json
@@ -191,6 +191,9 @@
           "title": "Managed Markdown Runtime",
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "framework"
+          ],
           "properties": {
             "framework": {
               "type": "string",
@@ -209,6 +212,9 @@
           "title": "Framework Runtime",
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "framework"
+          ],
           "properties": {
             "framework": {
               "type": "string",


### PR DESCRIPTION
- **feat: config for frameworkless hosting**
- **chore: docs**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a shared JSON Schema for `docs.cloud.json` and a guide for pointing projects to it, enabling frameworkless/managed docs with IDE autocomplete and validation. The schema is served at https://docs.farming-labs.dev/schema/cloud.json and supports both managed and framework runtimes.

- **New Features**
  - Adds `website/public/schema/cloud.json` (strict top-level contract, managed defaults, framework runtime support like `nextjs`/`astro`, examples; unknown keys allowed only under `extensions`).
  - Adds guide “Use the Shared `docs.cloud.json` Schema” with minimal config, managed-mode paths, frameworkless flow, and when to host your own schema.
  - Updates Guides index to link to the new guide.

<sup>Written for commit f80f4d53e9f42129874aeabe3c1c3dac9ccc792b. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

