### PR TITLE
feat: cloud analytics onEvent callback

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDocsCloudAnalytics } from "./cloud-analytics.js";
 import { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
 import type { DocsAnalyticsEvent, DocsAnalyticsEventType } from "./types.js";
 
@@ -39,6 +40,13 @@ const ALL_ANALYTICS_EVENTS = [
 ] as const satisfies readonly DocsAnalyticsEventType[];
 
 describe("analytics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY;
+  });
+
   it("emits every built-in analytics event type through the shared hook", async () => {
     const events: DocsAnalyticsEvent[] = [];
 
@@ -121,5 +129,178 @@ describe("analytics", () => {
       console: false,
       includeInputs: true,
     });
+  });
+
+  it("posts Docs Cloud analytics events to the configured ingestion endpoint", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsAnalyticsEvent(
+      createDocsCloudAnalytics({
+        projectId: "project_123",
+        console: false,
+        includeInputs: true,
+      }),
+      {
+        type: "page_view",
+        source: "client",
+        path: "/docs",
+        properties: {
+          title: "Home",
+        },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs.farming-labs.dev/api/analytics/events",
+      expect.objectContaining({
+        method: "POST",
+        keepalive: true,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1];
+    expect(typeof request?.body).toBe("string");
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      projectId: "project_123",
+      event: {
+        type: "page_view",
+        source: "client",
+        path: "/docs",
+      },
+    });
+  });
+
+  it("no-ops Docs Cloud analytics events when endpoint or project id is missing", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsAnalyticsEvent(
+      createDocsCloudAnalytics({
+        console: false,
+      }),
+      {
+        type: "page_view",
+        source: "client",
+      },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("internally wraps analytics with the Docs Cloud sink when cloud env is enabled", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env";
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const seen: DocsAnalyticsEvent[] = [];
+
+    await emitDocsAnalyticsEvent(
+      {
+        console: false,
+        onEvent(event) {
+          seen.push(event);
+        },
+      },
+      {
+        type: "feedback_submit",
+        source: "client",
+        path: "/docs",
+        properties: {
+          value: "positive",
+        },
+      },
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs.farming-labs.dev/api/analytics/events",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("preserves the user onEvent callback when Docs Cloud delivery fails", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env_failure";
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const seen: DocsAnalyticsEvent[] = [];
+
+    await emitDocsAnalyticsEvent(
+      {
+        console: false,
+        onEvent(event) {
+          seen.push(event);
+        },
+      },
+      {
+        type: "page_view",
+        source: "client",
+        path: "/docs",
+      },
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.path).toBe("/docs");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still sends Docs Cloud analytics when the user onEvent throws", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env_user_throw";
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const userOnEvent = vi.fn(async () => {
+      throw new Error("user callback failed");
+    });
+
+    await emitDocsAnalyticsEvent(
+      {
+        console: false,
+        onEvent: userOnEvent,
+      },
+      {
+        type: "feedback_submit",
+        source: "client",
+        path: "/docs",
+      },
+    );
+
+    expect(userOnEvent).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables analytics by default when Docs Cloud env is enabled and config is omitted", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_default";
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolved = resolveDocsAnalyticsConfig();
+    expect(resolved.enabled).toBe(true);
+
+    await emitDocsAnalyticsEvent(undefined, {
+      type: "page_view",
+      source: "client",
+      path: "/docs",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -132,7 +132,9 @@ describe("analytics", () => {
   });
 
   it("posts Docs Cloud analytics events to the configured ingestion endpoint", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
@@ -176,7 +178,9 @@ describe("analytics", () => {
   });
 
   it("no-ops Docs Cloud analytics events when endpoint or project id is missing", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
@@ -196,7 +200,9 @@ describe("analytics", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env";
 
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const seen: DocsAnalyticsEvent[] = [];
@@ -232,7 +238,7 @@ describe("analytics", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env_failure";
 
-    const fetchMock = vi.fn(async () => {
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(async () => {
       throw new Error("network down");
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -262,7 +268,9 @@ describe("analytics", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_env_user_throw";
 
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const userOnEvent = vi.fn(async () => {
@@ -289,7 +297,9 @@ describe("analytics", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "true";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_default";
 
-    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const resolved = resolveDocsAnalyticsConfig();

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -1,3 +1,7 @@
+import {
+  resolveDocsCloudAnalyticsOptions,
+  sendDocsCloudAnalyticsEvent,
+} from "./cloud-analytics.js";
 import type { DocsAnalyticsConfig, DocsAnalyticsEvent, DocsAnalyticsEventInput } from "./types.js";
 
 export interface ResolvedDocsAnalyticsConfig {
@@ -5,6 +9,39 @@ export interface ResolvedDocsAnalyticsConfig {
   console: false | "log" | "info" | "debug";
   includeInputs: boolean;
   onEvent?: (event: DocsAnalyticsEvent) => void | Promise<void>;
+}
+
+function composeAnalyticsHandlers(
+  userOnEvent: DocsAnalyticsConfig["onEvent"] | undefined,
+  cloudOnEvent: ((event: DocsAnalyticsEvent) => Promise<void>) | undefined,
+): ((event: DocsAnalyticsEvent) => Promise<void>) | undefined {
+  if (typeof userOnEvent !== "function" && !cloudOnEvent) {
+    return undefined;
+  }
+
+  return async (event: DocsAnalyticsEvent) => {
+    let userError: unknown;
+
+    if (typeof userOnEvent === "function") {
+      try {
+        await userOnEvent(event);
+      } catch (error) {
+        userError = error;
+      }
+    }
+
+    if (cloudOnEvent) {
+      try {
+        await cloudOnEvent(event);
+      } catch {
+        // Docs Cloud delivery should never interfere with user analytics hooks.
+      }
+    }
+
+    if (typeof userError !== "undefined") {
+      throw userError;
+    }
+  };
 }
 
 function resolveConsoleLevel(
@@ -20,11 +57,27 @@ function resolveConsoleLevel(
 export function resolveDocsAnalyticsConfig(
   analytics?: boolean | DocsAnalyticsConfig,
 ): ResolvedDocsAnalyticsConfig {
+  const cloudOptions = resolveDocsCloudAnalyticsOptions(analytics);
+  const cloudOnEvent = cloudOptions
+    ? async (event: DocsAnalyticsEvent) => {
+        await sendDocsCloudAnalyticsEvent(cloudOptions, event);
+      }
+    : undefined;
+
   if (!analytics) {
+    if (!cloudOnEvent) {
+      return {
+        enabled: false,
+        console: false,
+        includeInputs: false,
+      };
+    }
+
     return {
-      enabled: false,
+      enabled: true,
       console: false,
       includeInputs: false,
+      onEvent: cloudOnEvent,
     };
   }
 
@@ -33,16 +86,19 @@ export function resolveDocsAnalyticsConfig(
       enabled: true,
       console: "info",
       includeInputs: false,
+      onEvent: cloudOnEvent,
     };
   }
 
-  const hasEventHandler = typeof analytics.onEvent === "function";
+  const userOnEvent = analytics.onEvent;
+  const hasEventHandler = typeof userOnEvent === "function" || Boolean(cloudOnEvent);
+  const onEvent = composeAnalyticsHandlers(userOnEvent, cloudOnEvent);
 
   return {
     enabled: analytics.enabled !== false,
     console: resolveConsoleLevel(analytics.console, hasEventHandler),
     includeInputs: analytics.includeInputs === true,
-    onEvent: analytics.onEvent,
+    onEvent,
   };
 }
 

--- a/packages/docs/src/cli/dev.test.ts
+++ b/packages/docs/src/cli/dev.test.ts
@@ -423,10 +423,53 @@ title: "Home"
       "utf-8",
     );
 
+    expect(docsConfig).not.toContain("createDocsCloudAnalytics");
     expect(docsConfig).toContain("analytics: {");
     expect(docsConfig).toContain("enabled: true");
     expect(docsConfig).toContain('console: "info"');
     expect(docsConfig).toContain("includeInputs: false");
+  });
+
+  it("enables runtime analytics by default when cloud.enabled is true", () => {
+    const projectRoot = makeTempProject();
+
+    writeFile(
+      projectRoot,
+      "docs.json",
+      JSON.stringify(
+        {
+          docs: {
+            mode: "frameworkless",
+            runtime: "nextjs",
+          },
+          cloud: {
+            enabled: true,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(
+      projectRoot,
+      "docs/index.mdx",
+      `---
+title: "Home"
+---
+
+# Home
+`,
+    );
+
+    materializeManagedRuntime(projectRoot);
+
+    const docsConfig = fs.readFileSync(
+      path.join(projectRoot, ".docs/site/docs.config.ts"),
+      "utf-8",
+    );
+
+    expect(docsConfig).toContain("analytics: {");
+    expect(docsConfig).toContain("console: false");
   });
 
   it("tracks source changes through the computed stamp", () => {

--- a/packages/docs/src/cli/dev.ts
+++ b/packages/docs/src/cli/dev.ts
@@ -738,7 +738,14 @@ function readManagedDocsProject(projectRoot: string): ManagedDocsProject {
     titleTemplate: parsed.data.site?.titleTemplate ?? `%s | ${siteName}`,
     description: parsed.data.site?.description ?? `Documentation for ${siteName}.`,
     theme,
-    analytics: parsed.data.cloud?.analytics,
+    analytics:
+      typeof parsed.data.cloud?.analytics !== "undefined"
+        ? parsed.data.cloud.analytics
+        : parsed.data.cloud?.enabled
+          ? {
+              console: false,
+            }
+          : undefined,
   };
 }
 

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -56,8 +56,7 @@ export function resolveDocsCloudAnalyticsOptions(
   }
 
   const projectId =
-    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
-    readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
   const apiKey =
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY") ??
     readRuntimeEnv("DOCS_CLOUD_ANALYTICS_KEY");

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -1,0 +1,122 @@
+import type { DocsAnalyticsConfig, DocsAnalyticsEvent } from "./types.js";
+
+export interface DocsCloudAnalyticsOptions {
+  enabled?: boolean;
+  console?: DocsAnalyticsConfig["console"];
+  includeInputs?: boolean;
+  projectId?: string;
+  apiKey?: string;
+}
+
+const DOCS_CLOUD_ANALYTICS_OPTIONS = Symbol.for("@farming-labs/docs/cloud-analytics");
+const DOCS_CLOUD_ANALYTICS_ENDPOINT = "https://docs.farming-labs.dev/api/analytics/events";
+
+type DocsAnalyticsConfigWithCloud = DocsAnalyticsConfig & {
+  [DOCS_CLOUD_ANALYTICS_OPTIONS]?: DocsCloudAnalyticsOptions;
+};
+
+function readRuntimeEnv(name: string): string | undefined {
+  if (
+    typeof process !== "undefined" &&
+    process.env &&
+    typeof process.env[name] === "string" &&
+    process.env[name]!.trim().length > 0
+  ) {
+    return process.env[name]!.trim();
+  }
+
+  return undefined;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  return /^(1|true|yes|on)$/i.test(value);
+}
+
+export function resolveDocsCloudAnalyticsOptions(
+  analytics?: boolean | DocsAnalyticsConfig,
+): DocsCloudAnalyticsOptions | null {
+  if (analytics && typeof analytics === "object") {
+    const explicit = (analytics as DocsAnalyticsConfigWithCloud)[DOCS_CLOUD_ANALYTICS_OPTIONS];
+    if (explicit) {
+      return explicit;
+    }
+  }
+
+  const enabled = isTruthyEnv(
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED") ??
+      readRuntimeEnv("DOCS_CLOUD_ANALYTICS_ENABLED"),
+  );
+
+  if (!enabled) {
+    return null;
+  }
+
+  const projectId =
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
+    readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
+  const apiKey =
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY") ??
+    readRuntimeEnv("DOCS_CLOUD_ANALYTICS_KEY");
+
+  if (!projectId) {
+    return null;
+  }
+
+  return {
+    projectId,
+    apiKey,
+  };
+}
+
+export async function sendDocsCloudAnalyticsEvent(
+  options: DocsCloudAnalyticsOptions,
+  event: DocsAnalyticsEvent,
+) {
+  if (typeof fetch !== "function") {
+    return;
+  }
+
+  const endpoint = DOCS_CLOUD_ANALYTICS_ENDPOINT;
+  const projectId = options.projectId?.trim();
+  if (!endpoint || !projectId) {
+    return;
+  }
+
+  try {
+    await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(options.apiKey
+          ? {
+              authorization: `Bearer ${options.apiKey}`,
+            }
+          : {}),
+      },
+      body: JSON.stringify({
+        projectId,
+        event,
+      }),
+      keepalive: true,
+    });
+  } catch {
+    // Analytics should never break the docs runtime.
+  }
+}
+
+export function createDocsCloudAnalytics(
+  options: DocsCloudAnalyticsOptions = {},
+): DocsAnalyticsConfig {
+  const analytics: DocsAnalyticsConfigWithCloud = {
+    enabled: options.enabled,
+    console: options.console,
+    includeInputs: options.includeInputs,
+  };
+
+  analytics[DOCS_CLOUD_ANALYTICS_OPTIONS] = options;
+  return analytics;
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -10,6 +10,7 @@
 import type { DocsConfig } from "./types.js";
 
 export { defineDocs } from "./define-docs.js";
+export { createDocsCloudAnalytics } from "./cloud-analytics.js";
 export { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
 export { resolveChangelogConfig } from "./changelog.js";
 export { deepMerge } from "./utils.js";
@@ -153,6 +154,7 @@ export type {
   DocsAnalyticsSource,
 } from "./types.js";
 export type { ResolvedDocsAnalyticsConfig } from "./analytics.js";
+export type { DocsCloudAnalyticsOptions } from "./cloud-analytics.js";
 export type { ChangelogEntrySummary, ResolvedChangelogConfig } from "./changelog.js";
 export type { ResolvedDocsI18n, DocsPathMatch } from "./i18n.js";
 export type {

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -1,3 +1,4 @@
+export { createDocsCloudAnalytics } from "./cloud-analytics.js";
 export { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "./analytics.js";
 export {
   resolveApiReferenceConfig,
@@ -71,3 +72,4 @@ export type {
   DocsAnalyticsEventInput,
 } from "./types.js";
 export type { ResolvedDocsAnalyticsConfig } from "./analytics.js";
+export type { DocsCloudAnalyticsOptions } from "./cloud-analytics.js";


### PR DESCRIPTION
- **feat: cloud analytics onEvent callback**
- **chore: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Docs Cloud analytics sink that posts events via an internal onEvent handler. When cloud analytics is enabled, events are sent to the Farming Labs ingestion endpoint without interfering with user callbacks.

- New Features
  - Added `createDocsCloudAnalytics(options)` and `DocsCloudAnalyticsOptions`; reads `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED`/`DOCS_CLOUD_ANALYTICS_ENABLED`, `*_PROJECT_ID`, `*_ANALYTICS_KEY`.
  - `resolveDocsAnalyticsConfig` auto-enables analytics when cloud is enabled (env or `cloud.enabled: true` in `docs.json`) and wires a cloud onEvent, even if `analytics` is omitted.
  - Composes user `onEvent` with cloud delivery; user errors propagate, cloud errors are swallowed; cloud still sends if the user handler throws.
  - Sends POSTs to https://docs.farming-labs.dev/api/analytics/events with `projectId` and optional `Authorization`; no-op if misconfigured.
  - CLI dev defaults to `analytics: { console: false }` when `cloud.enabled` is true.
  - New exports from `packages/docs`: `createDocsCloudAnalytics`, `DocsCloudAnalyticsOptions`.

<sup>Written for commit 261cc73493a2c87633f3245fa261755ff1557032. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

