### PR TITLE
fix: JSON RPC response compat

### DIFF
--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -408,6 +408,82 @@ No frontmatter title here.
     expect(deleteResponse.status).toBe(200);
   });
 
+  it("returns JSON-RPC errors for missing or expired MCP sessions", async () => {
+    const rootDir = createTempDocsProject();
+    const source = createFilesystemDocsMcpSource({
+      rootDir,
+      entry: "docs",
+      contentDir: "docs",
+      siteTitle: "Example Docs",
+    });
+
+    const handlers = createDocsMcpHttpHandler({
+      source,
+      mcp: { enabled: true, name: "Example Docs" },
+    });
+
+    const missingSessionResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tools-without-session",
+          method: "tools/list",
+          params: {},
+        }),
+      }),
+    });
+
+    expect(missingSessionResponse.status).toBe(400);
+    await expect(missingSessionResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "tools-without-session",
+      error: {
+        code: -32000,
+        message: expect.stringContaining("MCP session not initialized"),
+        data: {
+          reason: "session_not_initialized",
+        },
+      },
+    });
+
+    const expiredSessionResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+          "mcp-session-id": "expired-session",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tools-expired-session",
+          method: "tools/list",
+          params: {},
+        }),
+      }),
+    });
+
+    expect(expiredSessionResponse.status).toBe(404);
+    await expect(expiredSessionResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: "tools-expired-session",
+      error: {
+        code: -32001,
+        message: expect.stringContaining("Session not found"),
+        data: {
+          reason: "session_not_found",
+        },
+      },
+    });
+  });
+
   it("emits analytics for MCP requests, tools, and agent page reads", async () => {
     const rootDir = createTempDocsProject();
     const source = createFilesystemDocsMcpSource({
@@ -691,7 +767,7 @@ No frontmatter title here.
     expect(searchPayload.result?.content?.[0]?.text).not.toContain("#quickstart");
   });
 
-  it("returns 404 responses when MCP is disabled", async () => {
+  it("returns JSON-RPC 404 responses when MCP is disabled", async () => {
     const rootDir = createTempDocsProject();
     const source = createFilesystemDocsMcpSource({
       rootDir,
@@ -722,7 +798,15 @@ No frontmatter title here.
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toMatchObject({
-      error: expect.stringContaining("MCP is disabled"),
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32000,
+        message: expect.stringContaining("MCP is disabled"),
+        data: {
+          reason: "mcp_disabled",
+        },
+      },
     });
   });
 

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -498,23 +498,21 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     defaultVersion: options.defaultVersion,
   });
 
+  const disabledMessage =
+    "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.";
+
   if (!resolved.enabled) {
     return {
-      GET: async () =>
-        createJsonErrorResponse(
-          404,
-          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
-        ),
-      POST: async () =>
-        createJsonErrorResponse(
-          404,
-          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
-        ),
-      DELETE: async () =>
-        createJsonErrorResponse(
-          404,
-          "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.",
-        ),
+      GET: async () => createJsonErrorResponse(404, disabledMessage),
+      POST: async ({ request }) =>
+        createJsonRpcErrorResponse({
+          status: 404,
+          code: -32000,
+          message: disabledMessage,
+          id: readJsonRpcId(await parseJsonBody(request)),
+          data: { reason: "mcp_disabled" },
+        }),
+      DELETE: async () => createJsonErrorResponse(404, disabledMessage),
     };
   }
 
@@ -552,10 +550,12 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     const existing = sessionId ? sessions.get(sessionId) : undefined;
 
     let parsedBody: unknown;
+    let bodyParseFailed = false;
     if (method === "POST") {
       try {
         parsedBody = await request.clone().json();
       } catch {
+        bodyParseFailed = true;
         parsedBody = undefined;
       }
     }
@@ -575,12 +575,27 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     });
 
     if (!existing) {
+      if (method === "POST" && bodyParseFailed) {
+        return createJsonRpcErrorResponse({
+          status: 400,
+          code: -32700,
+          message: "Parse error: Invalid JSON",
+        });
+      }
+
       if (!initializeRequest) {
-        const status = method === "DELETE" ? 404 : 400;
-        return createJsonErrorResponse(
+        const status = sessionId || method === "DELETE" ? 404 : 400;
+        return createJsonRpcErrorResponse({
           status,
-          "MCP session not initialized. Start with an initialize request against this endpoint.",
-        );
+          code: sessionId ? -32001 : -32000,
+          message: sessionId
+            ? "Session not found. Reinitialize the MCP client before calling docs tools."
+            : "MCP session not initialized. Start with an initialize request against this endpoint.",
+          id: readJsonRpcId(parsedBody),
+          data: {
+            reason: sessionId ? "session_not_found" : "session_not_initialized",
+          },
+        });
       }
 
       const created = await createSession();
@@ -614,6 +629,46 @@ function createJsonErrorResponse(status: number, error: string): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.clone().json();
+  } catch {
+    return undefined;
+  }
+}
+
+function readJsonRpcId(value: unknown): string | number | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const id = (value as { id?: unknown }).id;
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+function createJsonRpcErrorResponse({
+  status,
+  code,
+  message,
+  id = null,
+  data,
+}: {
+  status: number;
+  code: number;
+  message: string;
+  id?: string | number | null;
+  data?: Record<string, unknown>;
+}): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      error: data ? { code, message, data } : { code, message },
+    }),
+    {
+      status,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 }
 
 function normalizePathSegment(value: string): string {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make MCP POST responses JSON‑RPC 2.0 compatible in `packages/docs`, including proper error objects for disabled MCP, missing/expired sessions, and parse errors. This aligns the API with JSON‑RPC clients and updates tests.

- **Bug Fixes**
  - POST now returns JSON‑RPC errors with `id`, `code`, `message`, and `data.reason`.
  - Error mapping: `mcp_disabled` → code `-32000` (404), `session_not_initialized` → `-32000` (400), `session_not_found` → `-32001` (404), parse error → `-32700` (400).
  - Added helpers: `parseJsonBody`, `readJsonRpcId`, `createJsonRpcErrorResponse`; GET/DELETE remain plain JSON errors.
  - Tests cover missing/expired sessions and disabled MCP responses.

<sup>Written for commit 56e85cf66f7fcdfbbae827ac7fbc9a6b8e6a5e73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

