### PR TITLE
feat: infra for upstreaming analytics with custom config callbacks

### DIFF
--- a/examples/frameworkless/README.md
+++ b/examples/frameworkless/README.md
@@ -50,7 +50,12 @@ Current example config:
     ]
   },
   "cloud": {
-    "enabled": false
+    "enabled": false,
+    "analytics": {
+      "enabled": true,
+      "console": "info",
+      "includeInputs": false
+    }
   }
 }
 ```

--- a/examples/frameworkless/docs.json
+++ b/examples/frameworkless/docs.json
@@ -26,6 +26,11 @@
     "preset": "colorful"
   },
   "cloud": {
-    "enabled": false
+    "enabled": false,
+    "analytics": {
+      "enabled": true,
+      "console": "info",
+      "includeInputs": false
+    }
   }
 }

--- a/examples/frameworkless/docs/index.mdx
+++ b/examples/frameworkless/docs/index.mdx
@@ -26,7 +26,12 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
     "root": ".docs/site"
   },
   "cloud": {
-    "enabled": false
+    "enabled": false,
+    "analytics": {
+      "enabled": true,
+      "console": "info",
+      "includeInputs": false
+    }
   }
 }
 ```
@@ -34,6 +39,10 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
 - `docs.mode` describes how the project is authored
 - `docs.runtime` is the generated docs runtime choice
 - `cloud.enabled` turns the Docs Cloud service layer on or off
+- `cloud.analytics` is the Docs Cloud analytics contract for the serializable runtime subset
+
+Even with `cloud.enabled: false`, frameworkless local preview can still materialize the serializable
+`cloud.analytics` subset into the generated hidden runtime.
 
 See the full contract in the
 [`docs.json` guide](https://docs.farming-labs.dev/docs/guides/docs-json).

--- a/packages/docs/src/cli/dev.test.ts
+++ b/packages/docs/src/cli/dev.test.ts
@@ -380,6 +380,55 @@ title: "Home"
     );
   });
 
+  it("materializes cloud.analytics into the generated docs runtime config", () => {
+    const projectRoot = makeTempProject();
+
+    writeFile(
+      projectRoot,
+      "docs.json",
+      JSON.stringify(
+        {
+          docs: {
+            mode: "frameworkless",
+            runtime: "nextjs",
+          },
+          cloud: {
+            enabled: true,
+            analytics: {
+              enabled: true,
+              console: "info",
+              includeInputs: false,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(
+      projectRoot,
+      "docs/index.mdx",
+      `---
+title: "Home"
+---
+
+# Home
+`,
+    );
+
+    materializeManagedRuntime(projectRoot);
+
+    const docsConfig = fs.readFileSync(
+      path.join(projectRoot, ".docs/site/docs.config.ts"),
+      "utf-8",
+    );
+
+    expect(docsConfig).toContain("analytics: {");
+    expect(docsConfig).toContain("enabled: true");
+    expect(docsConfig).toContain('console: "info"');
+    expect(docsConfig).toContain("includeInputs: false");
+  });
+
   it("tracks source changes through the computed stamp", () => {
     const projectRoot = makeTempProject();
 

--- a/packages/docs/src/cli/dev.ts
+++ b/packages/docs/src/cli/dev.ts
@@ -80,6 +80,7 @@ interface ManagedDocsProject {
   titleTemplate: string;
   description: string;
   theme: ManagedThemePreset;
+  analytics?: ManagedCloudAnalyticsConfig;
 }
 
 interface ManagedOpenApiSpec {
@@ -102,6 +103,14 @@ interface MaterializedManagedRuntime {
   apiReference: SyncResult;
   homeTarget: string;
 }
+
+type ManagedCloudAnalyticsConfig =
+  | boolean
+  | {
+      enabled?: boolean;
+      console?: boolean | "log" | "info" | "debug";
+      includeInputs?: boolean;
+    };
 
 export interface DevOptions {
   verbose?: boolean;
@@ -286,6 +295,18 @@ const managedConfigSchema = z
     cloud: z
       .object({
         enabled: z.boolean().optional(),
+        analytics: z
+          .union([
+            z.boolean(),
+            z
+              .object({
+                enabled: z.boolean().optional(),
+                console: z.union([z.boolean(), z.enum(["log", "info", "debug"])]).optional(),
+                includeInputs: z.boolean().optional(),
+              })
+              .passthrough(),
+          ])
+          .optional(),
       })
       .passthrough()
       .optional(),
@@ -717,6 +738,7 @@ function readManagedDocsProject(projectRoot: string): ManagedDocsProject {
     titleTemplate: parsed.data.site?.titleTemplate ?? `%s | ${siteName}`,
     description: parsed.data.site?.description ?? `Documentation for ${siteName}.`,
     theme,
+    analytics: parsed.data.cloud?.analytics,
   };
 }
 
@@ -844,6 +866,7 @@ function renderDocsConfigFile(options: {
   titleTemplate: string;
   description: string;
   theme: ManagedThemePreset;
+  analytics?: ManagedCloudAnalyticsConfig;
   apiReference?: {
     path: string;
     specUrl: string;
@@ -858,6 +881,7 @@ function renderDocsConfigFile(options: {
   },
 `
     : "";
+  const analyticsBlock = renderManagedAnalyticsBlock(options.analytics);
 
   return `import { defineDocs } from "@farming-labs/docs";
 import { ${options.theme.factory} } from "${options.theme.importPath}";
@@ -876,8 +900,40 @@ export default defineDocs({
     titleTemplate: ${JSON.stringify(options.titleTemplate)},
     description: ${JSON.stringify(options.description)},
   },
-${apiReferenceBlock}});
+${analyticsBlock}${apiReferenceBlock}});
 `;
+}
+
+function renderManagedAnalyticsBlock(
+  analytics: ManagedCloudAnalyticsConfig | undefined,
+): string {
+  if (typeof analytics === "undefined") {
+    return "";
+  }
+
+  if (typeof analytics === "boolean") {
+    return `  analytics: ${analytics},\n`;
+  }
+
+  const properties: string[] = [];
+
+  if (typeof analytics.enabled === "boolean") {
+    properties.push(`    enabled: ${analytics.enabled},`);
+  }
+
+  if (typeof analytics.console !== "undefined") {
+    properties.push(`    console: ${JSON.stringify(analytics.console)},`);
+  }
+
+  if (typeof analytics.includeInputs === "boolean") {
+    properties.push(`    includeInputs: ${analytics.includeInputs},`);
+  }
+
+  if (properties.length === 0) {
+    return "  analytics: {},\n";
+  }
+
+  return `  analytics: {\n${properties.join("\n")}\n  },\n`;
 }
 
 function renderManagedApiReferenceLayout(): string {
@@ -1380,6 +1436,7 @@ export function materializeManagedRuntime(projectRoot: string): MaterializedMana
       titleTemplate: project.titleTemplate,
       description: project.description,
       theme: project.theme,
+      analytics: project.analytics,
       apiReference: project.apiReferenceSpec
         ? {
             path: apiReferenceRoute,
@@ -1399,6 +1456,7 @@ export function materializeManagedRuntime(projectRoot: string): MaterializedMana
         titleTemplate: project.titleTemplate,
         description: project.description,
         theme: project.theme,
+        analytics: project.analytics,
       }),
     );
   } else {

--- a/packages/docs/src/cli/dev.ts
+++ b/packages/docs/src/cli/dev.ts
@@ -904,9 +904,7 @@ ${analyticsBlock}${apiReferenceBlock}});
 `;
 }
 
-function renderManagedAnalyticsBlock(
-  analytics: ManagedCloudAnalyticsConfig | undefined,
-): string {
+function renderManagedAnalyticsBlock(analytics: ManagedCloudAnalyticsConfig | undefined): string {
   if (typeof analytics === "undefined") {
     return "";
   }

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -19,6 +19,11 @@ export default defineDocs({
 
 `analytics: true` logs every framework event to the console with the `[farming-labs:analytics]` prefix.
 
+<Callout type="info" title="Frameworkless docs.json support">
+  When you are using frameworkless `docs.json`, the serializable subset can live under
+  `cloud.analytics`. Use `docs.config.ts` when you need executable hooks like `onEvent`.
+</Callout>
+
 ## Send Events To Your Own Sink
 
 ```ts title="docs.config.ts"

--- a/website/app/docs/guides/docs-json/page.mdx
+++ b/website/app/docs/guides/docs-json/page.mdx
@@ -64,6 +64,11 @@ Hosted features live under `cloud`:
 {
   "cloud": {
     "enabled": true,
+    "analytics": {
+      "enabled": true,
+      "console": "info",
+      "includeInputs": false
+    },
     "preview": {
       "enabled": true
     },
@@ -86,6 +91,48 @@ This keeps product packaging separate from docs structure:
 - `frameworkless` is an authoring mode
 - `nextjs` is a runtime
 - Docs Cloud is the hosted layer that can add preview, publish, AI, and deploy services
+
+## Cloud Analytics
+
+Use `cloud.analytics` when you want the shared repo contract to carry analytics settings for Docs
+Cloud and for frameworkless generated runtimes.
+
+```json
+{
+  "cloud": {
+    "enabled": true,
+    "analytics": true
+  }
+}
+```
+
+Or, when you need the serializable subset:
+
+```json
+{
+  "cloud": {
+    "enabled": true,
+    "analytics": {
+      "enabled": true,
+      "console": "info",
+      "includeInputs": false
+    }
+  }
+}
+```
+
+`cloud.analytics` is intentionally limited to JSON-safe options:
+
+- `enabled`
+- `console`
+- `includeInputs`
+
+Function hooks such as `onEvent` still belong in `docs.config.ts`, because `docs.json` is a repo
+contract and not an executable config file.
+
+For frameworkless projects, this serializable subset can be materialized into the generated hidden
+runtime even before the repo is fully connected to hosted Docs Cloud services. For framework-owned
+apps, `docs.config.ts` remains the canonical place for advanced runtime analytics behavior.
 
 Set `cloud.enabled` to `false` when the repo is using `docs.json` only as a local project contract.
 Set it to `true` once the repo is actually connected to Docs Cloud services.

--- a/website/public/schema/cloud.json
+++ b/website/public/schema/cloud.json
@@ -656,6 +656,48 @@
               "description": "Whether Docs Cloud should manage hosted docs deployments for this project."
             }
           }
+        },
+        "analytics": {
+          "description": "Hosted analytics settings for Docs Cloud. Frameworkless projects can also materialize this serializable subset into the generated docs runtime.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Enable or disable Docs Cloud analytics with default behavior."
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Serializable analytics options. Function callbacks such as onEvent still belong in docs.config.ts.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Whether Docs Cloud analytics is enabled for this project."
+                },
+                "console": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "log",
+                        "info",
+                        "debug"
+                      ]
+                    }
+                  ],
+                  "description": "Console logging mode for generated frameworkless runtime analytics."
+                },
+                "includeInputs": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether raw search queries, AI questions, feedback comments, and copied content may be included."
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -811,6 +853,11 @@
       },
       "cloud": {
         "enabled": true,
+        "analytics": {
+          "enabled": true,
+          "console": "info",
+          "includeInputs": false
+        },
         "preview": {
           "enabled": true
         },
@@ -849,6 +896,7 @@
       },
       "cloud": {
         "enabled": true,
+        "analytics": true,
         "preview": {
           "enabled": true
         },

--- a/website/public/schema/docs.json
+++ b/website/public/schema/docs.json
@@ -656,6 +656,48 @@
               "description": "Whether Docs Cloud should manage hosted docs deployments for this project."
             }
           }
+        },
+        "analytics": {
+          "description": "Hosted analytics settings for Docs Cloud. Frameworkless projects can also materialize this serializable subset into the generated docs runtime.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Enable or disable Docs Cloud analytics with default behavior."
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Serializable analytics options. Function callbacks such as onEvent still belong in docs.config.ts.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Whether Docs Cloud analytics is enabled for this project."
+                },
+                "console": {
+                  "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "log",
+                        "info",
+                        "debug"
+                      ]
+                    }
+                  ],
+                  "description": "Console logging mode for generated frameworkless runtime analytics."
+                },
+                "includeInputs": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether raw search queries, AI questions, feedback comments, and copied content may be included."
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -811,6 +853,11 @@
       },
       "cloud": {
         "enabled": true,
+        "analytics": {
+          "enabled": true,
+          "console": "info",
+          "includeInputs": false
+        },
         "preview": {
           "enabled": true
         },
@@ -849,6 +896,7 @@
       },
       "cloud": {
         "enabled": true,
+        "analytics": true,
         "preview": {
           "enabled": true
         },


### PR DESCRIPTION
- **feat: infra for analytics upstreams**
- **chore: format**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `cloud.analytics` in `docs.json` and pipes it into the generated docs runtime for frameworkless projects. This lets repos upstream analytics settings (console logging and input collection) for local previews and Docs Cloud.

- **New Features**
  - Add `cloud.analytics` (boolean or object) with `enabled`, `console` (`true|false|"log"|"info"|"debug"`), and `includeInputs`.
  - Materialize this subset into the generated `.docs/site/docs.config.ts`, even when `cloud.enabled: false`.
  - Extend CLI parsing and rendering to read and emit analytics config.
  - Add tests to verify materialization.
  - Update guides and JSON schemas to document the contract and clarify that function hooks like `onEvent` remain in `docs.config.ts`.

<sup>Written for commit 1b528feafe79e1e50251b54aa1b7fb050c7882b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

