### PR TITLE
feat: hidden behavior for parent sidebar element

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -231,7 +231,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
-    folderIndexBehavior?: "link" | "toggle";
+    folderIndexBehavior?: "link" | "toggle" | "hidden";
     order: number;
   }
 

--- a/packages/docs/src/sidebar.test.ts
+++ b/packages/docs/src/sidebar.test.ts
@@ -20,6 +20,14 @@ describe("resolveSidebarFolderIndexBehavior", () => {
       }),
     ).toBe("toggle");
   });
+
+  it("returns hidden mode when configured", () => {
+    expect(
+      resolveSidebarFolderIndexBehavior({
+        folderIndexBehavior: "hidden",
+      }),
+    ).toBe("hidden");
+  });
 });
 
 describe("resolveSidebarFolderIndexBehaviorForPath", () => {
@@ -59,6 +67,11 @@ describe("resolvePageSidebarFolderIndexBehavior", () => {
         folderIndexBehavior: "toggle",
       }),
     ).toBe("toggle");
+    expect(
+      resolvePageSidebarFolderIndexBehavior({
+        folderIndexBehavior: "hidden",
+      }),
+    ).toBe("hidden");
   });
 
   it("ignores invalid sidebar frontmatter values", () => {
@@ -132,6 +145,48 @@ describe("applySidebarFolderIndexBehavior", () => {
               ],
             },
             { type: "page", name: "Button", url: "/docs/components/button" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("removes the folder index link while keeping child pages in hidden mode", () => {
+    const tree = {
+      name: "Docs",
+      children: [
+        {
+          type: "folder",
+          name: "Overview",
+          url: "/docs/overview",
+          index: { type: "page", name: "Overview", url: "/docs/overview" },
+          children: [
+            { type: "page", name: "What is Surge", url: "/docs/overview/what-is-surge" },
+            {
+              type: "page",
+              name: "Send Your First Message",
+              url: "/docs/overview/send-your-first-message",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(applySidebarFolderIndexBehavior(tree, "hidden")).toEqual({
+      name: "Docs",
+      children: [
+        {
+          type: "folder",
+          name: "Overview",
+          index: undefined,
+          url: undefined,
+          children: [
+            { type: "page", name: "What is Surge", url: "/docs/overview/what-is-surge" },
+            {
+              type: "page",
+              name: "Send Your First Message",
+              url: "/docs/overview/send-your-first-message",
+            },
           ],
         },
       ],

--- a/packages/docs/src/sidebar.ts
+++ b/packages/docs/src/sidebar.ts
@@ -11,7 +11,7 @@ export function resolvePageSidebarFolderIndexBehavior(
   if (!sidebar || typeof sidebar !== "object") return undefined;
 
   const value = (sidebar as { folderIndexBehavior?: unknown }).folderIndexBehavior;
-  return value === "link" || value === "toggle" ? value : undefined;
+  return value === "link" || value === "toggle" || value === "hidden" ? value : undefined;
 }
 
 function normalizeSidebarFolderBehaviorPath(path: string | undefined): string | undefined {
@@ -42,6 +42,7 @@ export function resolveSidebarFolderIndexBehavior(
 ): SidebarFolderIndexBehavior {
   if (sidebar === undefined || sidebar === true || sidebar === false) return defaultBehavior;
   if (sidebar.folderIndexBehavior === "toggle") return "toggle";
+  if (sidebar.folderIndexBehavior === "hidden") return "hidden";
   if (sidebar.folderIndexBehavior === "link") return "link";
   return defaultBehavior;
 }
@@ -60,7 +61,9 @@ export function resolveSidebarFolderIndexBehaviorForPath(
 
   for (const [rawPath, override] of Object.entries(sidebar.folderIndexBehaviorOverrides ?? {})) {
     if (normalizeSidebarFolderBehaviorPath(rawPath) === normalizedPath) {
-      return override === "link" || override === "toggle" ? override : fallback;
+      return override === "link" || override === "toggle" || override === "hidden"
+        ? override
+        : fallback;
     }
   }
 
@@ -108,16 +111,28 @@ export function applySidebarFolderIndexBehavior<TTree extends { children: unknow
         ? ((candidate.index as { url?: string }).url ?? undefined)
         : undefined);
     const explicitBehavior =
-      candidate.folderIndexBehavior === "link" || candidate.folderIndexBehavior === "toggle"
+      candidate.folderIndexBehavior === "link" ||
+      candidate.folderIndexBehavior === "toggle" ||
+      candidate.folderIndexBehavior === "hidden"
         ? candidate.folderIndexBehavior
         : undefined;
     const behavior = explicitBehavior ?? resolveBehavior(folderPath);
 
-    if (behavior !== "toggle") {
+    if (behavior === "link") {
       return {
         ...candidate,
         folderIndexBehavior: undefined,
         index,
+        children,
+      };
+    }
+
+    if (behavior === "hidden") {
+      return {
+        ...candidate,
+        folderIndexBehavior: undefined,
+        index: undefined,
+        url: undefined,
         children,
       };
     }

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -445,7 +445,7 @@ export interface SidebarComponentProps {
  * - `"toggle"` — clicking the parent row only expands/collapses children, and the
  *   landing page is rendered as the first child item instead
  */
-export type SidebarFolderIndexBehavior = "link" | "toggle";
+export type SidebarFolderIndexBehavior = "link" | "toggle" | "hidden";
 
 export type SidebarFolderIndexBehaviorOverrides = Record<string, SidebarFolderIndexBehavior>;
 
@@ -528,6 +528,8 @@ export interface SidebarConfig {
    * - `"link"` — clicking the parent row navigates to the folder landing page
    * - `"toggle"` — clicking the parent row only expands/collapses children, and the
    *   folder landing page appears as the first child item instead
+   * - `"hidden"` — the folder landing page route still exists, but the parent row
+   *   becomes a plain label and only the child pages appear in the sidebar
    *
    * This is the global default. Individual folder pages can still override it with
    * page frontmatter:
@@ -535,7 +537,7 @@ export interface SidebarConfig {
    * ```mdx
    * ---
    * sidebar:
-   *   folderIndexBehavior: "toggle"
+   *   folderIndexBehavior: "hidden"
    * ---
    * ```
    *

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -366,6 +366,45 @@ describe("createDocsLayout pageActions", () => {
     });
   });
 
+  it("keeps only child pages in the folder when sidebar.folderIndexBehavior is hidden", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "overview", "what-is-surge"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "page.mdx"),
+      "---\ntitle: Overview\nsidebar:\n  folderIndexBehavior: hidden\n---\n\n# Overview\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "what-is-surge", "page.mdx"),
+      "---\ntitle: What is Surge\n---\n\n# What is Surge\n",
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({
+      entry: "docs",
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const sidebarTree = findDocsLayoutTree(tree);
+    const overviewNode = (sidebarTree?.children as Array<Record<string, unknown>>).find(
+      (entry) => entry.name === "Overview",
+    );
+
+    expect(overviewNode).toMatchObject({
+      type: "folder",
+      index: undefined,
+      url: undefined,
+      children: [
+        expect.objectContaining({
+          type: "page",
+          name: "What is Surge",
+          url: "/docs/overview/what-is-surge",
+        }),
+      ],
+    });
+  });
+
   it("applies sidebar.folderIndexBehaviorOverrides selectively", () => {
     mkdirSync(join(tmpDir, "app", "docs", "components", "button"), { recursive: true });
     mkdirSync(join(tmpDir, "app", "docs", "guides", "writing"), { recursive: true });

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -271,12 +271,14 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
 
   if (fs.existsSync(path.join(docsDir, "page.mdx"))) {
     const data = readFrontmatter(path.join(docsDir, "page.mdx"));
-    rootChildren.push({
-      type: "page",
-      name: (data.title as string) ?? "Documentation",
-      url: `/${ctx.entryPath}`,
-      icon: resolveIcon(data.icon as string | undefined, icons),
-    });
+    if (data.hidden !== true) {
+      rootChildren.push({
+        type: "page",
+        name: (data.title as string) ?? "Documentation",
+        url: `/${ctx.entryPath}`,
+        icon: resolveIcon(data.icon as string | undefined, icons),
+      });
+    }
   }
 
   function buildNode(
@@ -297,8 +299,22 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
     const url = `/${ctx.entryPath}/${slug.join("/")}`;
     const icon = resolveIcon(data.icon as string | undefined, icons);
     const displayName = (data.title as string) ?? name.replace(/-/g, " ");
+    const hasChildren = hasChildPages(full, excludedDirs);
 
-    if (hasChildPages(full, excludedDirs)) {
+    if (data.hidden === true) {
+      if (!hasChildren) return null;
+
+      const folderChildren = scanDir(full, slug, slugOrder);
+      return {
+        type: "folder",
+        name: displayName,
+        icon,
+        children: folderChildren,
+        ...(flat ? { collapsible: false, defaultOpen: true } : {}),
+      };
+    }
+
+    if (hasChildren) {
       const folderChildren = scanDir(full, slug, slugOrder);
       return {
         type: "folder",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -42,7 +42,7 @@ interface FolderNode {
   name: string;
   icon?: ReactNode;
   index?: PageNode;
-  folderIndexBehavior?: "link" | "toggle";
+  folderIndexBehavior?: "link" | "toggle" | "hidden";
   children: TreeNode[];
   collapsible?: boolean;
   defaultOpen?: boolean;

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -30,7 +30,7 @@ interface FolderNode {
   name: string;
   icon?: ReactNode;
   index?: PageNode;
-  folderIndexBehavior?: "link" | "toggle";
+  folderIndexBehavior?: "link" | "toggle" | "hidden";
   children: (PageNode | FolderNode)[];
   collapsible?: boolean;
   defaultOpen?: boolean;

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -218,7 +218,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
-    folderIndexBehavior?: "link" | "toggle";
+    folderIndexBehavior?: "link" | "toggle" | "hidden";
     order: number;
   }
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -239,7 +239,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
-    folderIndexBehavior?: "link" | "toggle";
+    folderIndexBehavior?: "link" | "toggle" | "hidden";
     order: number;
   }
 

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -205,7 +205,7 @@ function navTreeFromMap(
     title: string;
     url: string;
     icon?: string;
-    folderIndexBehavior?: "link" | "toggle";
+    folderIndexBehavior?: "link" | "toggle" | "hidden";
     order: number;
   }
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -610,11 +610,11 @@ Set `enabled: false` to hide the toggle or force a single mode.
 
 ## Sidebar and breadcrumb
 
-- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`. A folder landing page can also override both with frontmatter:
+- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehavior: "hidden"` when the folder landing-page route should still exist but the sidebar should render that folder as a plain label with child links only. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`. A folder landing page can also override both with frontmatter:
   ```mdx
   ---
   sidebar:
-    folderIndexBehavior: "toggle"
+    folderIndexBehavior: "hidden"
   ---
   ```
 - **breadcrumb:** `true` (default) or `BreadcrumbConfig` to show/hide or configure breadcrumb.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -152,6 +152,10 @@ sidebar:
 ---
 ```
 
+If you want to remove the parent page from the sidebar entirely while keeping its child pages,
+set `sidebar.folderIndexBehavior: "hidden"` on that folder landing page. In a flat sidebar this
+renders as a plain section label with child links underneath, without a parent navigation target.
+
 ## Machine-readable markdown routes
 
 No separate config flag is required for machine-readable page markdown.

--- a/website/app/docs/customization/sidebar/page.mdx
+++ b/website/app/docs/customization/sidebar/page.mdx
@@ -75,9 +75,9 @@ inside the group, and clicking the parent row no longer changes the URL. Set
 If you want to remove the folder landing-page link entirely and only show the child pages, use
 `folderIndexBehavior: "hidden"`:
 
-```mdx title="app/docs/overview/page.mdx"
+```mdx title="app/docs/sending/page.mdx"
 ---
-title: "Overview"
+title: "Sending Messages"
 sidebar:
   folderIndexBehavior: "hidden"
 ---
@@ -85,7 +85,9 @@ sidebar:
 
 With `folderIndexBehavior: "hidden"`, the route still exists, but the framework omits the
 landing-page link from the sidebar tree. In the default flat sidebar, that gives you a label-only
-parent row with a plain list of children underneath.
+parent row with a plain list of children underneath. For example, a `Sending Messages` section can
+stay available at `/docs/sending` while the sidebar only shows its child pages like `Send to One
+Person`, `Send to Many People`, and `Track Message Delivery`.
 
 If you only want that behavior in selected sections, use
 `sidebar.folderIndexBehaviorOverrides` and key each override by the folder landing-page URL:

--- a/website/app/docs/customization/sidebar/page.mdx
+++ b/website/app/docs/customization/sidebar/page.mdx
@@ -59,8 +59,8 @@ app/docs/
       page.mdx           # Child page
 ```
 
-Use `sidebar.folderIndexBehavior` when you want to control whether the parent row navigates or only
-expands/collapses:
+Use `sidebar.folderIndexBehavior` when you want to control whether the parent row navigates, only
+expands/collapses, or stays as a plain label:
 
 ```tsx title="docs.config.tsx"
 sidebar: {
@@ -71,6 +71,21 @@ sidebar: {
 With `folderIndexBehavior: "toggle"`, the folder landing page is rendered as the first child item
 inside the group, and clicking the parent row no longer changes the URL. Set
 `folderIndexBehavior: "link"` if you want the parent row itself to navigate.
+
+If you want to remove the folder landing-page link entirely and only show the child pages, use
+`folderIndexBehavior: "hidden"`:
+
+```mdx title="app/docs/overview/page.mdx"
+---
+title: "Overview"
+sidebar:
+  folderIndexBehavior: "hidden"
+---
+```
+
+With `folderIndexBehavior: "hidden"`, the route still exists, but the framework omits the
+landing-page link from the sidebar tree. In the default flat sidebar, that gives you a label-only
+parent row with a plain list of children underneath.
 
 If you only want that behavior in selected sections, use
 `sidebar.folderIndexBehaviorOverrides` and key each override by the folder landing-page URL:
@@ -106,6 +121,9 @@ Render all sidebar items without collapsible sections (Mintlify-style):
 ```tsx title="docs.config.tsx"
 sidebar: { flat: true },
 ```
+
+Pair `flat: true` with `folderIndexBehavior: "hidden"` on a folder landing page when you want a Mintlify-style
+section label with child links, but no parent navigation target.
 
 ## Sidebar Header & Footer
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -876,8 +876,8 @@ Sidebar visibility and customization. See [Sidebar](/docs/customization/sidebar)
 | `banner`      | `ReactNode`                                      | —       | Content rendered above nav items                                                                             |
 | `collapsible` | `boolean`                                        | `true`  | Whether sidebar is collapsible on desktop                                                                    |
 | `flat`        | `boolean`                                        | `false` | Render all items flat (Mintlify-style, no collapsible groups)                                                |
-| `folderIndexBehavior` | `"link" \| "toggle"`                    | adapter default | Whether folder parents with their own page navigate on click or only expand/collapse                         |
-| `folderIndexBehaviorOverrides` | `Record<string, "link" \| "toggle">` | — | Selective per-folder overrides keyed by the folder landing-page URL                                          |
+| `folderIndexBehavior` | `"link" \| "toggle" \| "hidden"`       | adapter default | Whether folder parents with their own page navigate, only expand/collapse, or render as label-only groups |
+| `folderIndexBehaviorOverrides` | `Record<string, "link" \| "toggle" \| "hidden">` | — | Selective per-folder overrides keyed by the folder landing-page URL |
 
 Folder landing pages can still override both of those with frontmatter:
 
@@ -1336,7 +1336,7 @@ Page-level sidebar metadata used while building the docs navigation tree.
 
 | Property              | Type                 | Description |
 | --------------------- | -------------------- | ----------- |
-| `folderIndexBehavior` | `"link" \| "toggle"` | Override how this folder page behaves in the default sidebar when it has child pages |
+| `folderIndexBehavior` | `"link" \| "toggle" \| "hidden"` | Override how this folder page behaves in the default sidebar when it has child pages |
 
 ```mdx title="app/docs/components/page.mdx"
 ---
@@ -1351,6 +1351,8 @@ Notes:
 - this is only read from folder landing pages such as `page.mdx` / `index.md`
 - it overrides global `sidebar.folderIndexBehavior`
 - it also overrides `sidebar.folderIndexBehaviorOverrides` for that same folder
+- `folderIndexBehavior: "hidden"` keeps the folder route available but omits the folder index
+  link from the sidebar tree; in flat mode this becomes a label-only group with child links only
 
 **Static OG example** — use `openGraph` and `twitter` in frontmatter to serve a static image instead of the dynamic OG endpoint:
 


### PR DESCRIPTION
- **fix: parent toggle behaviour**
- **chore: added hidden options**
- **chore: config**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new sidebar folder behavior `hidden` and fixes parent click/toggle handling. Folders can now render as label-only (no parent link) while keeping child pages visible across `astro`, `nuxt`, `svelte`, `tanstack-start`, and `fumadocs`.

- **New Features**
  - Support `folderIndexBehavior: "hidden"` in config, per-folder overrides, and page frontmatter; removes the folder index link/URL but keeps child pages.
  - `fumadocs` also respects `hidden: true` frontmatter to omit a page from the sidebar tree when needed.
  - Updated types and tree builders in `packages/docs` and `packages/fumadocs`; added tests and docs explaining usage and flat-mode pairing.

- **Bug Fixes**
  - Correctly applies link/toggle/hidden behaviors so parent rows navigate, toggle, or render as label-only as configured.

<sup>Written for commit 77a442bc0fbdd7a6b8e907c3adb93dccdd0112db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

