### PR TITLE
feat: docs selector menu

### DIFF
--- a/examples/next/app/global.css
+++ b/examples/next/app/global.css
@@ -1,2 +1,2 @@
 @import "tailwindcss";
-@import "@farming-labs/theme/ledger/css";
+@import "@farming-labs/theme/colorful/css";

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -18,7 +18,7 @@ import {
   Users,
   Mail,
 } from "lucide-react";
-import { ledger } from "@farming-labs/theme/ledger";
+import { colorful } from "@farming-labs/theme/colorful";
 
 const typesenseBaseUrl = process.env.TYPESENSE_URL ?? process.env.TYPESENSE_BASE_URL;
 const typesenseCollection = process.env.TYPESENSE_COLLECTION ?? "docs";
@@ -82,7 +82,7 @@ export default defineDocs({
     branch: "main",
     directory: "examples/next",
   },
-  theme: ledger({
+  theme: colorful({
     ui: {
       layout: {
         sidebarWidth: 300,

--- a/packages/next/src/api-reference.tsx
+++ b/packages/next/src/api-reference.tsx
@@ -9,9 +9,13 @@ import {
   resolveApiReferenceConfig,
   resolveApiReferenceRenderer,
 } from "@farming-labs/docs/server";
+import {
+  SidebarTabsDropdown,
+  type SidebarTabWithProps,
+} from "fumadocs-ui/components/sidebar/tabs/dropdown";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import DocsClientCallbacks from "./client-callbacks.js";
 
 export { resolveApiReferenceConfig };
@@ -452,36 +456,13 @@ export function buildNextOpenApiDocument(config: DocsConfig): Record<string, unk
   };
 }
 
-function SwitcherGlyph({
-  kind,
-  radius,
-  active,
-}: {
-  kind: "docs" | "api";
-  radius: string;
-  active: boolean;
-}) {
+function SwitcherGlyph({ kind }: { kind: "docs" | "api" }) {
   const isApi = kind === "api";
 
   return (
-    <span
-      className="fd-api-reference-switcher-glyph"
-      data-active={active ? "true" : "false"}
-      aria-hidden="true"
-      style={{
-        display: "inline-flex",
-        width: 22,
-        height: 22,
-        alignItems: "center",
-        justifyContent: "center",
-        color: active
-          ? "var(--color-fd-primary, currentColor)"
-          : "var(--fd-api-switcher-muted, var(--color-fd-muted-foreground, rgba(255,255,255,0.72)))",
-        borderRadius: radius,
-      }}
-    >
+    <span className="fd-api-reference-switcher-glyph" data-kind={kind} aria-hidden="true">
       {isApi ? (
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+        <svg viewBox="0 0 24 24" fill="none">
           <path
             d="M8 8L4 12L8 16M16 8L20 12L16 16M13.5 6L10.5 18"
             stroke="currentColor"
@@ -491,7 +472,7 @@ function SwitcherGlyph({
           />
         </svg>
       ) : (
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+        <svg viewBox="0 0 24 24" fill="none">
           <path
             d="M4.75 6.75C4.75 5.64543 5.64543 4.75 6.75 4.75H11.25V19.25H6.75C5.64543 19.25 4.75 18.3546 4.75 17.25V6.75ZM12.75 4.75H17.25C18.3546 4.75 19.25 5.64543 19.25 6.75V17.25C19.25 18.3546 18.3546 19.25 17.25 19.25H12.75V4.75Z"
             stroke="currentColor"
@@ -502,67 +483,6 @@ function SwitcherGlyph({
       )}
     </span>
   );
-}
-
-function ChevronStack() {
-  return (
-    <span
-      className="fd-api-reference-switcher-chevron"
-      aria-hidden="true"
-      style={{
-        display: "inline-flex",
-        flexDirection: "column",
-        gap: 2,
-      }}
-    >
-      <svg width="11" height="7" viewBox="0 0 10 6" fill="none">
-        <path d="M1 5L5 1L9 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-      <svg width="11" height="7" viewBox="0 0 10 6" fill="none">
-        <path d="M1 1L5 5L9 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-    </span>
-  );
-}
-
-function getApiReferenceSwitcherTheme(config: DocsConfig) {
-  const themeName = config.theme?.name?.toLowerCase() ?? "";
-  const isPixelBorder = themeName.includes("pixel-border");
-  const isDarksharp = themeName.includes("darksharp");
-  const isShiny = themeName.includes("shiny");
-  const radius =
-    config.theme?.ui?.radius ?? (isPixelBorder || isDarksharp ? "0px" : "var(--radius, 0.75rem)");
-
-  return {
-    cardRadius: radius,
-    iconRadius: radius,
-    backgroundImage: isPixelBorder
-      ? "repeating-linear-gradient(-45deg, color-mix(in srgb, var(--color-fd-border) 10%, transparent), color-mix(in srgb, var(--color-fd-border) 10%, transparent) 1px, transparent 1px, transparent 6px)"
-      : undefined,
-    boxShadow:
-      isPixelBorder || isDarksharp
-        ? "none"
-        : isShiny
-          ? "0 14px 40px color-mix(in srgb, var(--color-fd-border, #2a2a2a) 18%, transparent)"
-          : "0 0 0 1px color-mix(in srgb, var(--color-fd-border, #2a2a2a) 32%, transparent)",
-    titleStyle: {
-      fontFamily: isPixelBorder
-        ? "var(--fd-font-mono, var(--font-geist-mono, ui-monospace, monospace))"
-        : "var(--fd-font-sans, var(--font-geist-sans, system-ui, sans-serif))",
-      textTransform: isPixelBorder ? ("uppercase" as const) : undefined,
-      letterSpacing: isPixelBorder ? "0.08em" : undefined,
-      fontSize: isPixelBorder ? 12 : 13,
-    },
-    descriptionStyle: {
-      fontFamily: isPixelBorder
-        ? "var(--fd-font-mono, var(--font-geist-mono, ui-monospace, monospace))"
-        : "var(--fd-font-sans, var(--font-geist-sans, system-ui, sans-serif))",
-      textTransform: isPixelBorder ? ("uppercase" as const) : undefined,
-      letterSpacing: isPixelBorder ? "0.04em" : undefined,
-      fontSize: isPixelBorder ? 11 : 11,
-      opacity: isPixelBorder ? 0.74 : 0.72,
-    },
-  };
 }
 
 const API_REFERENCE_COLOR_MAP: Record<string, string> = {
@@ -771,136 +691,32 @@ function ApiReferenceServerUrlPatchScript({ serverUrl }: { serverUrl?: string })
   );
 }
 
-function SwitcherOption({
-  href,
-  kind,
-  title,
-  description,
-  current,
-  config,
-}: {
-  href: string;
-  kind: "docs" | "api";
-  title: string;
-  description: string;
-  current: boolean;
-  config: DocsConfig;
-}) {
-  const theme = getApiReferenceSwitcherTheme(config);
-
-  return (
-    <Link
-      className="fd-api-reference-switcher-option"
-      data-current={current ? "true" : "false"}
-      href={href}
-      prefetch
-      style={{
-        display: "grid",
-        gridTemplateColumns: "22px minmax(0, 1fr)",
-        gap: 12,
-        alignItems: "start",
-        padding: "11px 12px",
-        borderRadius: "0.625rem",
-        textDecoration: "none",
-        color: "inherit",
-        backgroundImage: current ? theme.backgroundImage : undefined,
-      }}
-    >
-      <span
-        style={{
-          display: "inline-flex",
-          alignSelf: "start",
-          paddingTop: 1,
-        }}
-      >
-        <SwitcherGlyph kind={kind} radius={theme.iconRadius} active={current} />
-      </span>
-      <span style={{ display: "flex", minWidth: 0, flexDirection: "column", gap: 3 }}>
-        <span style={{ fontWeight: 600, lineHeight: 1.2, ...theme.titleStyle }}>{title}</span>
-        <span style={{ lineHeight: 1.4, ...theme.descriptionStyle }}>{description}</span>
-      </span>
-    </Link>
-  );
-}
-
 function ApiReferenceSwitcher({
   docsUrl,
   apiUrl,
-  current,
-  config,
 }: {
   docsUrl: string;
   apiUrl: string;
   current: "docs" | "api";
   config: DocsConfig;
 }) {
-  const currentLabel = current === "api" ? "API Reference" : "Documentation";
-  const theme = getApiReferenceSwitcherTheme(config);
-  const themeStyle = resolveApiReferenceThemeStyle(config);
-  const switcherStyle = {
-    position: "relative",
-    marginBottom: 16,
-    overflow: "hidden",
-    backgroundImage: theme.backgroundImage,
-    boxShadow: theme.boxShadow,
-    ["--fd-api-switcher-card-radius" as const]: theme.cardRadius,
-    ["--fd-api-switcher-icon-radius" as const]: theme.iconRadius,
-    ["--fd-api-switcher-shadow" as const]: theme.boxShadow,
-  } as CSSProperties;
+  const options: SidebarTabWithProps[] = [
+    {
+      url: docsUrl,
+      title: "Documentation",
+      description: "Guides & concepts",
+      icon: <SwitcherGlyph kind="docs" />,
+    },
+    {
+      url: apiUrl,
+      title: "API Reference",
+      description: "Endpoints & examples",
+      icon: <SwitcherGlyph kind="api" />,
+    },
+  ];
 
   return (
-    <details
-      className="fd-api-reference-switcher"
-      data-theme-style={themeStyle}
-      style={switcherStyle}
-    >
-      <summary
-        className="fd-api-reference-switcher-summary"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: 10,
-          cursor: "pointer",
-          padding: "10px 13px",
-        }}
-      >
-        <span style={{ display: "flex", minWidth: 0, alignItems: "center", gap: 10 }}>
-          <SwitcherGlyph kind={current} radius={theme.iconRadius} active />
-          <span style={{ fontWeight: 600, lineHeight: 1.2, ...theme.titleStyle }}>
-            {currentLabel}
-          </span>
-        </span>
-        <ChevronStack />
-      </summary>
-
-      <div
-        className="fd-api-reference-switcher-options"
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
-          padding: "8px 8px 9px",
-        }}
-      >
-        <SwitcherOption
-          href={docsUrl}
-          kind="docs"
-          title="Documentation"
-          description="Guides & concepts"
-          current={current === "docs"}
-          config={config}
-        />
-        <SwitcherOption
-          href={apiUrl}
-          kind="api"
-          title="API Reference"
-          description="Endpoints & examples"
-          current={current === "api"}
-          config={config}
-        />
-      </div>
-    </details>
+    <SidebarTabsDropdown className="fd-api-reference-switcher w-full mb-4" options={options} />
   );
 }
 

--- a/packages/next/styles/api-reference.css
+++ b/packages/next/styles/api-reference.css
@@ -39,126 +39,33 @@
   --color-fd-overlay: hsla(0, 0%, 0%, 0.2);
 }
 
-.fd-api-reference-switcher {
-  --fd-api-switcher-card-radius: var(--radius, 0.75rem);
-  --fd-api-switcher-icon-radius: var(--radius, 0.75rem);
-  --fd-api-switcher-shadow: none;
-  --fd-api-switcher-surface: var(--color-fd-card);
-  --fd-api-switcher-summary-surface: color-mix(
-    in srgb,
-    var(--color-fd-secondary) 72%,
-    var(--color-fd-card) 28%
-  );
-  --fd-api-switcher-border: color-mix(in srgb, var(--color-fd-border) 92%, transparent);
-  --fd-api-switcher-muted: rgb(71 85 105 / 0.84);
-  --fd-api-switcher-current-surface: color-mix(
-    in srgb,
-    var(--color-fd-primary, rgb(214 145 0)) 12%,
-    var(--color-fd-card) 88%
-  );
-  --fd-api-switcher-current-border: color-mix(
-    in srgb,
-    var(--color-fd-primary, rgb(214 145 0)) 22%,
-    transparent
-  );
-  --fd-api-switcher-glyph-surface: color-mix(
-    in srgb,
-    var(--color-fd-secondary) 64%,
-    var(--color-fd-card) 36%
-  );
+button.fd-api-reference-switcher {
+  width: 100%;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-fd-border) !important;
 }
 
-.dark .fd-api-reference-switcher {
-  --fd-api-switcher-shadow: 0 0 0 1px rgb(255 255 255 / 0.06);
-  --fd-api-switcher-surface: color-mix(in srgb, rgb(20 20 20) 94%, transparent);
-  --fd-api-switcher-summary-surface: color-mix(in srgb, rgb(28 28 28) 96%, transparent);
-  --fd-api-switcher-border: rgb(255 255 255 / 0.08);
-  --fd-api-switcher-muted: rgb(255 255 255 / 0.68);
-  --fd-api-switcher-current-surface: color-mix(
-    in srgb,
-    var(--color-fd-primary, rgb(250 204 21)) 18%,
-    transparent
-  );
-  --fd-api-switcher-current-border: color-mix(
-    in srgb,
-    var(--color-fd-primary, rgb(250 204 21)) 22%,
-    rgb(255 255 255 / 0.08)
-  );
-  --fd-api-switcher-glyph-surface: color-mix(in srgb, rgb(28 28 28) 94%, transparent);
-}
-
-.fd-api-reference-switcher {
-  border: 1px solid var(--fd-api-switcher-border);
-  border-radius: var(--fd-api-switcher-card-radius);
-  background: var(--fd-api-switcher-surface);
-  box-shadow: var(--fd-api-switcher-shadow);
-}
-
-.fd-api-reference-switcher-summary {
-  list-style: none;
-  background: var(--fd-api-switcher-summary-surface);
-  border-radius: calc(var(--fd-api-switcher-card-radius) - 1px);
-  color: inherit;
-  border-bottom: 1px solid color-mix(in srgb, var(--fd-api-switcher-border) 72%, transparent);
-}
-
-.fd-api-reference-switcher-summary::-webkit-details-marker {
-  display: none;
-}
-
-.fd-api-reference-switcher-options {
-  background: var(--fd-api-switcher-surface);
-}
-
-.fd-api-reference-switcher-option {
-  border: 1px solid transparent;
-  transition:
-    background-color 150ms ease,
-    border-color 150ms ease,
-    color 150ms ease;
-}
-
-.fd-api-reference-switcher-option:hover {
-  background: color-mix(in srgb, var(--color-fd-accent) 55%, transparent);
-}
-
-.fd-api-reference-switcher-option[data-current="true"] {
-  background: var(--fd-api-switcher-current-surface);
-  border-color: var(--fd-api-switcher-current-border);
+button.fd-api-reference-switcher:hover,
+button.fd-api-reference-switcher[data-state="open"] {
+  border-color: var(--color-fd-border) !important;
 }
 
 .fd-api-reference-switcher-glyph {
-  border: 1px solid var(--fd-api-switcher-border);
-  border-radius: var(--fd-api-switcher-icon-radius);
-  background: var(--fd-api-switcher-glyph-surface);
-  box-shadow: var(--fd-api-switcher-shadow);
+  display: inline-flex;
+  width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in srgb, var(--color-fd-primary) 82%, var(--color-fd-foreground));
 }
 
-.fd-api-reference-switcher-glyph[data-active="false"] {
-  color: var(--fd-api-switcher-muted);
+.fd-api-reference-switcher-glyph[data-kind="api"] {
+  color: color-mix(in srgb, var(--color-fd-primary) 64%, var(--color-fd-muted-foreground));
 }
 
-.fd-api-reference-switcher-chevron {
-  color: var(--fd-api-switcher-muted);
-}
-
-.light .fd-api-reference-switcher {
-  --fd-api-switcher-surface: var(--color-fd-card);
-  --fd-api-switcher-summary-surface: color-mix(
-    in srgb,
-    var(--color-fd-primary) 12%,
-    var(--color-fd-card) 88%
-  );
-  --fd-api-switcher-current-surface: color-mix(
-    in srgb,
-    var(--color-fd-primary) 14%,
-    var(--color-fd-card) 86%
-  );
-  --fd-api-switcher-glyph-surface: color-mix(
-    in srgb,
-    var(--color-fd-primary) 10%,
-    var(--color-fd-card) 90%
-  );
+.fd-api-reference-switcher-glyph svg {
+  width: 100%;
+  height: 100%;
 }
 
 .light .fd-api-reference-route article .border,
@@ -181,44 +88,6 @@
 
 .light .fd-api-reference-route article .text-fd-muted-foreground {
   color: rgb(71 85 105 / 0.9);
-}
-
-.light .fd-api-reference-switcher[data-theme-style="colorful"] .fd-api-reference-switcher-summary {
-  background: color-mix(in srgb, var(--color-fd-primary) 18%, white 82%);
-  color: var(--color-fd-primary);
-}
-
-.light .fd-api-reference-switcher[data-theme-style="colorful"] {
-  border-color: color-mix(in srgb, var(--color-fd-primary) 28%, var(--color-fd-border));
-  background: var(--color-fd-card);
-  box-shadow: none;
-}
-
-.light
-  .fd-api-reference-switcher[data-theme-style="colorful"]
-  .fd-api-reference-switcher-summary
-  .fd-api-reference-switcher-chevron {
-  color: color-mix(in srgb, var(--color-fd-primary) 78%, black 22%);
-}
-
-.light
-  .fd-api-reference-switcher[data-theme-style="colorful"]
-  .fd-api-reference-switcher-summary
-  .fd-api-reference-switcher-glyph {
-  background: color-mix(in srgb, var(--color-fd-primary) 24%, white 76%);
-  border-color: color-mix(in srgb, var(--color-fd-primary) 38%, var(--color-fd-border));
-  color: var(--color-fd-primary);
-}
-
-.light .fd-api-reference-switcher[data-theme-style="colorful"] .fd-api-reference-switcher-options {
-  background: var(--color-fd-card);
-}
-
-.light
-  .fd-api-reference-switcher[data-theme-style="colorful"]
-  .fd-api-reference-switcher-option[data-current="true"] {
-  background: color-mix(in srgb, var(--color-fd-primary) 18%, white 82%);
-  border-color: color-mix(in srgb, var(--color-fd-primary) 32%, var(--color-fd-border));
 }
 
 .light


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a docs selector dropdown in the API sidebar to switch between Documentation and API Reference. Replaces the custom switcher with `fumadocs-ui` and updates the example to the `@farming-labs/theme/colorful` theme.

- **New Features**
  - Sidebar dropdown to switch between Docs and API using `fumadocs-ui`’s `SidebarTabsDropdown`.
  - Includes labeled options with icons and short descriptions.

- **Refactors**
  - Removed bespoke switcher logic and heavy CSS; now relies on `SidebarTabsDropdown`.
  - Simplified glyph styling and button rules; switched example imports to `@farming-labs/theme/colorful` and `colorful()` in config.

<sup>Written for commit e56ad9982acc81c3dad197a08b0e57c244858f34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

