### PR TITLE
feat: analytics event with callback

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -34,6 +34,7 @@ import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
   buildDocsAgentDiscoverySpec,
+  emitDocsAnalyticsEvent,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -484,6 +485,7 @@ function findPageInMap(
  */
 export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const entry = (config.entry as string) ?? "docs";
+  const analytics = config.analytics;
   const contentDirBase =
     ((config as Record<string, unknown>).contentDir as string | undefined) ?? entry;
   const rootDir = path.resolve(
@@ -924,6 +926,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
+    const searchStartedAt = Date.now();
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
@@ -931,6 +934,20 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+    });
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_search",
+      source: "server",
+      url: context.request.url,
+      path: url.pathname,
+      locale: ctx.locale,
+      input: { query },
+      properties: {
+        queryLength: query.length,
+        resultCount: results.length,
+        pathname: url.searchParams.get("pathname") ?? undefined,
+        durationMs: Math.max(0, Date.now() - searchStartedAt),
+      },
     });
 
     return new Response(JSON.stringify(results), {
@@ -973,7 +990,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(context: { request: Request }): Promise<Response> {
+    const requestUrl = new URL(context.request.url);
+    const requestStartedAt = Date.now();
     if (!aiConfig.enabled) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        properties: { reason: "disabled" },
+      });
       return new Response(
         JSON.stringify({
           error: "AI is not enabled. Set `ai: { enabled: true }` in your docs config to enable it.",
@@ -988,6 +1014,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       (typeof process !== "undefined" ? process.env?.OPENAI_API_KEY : undefined);
 
     if (!resolvedKey) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        properties: {
+          reason: "missing_api_key",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({
           error:
@@ -1003,6 +1039,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     try {
       body = await context.request.json();
     } catch {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "invalid_json",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "Invalid JSON body. Expected { messages: [...] }" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -1011,6 +1058,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const messages = body.messages;
     if (!Array.isArray(messages) || messages.length === 0) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_messages",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "messages array is required and must not be empty." }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -1019,6 +1077,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
     if (!lastUserMessage) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_user_message",
+          messageCount: messages.length,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(JSON.stringify({ error: "At least one user message is required." }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1054,6 +1124,21 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const resolved = resolveAIModelAndProvider(aiConfig, requestedModel);
     const finalKey = resolved.apiKey ?? resolvedKey;
 
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_request",
+      source: "server",
+      url: context.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+      },
+    });
+
     const llmResponse = await fetch(`${resolved.baseUrl}/chat/completions`, {
       method: "POST",
       headers: {
@@ -1065,11 +1150,44 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     if (!llmResponse.ok) {
       const errText = await llmResponse.text().catch(() => "Unknown error");
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        input: { question: lastUserMessage.content },
+        properties: {
+          reason: "llm_error",
+          status: llmResponse.status,
+          messageCount: messages.length,
+          questionLength: lastUserMessage.content.length,
+          retrievedCount: scored.length,
+          model: resolved.model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: `LLM API error (${llmResponse.status}): ${errText}` }),
         { status: 502, headers: { "Content-Type": "application/json" } },
       );
     }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_response",
+      source: "server",
+      url: context.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
 
     return new Response(llmResponse.body, {
       headers: {
@@ -1107,6 +1225,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    analytics,
     defaultName: mcpSiteTitle,
   });
 

--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
+import type { DocsAnalyticsEvent, DocsAnalyticsEventType } from "./types.js";
+
+const ALL_ANALYTICS_EVENTS = [
+  "page_view",
+  "search_open",
+  "search_close",
+  "search_query",
+  "search_result_click",
+  "search_error",
+  "ai_open",
+  "ai_close",
+  "ai_question",
+  "ai_response",
+  "ai_error",
+  "ai_clear",
+  "page_action_copy_markdown",
+  "page_action_open_docs_menu",
+  "page_action_open_docs",
+  "code_block_copy",
+  "feedback_select",
+  "feedback_submit",
+  "feedback_error",
+  "agent_read",
+  "agent_spec_request",
+  "agent_feedback_schema",
+  "agent_feedback_submit",
+  "agent_feedback_error",
+  "markdown_request",
+  "llms_request",
+  "skill_request",
+  "api_search",
+  "api_ai_request",
+  "api_ai_response",
+  "api_ai_error",
+  "mcp_request",
+  "mcp_tool",
+] as const satisfies readonly DocsAnalyticsEventType[];
+
+describe("analytics", () => {
+  it("emits every built-in analytics event type through the shared hook", async () => {
+    const events: DocsAnalyticsEvent[] = [];
+
+    for (const type of ALL_ANALYTICS_EVENTS) {
+      await emitDocsAnalyticsEvent(
+        {
+          console: false,
+          includeInputs: true,
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+        {
+          type,
+          source: type.startsWith("mcp_") ? "mcp" : "server",
+          input: {
+            query: "install",
+            question: "How do I install this?",
+            feedbackComment: "Useful",
+            content: "pnpm install",
+          },
+          properties: {
+            index: events.length,
+          },
+        },
+      );
+    }
+
+    expect(events.map((event) => event.type)).toEqual(ALL_ANALYTICS_EVENTS);
+    expect(events).toHaveLength(ALL_ANALYTICS_EVENTS.length);
+    expect(events.every((event) => typeof event.timestamp === "string")).toBe(true);
+    expect(events[0]?.input).toEqual({
+      query: "install",
+      question: "How do I install this?",
+      feedbackComment: "Useful",
+      content: "pnpm install",
+    });
+  });
+
+  it("omits raw input fields unless includeInputs is enabled", async () => {
+    const events: DocsAnalyticsEvent[] = [];
+
+    await emitDocsAnalyticsEvent(
+      {
+        console: false,
+        onEvent(event) {
+          events.push(event);
+        },
+      },
+      {
+        type: "api_search",
+        source: "server",
+        input: {
+          query: "private query",
+        },
+        properties: {
+          queryLength: 13,
+        },
+      },
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.input).toBeUndefined();
+    expect(events[0]?.properties).toEqual({ queryLength: 13 });
+  });
+
+  it("resolves analytics defaults for booleans and object configs", () => {
+    expect(resolveDocsAnalyticsConfig()).toMatchObject({
+      enabled: false,
+      console: false,
+      includeInputs: false,
+    });
+    expect(resolveDocsAnalyticsConfig(true)).toMatchObject({
+      enabled: true,
+      console: "info",
+      includeInputs: false,
+    });
+    expect(resolveDocsAnalyticsConfig({ console: false, includeInputs: true })).toMatchObject({
+      enabled: true,
+      console: false,
+      includeInputs: true,
+    });
+  });
+});

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -1,0 +1,89 @@
+import type { DocsAnalyticsConfig, DocsAnalyticsEvent, DocsAnalyticsEventInput } from "./types.js";
+
+export interface ResolvedDocsAnalyticsConfig {
+  enabled: boolean;
+  console: false | "log" | "info" | "debug";
+  includeInputs: boolean;
+  onEvent?: (event: DocsAnalyticsEvent) => void | Promise<void>;
+}
+
+function resolveConsoleLevel(
+  value: boolean | "log" | "info" | "debug" | undefined,
+  hasEventHandler: boolean,
+): false | "log" | "info" | "debug" {
+  if (value === false) return false;
+  if (value === true) return "info";
+  if (value === "log" || value === "info" || value === "debug") return value;
+  return hasEventHandler ? false : "info";
+}
+
+export function resolveDocsAnalyticsConfig(
+  analytics?: boolean | DocsAnalyticsConfig,
+): ResolvedDocsAnalyticsConfig {
+  if (!analytics) {
+    return {
+      enabled: false,
+      console: false,
+      includeInputs: false,
+    };
+  }
+
+  if (analytics === true) {
+    return {
+      enabled: true,
+      console: "info",
+      includeInputs: false,
+    };
+  }
+
+  const hasEventHandler = typeof analytics.onEvent === "function";
+
+  return {
+    enabled: analytics.enabled !== false,
+    console: resolveConsoleLevel(analytics.console, hasEventHandler),
+    includeInputs: analytics.includeInputs === true,
+    onEvent: analytics.onEvent,
+  };
+}
+
+function normalizeAnalyticsEvent(
+  event: DocsAnalyticsEventInput,
+  config: ResolvedDocsAnalyticsConfig,
+): DocsAnalyticsEvent {
+  const normalized: DocsAnalyticsEvent = {
+    ...event,
+    source: event.source ?? "server",
+    timestamp: event.timestamp ?? new Date().toISOString(),
+  };
+
+  if (!config.includeInputs && normalized.input) {
+    delete normalized.input;
+  }
+
+  return normalized;
+}
+
+export async function emitDocsAnalyticsEvent(
+  analytics: boolean | DocsAnalyticsConfig | undefined,
+  event: DocsAnalyticsEventInput,
+): Promise<void> {
+  const resolved = resolveDocsAnalyticsConfig(analytics);
+  if (!resolved.enabled) return;
+
+  const normalized = normalizeAnalyticsEvent(event, resolved);
+
+  if (resolved.console) {
+    const logger = console[resolved.console] ?? console.info;
+    logger.call(console, "[farming-labs:analytics]", normalized);
+  }
+
+  if (!resolved.onEvent) return;
+
+  try {
+    await resolved.onEvent(normalized);
+  } catch (error) {
+    if (resolved.console !== false) {
+      console.warn("[farming-labs:analytics] onEvent failed", error);
+    }
+  }
+}

--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -15,6 +15,7 @@ export function defineDocs(config: DocsConfig): DocsConfig {
     breadcrumb: config.breadcrumb,
     sidebar: config.sidebar,
     components: config.components,
+    analytics: config.analytics,
     onCopyClick: config.onCopyClick,
     feedback: config.feedback,
     search: config.search,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -10,6 +10,7 @@
 import type { DocsConfig } from "./types.js";
 
 export { defineDocs } from "./define-docs.js";
+export { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
 export { resolveChangelogConfig } from "./changelog.js";
 export { deepMerge } from "./utils.js";
 export { createTheme, extendTheme } from "./create-theme.js";
@@ -144,7 +145,14 @@ export type {
   CustomDocsSearchConfig,
   DocsSearchEmbeddingsConfig,
   McpDocsSearchConfig,
+  DocsAnalyticsConfig,
+  DocsAnalyticsEvent,
+  DocsAnalyticsEventInput,
+  DocsAnalyticsEventType,
+  DocsAnalyticsInput,
+  DocsAnalyticsSource,
 } from "./types.js";
+export type { ResolvedDocsAnalyticsConfig } from "./analytics.js";
 export type { ChangelogEntrySummary, ResolvedChangelogConfig } from "./changelog.js";
 export type { ResolvedDocsI18n, DocsPathMatch } from "./i18n.js";
 export type {

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types";
+import type { DocsAnalyticsEvent } from "./types.js";
 import {
   createDocsMcpHttpHandler,
   createFilesystemDocsMcpSource,
@@ -405,6 +406,121 @@ No frontmatter title here.
     });
 
     expect(deleteResponse.status).toBe(200);
+  });
+
+  it("emits analytics for MCP requests, tools, and agent page reads", async () => {
+    const rootDir = createTempDocsProject();
+    const source = createFilesystemDocsMcpSource({
+      rootDir,
+      entry: "docs",
+      contentDir: "docs",
+      siteTitle: "Example Docs",
+    });
+    const events: DocsAnalyticsEvent[] = [];
+
+    const handlers = createDocsMcpHttpHandler({
+      source,
+      mcp: { enabled: true, name: "Example Docs" },
+      analytics: {
+        console: false,
+        onEvent(event) {
+          events.push(event);
+        },
+      },
+    });
+
+    const initializeResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: LATEST_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: {
+              name: "vitest",
+              version: "1.0.0",
+            },
+          },
+        }),
+      }),
+    });
+
+    const sessionId = initializeResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    let requestId = 2;
+    async function callTool(name: string, args: Record<string, unknown>) {
+      const response = await handlers.POST({
+        request: new Request("http://localhost/api/docs/mcp", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "application/json, text/event-stream",
+            "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+            "mcp-session-id": sessionId!,
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: requestId++,
+            method: "tools/call",
+            params: {
+              name,
+              arguments: args,
+            },
+          }),
+        }),
+      });
+
+      return parseMcpPayload<{ result?: unknown }>(response);
+    }
+
+    await callTool("list_pages", {});
+    await callTool("get_navigation", {});
+    await callTool("search_docs", { query: "generated example paths" });
+    await callTool("read_page", { path: "guides/quickstart" });
+    await callTool("read_page", { path: "missing" });
+
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining(["mcp_request", "mcp_tool", "agent_read"]),
+    );
+    expect(events.filter((event) => event.type === "mcp_request")).toHaveLength(6);
+    expect(
+      events.filter((event) => event.type === "mcp_tool").map((event) => event.properties),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tool: "list_pages", resultCount: 3 }),
+        expect.objectContaining({ tool: "get_navigation" }),
+        expect.objectContaining({ tool: "search_docs", queryLength: 23 }),
+        expect.objectContaining({ tool: "read_page", found: true }),
+        expect.objectContaining({ tool: "read_page", found: false }),
+      ]),
+    );
+    expect(
+      events.filter((event) => event.type === "agent_read").map((event) => event.properties),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          delivery: "mcp_tool",
+          tool: "read_page",
+          requestedPath: "guides/quickstart",
+          found: true,
+        }),
+        expect.objectContaining({
+          delivery: "mcp_tool",
+          tool: "read_page",
+          requestedPath: "missing",
+          found: false,
+        }),
+      ]),
+    );
   });
 
   it("uses the shared search adapter pipeline for search_docs", async () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -10,7 +10,9 @@ import * as z from "zod/v4";
 import { stripGeneratedAgentProvenance } from "./agent-provenance.js";
 import { normalizeDocsRelated, renderDocsRelatedMarkdownLines } from "./related.js";
 import { performDocsSearch } from "./search.js";
+import { emitDocsAnalyticsEvent } from "./analytics.js";
 import type {
+  DocsAnalyticsConfig,
   DocsMcpConfig,
   DocsSearchConfig,
   DocsSearchSourcePage,
@@ -86,6 +88,7 @@ interface CreateDocsMcpServerOptions {
   source: DocsMcpSource;
   mcp?: boolean | DocsMcpConfig;
   search?: boolean | DocsSearchConfig;
+  analytics?: boolean | DocsAnalyticsConfig;
   defaultName?: string;
   defaultVersion?: string;
 }
@@ -211,6 +214,14 @@ export function createFilesystemDocsMcpSource(
   };
 }
 
+function nowMs() {
+  return Date.now();
+}
+
+function durationMs(startedAt: number) {
+  return Math.max(0, Date.now() - startedAt);
+}
+
 export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): Promise<McpServer> {
   const resolved = resolveDocsMcpConfig(options.mcp, {
     defaultName: options.defaultName ?? options.source.siteTitle ?? DEFAULT_MCP_NAME,
@@ -277,7 +288,18 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         annotations: { readOnlyHint: true },
       },
       async ({ locale }) => {
+        const startedAt = nowMs();
         const pages = toPageSummaries(dedupePages(await options.source.getPages(locale)));
+        await emitDocsAnalyticsEvent(options.analytics, {
+          type: "mcp_tool",
+          source: "mcp",
+          locale,
+          properties: {
+            tool: "list_pages",
+            resultCount: pages.length,
+            durationMs: durationMs(startedAt),
+          },
+        });
         return {
           content: [
             {
@@ -300,7 +322,17 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         annotations: { readOnlyHint: true },
       },
       async ({ locale }) => {
+        const startedAt = nowMs();
         const tree = await options.source.getNavigation(locale);
+        await emitDocsAnalyticsEvent(options.analytics, {
+          type: "mcp_tool",
+          source: "mcp",
+          locale,
+          properties: {
+            tool: "get_navigation",
+            durationMs: durationMs(startedAt),
+          },
+        });
         return {
           content: [
             {
@@ -323,6 +355,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         annotations: { readOnlyHint: true },
       },
       async ({ query, limit, locale }) => {
+        const startedAt = nowMs();
         const pages = dedupePages(await options.source.getPages(locale));
         const results = await performDocsSearch({
           pages: toSearchSourcePages(pages),
@@ -331,6 +364,19 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           locale,
           siteTitle: options.source.siteTitle,
           limit: limit ?? 10,
+        });
+        await emitDocsAnalyticsEvent(options.analytics, {
+          type: "mcp_tool",
+          source: "mcp",
+          locale,
+          input: { query },
+          properties: {
+            tool: "search_docs",
+            queryLength: query.length,
+            limit: limit ?? 10,
+            resultCount: results.length,
+            durationMs: durationMs(startedAt),
+          },
         });
         return {
           content: [
@@ -354,10 +400,34 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         annotations: { readOnlyHint: true },
       },
       async ({ path: requestedPath, locale }) => {
+        const startedAt = nowMs();
         const pages = dedupePages(await options.source.getPages(locale));
         const page = findDocsPage(pages, requestedPath, options.source.entry);
 
         if (!page) {
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "agent_read",
+            source: "mcp",
+            locale,
+            properties: {
+              delivery: "mcp_tool",
+              tool: "read_page",
+              requestedPath,
+              found: false,
+              durationMs: durationMs(startedAt),
+            },
+          });
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "mcp_tool",
+            source: "mcp",
+            locale,
+            properties: {
+              tool: "read_page",
+              path: requestedPath,
+              found: false,
+              durationMs: durationMs(startedAt),
+            },
+          });
           return {
             content: [
               {
@@ -375,11 +445,43 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           };
         }
 
+        const document = renderPageDocument(page);
+
+        await emitDocsAnalyticsEvent(options.analytics, {
+          type: "agent_read",
+          source: "mcp",
+          locale,
+          path: page.url,
+          properties: {
+            delivery: "mcp_tool",
+            tool: "read_page",
+            requestedPath,
+            slug: page.slug,
+            found: true,
+            contentLength: document.length,
+            durationMs: durationMs(startedAt),
+          },
+        });
+        await emitDocsAnalyticsEvent(options.analytics, {
+          type: "mcp_tool",
+          source: "mcp",
+          locale,
+          path: page.url,
+          properties: {
+            tool: "read_page",
+            requestedPath,
+            slug: page.slug,
+            found: true,
+            contentLength: document.length,
+            durationMs: durationMs(startedAt),
+          },
+        });
+
         return {
           content: [
             {
               type: "text",
-              text: renderPageDocument(page),
+              text: document,
             },
           ],
         };
@@ -443,6 +545,7 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
   }
 
   async function handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
     const method = request.method.toUpperCase();
     const sessionId =
       request.headers.get("mcp-session-id") ?? request.headers.get("Mcp-Session-Id");
@@ -458,6 +561,18 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     }
 
     const initializeRequest = method === "POST" && parsedBody && isInitializeRequest(parsedBody);
+
+    await emitDocsAnalyticsEvent(options.analytics, {
+      type: "mcp_request",
+      source: "mcp",
+      url: request.url,
+      path: url.pathname,
+      properties: {
+        method,
+        hasSession: Boolean(existing),
+        initialize: Boolean(initializeRequest),
+      },
+    });
 
     if (!existing) {
       if (!initializeRequest) {

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -1,3 +1,4 @@
+export { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
 export {
   resolveApiReferenceConfig,
   resolveApiReferenceRenderer,
@@ -65,4 +66,8 @@ export type {
   DocsSearchResult,
   DocsSearchSourcePage,
   McpDocsSearchConfig,
+  DocsAnalyticsConfig,
+  DocsAnalyticsEvent,
+  DocsAnalyticsEventInput,
 } from "./types.js";
+export type { ResolvedDocsAnalyticsConfig } from "./analytics.js";

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -678,6 +678,89 @@ export interface PageActionsConfig {
   alignment?: "left" | "right";
 }
 
+export type DocsAnalyticsSource = "client" | "server" | "mcp";
+
+export type DocsAnalyticsEventType =
+  | "page_view"
+  | "search_open"
+  | "search_close"
+  | "search_query"
+  | "search_result_click"
+  | "search_error"
+  | "ai_open"
+  | "ai_close"
+  | "ai_question"
+  | "ai_response"
+  | "ai_error"
+  | "ai_clear"
+  | "page_action_copy_markdown"
+  | "page_action_open_docs_menu"
+  | "page_action_open_docs"
+  | "code_block_copy"
+  | "feedback_select"
+  | "feedback_submit"
+  | "feedback_error"
+  | "agent_read"
+  | "agent_spec_request"
+  | "agent_feedback_schema"
+  | "agent_feedback_submit"
+  | "agent_feedback_error"
+  | "markdown_request"
+  | "llms_request"
+  | "skill_request"
+  | "api_search"
+  | "api_ai_request"
+  | "api_ai_response"
+  | "api_ai_error"
+  | "mcp_request"
+  | "mcp_tool";
+
+export interface DocsAnalyticsInput {
+  query?: string;
+  question?: string;
+  feedbackComment?: string;
+  content?: string;
+}
+
+export interface DocsAnalyticsEvent {
+  type: DocsAnalyticsEventType | (string & {});
+  timestamp: string;
+  source: DocsAnalyticsSource;
+  url?: string;
+  path?: string;
+  referrer?: string;
+  locale?: string;
+  input?: DocsAnalyticsInput;
+  properties?: Record<string, unknown>;
+}
+
+export type DocsAnalyticsEventInput = Omit<DocsAnalyticsEvent, "timestamp" | "source"> & {
+  timestamp?: string;
+  source?: DocsAnalyticsSource;
+};
+
+export interface DocsAnalyticsConfig {
+  /** Enable analytics event emission. Defaults to `true` when this object is provided. */
+  enabled?: boolean;
+  /**
+   * Log analytics events to the console.
+   *
+   * `analytics: true` logs with `console.info`. When `onEvent` is provided,
+   * console logging is disabled unless this is set.
+   */
+  console?: boolean | "log" | "info" | "debug";
+  /**
+   * Include raw search queries, AI questions, feedback comments, and copied
+   * content in emitted events.
+   *
+   * Defaults to `false`; events still include safe metadata such as lengths,
+   * counts, routes, status, and duration.
+   */
+  includeInputs?: boolean;
+  /** Callback fired for every analytics event. */
+  onEvent?: (event: DocsAnalyticsEvent) => void | Promise<void>;
+}
+
 /**
  * Configuration for the "Last updated" date display.
  *
@@ -1738,6 +1821,17 @@ export interface DocsConfig {
   staticExport?: boolean;
   /** Theme configuration - single source of truth for UI */
   theme?: DocsTheme;
+  /**
+   * Built-in analytics event stream for docs interactions.
+   *
+   * - `false` or omitted -> analytics disabled (default)
+   * - `true` -> log all framework events to the console
+   * - `{ onEvent(event) { ... } }` -> send events to your analytics sink
+   *
+   * Raw queries, AI questions, feedback comments, and copied content are not
+   * included unless `includeInputs: true` is set.
+   */
+  analytics?: boolean | DocsAnalyticsConfig;
   /**
    * GitHub repository URL or config. Enables "Edit on GitHub" links
    * on each docs page footer, pointing to the source `.mdx` file.

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -1163,15 +1163,33 @@ export function FloatingAIChat({
     setMounted(true);
   }, []);
 
+  const closeFloatingAI = useCallback(
+    (trigger: "button" | "escape" | "overlay") => {
+      setIsOpen((wasOpen) => {
+        if (wasOpen && analytics) {
+          emitClientAnalyticsEvent({
+            type: "ai_close",
+            properties: {
+              mode: floatingStyle === "full-modal" ? "full-modal" : "floating",
+              trigger,
+            },
+          });
+        }
+        return false;
+      });
+    },
+    [analytics, floatingStyle],
+  );
+
   useEffect(() => {
     if (isOpen) {
       const handler = (e: globalThis.KeyboardEvent) => {
-        if (e.key === "Escape") setIsOpen(false);
+        if (e.key === "Escape") closeFloatingAI("escape");
       };
       document.addEventListener("keydown", handler);
       return () => document.removeEventListener("keydown", handler);
     }
-  }, [isOpen]);
+  }, [closeFloatingAI, isOpen]);
 
   useEffect(() => {
     if (isOpen && (floatingStyle === "modal" || floatingStyle === "full-modal"))
@@ -1190,6 +1208,7 @@ export function FloatingAIChat({
         api={api}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
+        closeAI={closeFloatingAI}
         messages={messages}
         setMessages={setMessages}
         aiInput={aiInput}
@@ -1216,7 +1235,9 @@ export function FloatingAIChat({
 
   return createPortal(
     <>
-      {isOpen && isModal && <div onClick={() => setIsOpen(false)} className="fd-ai-overlay" />}
+      {isOpen && isModal && (
+        <div onClick={() => closeFloatingAI("overlay")} className="fd-ai-overlay" />
+      )}
 
       {isOpen && (
         <div
@@ -1228,7 +1249,7 @@ export function FloatingAIChat({
             <SparklesIcon size={16} />
             <span className="fd-ai-header-title">Ask {aiName}</span>
             {isModal && <kbd className="fd-ai-esc">ESC</kbd>}
-            <button onClick={() => setIsOpen(false)} className="fd-ai-close-btn">
+            <button onClick={() => closeFloatingAI("button")} className="fd-ai-close-btn">
               <XIcon />
             </button>
           </div>
@@ -1303,6 +1324,7 @@ function FullModalAIChat({
   api,
   isOpen,
   setIsOpen,
+  closeAI,
   messages,
   setMessages,
   aiInput,
@@ -1322,6 +1344,7 @@ function FullModalAIChat({
   api: string;
   isOpen: boolean;
   setIsOpen: (v: boolean) => void;
+  closeAI: (trigger: "button" | "escape" | "overlay") => void;
   messages: ChatMessage[];
   setMessages: (m: ChatMessage[]) => void;
   aiInput: string;
@@ -1503,12 +1526,12 @@ function FullModalAIChat({
         <div
           className="fd-ai-fm-overlay"
           onClick={(e) => {
-            if (e.target === e.currentTarget) setIsOpen(false);
+            if (e.target === e.currentTarget) closeAI("overlay");
           }}
         >
           {/* Close button */}
           <div className="fd-ai-fm-topbar">
-            <button onClick={() => setIsOpen(false)} className="fd-ai-fm-close-btn">
+            <button onClick={() => closeAI("button")} className="fd-ai-fm-close-btn">
               <XIcon />
             </button>
           </div>
@@ -1732,14 +1755,30 @@ export function AIModalDialog({
   const [aiInput, setAiInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
 
+  const closeModalAI = useCallback(
+    (trigger: "button" | "escape" | "overlay") => {
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "ai_close",
+          properties: {
+            mode: "modal",
+            trigger,
+          },
+        });
+      }
+      onOpenChange(false);
+    },
+    [analytics, onOpenChange],
+  );
+
   useEffect(() => {
     if (!open) return;
     const handler = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape") onOpenChange(false);
+      if (e.key === "Escape") closeModalAI("escape");
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open, onOpenChange]);
+  }, [closeModalAI, open]);
 
   useEffect(() => {
     if (open) document.body.style.overflow = "hidden";
@@ -1755,7 +1794,7 @@ export function AIModalDialog({
 
   return createPortal(
     <>
-      <div onClick={() => onOpenChange(false)} className="fd-ai-overlay" />
+      <div onClick={() => closeModalAI("overlay")} className="fd-ai-overlay" />
       <div
         role="dialog"
         aria-modal="true"
@@ -1774,7 +1813,7 @@ export function AIModalDialog({
           <SparklesIcon size={16} />
           <span className="fd-ai-header-title">Ask {aiName}</span>
           <kbd className="fd-ai-esc">ESC</kbd>
-          <button onClick={() => onOpenChange(false)} className="fd-ai-close-btn">
+          <button onClick={() => closeModalAI("button")} className="fd-ai-close-btn">
             <XIcon />
           </button>
         </div>

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -21,6 +21,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { highlight } from "sugar-high";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -497,6 +498,8 @@ function AIChat({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics,
+  surface = "chat",
 }: {
   api: string;
   messages: ChatMessage[];
@@ -511,6 +514,8 @@ function AIChat({
   loadingComponentHtml?: string;
   models?: AIModelOption[];
   defaultModelId?: string;
+  analytics?: boolean;
+  surface?: string;
 }) {
   const label = aiLabel || "AI";
   const aiInputRef = useRef<HTMLInputElement>(null);
@@ -539,6 +544,19 @@ function AIChat({
       setAiInput("");
       setIsStreaming(true);
       setMessages([...newMessages, { role: "assistant", content: "" }]);
+      const startedAt = Date.now();
+
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "ai_question",
+          properties: {
+            surface,
+            questionLength: question.length,
+            messageCount: newMessages.length,
+            model: effectiveModelId,
+          },
+        });
+      }
 
       try {
         const res = await fetch(api, {
@@ -558,6 +576,17 @@ function AIChat({
           } catch {}
           setMessages([...newMessages, { role: "assistant", content: errMsg }]);
           setIsStreaming(false);
+          if (analytics) {
+            emitClientAnalyticsEvent({
+              type: "ai_error",
+              properties: {
+                surface,
+                status: res.status,
+                questionLength: question.length,
+                durationMs: Math.max(0, Date.now() - startedAt),
+              },
+            });
+          }
           return;
         }
 
@@ -589,15 +618,47 @@ function AIChat({
         }
         if (assistantContent)
           setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "ai_response",
+            properties: {
+              surface,
+              questionLength: question.length,
+              responseLength: assistantContent.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+              model: effectiveModelId,
+            },
+          });
+        }
       } catch {
         setMessages([
           ...newMessages,
           { role: "assistant", content: "Failed to connect. Please try again." },
         ]);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "ai_error",
+            properties: {
+              surface,
+              questionLength: question.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+            },
+          });
+        }
       }
       setIsStreaming(false);
     },
-    [messages, api, isStreaming, setMessages, setAiInput, setIsStreaming, effectiveModelId],
+    [
+      messages,
+      api,
+      isStreaming,
+      setMessages,
+      setAiInput,
+      setIsStreaming,
+      effectiveModelId,
+      analytics,
+      surface,
+    ],
   );
 
   const handleAskAI = useCallback(async () => {
@@ -680,6 +741,14 @@ function AIChat({
               onClick={() => {
                 setMessages([]);
                 setAiInput("");
+                if (analytics) {
+                  emitClientAnalyticsEvent({
+                    type: "ai_clear",
+                    properties: {
+                      surface,
+                    },
+                  });
+                }
               }}
               className="fd-ai-clear-btn"
             >
@@ -725,6 +794,7 @@ export function DocsSearchDialog({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics = false,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -735,6 +805,7 @@ export function DocsSearchDialog({
   loadingComponentHtml?: string;
   models?: AIModelOption[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const [tab, setTab] = useState<"search" | "ai">("search");
   const [searchQuery, setSearchQuery] = useState("");
@@ -756,6 +827,15 @@ export function DocsSearchDialog({
 
   useEffect(() => {
     if (open) {
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "search_open",
+          properties: {
+            mode: "ai-dialog",
+            tab,
+          },
+        });
+      }
       setSearchQuery("");
       setSearchResults([]);
       setActiveIndex(0);
@@ -763,7 +843,7 @@ export function DocsSearchDialog({
         if (tab === "search") searchInputRef.current?.focus();
       }, 50);
     }
-  }, [open, tab]);
+  }, [analytics, open, tab]);
 
   useEffect(() => {
     if (!open) return;
@@ -790,6 +870,7 @@ export function DocsSearchDialog({
     }
     setIsSearching(true);
     const timer = setTimeout(async () => {
+      const startedAt = Date.now();
       try {
         const requestUrl = new URL(api, window.location.origin);
         requestUrl.searchParams.set("query", searchQuery);
@@ -798,12 +879,34 @@ export function DocsSearchDialog({
           const data = await res.json();
           setSearchResults(data);
           setActiveIndex(0);
+          if (analytics) {
+            emitClientAnalyticsEvent({
+              type: "search_query",
+              properties: {
+                mode: "ai-dialog",
+                queryLength: searchQuery.length,
+                resultCount: Array.isArray(data) ? data.length : 0,
+                durationMs: Math.max(0, Date.now() - startedAt),
+              },
+            });
+          }
         }
-      } catch {}
+      } catch {
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "search_error",
+            properties: {
+              mode: "ai-dialog",
+              queryLength: searchQuery.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+            },
+          });
+        }
+      }
       setIsSearching(false);
     }, 150);
     return () => clearTimeout(timer);
-  }, [searchQuery, api, tab]);
+  }, [analytics, searchQuery, api, tab]);
 
   const handleSearchKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
@@ -815,6 +918,19 @@ export function DocsSearchDialog({
     } else if (e.key === "Enter" && searchResults[activeIndex]) {
       e.preventDefault();
       onOpenChange(false);
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "search_result_click",
+          path: searchResults[activeIndex].url,
+          properties: {
+            mode: "ai-dialog",
+            resultId: searchResults[activeIndex].id,
+            resultUrl: searchResults[activeIndex].url,
+            resultType: searchResults[activeIndex].type,
+            queryLength: searchQuery.length,
+          },
+        });
+      }
       window.location.href = searchResults[activeIndex].url;
     }
   };
@@ -848,7 +964,22 @@ export function DocsSearchDialog({
           >
             <SearchIcon /> Search
           </button>
-          <button onClick={() => setTab("ai")} className="fd-ai-tab" data-active={tab === "ai"}>
+          <button
+            onClick={() => {
+              setTab("ai");
+              if (analytics) {
+                emitClientAnalyticsEvent({
+                  type: "ai_open",
+                  properties: {
+                    mode: "ai-dialog",
+                    trigger: "tab",
+                  },
+                });
+              }
+            }}
+            className="fd-ai-tab"
+            data-active={tab === "ai"}
+          >
             <SparklesIcon /> Ask {aiName}
           </button>
           <div style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center" }}>
@@ -878,6 +1009,19 @@ export function DocsSearchDialog({
                     key={result.id}
                     onClick={() => {
                       onOpenChange(false);
+                      if (analytics) {
+                        emitClientAnalyticsEvent({
+                          type: "search_result_click",
+                          path: result.url,
+                          properties: {
+                            mode: "ai-dialog",
+                            resultId: result.id,
+                            resultUrl: result.url,
+                            resultType: result.type,
+                            queryLength: searchQuery.length,
+                          },
+                        });
+                      }
                       window.location.href = result.url;
                     }}
                     onMouseEnter={() => setActiveIndex(i)}
@@ -919,6 +1063,8 @@ export function DocsSearchDialog({
             loadingComponentHtml={loadingComponentHtml}
             models={models}
             defaultModelId={effectiveModelId}
+            analytics={analytics}
+            surface="ai-dialog"
           />
         )}
       </div>
@@ -993,6 +1139,7 @@ export function FloatingAIChat({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics = false,
 }: {
   api?: string;
   position?: FloatingPosition;
@@ -1004,6 +1151,7 @@ export function FloatingAIChat({
   loadingComponentHtml?: string;
   models?: AIModelOption[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -1056,6 +1204,7 @@ export function FloatingAIChat({
         position={position}
         models={models}
         defaultModelId={defaultModelId}
+        analytics={analytics}
       />
     );
   }
@@ -1096,6 +1245,8 @@ export function FloatingAIChat({
             aiLabel={aiLabel}
             loaderVariant={loaderVariant}
             loadingComponentHtml={loadingComponentHtml}
+            analytics={analytics}
+            surface="floating"
           />
         </div>
       )}
@@ -1103,14 +1254,36 @@ export function FloatingAIChat({
       {!isOpen &&
         (triggerComponentHtml ? (
           <div
-            onClick={() => setIsOpen(true)}
+            onClick={() => {
+              setIsOpen(true);
+              if (analytics) {
+                emitClientAnalyticsEvent({
+                  type: "ai_open",
+                  properties: {
+                    mode: "floating",
+                    trigger: "custom-trigger",
+                  },
+                });
+              }
+            }}
             className="fd-ai-floating-trigger"
             style={btnPosition}
             dangerouslySetInnerHTML={{ __html: triggerComponentHtml }}
           />
         ) : (
           <button
-            onClick={() => setIsOpen(true)}
+            onClick={() => {
+              setIsOpen(true);
+              if (analytics) {
+                emitClientAnalyticsEvent({
+                  type: "ai_open",
+                  properties: {
+                    mode: "floating",
+                    trigger: "button",
+                  },
+                });
+              }
+            }}
             aria-label={`Ask ${aiName}`}
             className="fd-ai-floating-btn"
             style={btnPosition}
@@ -1144,6 +1317,7 @@ function FullModalAIChat({
   position,
   models,
   defaultModelId,
+  analytics,
 }: {
   api: string;
   isOpen: boolean;
@@ -1162,6 +1336,7 @@ function FullModalAIChat({
   position: FloatingPosition;
   models?: AIModelOption[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const label = aiLabel || "AI";
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1195,6 +1370,19 @@ function FullModalAIChat({
       setAiInput("");
       setIsStreaming(true);
       setMessages([...newMessages, { role: "assistant", content: "" }]);
+      const startedAt = Date.now();
+
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "ai_question",
+          properties: {
+            surface: "full-modal",
+            questionLength: question.length,
+            messageCount: newMessages.length,
+            model: effectiveModelId,
+          },
+        });
+      }
 
       try {
         const res = await fetch(api, {
@@ -1214,6 +1402,17 @@ function FullModalAIChat({
           } catch {}
           setMessages([...newMessages, { role: "assistant", content: errMsg }]);
           setIsStreaming(false);
+          if (analytics) {
+            emitClientAnalyticsEvent({
+              type: "ai_error",
+              properties: {
+                surface: "full-modal",
+                status: res.status,
+                questionLength: question.length,
+                durationMs: Math.max(0, Date.now() - startedAt),
+              },
+            });
+          }
           return;
         }
 
@@ -1245,15 +1444,46 @@ function FullModalAIChat({
         }
         if (assistantContent)
           setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "ai_response",
+            properties: {
+              surface: "full-modal",
+              questionLength: question.length,
+              responseLength: assistantContent.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+              model: effectiveModelId,
+            },
+          });
+        }
       } catch {
         setMessages([
           ...newMessages,
           { role: "assistant", content: "Failed to connect. Please try again." },
         ]);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "ai_error",
+            properties: {
+              surface: "full-modal",
+              questionLength: question.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+            },
+          });
+        }
       }
       setIsStreaming(false);
     },
-    [messages, api, isStreaming, setMessages, setAiInput, setIsStreaming, effectiveModelId],
+    [
+      messages,
+      api,
+      isStreaming,
+      setMessages,
+      setAiInput,
+      setIsStreaming,
+      effectiveModelId,
+      analytics,
+    ],
   );
 
   const canSend = !!(aiInput.trim() && !isStreaming);
@@ -1320,12 +1550,34 @@ function FullModalAIChat({
         {!isOpen ? (
           triggerComponentHtml ? (
             <div
-              onClick={() => setIsOpen(true)}
+              onClick={() => {
+                setIsOpen(true);
+                if (analytics) {
+                  emitClientAnalyticsEvent({
+                    type: "ai_open",
+                    properties: {
+                      mode: "full-modal",
+                      trigger: "custom-trigger",
+                    },
+                  });
+                }
+              }}
               dangerouslySetInnerHTML={{ __html: triggerComponentHtml }}
             />
           ) : (
             <button
-              onClick={() => setIsOpen(true)}
+              onClick={() => {
+                setIsOpen(true);
+                if (analytics) {
+                  emitClientAnalyticsEvent({
+                    type: "ai_open",
+                    properties: {
+                      mode: "full-modal",
+                      trigger: "button",
+                    },
+                  });
+                }
+              }}
               className="fd-ai-fm-trigger-btn"
               aria-label={`Ask ${label}`}
             >
@@ -1403,6 +1655,14 @@ function FullModalAIChat({
                     if (!isStreaming) {
                       setMessages([]);
                       setAiInput("");
+                      if (analytics) {
+                        emitClientAnalyticsEvent({
+                          type: "ai_clear",
+                          properties: {
+                            surface: "full-modal",
+                          },
+                        });
+                      }
                     }
                   }}
                   aria-disabled={isStreaming}
@@ -1455,6 +1715,7 @@ export function AIModalDialog({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics = false,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -1465,6 +1726,7 @@ export function AIModalDialog({
   loadingComponentHtml?: string;
   models?: AIModelOption[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [aiInput, setAiInput] = useState("");
@@ -1531,6 +1793,8 @@ export function AIModalDialog({
           loadingComponentHtml={loadingComponentHtml}
           models={models}
           defaultModelId={defaultModelId}
+          analytics={analytics}
+          surface="modal"
         />
 
         <div className="fd-ai-modal-footer">
@@ -1541,6 +1805,14 @@ export function AIModalDialog({
                 if (!isStreaming) {
                   setMessages([]);
                   setAiInput("");
+                  if (analytics) {
+                    emitClientAnalyticsEvent({
+                      type: "ai_clear",
+                      properties: {
+                        surface: "modal",
+                      },
+                    });
+                  }
                 }
               }}
               aria-disabled={isStreaming}

--- a/packages/fumadocs/src/client-analytics.test.ts
+++ b/packages/fumadocs/src/client-analytics.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DocsAnalyticsEvent, DocsAnalyticsEventType } from "@farming-labs/docs";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
+
+const CLIENT_ANALYTICS_EVENTS = [
+  "page_view",
+  "search_open",
+  "search_close",
+  "search_query",
+  "search_result_click",
+  "search_error",
+  "ai_open",
+  "ai_question",
+  "ai_response",
+  "ai_error",
+  "ai_clear",
+  "page_action_copy_markdown",
+  "page_action_open_docs_menu",
+  "page_action_open_docs",
+  "code_block_copy",
+  "feedback_select",
+  "feedback_submit",
+  "feedback_error",
+] as const satisfies readonly DocsAnalyticsEventType[];
+
+interface TestWindow extends Partial<Window> {
+  __fdAnalytics__?: (event: DocsAnalyticsEvent) => void | Promise<void>;
+  __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
+}
+
+function installClientGlobals(onEvent?: (event: DocsAnalyticsEvent) => void) {
+  const dispatched: Array<{ type: string; detail?: DocsAnalyticsEvent }> = [];
+  const target: TestWindow = {
+    location: {
+      href: "https://docs.example.com/docs/installation?tab=next",
+      pathname: "/docs/installation",
+    } as Location,
+    dispatchEvent(event) {
+      dispatched.push(event as CustomEvent<DocsAnalyticsEvent>);
+      return true;
+    },
+  };
+
+  if (onEvent) target.__fdAnalytics__ = onEvent;
+
+  vi.stubGlobal("window", target);
+  vi.stubGlobal("document", {
+    referrer: "https://example.com/search",
+  });
+
+  return { dispatched, target };
+}
+
+describe("client analytics", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("emits every client analytics event through the browser hook and DOM event", () => {
+    const events: DocsAnalyticsEvent[] = [];
+    const { dispatched } = installClientGlobals((event) => events.push(event));
+
+    for (const type of CLIENT_ANALYTICS_EVENTS) {
+      emitClientAnalyticsEvent({
+        type,
+        properties: {
+          index: events.length,
+        },
+      });
+    }
+
+    expect(events.map((event) => event.type)).toEqual(CLIENT_ANALYTICS_EVENTS);
+    expect(events).toHaveLength(CLIENT_ANALYTICS_EVENTS.length);
+    expect(events[0]).toMatchObject({
+      source: "client",
+      url: "https://docs.example.com/docs/installation?tab=next",
+      path: "/docs/installation",
+      referrer: "https://example.com/search",
+    });
+    expect(dispatched.map((event) => event.type)).toEqual(
+      Array(CLIENT_ANALYTICS_EVENTS.length).fill("fd:analytics"),
+    );
+    expect(dispatched[0]?.detail?.type).toBe("page_view");
+  });
+
+  it("queues client events until the analytics hook is installed", () => {
+    const { target } = installClientGlobals();
+
+    emitClientAnalyticsEvent({
+      type: "page_view",
+      properties: {
+        title: "Installation",
+      },
+    });
+
+    expect(target.__fdAnalyticsQueue__).toHaveLength(1);
+    expect(target.__fdAnalyticsQueue__?.[0]).toMatchObject({
+      type: "page_view",
+      source: "client",
+      path: "/docs/installation",
+    });
+  });
+});

--- a/packages/fumadocs/src/client-analytics.test.ts
+++ b/packages/fumadocs/src/client-analytics.test.ts
@@ -10,6 +10,7 @@ const CLIENT_ANALYTICS_EVENTS = [
   "search_result_click",
   "search_error",
   "ai_open",
+  "ai_close",
   "ai_question",
   "ai_response",
   "ai_error",
@@ -99,5 +100,18 @@ describe("client analytics", () => {
       source: "client",
       path: "/docs/installation",
     });
+  });
+
+  it("does not throw when analytics hooks reject or DOM listeners throw", () => {
+    const { target } = installClientGlobals(() => Promise.reject(new Error("analytics failed")));
+    target.dispatchEvent = () => {
+      throw new Error("listener failed");
+    };
+
+    expect(() =>
+      emitClientAnalyticsEvent({
+        type: "search_open",
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/fumadocs/src/client-analytics.ts
+++ b/packages/fumadocs/src/client-analytics.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import type { DocsAnalyticsEvent, DocsAnalyticsEventInput } from "@farming-labs/docs";
+
+interface DocsAnalyticsWindow extends Window {
+  __fdAnalytics__?: (event: DocsAnalyticsEvent) => void | Promise<void>;
+  __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
+}
+
+export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
+  if (typeof window === "undefined") return;
+
+  const normalized: DocsAnalyticsEvent = {
+    ...event,
+    source: "client",
+    path: window.location.pathname,
+    url: window.location.href,
+    referrer: document.referrer || undefined,
+    timestamp: new Date().toISOString(),
+  };
+
+  const target = window as DocsAnalyticsWindow;
+  try {
+    if (target.__fdAnalytics__) {
+      void target.__fdAnalytics__(normalized);
+    } else {
+      target.__fdAnalyticsQueue__ = [...(target.__fdAnalyticsQueue__ ?? []), normalized].slice(-50);
+    }
+  } catch {
+    // Analytics should never break the docs UI.
+  }
+
+  window.dispatchEvent(new CustomEvent("fd:analytics", { detail: normalized }));
+}

--- a/packages/fumadocs/src/client-analytics.ts
+++ b/packages/fumadocs/src/client-analytics.ts
@@ -22,13 +22,15 @@ export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
   const target = window as DocsAnalyticsWindow;
   try {
     if (target.__fdAnalytics__) {
-      void target.__fdAnalytics__(normalized);
+      Promise.resolve(target.__fdAnalytics__(normalized)).catch(() => {
+        // Analytics should never break the docs UI.
+      });
     } else {
       target.__fdAnalyticsQueue__ = [...(target.__fdAnalyticsQueue__ ?? []), normalized].slice(-50);
     }
+
+    window.dispatchEvent(new CustomEvent("fd:analytics", { detail: normalized }));
   } catch {
     // Analytics should never break the docs UI.
   }
-
-  window.dispatchEvent(new CustomEvent("fd:analytics", { detail: normalized }));
 }

--- a/packages/fumadocs/src/docs-ai-features.tsx
+++ b/packages/fumadocs/src/docs-ai-features.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect } from "react";
 import { DocsSearchDialog, FloatingAIChat, AIModalDialog } from "./ai-search-dialog.js";
 import { useWindowSearchParams } from "./client-location.js";
 import { resolveClientLocale, withLangInUrl } from "./i18n.js";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 interface DocsAIFeaturesProps {
   mode: "search" | "floating" | "sidebar-icon";
@@ -33,6 +34,7 @@ interface DocsAIFeaturesProps {
   loadingComponentHtml?: string;
   models?: { id: string; label: string }[];
   defaultModelId?: string;
+  analytics?: boolean;
 }
 
 export function DocsAIFeatures({
@@ -48,6 +50,7 @@ export function DocsAIFeatures({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics = false,
 }: DocsAIFeaturesProps) {
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
@@ -63,6 +66,7 @@ export function DocsAIFeatures({
         loadingComponentHtml={loadingComponentHtml}
         models={models}
         defaultModelId={defaultModelId}
+        analytics={analytics}
       />
     );
   }
@@ -77,6 +81,7 @@ export function DocsAIFeatures({
         loadingComponentHtml={loadingComponentHtml}
         models={models}
         defaultModelId={defaultModelId}
+        analytics={analytics}
       />
     );
   }
@@ -93,6 +98,7 @@ export function DocsAIFeatures({
       loadingComponentHtml={loadingComponentHtml}
       models={models}
       defaultModelId={defaultModelId}
+      analytics={analytics}
     />
   );
 }
@@ -105,6 +111,7 @@ function SearchModeAI({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics,
 }: {
   api: string;
   suggestedQuestions?: string[];
@@ -113,6 +120,7 @@ function SearchModeAI({
   loadingComponentHtml?: string;
   models?: { id: string; label: string }[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -123,11 +131,20 @@ function SearchModeAI({
         e.stopPropagation();
         e.stopImmediatePropagation();
         setOpen(true);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "search_open",
+            properties: {
+              mode: "ai-search",
+              trigger: "keyboard",
+            },
+          });
+        }
       }
     }
     document.addEventListener("keydown", handler, true);
     return () => document.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [analytics]);
 
   useEffect(() => {
     function handler(e: MouseEvent) {
@@ -140,11 +157,20 @@ function SearchModeAI({
         e.stopPropagation();
         e.stopImmediatePropagation();
         setOpen(true);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "search_open",
+            properties: {
+              mode: "ai-search",
+              trigger: "button",
+            },
+          });
+        }
       }
     }
     document.addEventListener("click", handler, true);
     return () => document.removeEventListener("click", handler, true);
-  }, []);
+  }, [analytics]);
 
   return (
     <DocsSearchDialog
@@ -157,6 +183,7 @@ function SearchModeAI({
       loadingComponentHtml={loadingComponentHtml}
       models={models}
       defaultModelId={defaultModelId}
+      analytics={analytics}
     />
   );
 }
@@ -169,6 +196,7 @@ function SidebarIconModeAI({
   loadingComponentHtml,
   models,
   defaultModelId,
+  analytics,
 }: {
   api: string;
   suggestedQuestions?: string[];
@@ -177,6 +205,7 @@ function SidebarIconModeAI({
   loadingComponentHtml?: string;
   models?: { id: string; label: string }[];
   defaultModelId?: string;
+  analytics?: boolean;
 }) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
@@ -197,9 +226,27 @@ function SidebarIconModeAI({
   useEffect(() => {
     function onSearch() {
       setSearchOpen(true);
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "search_open",
+          properties: {
+            mode: "sidebar-icon",
+            trigger: "sidebar-search",
+          },
+        });
+      }
     }
     function onAI() {
       setAiOpen(true);
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "ai_open",
+          properties: {
+            mode: "sidebar-icon",
+            trigger: "sidebar-ai",
+          },
+        });
+      }
     }
     window.addEventListener("fd-open-search", onSearch);
     window.addEventListener("fd-open-ai", onAI);
@@ -207,7 +254,7 @@ function SidebarIconModeAI({
       window.removeEventListener("fd-open-search", onSearch);
       window.removeEventListener("fd-open-ai", onAI);
     };
-  }, []);
+  }, [analytics]);
 
   return (
     <>
@@ -221,6 +268,7 @@ function SidebarIconModeAI({
         loadingComponentHtml={loadingComponentHtml}
         models={models}
         defaultModelId={defaultModelId}
+        analytics={analytics}
       />
       <AIModalDialog
         open={aiOpen}
@@ -232,6 +280,7 @@ function SidebarIconModeAI({
         loadingComponentHtml={loadingComponentHtml}
         models={models}
         defaultModelId={defaultModelId}
+        analytics={analytics}
       />
     </>
   );

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import type { DocsAnalyticsEvent } from "@farming-labs/docs";
 import { createDocsAPI, createDocsMCPAPI } from "./docs-api.js";
 
 function createDeferredPromise<T = void>() {
@@ -667,6 +668,326 @@ Config content.
     );
     expect(substringAcceptResponse.headers.get("content-type")).not.toContain("text/markdown");
     expect(await substringAcceptResponse.text()).toBe("[]");
+  });
+
+  it("emits agent_read analytics for markdown API, .md routes, and Accept header reads", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-read-analytics-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "guides", "setup"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    writeFileSync(
+      join(rootDir, "app", "docs", "guides", "setup", "page.mdx"),
+      `---
+title: "Setup"
+---
+
+# Setup
+
+Install the package.
+`,
+    );
+
+    const events: Array<{
+      type: string;
+      source?: string;
+      path?: string;
+      properties?: Record<string, unknown>;
+    }> = [];
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      analytics: {
+        console: false,
+        onEvent(event) {
+          events.push(event);
+        },
+      },
+    });
+
+    await GET(new Request("http://localhost/api/docs?format=markdown&path=guides/setup"));
+    await GET(new Request("http://localhost/docs/guides/setup.md"));
+    await GET(
+      new Request("http://localhost/docs/guides/setup", {
+        headers: { accept: "text/markdown" },
+      }),
+    );
+
+    const agentReads = events.filter((event) => event.type === "agent_read");
+    expect(agentReads).toHaveLength(3);
+    expect(agentReads.map((event) => event.properties?.delivery)).toEqual([
+      "api_format",
+      "md_route",
+      "accept_header",
+    ]);
+    expect(agentReads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "server",
+          path: "/api/docs",
+          properties: expect.objectContaining({
+            requestedPath: "guides/setup",
+            found: true,
+          }),
+        }),
+        expect.objectContaining({
+          source: "server",
+          path: "/docs/guides/setup.md",
+          properties: expect.objectContaining({
+            requestedPath: "guides/setup",
+            found: true,
+          }),
+        }),
+        expect.objectContaining({
+          source: "server",
+          path: "/docs/guides/setup",
+          properties: expect.objectContaining({
+            requestedPath: "guides/setup",
+            found: true,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("emits analytics for docs API, agent, markdown, feedback, and search routes", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-analytics-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "guides", "setup"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+description: "Start here"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "app", "docs", "guides", "setup", "page.mdx"),
+      `---
+title: "Setup"
+description: "Install the framework"
+---
+
+# Setup
+
+Install the package.
+`,
+    );
+    writeFileSync(join(rootDir, "skill.md"), "# Site skill\n\nUse the framework routes.\n");
+
+    const events: DocsAnalyticsEvent[] = [];
+    const onFeedback = vi.fn(async () => undefined);
+    const { GET, POST } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      analytics: {
+        console: false,
+        onEvent(event) {
+          events.push(event);
+        },
+      },
+      feedback: {
+        agent: {
+          enabled: true,
+          onFeedback,
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              task: { type: "string" },
+              outcome: { type: "string" },
+            },
+            required: ["task", "outcome"],
+          },
+        },
+      },
+    });
+
+    await GET(new Request("http://localhost/api/docs/agent/spec"));
+    await GET(new Request("http://localhost/api/docs/agent/feedback/schema"));
+    await GET(new Request("http://localhost/api/docs?format=skill"));
+    await GET(new Request("http://localhost/api/docs?format=markdown&path=guides/setup"));
+    await GET(new Request("http://localhost/docs/guides/setup.md"));
+    await GET(
+      new Request("http://localhost/docs/guides/setup", {
+        headers: { accept: "text/markdown" },
+      }),
+    );
+    await GET(new Request("http://localhost/api/docs?format=llms"));
+    await GET(new Request("http://localhost/api/docs?format=llms-full"));
+    await GET(new Request("http://localhost/api/docs?query=install"));
+
+    const invalidFeedback = await POST(
+      new Request("http://localhost/api/docs/agent/feedback", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          payload: {
+            task: "validate analytics",
+          },
+        }),
+      }),
+    );
+    expect(invalidFeedback.status).toBe(400);
+
+    const validFeedback = await POST(
+      new Request("http://localhost/api/docs/agent/feedback", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          context: {
+            page: "/docs/guides/setup",
+          },
+          payload: {
+            task: "validate analytics",
+            outcome: "implemented",
+          },
+        }),
+      }),
+    );
+    expect(validFeedback.status).toBe(201);
+
+    const disabledAi = await POST(
+      new Request("http://localhost/api/docs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "How do I install?" }],
+        }),
+      }),
+    );
+    expect(disabledAi.status).toBe(404);
+
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([
+        "agent_spec_request",
+        "agent_feedback_schema",
+        "skill_request",
+        "agent_read",
+        "markdown_request",
+        "llms_request",
+        "api_search",
+        "agent_feedback_error",
+        "agent_feedback_submit",
+        "api_ai_error",
+      ]),
+    );
+    expect(
+      events.filter((event) => event.type === "agent_read").map((event) => event.properties),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ delivery: "api_format", found: true }),
+        expect.objectContaining({ delivery: "md_route", found: true }),
+        expect.objectContaining({ delivery: "accept_header", found: true }),
+      ]),
+    );
+    expect(events.find((event) => event.type === "api_search")).toMatchObject({
+      source: "server",
+      path: "/api/docs",
+      properties: expect.objectContaining({
+        queryLength: 7,
+      }),
+    });
+    expect(events.find((event) => event.type === "agent_feedback_submit")).toMatchObject({
+      properties: expect.objectContaining({
+        handled: true,
+        payloadKeys: ["task", "outcome"],
+      }),
+    });
+    expect(events.find((event) => event.type === "api_ai_error")).toMatchObject({
+      properties: expect.objectContaining({
+        reason: "disabled",
+      }),
+    });
+  });
+
+  it("emits analytics for successful Ask AI requests and responses", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-analytics-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Installation"
+---
+
+# Installation
+
+Install the framework with pnpm.
+`,
+    );
+
+    const events: DocsAnalyticsEvent[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("data: {}\n\n", {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+        },
+      }),
+    ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        rootDir,
+        entry: "docs",
+        ai: {
+          enabled: true,
+          apiKey: "test-key",
+          baseUrl: "https://llm.example/v1",
+          model: "test-model",
+        },
+        analytics: {
+          console: false,
+          onEvent(event) {
+            events.push(event);
+          },
+        },
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "Install" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(events.map((event) => event.type)).toEqual(["api_ai_request", "api_ai_response"]);
+      expect(events[0]).toMatchObject({
+        properties: expect.objectContaining({
+          model: "test-model",
+          questionLength: 7,
+          retrievedCount: 1,
+        }),
+      });
+      expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe(
+        "https://llm.example/v1/chat/completions",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
   });
 
   it("returns 404 for markdown mode when the requested page does not exist", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -27,11 +27,13 @@ import {
   normalizeDocsRelated,
   renderDocsRelatedMarkdownLines,
   resolveChangelogConfig,
+  emitDocsAnalyticsEvent,
   resolveDocsI18n,
   resolveDocsLocale,
 } from "@farming-labs/docs";
 import type {
   ChangelogConfig,
+  DocsAnalyticsConfig,
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
   DocsI18nConfig,
@@ -98,6 +100,8 @@ interface DocsAPIOptions {
   i18n?: DocsI18nConfig;
   /** Search configuration */
   search?: boolean | DocsSearchConfig;
+  /** Analytics configuration */
+  analytics?: boolean | DocsAnalyticsConfig;
   /** Feedback configuration */
   feedback?: boolean | FeedbackConfig;
   /** MCP configuration used for the agent discovery spec. */
@@ -112,6 +116,7 @@ interface DocsMCPAPIOptions {
   ordering?: "alphabetical" | "numeric" | OrderingItem[];
   mcp?: boolean | DocsMcpConfig;
   search?: boolean | DocsSearchConfig;
+  analytics?: boolean | DocsAnalyticsConfig;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -1261,15 +1266,17 @@ function acceptsMarkdown(request: Request): boolean {
     });
 }
 
-function resolveMarkdownRequest(
-  entry: string,
-  url: URL,
-  request: Request,
-): { requestedPath: string } | null {
+type MarkdownRequest = {
+  requestedPath: string;
+  delivery: "api_format" | "md_route" | "accept_header";
+};
+
+function resolveMarkdownRequest(entry: string, url: URL, request: Request): MarkdownRequest | null {
   const format = url.searchParams.get("format")?.trim();
   if (format === "markdown") {
     return {
       requestedPath: url.searchParams.get("path")?.trim() ?? "",
+      delivery: "api_format",
     };
   }
 
@@ -1277,24 +1284,26 @@ function resolveMarkdownRequest(
   const normalizedEntry = `/${normalizePathSegment(entry)}`;
 
   if (pathname === `${normalizedEntry}.md`) {
-    return { requestedPath: "" };
+    return { requestedPath: "", delivery: "md_route" };
   }
 
   const slugPrefix = `${normalizedEntry}/`;
   if (pathname.startsWith(slugPrefix) && pathname.endsWith(".md")) {
     return {
       requestedPath: pathname.slice(slugPrefix.length, -3),
+      delivery: "md_route",
     };
   }
 
   if (acceptsMarkdown(request)) {
     if (pathname === normalizedEntry) {
-      return { requestedPath: "" };
+      return { requestedPath: "", delivery: "accept_header" };
     }
 
     if (pathname.startsWith(slugPrefix)) {
       return {
         requestedPath: pathname.slice(slugPrefix.length),
+        delivery: "accept_header",
       };
     }
   }
@@ -1513,12 +1522,28 @@ async function handleAskAI(
   request: Request,
   indexes: DocsSearchSourcePage[],
   aiConfig: AIOptions,
+  analytics?: boolean | DocsAnalyticsConfig,
+  analyticsContext: { locale?: string } = {},
 ): Promise<Response> {
+  const url = new URL(request.url);
+  const requestStartedAt = Date.now();
+
   // ── Parse request ──────────────────────────────────────────────
   let body: { messages?: ChatMessage[]; model?: string };
   try {
     body = await request.json();
   } catch {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      properties: {
+        reason: "invalid_json",
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
     return Response.json(
       { error: "Invalid JSON body. Expected { messages: [...] }" },
       { status: 400 },
@@ -1527,6 +1552,17 @@ async function handleAskAI(
 
   const messages = body.messages;
   if (!Array.isArray(messages) || messages.length === 0) {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      properties: {
+        reason: "missing_messages",
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
     return Response.json(
       { error: "messages array is required and must not be empty." },
       { status: 400 },
@@ -1535,6 +1571,18 @@ async function handleAskAI(
 
   const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
   if (!lastUserMessage) {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      properties: {
+        reason: "missing_user_message",
+        messageCount: messages.length,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
     return Response.json({ error: "At least one user message is required." }, { status: 400 });
   }
 
@@ -1585,6 +1633,22 @@ async function handleAskAI(
   const resolved = resolveModelAndProvider(aiConfig, requestedModel);
 
   if (!resolved.apiKey) {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      input: { question: query },
+      properties: {
+        reason: "missing_api_key",
+        messageCount: messages.length,
+        questionLength: query.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
     return Response.json(
       {
         error: `AI is enabled but no API key was found. Either set apiKey in your docs.config ai section, configure a provider, or add OPENAI_API_KEY to your .env.local file.`,
@@ -1592,6 +1656,21 @@ async function handleAskAI(
       { status: 500 },
     );
   }
+
+  await emitDocsAnalyticsEvent(analytics, {
+    type: "api_ai_request",
+    source: "server",
+    url: request.url,
+    path: url.pathname,
+    locale: analyticsContext.locale,
+    input: { question: query },
+    properties: {
+      messageCount: messages.length,
+      questionLength: query.length,
+      retrievedCount: scored.length,
+      model: resolved.model,
+    },
+  });
 
   const llmResponse = await fetch(`${resolved.baseUrl}/chat/completions`, {
     method: "POST",
@@ -1608,11 +1687,44 @@ async function handleAskAI(
 
   if (!llmResponse.ok) {
     const errText = await llmResponse.text().catch(() => "Unknown error");
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      input: { question: query },
+      properties: {
+        reason: "llm_error",
+        status: llmResponse.status,
+        messageCount: messages.length,
+        questionLength: query.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
     return Response.json(
       { error: `LLM API error (${llmResponse.status}): ${errText}` },
       { status: 502 },
     );
   }
+
+  await emitDocsAnalyticsEvent(analytics, {
+    type: "api_ai_response",
+    source: "server",
+    url: request.url,
+    path: url.pathname,
+    locale: analyticsContext.locale,
+    input: { question: query },
+    properties: {
+      messageCount: messages.length,
+      questionLength: query.length,
+      retrievedCount: scored.length,
+      model: resolved.model,
+      durationMs: Math.max(0, Date.now() - requestStartedAt),
+    },
+  });
 
   // Proxy the SSE stream directly to the client
   return new Response(llmResponse.body, {
@@ -1727,6 +1839,7 @@ function generateLlmsTxt(
 export function createDocsAPI(options?: DocsAPIOptions) {
   const root = options?.rootDir ?? process.cwd();
   const entry = options?.entry ?? readEntry(root);
+  const analytics = options?.analytics;
   const appDir = getNextAppDir(root);
   const contentDir = options?.contentDir ?? path.join(appDir, entry);
   const changelogConfig = resolveChangelogConfig(options?.changelog);
@@ -1933,6 +2046,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       const ctx = resolveContextFromRequest(request);
       const url = new URL(request.url);
       if (resolveAgentSpecRequest(url)) {
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "agent_spec_request",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            method: "GET",
+          },
+        });
         return Response.json(
           buildAgentSpec({
             origin: url.origin,
@@ -1967,6 +2090,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           );
         }
 
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "agent_feedback_schema",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            method: "GET",
+          },
+        });
         return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
           headers: {
             "Content-Type": "application/schema+json; charset=utf-8",
@@ -1977,6 +2110,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       if (resolveSkillRequest(url)) {
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "skill_request",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            method: "GET",
+          },
+        });
         return new Response(
           readRootSkillDocument(root) ??
             renderSkillDocument({
@@ -2004,6 +2147,30 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         const document = await getMarkdownDocument(ctx, markdownRequest.requestedPath);
 
         if (!document) {
+          await emitDocsAnalyticsEvent(analytics, {
+            type: "agent_read",
+            source: "server",
+            url: request.url,
+            path: url.pathname,
+            locale: ctx.locale,
+            properties: {
+              requestedPath: markdownRequest.requestedPath,
+              delivery: markdownRequest.delivery,
+              found: false,
+            },
+          });
+          await emitDocsAnalyticsEvent(analytics, {
+            type: "markdown_request",
+            source: "server",
+            url: request.url,
+            path: url.pathname,
+            locale: ctx.locale,
+            properties: {
+              requestedPath: markdownRequest.requestedPath,
+              delivery: markdownRequest.delivery,
+              found: false,
+            },
+          });
           return new Response("Not Found", {
             status: 404,
             headers: {
@@ -2013,6 +2180,32 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           });
         }
 
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "agent_read",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            requestedPath: markdownRequest.requestedPath,
+            delivery: markdownRequest.delivery,
+            found: true,
+            contentLength: document.length,
+          },
+        });
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "markdown_request",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            requestedPath: markdownRequest.requestedPath,
+            delivery: markdownRequest.delivery,
+            found: true,
+            contentLength: document.length,
+          },
+        });
         return new Response(document, {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -2024,6 +2217,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
       const llmsFormat = resolveLlmsTxtFormat(url);
       if (llmsFormat === "llms") {
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "llms_request",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            format: "llms",
+          },
+        });
         return new Response(getLlmsContent(ctx).llmsTxt, {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
@@ -2033,6 +2236,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       if (llmsFormat === "llms-full") {
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "llms_request",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          locale: ctx.locale,
+          properties: {
+            format: "llms-full",
+          },
+        });
         return new Response(getLlmsContent(ctx).llmsFullTxt, {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
@@ -2048,6 +2261,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         });
       }
 
+      const searchStartedAt = Date.now();
       const results = await performDocsSearch({
         pages: getIndexes(ctx),
         query,
@@ -2055,6 +2269,20 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         locale: ctx.locale,
         pathname: url.searchParams.get("pathname") ?? undefined,
         siteTitle: llmsConfig.siteTitle ?? "Documentation",
+      });
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_search",
+        source: "server",
+        url: request.url,
+        path: url.pathname,
+        locale: ctx.locale,
+        input: { query },
+        properties: {
+          queryLength: query.length,
+          resultCount: results.length,
+          pathname: url.searchParams.get("pathname") ?? undefined,
+          durationMs: Math.max(0, Date.now() - searchStartedAt),
+        },
       });
 
       return new Response(JSON.stringify(results), {
@@ -2068,10 +2296,8 @@ export function createDocsAPI(options?: DocsAPIOptions) {
      * Response: SSE stream of chat completion chunks.
      */
     async POST(request: Request): Promise<Response> {
-      const agentFeedbackRequest = resolveAgentFeedbackRequest(
-        new URL(request.url),
-        agentFeedbackConfig,
-      );
+      const url = new URL(request.url);
+      const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
 
       if (agentFeedbackRequest) {
         if (agentFeedbackRequest.kind === "schema") {
@@ -2087,25 +2313,77 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         }
 
         const parsed = await parseAgentFeedbackData(request);
-        if (!parsed.ok) return parsed.response;
+        if (!parsed.ok) {
+          await emitDocsAnalyticsEvent(analytics, {
+            type: "agent_feedback_error",
+            source: "server",
+            url: request.url,
+            path: url.pathname,
+            properties: {
+              reason: "invalid_body",
+            },
+          });
+          return parsed.response;
+        }
 
         const payloadError = validateAgentFeedbackPayload(
           parsed.data.payload,
           agentFeedbackConfig.payloadSchema,
         );
         if (payloadError) {
+          await emitDocsAnalyticsEvent(analytics, {
+            type: "agent_feedback_error",
+            source: "server",
+            url: request.url,
+            path: url.pathname,
+            properties: {
+              reason: "invalid_payload",
+              error: payloadError,
+            },
+          });
           return Response.json({ error: payloadError }, { status: 400 });
         }
 
         if (!agentFeedbackConfig.onFeedback) {
+          await emitDocsAnalyticsEvent(analytics, {
+            type: "agent_feedback_submit",
+            source: "server",
+            url: request.url,
+            path: url.pathname,
+            properties: {
+              handled: false,
+              payloadKeys: Object.keys(parsed.data.payload),
+              hasContext: Boolean(parsed.data.context),
+            },
+          });
           return Response.json({ ok: true, handled: false }, { status: 202 });
         }
 
         await agentFeedbackConfig.onFeedback(parsed.data);
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "agent_feedback_submit",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          properties: {
+            handled: true,
+            payloadKeys: Object.keys(parsed.data.payload),
+            hasContext: Boolean(parsed.data.context),
+          },
+        });
         return Response.json({ ok: true, handled: true }, { status: 201 });
       }
 
       if (!aiConfig.enabled) {
+        await emitDocsAnalyticsEvent(analytics, {
+          type: "api_ai_error",
+          source: "server",
+          url: request.url,
+          path: url.pathname,
+          properties: {
+            reason: "disabled",
+          },
+        });
         return Response.json(
           {
             error:
@@ -2116,7 +2394,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       const ctx = resolveContextFromRequest(request);
-      return handleAskAI(request, getIndexes(ctx), aiConfig);
+      return handleAskAI(request, getIndexes(ctx), aiConfig, analytics, { locale: ctx.locale });
     },
   };
 }
@@ -2152,6 +2430,7 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
     source,
     mcp: options.mcp ?? readMcpConfig(rootDir),
     search: options.search,
+    analytics: options.analytics,
     defaultName: navTitle,
   });
 

--- a/packages/fumadocs/src/docs-client-hooks.tsx
+++ b/packages/fumadocs/src/docs-client-hooks.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { emitDocsAnalyticsEvent } from "@farming-labs/docs";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 import type {
   CodeBlockCopyData,
   DocsAnalyticsConfig,
@@ -85,7 +86,6 @@ function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
       if (!code) return;
 
       const content = code.textContent ?? "";
-      const url = window.location.href;
       const language =
         code.getAttribute("data-language") ?? figure.getAttribute("data-language") ?? undefined;
       const title =
@@ -93,11 +93,8 @@ function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
         (figure.querySelector(".fd-codeblock-title-text") as HTMLElement)?.textContent?.trim() ??
         undefined;
 
-      void emitDocsAnalyticsEvent(analytics, {
+      emitClientAnalyticsEvent({
         type: "code_block_copy",
-        source: "client",
-        url,
-        path: window.location.pathname,
         input: { content },
         properties: {
           title,

--- a/packages/fumadocs/src/docs-client-hooks.tsx
+++ b/packages/fumadocs/src/docs-client-hooks.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { useEffect } from "react";
-import type { CodeBlockCopyData, DocsFeedbackData } from "@farming-labs/docs";
+import { emitDocsAnalyticsEvent } from "@farming-labs/docs";
+import type {
+  CodeBlockCopyData,
+  DocsAnalyticsConfig,
+  DocsAnalyticsEvent,
+  DocsFeedbackData,
+} from "@farming-labs/docs";
 
 type CopyHandler = (data: CodeBlockCopyData) => void;
 type FeedbackHandler = (data: DocsFeedbackData) => void | Promise<void>;
+type AnalyticsHandler = (event: DocsAnalyticsEvent) => void | Promise<void>;
 
 interface DocsWindowHooks extends Window {
   __fdOnCopyClick__?: CopyHandler;
   __fdOnFeedback__?: FeedbackHandler;
+  __fdAnalytics__?: AnalyticsHandler;
+  __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
 }
 
 function useWindowHook<K extends keyof DocsWindowHooks>(key: K, handler: DocsWindowHooks[K]) {
@@ -32,15 +41,90 @@ function useWindowHook<K extends keyof DocsWindowHooks>(key: K, handler: DocsWin
   }, [handler, key]);
 }
 
+function useAnalyticsHook(analytics?: boolean | DocsAnalyticsConfig) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!analytics) return;
+
+    const target = window as DocsWindowHooks;
+    const handler = (event: DocsAnalyticsEvent) => {
+      void emitDocsAnalyticsEvent(analytics, event);
+    };
+    const previous = target.__fdAnalytics__;
+    target.__fdAnalytics__ = handler;
+
+    const queued = target.__fdAnalyticsQueue__ ?? [];
+    delete target.__fdAnalyticsQueue__;
+    for (const event of queued) handler(event);
+
+    return () => {
+      if (target.__fdAnalytics__ === handler) {
+        if (typeof previous === "function") {
+          target.__fdAnalytics__ = previous;
+        } else {
+          delete target.__fdAnalytics__;
+        }
+      }
+    };
+  }, [analytics]);
+}
+
+function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!analytics) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest?.("button")) return;
+
+      const figure = target.closest("figure");
+      if (!figure) return;
+
+      const code = figure.querySelector("pre code");
+      if (!code) return;
+
+      const content = code.textContent ?? "";
+      const url = window.location.href;
+      const language =
+        code.getAttribute("data-language") ?? figure.getAttribute("data-language") ?? undefined;
+      const title =
+        figure.querySelector("[data-title]")?.textContent?.trim() ??
+        (figure.querySelector(".fd-codeblock-title-text") as HTMLElement)?.textContent?.trim() ??
+        undefined;
+
+      void emitDocsAnalyticsEvent(analytics, {
+        type: "code_block_copy",
+        source: "client",
+        url,
+        path: window.location.pathname,
+        input: { content },
+        properties: {
+          title,
+          language,
+          contentLength: content.length,
+        },
+      });
+    };
+
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [analytics]);
+}
+
 export function DocsClientHooks({
   onCopyClick,
   onFeedback,
+  analytics,
 }: {
   onCopyClick?: CopyHandler;
   onFeedback?: FeedbackHandler;
+  analytics?: boolean | DocsAnalyticsConfig;
 }) {
   useWindowHook("__fdOnCopyClick__", onCopyClick);
   useWindowHook("__fdOnFeedback__", onFeedback);
+  useAnalyticsHook(analytics);
+  useCodeCopyAnalytics(analytics);
 
   return null;
 }

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { useState, useEffect, useRef, useMemo, useCallback, type ReactNode } from "react";
 import { useWindowSearchParams } from "./client-location.js";
 import { resolveClientLocale, withLangInUrl } from "./i18n.js";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 function cn(...classes: Array<string | undefined | null | false>) {
   return classes.filter(Boolean).join(" ");
@@ -363,9 +364,11 @@ interface ResultItem {
 export function DocsCommandSearch({
   api = "/api/docs",
   locale,
+  analytics = false,
 }: {
   api?: string;
   locale?: string;
+  analytics?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -381,6 +384,22 @@ export function DocsCommandSearch({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+
+  const setOpenWithAnalytics = useCallback(
+    (nextOpen: boolean, trigger: string) => {
+      setOpen(nextOpen);
+      if (!analytics) return;
+      emitClientAnalyticsEvent({
+        type: nextOpen ? "search_open" : "search_close",
+        locale: activeLocale,
+        properties: {
+          trigger,
+          mode: "command",
+        },
+      });
+    },
+    [activeLocale, analytics],
+  );
 
   useEffect(() => {
     setMounted(true);
@@ -401,12 +420,12 @@ export function DocsCommandSearch({
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
-        setOpen(true);
+        setOpenWithAnalytics(true, "keyboard");
       }
     }
     document.addEventListener("keydown", handler, true);
     return () => document.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [setOpenWithAnalytics]);
 
   useEffect(() => {
     function handler(e: MouseEvent) {
@@ -423,12 +442,12 @@ export function DocsCommandSearch({
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
-        setOpen(true);
+        setOpenWithAnalytics(true, "button");
       }
     }
     document.addEventListener("click", handler, true);
     return () => document.removeEventListener("click", handler, true);
-  }, []);
+  }, [setOpenWithAnalytics]);
 
   useEffect(() => {
     if (!debouncedQuery.trim()) {
@@ -440,6 +459,7 @@ export function DocsCommandSearch({
     setLoading(true);
 
     (async () => {
+      const startedAt = Date.now();
       try {
         const requestUrl = new URL(searchApi, window.location.origin);
         requestUrl.searchParams.set("query", debouncedQuery);
@@ -465,15 +485,39 @@ export function DocsCommandSearch({
         if (!cancelled) {
           setResults(items);
           setActiveIndex(0);
+          if (analytics) {
+            emitClientAnalyticsEvent({
+              type: "search_query",
+              locale: activeLocale,
+              properties: {
+                mode: "command",
+                queryLength: debouncedQuery.length,
+                resultCount: items.length,
+                durationMs: Math.max(0, Date.now() - startedAt),
+              },
+            });
+          }
         }
-      } catch {}
+      } catch {
+        if (!cancelled && analytics) {
+          emitClientAnalyticsEvent({
+            type: "search_error",
+            locale: activeLocale,
+            properties: {
+              mode: "command",
+              queryLength: debouncedQuery.length,
+              durationMs: Math.max(0, Date.now() - startedAt),
+            },
+          });
+        }
+      }
       if (!cancelled) setLoading(false);
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [activeLocale, debouncedQuery, searchApi]);
+  }, [activeLocale, analytics, debouncedQuery, searchApi]);
 
   useEffect(() => {
     if (open) {
@@ -512,12 +556,12 @@ export function DocsCommandSearch({
     if (!open) return;
     function handler(e: KeyboardEvent) {
       if (e.key === "Escape") {
-        setOpen(false);
+        setOpenWithAnalytics(false, "escape");
       }
     }
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open]);
+  }, [open, setOpenWithAnalytics]);
 
   const saveRecent = useCallback(
     (item: ResultItem) => {
@@ -533,12 +577,26 @@ export function DocsCommandSearch({
 
   const execute = useCallback(
     (item: ResultItem) => {
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "search_result_click",
+          locale: activeLocale,
+          path: item.url,
+          properties: {
+            mode: "command",
+            resultId: item.id,
+            resultUrl: item.url,
+            labelLength: item.label.length,
+            queryLength: query.length,
+          },
+        });
+      }
       saveRecent(item);
       setOpen(false);
       if (item.url.startsWith("http")) window.open(item.url, "_blank", "noopener");
       else window.location.href = item.url;
     },
-    [saveRecent],
+    [activeLocale, analytics, query.length, saveRecent],
   );
 
   const displayItems = useMemo(() => {
@@ -591,7 +649,7 @@ export function DocsCommandSearch({
 
   return createPortal(
     <>
-      <div className="omni-overlay" onClick={() => setOpen(false)} />
+      <div className="omni-overlay" onClick={() => setOpenWithAnalytics(false, "overlay")} />
       <div
         className="omni-content"
         role="dialog"
@@ -615,7 +673,11 @@ export function DocsCommandSearch({
               className="omni-search-input"
             />
             <kbd className="omni-kbd">⌘ K</kbd>
-            <button aria-label="Close" className="omni-close-btn" onClick={() => setOpen(false)}>
+            <button
+              aria-label="Close"
+              className="omni-close-btn"
+              onClick={() => setOpenWithAnalytics(false, "button")}
+            >
               <CloseIcon />
             </button>
           </div>

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { DocsFeedbackData, DocsFeedbackValue } from "@farming-labs/docs";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 interface DocsWindowHooks extends Window {
   __fdOnFeedback__?: (data: DocsFeedbackData) => void | Promise<void>;
@@ -17,6 +18,7 @@ export interface DocsFeedbackProps {
   negativeLabel?: string;
   submitLabel?: string;
   onFeedback?: (data: DocsFeedbackData) => void | Promise<void>;
+  analytics?: boolean;
 }
 
 function normalizePathname(pathname: string) {
@@ -139,6 +141,7 @@ export function DocsFeedback({
   negativeLabel = "Bad",
   submitLabel = "Submit",
   onFeedback,
+  analytics = false,
 }: DocsFeedbackProps) {
   const [selected, setSelected] = useState<DocsFeedbackValue | null>(null);
   const [comment, setComment] = useState("");
@@ -156,6 +159,17 @@ export function DocsFeedback({
   function handleSelect(value: DocsFeedbackValue) {
     setSelected(value);
     if (status !== "idle") setStatus("idle");
+    if (analytics) {
+      emitClientAnalyticsEvent({
+        type: "feedback_select",
+        locale,
+        path: normalizedPathname,
+        properties: {
+          value,
+          slug: resolveSlug(entry, normalizedPathname),
+        },
+      });
+    }
   }
 
   async function handleSubmit() {
@@ -164,12 +178,36 @@ export function DocsFeedback({
     setStatus("submitting");
 
     try {
-      await emitFeedback(
-        buildFeedbackPayload(selected, normalizedPathname, entry, comment, locale),
-        onFeedback,
-      );
+      const payload = buildFeedbackPayload(selected, normalizedPathname, entry, comment, locale);
+      await emitFeedback(payload, onFeedback);
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "feedback_submit",
+          locale,
+          path: normalizedPathname,
+          properties: {
+            value: payload.value,
+            slug: payload.slug,
+            hasComment: Boolean(payload.comment),
+            commentLength: payload.comment?.length ?? 0,
+          },
+        });
+      }
       setStatus("submitted");
     } catch {
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "feedback_error",
+          locale,
+          path: normalizedPathname,
+          properties: {
+            value: selected,
+            slug: resolveSlug(entry, normalizedPathname),
+            hasComment: Boolean(comment.trim()),
+            commentLength: comment.trim().length,
+          },
+        });
+      }
       setStatus("error");
     }
   }

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -10,6 +10,7 @@ import {
   buildPageTwitter,
   resolveChangelogConfig,
   resolveDocsAgentMdxContent,
+  resolveDocsAnalyticsConfig,
   resolvePageSidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 import type {
@@ -780,6 +781,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const tocConfig = config.theme?.ui?.layout?.toc;
   const tocEnabled = tocConfig?.enabled !== false;
   const tocStyle = (tocConfig as any)?.style as "default" | "directional" | undefined;
+  const analyticsEnabled = resolveDocsAnalyticsConfig(config.analytics).enabled;
 
   const localeContext = resolveDocsLocaleContext(config, options?.locale);
   const i18n = resolveDocsI18nConfig(getDocsI18n(config));
@@ -981,7 +983,11 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
         {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
         {!staticExport && (
           <Suspense fallback={null}>
-            <DocsCommandSearch api={docsApiUrl} locale={activeLocale} />
+            <DocsCommandSearch
+              api={docsApiUrl}
+              locale={activeLocale}
+              analytics={analyticsEnabled}
+            />
           </Suspense>
         )}
         {aiEnabled && (
@@ -999,6 +1005,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
               loadingComponentHtml={aiLoadingComponentHtml}
               models={aiModels}
               defaultModelId={aiDefaultModelId}
+              analytics={analyticsEnabled}
             />
           </Suspense>
         )}
@@ -1032,6 +1039,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             feedbackPositiveLabel={feedbackConfig.positiveLabel}
             feedbackNegativeLabel={feedbackConfig.negativeLabel}
             feedbackSubmitLabel={feedbackConfig.submitLabel}
+            analytics={analyticsEnabled}
           >
             {children}
           </DocsPageClient>

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -17,6 +17,7 @@ import { PageActions } from "./page-actions.js";
 import { useWindowSearchParams } from "./client-location.js";
 import { DocsFeedback } from "./docs-feedback.js";
 import { resolveClientLocale, withLangInUrl } from "./i18n.js";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 interface TOCItem {
   title: string;
@@ -93,6 +94,7 @@ interface DocsPageClientProps {
   feedbackNegativeLabel?: string;
   feedbackSubmitLabel?: string;
   feedbackOnFeedback?: (data: DocsFeedbackData) => void | Promise<void>;
+  analytics?: boolean;
   children: ReactNode;
 }
 
@@ -360,6 +362,7 @@ export function DocsPageClient({
   feedbackNegativeLabel,
   feedbackSubmitLabel,
   feedbackOnFeedback,
+  analytics = false,
   children,
 }: DocsPageClientProps) {
   const fdTocStyle = tocStyle === "directional" ? "clerk" : undefined;
@@ -378,6 +381,20 @@ export function DocsPageClient({
     (normalizedPath === changelogBasePath || normalizedPath.startsWith(`${changelogBasePath}/`))
   );
   const matchedReadingTime = readingTimeMap?.[normalizedPath];
+
+  useEffect(() => {
+    if (!analytics) return;
+    emitClientAnalyticsEvent({
+      type: "page_view",
+      locale: activeLocale,
+      path: normalizedPath,
+      properties: {
+        entry,
+        pathname: normalizedPath,
+        isChangelogRoute,
+      },
+    });
+  }, [analytics, activeLocale, entry, isChangelogRoute, normalizedPath]);
   const resolvedReadingTime = !isChangelogRoute
     ? readingTimeProp !== undefined
       ? readingTimeProp
@@ -539,6 +556,7 @@ export function DocsPageClient({
               providers={openDocsProviders}
               alignment={pageActionsAlignment}
               githubFileUrl={githubFileUrl}
+              analytics={analytics}
             />
           </div>
         )}
@@ -610,6 +628,7 @@ export function DocsPageClient({
               providers={openDocsProviders}
               alignment={pageActionsAlignment}
               githubFileUrl={githubFileUrl}
+              analytics={analytics}
             />
           </div>
           {readingTimeBlock}
@@ -630,6 +649,7 @@ export function DocsPageClient({
             negativeLabel={feedbackNegativeLabel}
             submitLabel={feedbackSubmitLabel}
             onFeedback={feedbackOnFeedback}
+            analytics={analytics}
           />
         )}
         {showFooter && (

--- a/packages/fumadocs/src/page-actions.tsx
+++ b/packages/fumadocs/src/page-actions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { usePathname } from "fumadocs-core/framework";
+import { emitClientAnalyticsEvent } from "./client-analytics.js";
 
 /** Serializable provider — icon is an HTML string, not JSX. */
 interface SerializedProvider {
@@ -17,6 +18,7 @@ interface PageActionsProps {
   alignment?: "left" | "right";
   /** GitHub file URL (edit view) for the current page. Used when urlTemplate contains {githubUrl}. */
   githubFileUrl?: string | null;
+  analytics?: boolean;
 }
 
 const CopyIcon = () => (
@@ -100,6 +102,7 @@ export function PageActions({
   providers,
   alignment = "left",
   githubFileUrl,
+  analytics = false,
 }: PageActionsProps) {
   const [copied, setCopied] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -112,17 +115,28 @@ export function PageActions({
     try {
       const article = document.querySelector("article");
       if (article) {
-        await navigator.clipboard.writeText(article.innerText || "");
+        const content = article.innerText || "";
+        await navigator.clipboard.writeText(content);
+        if (analytics) {
+          emitClientAnalyticsEvent({
+            type: "page_action_copy_markdown",
+            properties: {
+              contentLength: content.length,
+              pathname,
+            },
+          });
+        }
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       }
     } catch {
       // silent
     }
-  }, []);
+  }, [analytics, pathname]);
 
   const handleOpen = useCallback(
-    (template: string) => {
+    (provider: SerializedProvider) => {
+      const template = provider.urlTemplate;
       if (/\{githubUrl\}/.test(template) && !githubFileUrl) {
         setDropdownOpen(false);
         return;
@@ -133,10 +147,20 @@ export function PageActions({
         .replace(/\{url\}/g, encodeURIComponent(pageUrl))
         .replace(/\{mdxUrl\}/g, encodeURIComponent(mdxUrl))
         .replace(/\{githubUrl\}/g, githubFileUrl ?? "");
+      if (analytics) {
+        emitClientAnalyticsEvent({
+          type: "page_action_open_docs",
+          properties: {
+            provider: provider.name,
+            pathname,
+            usesGithubUrl: template.includes("{githubUrl}"),
+          },
+        });
+      }
       window.open(url, "_blank", "noopener,noreferrer");
       setDropdownOpen(false);
     },
-    [pathname, githubFileUrl],
+    [analytics, pathname, githubFileUrl],
   );
 
   // Close dropdown on click outside
@@ -177,7 +201,19 @@ export function PageActions({
         <div ref={dropdownRef} className="fd-page-action-dropdown">
           <button
             type="button"
-            onClick={() => setDropdownOpen(!dropdownOpen)}
+            onClick={() => {
+              const next = !dropdownOpen;
+              setDropdownOpen(next);
+              if (analytics && next) {
+                emitClientAnalyticsEvent({
+                  type: "page_action_open_docs_menu",
+                  properties: {
+                    providerCount: resolvedProviders.length,
+                    pathname,
+                  },
+                });
+              }
+            }}
             className="fd-page-action-btn"
             aria-expanded={dropdownOpen}
           >
@@ -193,7 +229,7 @@ export function PageActions({
                   type="button"
                   role="menuitem"
                   className="fd-page-action-menu-item"
-                  onClick={() => handleOpen(provider.urlTemplate)}
+                  onClick={() => handleOpen(provider)}
                 >
                   {provider.iconHtml && (
                     <span

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -9,7 +9,7 @@ import type {
   AIConfig,
   OpenDocsProvider,
 } from "@farming-labs/docs";
-import { applySidebarFolderIndexBehavior } from "@farming-labs/docs";
+import { applySidebarFolderIndexBehavior, resolveDocsAnalyticsConfig } from "@farming-labs/docs";
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
@@ -327,6 +327,7 @@ export function TanstackDocsLayout({
   const tocConfig = config.theme?.ui?.layout?.toc;
   const tocEnabled = tocConfig?.enabled !== false;
   const tocStyle = tocConfig?.style as "default" | "directional" | undefined;
+  const analyticsEnabled = resolveDocsAnalyticsConfig(config.analytics).enabled;
   const docsApiUrl = withLangInUrl("/api/docs", locale);
   const navTitle = (config.nav?.title as ReactNode) ?? "Docs";
   const navUrl = withLangInUrl(config.nav?.url ?? `/${config.entry ?? "docs"}`, locale);
@@ -473,7 +474,7 @@ export function TanstackDocsLayout({
       {forcedTheme && <ForcedThemeScript theme={forcedTheme} />}
       {!staticExport && (
         <Suspense fallback={null}>
-          <DocsCommandSearch api={docsApiUrl} locale={locale} />
+          <DocsCommandSearch api={docsApiUrl} locale={locale} analytics={analyticsEnabled} />
         </Suspense>
       )}
       {aiEnabled && (
@@ -489,6 +490,7 @@ export function TanstackDocsLayout({
             loaderVariant={aiLoaderVariant}
             models={aiModels}
             defaultModelId={aiDefaultModelId}
+            analytics={analyticsEnabled}
           />
         </Suspense>
       )}
@@ -518,6 +520,7 @@ export function TanstackDocsLayout({
           feedbackPositiveLabel={feedbackConfig.positiveLabel}
           feedbackNegativeLabel={feedbackConfig.negativeLabel}
           feedbackSubmitLabel={feedbackConfig.submitLabel}
+          analytics={analyticsEnabled}
         >
           {children}
         </DocsPageClient>

--- a/packages/next/src/api-reference.tsx
+++ b/packages/next/src/api-reference.tsx
@@ -843,9 +843,9 @@ function ApiReferenceSwitcher({
     overflow: "hidden",
     backgroundImage: theme.backgroundImage,
     boxShadow: theme.boxShadow,
-    ["--fd-api-switcher-card-radius" as "--fd-api-switcher-card-radius"]: theme.cardRadius,
-    ["--fd-api-switcher-icon-radius" as "--fd-api-switcher-icon-radius"]: theme.iconRadius,
-    ["--fd-api-switcher-shadow" as "--fd-api-switcher-shadow"]: theme.boxShadow,
+    ["--fd-api-switcher-card-radius" as const]: theme.cardRadius,
+    ["--fd-api-switcher-icon-radius" as const]: theme.iconRadius,
+    ["--fd-api-switcher-shadow" as const]: theme.boxShadow,
   } as CSSProperties;
 
   return (

--- a/packages/next/src/client-callbacks.tsx
+++ b/packages/next/src/client-callbacks.tsx
@@ -41,6 +41,7 @@ export default function DocsClientCallbacks(props?: { apiReferencePrimaryServerU
   return (
     <DocsClientHooks
       onCopyClick={docsConfig.onCopyClick}
+      analytics={docsConfig.analytics}
       onFeedback={
         docsConfig.feedback && typeof docsConfig.feedback === "object"
           ? docsConfig.feedback.onFeedback

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -105,6 +105,7 @@ export const { GET, POST } = createDocsAPI({
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
   search: docsConfig.search,
+  analytics: docsConfig.analytics,
   ai: docsConfig.ai,
 });
 
@@ -122,6 +123,7 @@ export const { GET, POST, DELETE } = createDocsMCPAPI({
   nav: docsConfig.nav,
   ordering: docsConfig.ordering,
   search: docsConfig.search,
+  analytics: docsConfig.analytics,
   mcp: docsConfig.mcp,
 });
 

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -21,6 +21,7 @@ import { eventHandler, getRequestURL, readRawBody } from "h3";
 import {
   applySidebarFolderIndexBehavior,
   buildDocsAgentDiscoverySpec,
+  emitDocsAnalyticsEvent,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsMcpRequest,
@@ -471,6 +472,7 @@ function findPageInMap(
  */
 export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const entry = (config.entry as string) ?? "docs";
+  const analytics = config.analytics;
   const contentDirBase =
     ((config as Record<string, unknown>).contentDir as string | undefined) ?? entry;
   const rootDir = path.resolve(
@@ -913,6 +915,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
+    const searchStartedAt = Date.now();
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
@@ -920,6 +923,20 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+    });
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_search",
+      source: "server",
+      url: context.request.url,
+      path: url.pathname,
+      locale: ctx.locale,
+      input: { query },
+      properties: {
+        queryLength: query.length,
+        resultCount: results.length,
+        pathname: url.searchParams.get("pathname") ?? undefined,
+        durationMs: Math.max(0, Date.now() - searchStartedAt),
+      },
     });
 
     return new Response(JSON.stringify(results), {
@@ -962,7 +979,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(context: { request: Request }): Promise<Response> {
+    const requestUrl = new URL(context.request.url);
+    const requestStartedAt = Date.now();
     if (!aiConfig.enabled) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        properties: { reason: "disabled" },
+      });
       return new Response(
         JSON.stringify({
           error: "AI is not enabled. Set `ai: { enabled: true }` in your docs config to enable it.",
@@ -975,6 +1001,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       aiConfig.apiKey ?? (typeof process !== "undefined" ? process.env?.OPENAI_API_KEY : undefined);
 
     if (!resolvedKey) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        properties: {
+          reason: "missing_api_key",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({
           error:
@@ -990,6 +1026,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     try {
       body = await context.request.json();
     } catch {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "invalid_json",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "Invalid JSON body. Expected { messages: [...] }" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -998,6 +1045,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const messages = body.messages;
     if (!Array.isArray(messages) || messages.length === 0) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_messages",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "messages array is required and must not be empty." }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -1006,6 +1064,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
     if (!lastUserMessage) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_user_message",
+          messageCount: messages.length,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(JSON.stringify({ error: "At least one user message is required." }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1041,6 +1111,21 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const resolved = resolveAIModelAndProvider(aiConfig, requestedModel);
     const finalKey = resolved.apiKey ?? resolvedKey;
 
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_request",
+      source: "server",
+      url: context.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+      },
+    });
+
     const llmResponse = await fetch(`${resolved.baseUrl}/chat/completions`, {
       method: "POST",
       headers: {
@@ -1052,11 +1137,44 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     if (!llmResponse.ok) {
       const errText = await llmResponse.text().catch(() => "Unknown error");
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: context.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        input: { question: lastUserMessage.content },
+        properties: {
+          reason: "llm_error",
+          status: llmResponse.status,
+          messageCount: messages.length,
+          questionLength: lastUserMessage.content.length,
+          retrievedCount: scored.length,
+          model: resolved.model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: `LLM API error (${llmResponse.status}): ${errText}` }),
         { status: 502, headers: { "Content-Type": "application/json" } },
       );
     }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_response",
+      source: "server",
+      url: context.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
 
     return new Response(llmResponse.body, {
       headers: {
@@ -1094,6 +1212,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    analytics,
     defaultName: mcpSiteTitle,
   });
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -34,6 +34,7 @@ import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
   buildDocsAgentDiscoverySpec,
+  emitDocsAnalyticsEvent,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -493,6 +494,7 @@ function findPageInMap(
  */
 export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const entry = (config.entry as string) ?? "docs";
+  const analytics = config.analytics;
   const contentDirBase =
     ((config as Record<string, unknown>).contentDir as string | undefined) ?? entry;
   const rootDir = path.resolve(
@@ -932,6 +934,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
+    const searchStartedAt = Date.now();
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
@@ -939,6 +942,20 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: event.url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+    });
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_search",
+      source: "server",
+      url: event.request.url,
+      path: event.url.pathname,
+      locale: ctx.locale,
+      input: { query },
+      properties: {
+        queryLength: query.length,
+        resultCount: results.length,
+        pathname: event.url.searchParams.get("pathname") ?? undefined,
+        durationMs: Math.max(0, Date.now() - searchStartedAt),
+      },
     });
 
     return new Response(JSON.stringify(results), {
@@ -981,7 +998,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(event: RequestEvent): Promise<Response> {
+    const requestUrl = new URL(event.request.url);
+    const requestStartedAt = Date.now();
     if (!aiConfig.enabled) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        properties: { reason: "disabled" },
+      });
       return new Response(
         JSON.stringify({
           error: "AI is not enabled. Set `ai: { enabled: true }` in your docs config to enable it.",
@@ -996,6 +1022,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       (typeof process !== "undefined" ? process.env?.OPENAI_API_KEY : undefined);
 
     if (!resolvedKey) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        properties: {
+          reason: "missing_api_key",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({
           error:
@@ -1011,6 +1047,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     try {
       body = await event.request.json();
     } catch {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "invalid_json",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "Invalid JSON body. Expected { messages: [...] }" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -1019,6 +1066,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const messages = body.messages;
     if (!Array.isArray(messages) || messages.length === 0) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_messages",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "messages array is required and must not be empty." }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -1027,6 +1085,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const lastUserMessage = [...messages].reverse().find((m) => m.role === "user");
     if (!lastUserMessage) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_user_message",
+          messageCount: messages.length,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(JSON.stringify({ error: "At least one user message is required." }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1062,6 +1132,21 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const resolved = resolveAIModelAndProvider(aiConfig, requestedModel);
     const finalKey = resolved.apiKey ?? resolvedKey;
 
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_request",
+      source: "server",
+      url: event.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+      },
+    });
+
     const llmResponse = await fetch(`${resolved.baseUrl}/chat/completions`, {
       method: "POST",
       headers: {
@@ -1073,11 +1158,44 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     if (!llmResponse.ok) {
       const errText = await llmResponse.text().catch(() => "Unknown error");
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        input: { question: lastUserMessage.content },
+        properties: {
+          reason: "llm_error",
+          status: llmResponse.status,
+          messageCount: messages.length,
+          questionLength: lastUserMessage.content.length,
+          retrievedCount: scored.length,
+          model: resolved.model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: `LLM API error (${llmResponse.status}): ${errText}` }),
         { status: 502, headers: { "Content-Type": "application/json" } },
       );
     }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_response",
+      source: "server",
+      url: event.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
 
     return new Response(llmResponse.body, {
       headers: {
@@ -1115,6 +1233,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    analytics,
     defaultName: mcpSiteTitle,
   });
 

--- a/packages/tanstack-start/src/react.tsx
+++ b/packages/tanstack-start/src/react.tsx
@@ -52,6 +52,7 @@ export function TanstackDocsPage({
     <>
       <DocsClientHooks
         onCopyClick={config.onCopyClick}
+        analytics={config.analytics}
         onFeedback={
           typeof config.feedback === "object"
             ? (config.feedback as FeedbackConfig).onFeedback

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
   buildDocsAgentDiscoverySpec,
+  emitDocsAnalyticsEvent,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -472,6 +473,7 @@ function readRootSkillDocument(contentMap: ContentFileMap | null, rootDir: strin
 
 export function createDocsServer(config: Record<string, any>): DocsServer {
   const entry = config.entry ?? "docs";
+  const analytics = config.analytics;
   const ordering = config.ordering;
   const contentDirBase = config.contentDir ?? entry;
   const rootDir = path.resolve((config.rootDir as string | undefined) ?? process.cwd());
@@ -894,6 +896,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       });
     }
 
+    const searchStartedAt = Date.now();
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
@@ -901,6 +904,20 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+    });
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_search",
+      source: "server",
+      url: event.request.url,
+      path: url.pathname,
+      locale: ctx.locale,
+      input: { query },
+      properties: {
+        queryLength: query.length,
+        resultCount: results.length,
+        pathname: url.searchParams.get("pathname") ?? undefined,
+        durationMs: Math.max(0, Date.now() - searchStartedAt),
+      },
     });
 
     return new Response(JSON.stringify(results), {
@@ -938,7 +955,18 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   }
 
   async function POST(event: { request: Request }): Promise<Response> {
+    const requestUrl = new URL(event.request.url);
+    const requestStartedAt = Date.now();
     if (!aiConfig.enabled) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        properties: {
+          reason: "disabled",
+        },
+      });
       return new Response(
         JSON.stringify({
           error: "AI is not enabled. Set `ai: { enabled: true }` in your docs config to enable it.",
@@ -950,6 +978,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const resolvedKey = aiConfig.apiKey ?? process.env?.OPENAI_API_KEY;
 
     if (!resolvedKey) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        properties: {
+          reason: "missing_api_key",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({
           error:
@@ -965,6 +1003,17 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     try {
       body = await event.request.json();
     } catch {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "invalid_json",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "Invalid JSON body. Expected { messages: [...] }" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -973,6 +1022,17 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     const messages = body.messages;
     if (!Array.isArray(messages) || messages.length === 0) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_messages",
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: "messages array is required and must not be empty." }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -981,6 +1041,18 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     const lastUserMessage = [...messages].reverse().find((message) => message.role === "user");
     if (!lastUserMessage) {
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        properties: {
+          reason: "missing_user_message",
+          messageCount: messages.length,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(JSON.stringify({ error: "At least one user message is required." }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -1016,6 +1088,21 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const resolved = resolveAIModelAndProvider(aiConfig, requestedModel);
     const finalKey = resolved.apiKey ?? resolvedKey;
 
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_request",
+      source: "server",
+      url: event.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+      },
+    });
+
     const llmResponse = await fetch(`${resolved.baseUrl}/chat/completions`, {
       method: "POST",
       headers: {
@@ -1027,11 +1114,44 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     if (!llmResponse.ok) {
       const errText = await llmResponse.text().catch(() => "Unknown error");
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: event.request.url,
+        path: requestUrl.pathname,
+        locale: ctx.locale,
+        input: { question: lastUserMessage.content },
+        properties: {
+          reason: "llm_error",
+          status: llmResponse.status,
+          messageCount: messages.length,
+          questionLength: lastUserMessage.content.length,
+          retrievedCount: scored.length,
+          model: resolved.model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
       return new Response(
         JSON.stringify({ error: `LLM API error (${llmResponse.status}): ${errText}` }),
         { status: 502, headers: { "Content-Type": "application/json" } },
       );
     }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_response",
+      source: "server",
+      url: event.request.url,
+      path: requestUrl.pathname,
+      locale: ctx.locale,
+      input: { question: lastUserMessage.content },
+      properties: {
+        messageCount: messages.length,
+        questionLength: lastUserMessage.content.length,
+        retrievedCount: scored.length,
+        model: resolved.model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
 
     return new Response(llmResponse.body, {
       headers: {
@@ -1065,6 +1185,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       },
     },
     mcp: config.mcp,
+    analytics,
     defaultName: mcpSiteTitle,
   });
 

--- a/website/app/api/docs/mcp/route.ts
+++ b/website/app/api/docs/mcp/route.ts
@@ -9,6 +9,7 @@ export const { GET, POST, DELETE } = createDocsMCPAPI({
   nav: docsConfig.nav,
   ordering: docsConfig.ordering,
   search: docsConfig.search,
+  analytics: docsConfig.analytics,
   mcp: docsConfig.mcp,
 });
 

--- a/website/app/api/docs/route.ts
+++ b/website/app/api/docs/route.ts
@@ -9,6 +9,7 @@ export const { GET, POST } = createDocsAPI({
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
   search: docsConfig.search,
+  analytics: docsConfig.analytics,
   ai: docsConfig.ai,
 });
 

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -46,6 +46,12 @@ interface DocsAnalyticsEvent {
   path?: string;
   referrer?: string;
   locale?: string;
+  input?: {
+    query?: string;
+    question?: string;
+    feedbackComment?: string;
+    content?: string;
+  };
   properties?: Record<string, unknown>;
 }
 ```
@@ -56,7 +62,7 @@ Client events:
 
 - `page_view`
 - `search_open`, `search_close`, `search_query`, `search_result_click`, `search_error`
-- `ai_open`, `ai_question`, `ai_response`, `ai_error`, `ai_clear`
+- `ai_open`, `ai_close`, `ai_question`, `ai_response`, `ai_error`, `ai_clear`
 - `page_action_copy_markdown`, `page_action_open_docs_menu`, `page_action_open_docs`
 - `code_block_copy`
 - `feedback_select`, `feedback_submit`, `feedback_error`

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -1,0 +1,110 @@
+---
+title: "Analytics"
+description: "Log docs, search, AI, feedback, agent, and MCP events from one config hook"
+icon: "zap"
+order: 5.65
+---
+
+# Analytics
+
+Use the built-in analytics stream when you want visibility into how humans and agents use your docs. It tracks page views, search, Ask AI, feedback, page actions, code-copy, markdown/llms routes, agent feedback, and MCP requests through one typed event contract.
+
+## Quick Start
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  analytics: true,
+});
+```
+
+`analytics: true` logs every framework event to the console with the `[farming-labs:analytics]` prefix.
+
+## Send Events To Your Own Sink
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  analytics: {
+    async onEvent(event) {
+      await fetch("https://analytics.example.com/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(event),
+      });
+    },
+  },
+});
+```
+
+Events have this shape:
+
+```ts
+interface DocsAnalyticsEvent {
+  type: string;
+  timestamp: string;
+  source: "client" | "server" | "mcp";
+  url?: string;
+  path?: string;
+  referrer?: string;
+  locale?: string;
+  properties?: Record<string, unknown>;
+}
+```
+
+## Logged Events
+
+Client events:
+
+- `page_view`
+- `search_open`, `search_close`, `search_query`, `search_result_click`, `search_error`
+- `ai_open`, `ai_question`, `ai_response`, `ai_error`, `ai_clear`
+- `page_action_copy_markdown`, `page_action_open_docs_menu`, `page_action_open_docs`
+- `code_block_copy`
+- `feedback_select`, `feedback_submit`, `feedback_error`
+
+Server and agent events:
+
+- `api_search`
+- `api_ai_request`, `api_ai_response`, `api_ai_error`
+- `agent_read`
+- `markdown_request`, `llms_request`, `skill_request`
+- `agent_spec_request`, `agent_feedback_schema`, `agent_feedback_submit`, `agent_feedback_error`
+- `mcp_request`, `mcp_tool`
+
+`agent_read` fires when a page is read through the machine-readable surface: `/docs/page.md`,
+`/docs/page` with `Accept: text/markdown`, `GET /api/docs?format=markdown&path=page`, or MCP
+`read_page`. Its `properties.delivery` value is `md_route`, `accept_header`, `api_format`, or
+`mcp_tool`.
+
+## Input Privacy
+
+By default, analytics events only include safe metadata such as paths, counts, durations, status, result counts, model IDs, content lengths, and whether a comment exists.
+
+<Callout type="warning" title="Inputs are excluded by default">
+  Search queries, AI questions, feedback comments, and copied content are not included unless you
+  explicitly set `includeInputs: true`. This keeps analytics separate from prompt context and avoids
+  logging user-authored text by accident.
+</Callout>
+
+Enable raw input capture only when you have user consent and a retention policy:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  analytics: {
+    includeInputs: true,
+    onEvent(event) {
+      console.info(event);
+    },
+  },
+});
+```
+
+## Options
+
+| Option          | Type                                      | Default                      |
+| --------------- | ----------------------------------------- | ---------------------------- |
+| `enabled`       | `boolean`                                 | `true` when object is passed |
+| `console`       | `boolean \| "log" \| "info" \| "debug"` | `true` for `analytics: true` |
+| `includeInputs` | `boolean`                                 | `false`                      |
+| `onEvent`       | `(event) => void \| Promise<void>`        | `undefined`                  |
+
+When both `console` and `onEvent` are set, the framework logs to both places.

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customization"
-description: "Colors, typography, sidebar, components, agent primitives, OG images, AI chat, and page actions"
+description: "Colors, typography, sidebar, components, analytics, agent primitives, OG images, AI chat, and page actions"
 icon: "settings"
 order: 5
 ---
@@ -19,6 +19,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[OG Images](/docs/customization/og-images)** — Dynamic or static Open Graph images; what context your image generator receives; how the docs website does it
 - **[Ask AI](/docs/customization/ai-chat)** — RAG-powered AI chat with configurable LLM, floating/search modes, and more
 - **[Page Actions](/docs/customization/page-actions)** — "Copy Markdown" and "Open in LLM" buttons on doc pages
+- **[Analytics](/docs/customization/analytics)** — Log page views, search, AI, feedback, page actions, agent routes, and MCP usage
 - **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio, `/mcp`, and `/.well-known/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -43,6 +43,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `sidebar`     | `boolean \| SidebarConfig`                      | `true`           | Sidebar visibility and customization                                                 |
 | `icons`       | `Record<string, unknown>`                       | —                | Shared icon registry for frontmatter `icon` fields and built-ins like `Prompt`       |
 | `components`  | `Record<string, unknown>`                       | —                | Custom MDX component overrides, including built-ins like `HoverLink` and `Prompt`    |
+| `analytics`   | `boolean \| DocsAnalyticsConfig`                | `false`          | Built-in event stream for page views, search, AI, feedback, page actions, agent routes, and MCP |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void`              | —                | Callback when the user clicks the copy button on a code block (runs in addition to copy) |
 | `feedback`    | `boolean \| FeedbackConfig`                     | `false`          | Human page feedback UI plus optional agent feedback endpoints                        |
 | `agent`       | `DocsAgentConfig`                               | —                | Defaults for `docs agent compact` and related machine-docs workflows                 |
@@ -60,6 +61,32 @@ Top-level configuration object passed to `defineDocs()`.
 ---
 
 `components` is merged into the default MDX component map, so you can both add your own components and replace built-ins such as `Callout`, `Tabs`, `HoverLink`, or `Prompt`. For built-in defaults like `theme.ui.components.HoverLink` and `theme.ui.components.Prompt`, see [Creating themes](/docs/themes/creating-themes). For usage examples and a live demo, see [Components](/docs/customization/components).
+
+---
+
+## `analytics` and `DocsAnalyticsConfig`
+
+Built-in analytics event stream. See [Analytics](/docs/customization/analytics) for the full guide and event list.
+
+| Option          | Type                                      | Default                      | Description                                                        |
+| --------------- | ----------------------------------------- | ---------------------------- | ------------------------------------------------------------------ |
+| `enabled`       | `boolean`                                 | `true` when object is passed | Enable or disable the analytics stream                             |
+| `console`       | `boolean \| "log" \| "info" \| "debug"` | `true` for `analytics: true` | Log analytics events to the console                                |
+| `includeInputs` | `boolean`                                 | `false`                      | Include raw queries, AI questions, feedback comments, copied text   |
+| `onEvent`       | `(event) => void \| Promise<void>`        | —                            | Callback fired for every analytics event                           |
+
+```ts title="docs.config.ts"
+analytics: {
+  onEvent(event) {
+    console.info(event.type, event.properties);
+  },
+}
+```
+
+<Callout type="warning" title="Inputs stay out unless requested">
+  Search queries, AI questions, feedback comments, and copied content are omitted by default. Set
+  `includeInputs: true` only when your project is allowed to store that text.
+</Callout>
 
 ---
 

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -62,6 +62,9 @@ const searchConfig =
 export default defineDocs({
   entry: "docs",
   search: searchConfig,
+  analytics: {
+    console: "info",
+  },
   theme: pixelBorder({
     ui: {
       layout: { toc: { enabled: true, depth: 3, style: "directional" }, sidebarWidth: 320 },


### PR DESCRIPTION
- **feat: analytics event**
- **chore: lint**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a first-class analytics event stream for docs usage across client, server, and MCP, controlled by a new `analytics` config. Tracks page views, search, AI, feedback, page actions, code-copy, agent reads, API routes, and MCP, with console logging or a hook to forward events.

- **New Features**
  - New `analytics` option in `defineDocs`; exports `resolveDocsAnalyticsConfig`, `emitDocsAnalyticsEvent`, `ResolvedDocsAnalyticsConfig`, and types from `@farming-labs/docs`.
  - Client instrumentation via `emitClientAnalyticsEvent` and `DocsClientHooks` in page load, search dialog, AI chat, feedback, page actions, and code block copy; events include path, url, referrer, timestamp.
  - Server instrumentation in `docs-api`, MCP server, and framework servers (Astro, Nuxt, Svelte, TanStack Start) for search queries, agent reads, API search/AI requests, and MCP requests/tools; captures durations and errors.
  - Typed events include: `page_view`, `search_*`, `ai_*`, `feedback_*`, `page_action_*`, `code_block_copy`, `agent_*`, `api_*`, `mcp_*`.
  - Docs and tests added; new guide at `/docs/customization/analytics`; website enables `analytics: { console: "info" }`.

- **Migration**
  - Opt-in via `analytics: true` or `{ console?: false|"log"|"info"|"debug", includeInputs?, onEvent? }` in `docs.config.ts`.
  - To forward events, implement `analytics: { async onEvent(event) { /* send to your sink */ } }`. No other changes required.

<sup>Written for commit 35d7ae653ae6045062657f8f165af9815bb5120f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

