### PR TITLE
fix: folderIndexBehaviour overriden by page primitives

### DIFF
--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -230,6 +230,40 @@ No frontmatter title here.
     );
   });
 
+  it("omits hidden folder index pages from MCP pages while keeping their children", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-mcp-hidden-folder-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "docs", "overview", "what-is-surge"), { recursive: true });
+    writeFileSync(join(rootDir, "docs", "page.mdx"), "# Home\n");
+    writeFileSync(
+      join(rootDir, "docs", "overview", "page.mdx"),
+      `---
+title: "Overview"
+sidebar:
+  folderIndexBehavior: hidden
+---
+
+# Overview
+`,
+    );
+    writeFileSync(
+      join(rootDir, "docs", "overview", "what-is-surge", "page.mdx"),
+      "# What is Surge\n",
+    );
+
+    const source = createFilesystemDocsMcpSource({
+      rootDir,
+      entry: "docs",
+      contentDir: "docs",
+    });
+
+    const pages = await source.getPages();
+
+    expect(pages.some((page) => page.url === "/docs/overview")).toBe(false);
+    expect(pages.some((page) => page.url === "/docs/overview/what-is-surge")).toBe(true);
+  });
+
   it("serves a working MCP transport with the built-in tools", async () => {
     const rootDir = createTempDocsProject();
     const source = createFilesystemDocsMcpSource({

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -10,6 +10,7 @@ import * as z from "zod/v4";
 import { stripGeneratedAgentProvenance } from "./agent-provenance.js";
 import { normalizeDocsRelated, renderDocsRelatedMarkdownLines } from "./related.js";
 import { performDocsSearch } from "./search.js";
+import { resolvePageSidebarFolderIndexBehavior } from "./sidebar.js";
 import { emitDocsAnalyticsEvent } from "./analytics.js";
 import type {
   DocsAnalyticsConfig,
@@ -776,6 +777,45 @@ function stripMarkdownForMcp(content: string): string {
     .trim();
 }
 
+function resolveFilesystemDocsPageSource(dir: string): string | undefined {
+  return ["page.mdx", "page.md", "page.svx"]
+    .map((fileName) => path.join(dir, fileName))
+    .find((candidate) => fs.existsSync(candidate));
+}
+
+function hasVisibleDescendantFilesystemDocsPage(dir: string): boolean {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return false;
+  }
+
+  for (const name of entries.sort()) {
+    const full = path.join(dir, name);
+    try {
+      if (!fs.statSync(full).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const pageSource = resolveFilesystemDocsPageSource(full);
+    if (pageSource) {
+      try {
+        const data = matter(fs.readFileSync(pageSource, "utf-8")).data;
+        const hiddenFolderIndex = resolvePageSidebarFolderIndexBehavior(data.sidebar) === "hidden";
+        if (data.hidden !== true && !hiddenFolderIndex) return true;
+      } catch {
+        return true;
+      }
+    }
+
+    if (hasVisibleDescendantFilesystemDocsPage(full)) return true;
+  }
+
+  return false;
+}
+
 function scanFilesystemDocsPages(contentDirAbs: string, entry: string): ScannedDocsMcpPage[] {
   const pages: Array<ScannedDocsMcpPage & { relatedInput?: unknown }> = [];
 
@@ -797,6 +837,14 @@ function scanFilesystemDocsPages(contentDirAbs: string, entry: string): ScannedD
 
       const raw = fs.readFileSync(full, "utf-8");
       const { data, content } = matter(raw);
+      const baseName = name.replace(/\.(md|mdx|svx)$/, "");
+      const isIndex = baseName === "index" || baseName === "page" || baseName === "+page";
+      const hiddenFolderIndex =
+        isIndex &&
+        resolvePageSidebarFolderIndexBehavior(data.sidebar) === "hidden" &&
+        hasVisibleDescendantFilesystemDocsPage(dir);
+      if (hiddenFolderIndex) continue;
+
       const humanRawContent = resolveAgentMdxContent(content, "human");
       const pageAgentRawContent = resolveAgentMdxContent(content, "agent");
       const pageAgentContent =
@@ -804,8 +852,6 @@ function scanFilesystemDocsPages(contentDirAbs: string, entry: string): ScannedD
           ? stripMarkdownForMcp(pageAgentRawContent)
           : undefined;
 
-      const baseName = name.replace(/\.(md|mdx|svx)$/, "");
-      const isIndex = baseName === "index" || baseName === "page" || baseName === "+page";
       const slug = isIndex ? slugParts.join("/") : [...slugParts, baseName].join("/");
       const url = slug ? `/${entry}/${slug}` : `/${entry}`;
       const agentDoc = isIndex ? readFilesystemAgentDoc(dir) : undefined;

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -357,6 +357,53 @@ Install and configure the docs framework.
     expect(payload[0]?.content).toContain("Quickstart");
   });
 
+  it("omits hidden folder index pages from search and markdown lookups", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-hidden-folder-index-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "overview", "what-is-surge"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    writeFileSync(
+      join(rootDir, "app", "docs", "overview", "page.mdx"),
+      `---
+title: "Overview"
+sidebar:
+  folderIndexBehavior: hidden
+---
+
+# Overview
+
+This page should not be indexed as a standalone doc.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "app", "docs", "overview", "what-is-surge", "page.mdx"),
+      `---
+title: "What is Surge"
+---
+
+# What is Surge
+
+Surge overview child.
+`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      entry: "docs",
+    });
+
+    const searchResponse = await GET(new Request("http://localhost/api/docs?query=standalone"));
+    const searchPayload = (await searchResponse.json()) as Array<{ url: string }>;
+    expect(searchPayload.some((entry) => entry.url === "/docs/overview")).toBe(false);
+
+    const markdownResponse = await GET(
+      new Request("http://localhost/api/docs?format=markdown&path=overview"),
+    );
+    expect(markdownResponse.status).toBe(404);
+  });
+
   it("serves llms.txt aliases through the shared docs api handler", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-alias-route-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -1145,8 +1145,7 @@ function scanDocsDir(
           const rawContent = resolveAgentMdxContent(fileContent, "human");
           const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
           const content = stripMdx(rawContent);
-          const baseUrl =
-            slugParts.length === 0 ? `/${entry}` : `/${entry}/${slugParts.join("/")}`;
+          const baseUrl = slugParts.length === 0 ? `/${entry}` : `/${entry}/${slugParts.join("/")}`;
           const url = withLangInUrl(baseUrl, locale);
 
           indexes.push({
@@ -2073,9 +2072,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         : normalizedRequest.slice(normalizedEntry.length).replace(/^\/+/, "");
 
     for (const docsDir of ctx.docsDirs) {
-      const candidateDir = relativeSlug
-        ? path.join(docsDir, ...relativeSlug.split("/"))
-        : docsDir;
+      const candidateDir = relativeSlug ? path.join(docsDir, ...relativeSlug.split("/")) : docsDir;
       if (isHiddenFolderIndexPageDir(candidateDir)) return null;
     }
 

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -30,6 +30,7 @@ import {
   emitDocsAnalyticsEvent,
   resolveDocsI18n,
   resolveDocsLocale,
+  resolvePageSidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
 import type {
   ChangelogConfig,
@@ -1049,6 +1050,60 @@ function stripMdx(content: string): string {
     .trim();
 }
 
+function resolveDocsSearchPageSource(dir: string): string | undefined {
+  return ["page.mdx", "page.md"]
+    .map((fileName) => path.join(dir, fileName))
+    .find((candidate) => fs.existsSync(candidate));
+}
+
+function hasVisibleDescendantDocsSearchPage(dir: string): boolean {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return false;
+  }
+
+  for (const name of entries.sort()) {
+    const full = path.join(dir, name);
+    try {
+      if (!fs.statSync(full).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const pageSource = resolveDocsSearchPageSource(full);
+    if (pageSource) {
+      try {
+        const data = matter(fs.readFileSync(pageSource, "utf-8")).data;
+        const hiddenFolderIndex = resolvePageSidebarFolderIndexBehavior(data.sidebar) === "hidden";
+        if (data.hidden !== true && !hiddenFolderIndex) return true;
+      } catch {
+        return true;
+      }
+    }
+
+    if (hasVisibleDescendantDocsSearchPage(full)) return true;
+  }
+
+  return false;
+}
+
+function isHiddenFolderIndexPageDir(dir: string): boolean {
+  const pageSource = resolveDocsSearchPageSource(dir);
+  if (!pageSource) return false;
+
+  try {
+    const data = matter(fs.readFileSync(pageSource, "utf-8")).data;
+    return (
+      resolvePageSidebarFolderIndexBehavior(data.sidebar) === "hidden" &&
+      hasVisibleDescendantDocsSearchPage(dir)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function scanDocsDir(
   docsDir: string,
   entry: string,
@@ -1069,33 +1124,42 @@ function scanDocsDir(
     if (!fs.existsSync(dir)) return;
     if (isExcluded(dir)) return;
 
-    const pagePath = path.join(dir, "page.mdx");
-    if (fs.existsSync(pagePath)) {
+    const pageSource = resolveDocsSearchPageSource(dir);
+    if (pageSource) {
       try {
-        const raw = fs.readFileSync(pagePath, "utf-8");
+        const raw = fs.readFileSync(pageSource, "utf-8");
         const { data } = matter(raw);
-        const title =
-          (data.title as string) ||
-          slugParts[slugParts.length - 1]?.replace(/-/g, " ") ||
-          "Documentation";
-        const description = data.description as string | undefined;
-        const { content: fileContent } = matter(raw);
-        const rawContent = resolveAgentMdxContent(fileContent, "human");
-        const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
-        const content = stripMdx(rawContent);
-        const baseUrl = slugParts.length === 0 ? `/${entry}` : `/${entry}/${slugParts.join("/")}`;
-        const url = withLangInUrl(baseUrl, locale);
+        const hiddenFolderIndex =
+          resolvePageSidebarFolderIndexBehavior(data.sidebar) === "hidden" &&
+          hasVisibleDescendantDocsSearchPage(dir);
+        if (hiddenFolderIndex) {
+          // Hidden folder indexes should redirect to their first child at the
+          // app layer and should not remain searchable as standalone pages.
+        } else {
+          const title =
+            (data.title as string) ||
+            slugParts[slugParts.length - 1]?.replace(/-/g, " ") ||
+            "Documentation";
+          const description = data.description as string | undefined;
+          const { content: fileContent } = matter(raw);
+          const rawContent = resolveAgentMdxContent(fileContent, "human");
+          const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
+          const content = stripMdx(rawContent);
+          const baseUrl =
+            slugParts.length === 0 ? `/${entry}` : `/${entry}/${slugParts.join("/")}`;
+          const url = withLangInUrl(baseUrl, locale);
 
-        indexes.push({
-          title,
-          description,
-          relatedInput: data.related,
-          content,
-          rawContent,
-          agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
-          url,
-          locale,
-        });
+          indexes.push({
+            title,
+            description,
+            relatedInput: data.related,
+            content,
+            rawContent,
+            agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
+            url,
+            locale,
+          });
+        }
       } catch {
         // skip unreadable files
       }
@@ -2001,12 +2065,25 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   }
 
   async function getMarkdownDocument(ctx: DocsContext, requestedPath: string) {
+    const normalizedRequest = normalizeRequestedMarkdownPath(ctx.entryPath, requestedPath);
+    const normalizedEntry = `/${normalizePathSegment(ctx.entryPath)}`;
+    const relativeSlug =
+      normalizedRequest === normalizedEntry
+        ? ""
+        : normalizedRequest.slice(normalizedEntry.length).replace(/^\/+/, "");
+
+    for (const docsDir of ctx.docsDirs) {
+      const candidateDir = relativeSlug
+        ? path.join(docsDir, ...relativeSlug.split("/"))
+        : docsDir;
+      if (isHiddenFolderIndexPageDir(candidateDir)) return null;
+    }
+
     for (const source of getMarkdownSources(ctx)) {
       const page = findDocsMcpPage(ctx.entryPath, await source.getPages(), requestedPath);
       if (page) return renderMarkdownDocument(page);
     }
 
-    const normalizedRequest = normalizeRequestedMarkdownPath(ctx.entryPath, requestedPath);
     const fallbackPage = getIndexes(ctx).find(
       (page) => normalizeUrlPath(page.url) === normalizedRequest,
     );

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -26,8 +26,18 @@ type TestRewriteResult =
       fallback?: TestRewrite[];
     };
 
+type TestRedirect = {
+  source: string;
+  destination: string;
+  permanent: boolean;
+};
+
 async function readRewrites(nextConfig: ReturnType<typeof withDocs>) {
   return (nextConfig.rewrites as () => Promise<TestRewriteResult>)();
+}
+
+async function readRedirects(nextConfig: ReturnType<typeof withDocs>) {
+  return (nextConfig.redirects as () => Promise<TestRedirect[]>)();
 }
 
 function getBeforeFilesRewrites(result: TestRewriteResult): TestRewrite[] {
@@ -332,6 +342,47 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(acceptPattern.test("application/json, text/markdown;profile=agent;q=0")).toBe(false);
     expect(acceptPattern.test("text/markdown-v2")).toBe(false);
     expect(acceptPattern.test("application/not-text/markdownish")).toBe(false);
+  });
+
+  it("redirects hidden folder parents to their first visible child", async () => {
+    mkdirSync(join(tmpDir, "app", "docs", "overview", "what-is-surge"), { recursive: true });
+    mkdirSync(join(tmpDir, "app", "docs", "sending", "send-one"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "page.mdx"),
+      "---\ntitle: Overview\nsidebar:\n  folderIndexBehavior: hidden\n---\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "what-is-surge", "page.mdx"),
+      "# What is Surge\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "sending", "page.mdx"),
+      "---\ntitle: Sending\nsidebar:\n  folderIndexBehavior: hidden\n---\n",
+      "utf-8",
+    );
+    writeFileSync(join(tmpDir, "app", "docs", "sending", "send-one", "page.mdx"), "# Send\n");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const redirects = await readRedirects(nextConfig);
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/docs/overview",
+          destination: "/docs/overview/what-is-surge",
+          permanent: false,
+        }),
+        expect.objectContaining({
+          source: "/docs/sending",
+          destination: "/docs/sending/send-one",
+          permanent: false,
+        }),
+      ]),
+    );
   });
 
   it("adds agent feedback rewrites through the shared docs api handler when configured", async () => {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1296,9 +1296,7 @@ function buildHiddenFolderRedirects(docsDir: string, entry: string): NextRedirec
         if (destinationSlug && destinationSlug.join("/") !== slugParts.join("/")) {
           const source = slugParts.length > 0 ? `/${entry}/${slugParts.join("/")}` : `/${entry}`;
           const destination =
-            destinationSlug.length > 0
-              ? `/${entry}/${destinationSlug.join("/")}`
-              : `/${entry}`;
+            destinationSlug.length > 0 ? `/${entry}/${destinationSlug.join("/")}` : `/${entry}`;
 
           redirects.push({
             source,

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1045,6 +1045,13 @@ type NextRewrite = {
   [key: string]: unknown;
 };
 
+type NextRedirect = {
+  source: string;
+  destination: string;
+  permanent: boolean;
+  [key: string]: unknown;
+};
+
 type NextRewriteResult =
   | NextRewrite[]
   | {
@@ -1179,6 +1186,138 @@ function dedupeRewrites(rewrites: NextRewrite[]): NextRewrite[] {
   return result;
 }
 
+function dedupeRedirects(redirects: NextRedirect[]): NextRedirect[] {
+  const seen = new Set<string>();
+  const result: NextRedirect[] = [];
+
+  for (const redirect of redirects) {
+    const key = redirect.source;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(redirect);
+  }
+
+  return result;
+}
+
+function resolveDocsPageSourceFile(dir: string): string | undefined {
+  return ["page.mdx", "page.md"]
+    .map((fileName) => join(dir, fileName))
+    .find((candidate) => existsSync(candidate));
+}
+
+function readDocsPageFrontmatter(filePath: string): Record<string, unknown> {
+  try {
+    return matter(readFileSync(filePath, "utf-8")).data;
+  } catch {
+    return {};
+  }
+}
+
+function resolveDocsPageOrder(dir: string): number {
+  const pageSource = resolveDocsPageSourceFile(dir);
+  if (!pageSource) return Number.POSITIVE_INFINITY;
+
+  const data = readDocsPageFrontmatter(pageSource);
+  return typeof data.order === "number" ? data.order : Number.POSITIVE_INFINITY;
+}
+
+function resolveDocsPageFolderIndexBehavior(data: Record<string, unknown>): string | undefined {
+  const sidebar = data.sidebar;
+  if (!sidebar || typeof sidebar !== "object") return undefined;
+
+  const value = (sidebar as { folderIndexBehavior?: unknown }).folderIndexBehavior;
+  return value === "link" || value === "toggle" || value === "hidden" ? value : undefined;
+}
+
+function listSortedDocsChildDirectories(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  return entries
+    .map((name) => ({ name, fullPath: join(dir, name) }))
+    .filter(({ fullPath }) => {
+      try {
+        return statSync(fullPath).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort((left, right) => {
+      const leftOrder = resolveDocsPageOrder(left.fullPath);
+      const rightOrder = resolveDocsPageOrder(right.fullPath);
+      if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+      return left.name.localeCompare(right.name);
+    })
+    .map(({ name }) => name);
+}
+
+function findFirstVisibleDocsChildSlug(dir: string, slugParts: string[]): string[] | undefined {
+  for (const name of listSortedDocsChildDirectories(dir)) {
+    const childDir = join(dir, name);
+    const childSlugParts = [...slugParts, name];
+    const pageSource = resolveDocsPageSourceFile(childDir);
+
+    if (!pageSource) {
+      const descendant = findFirstVisibleDocsChildSlug(childDir, childSlugParts);
+      if (descendant) return descendant;
+      continue;
+    }
+
+    const data = readDocsPageFrontmatter(pageSource);
+    const folderIndexBehavior = resolveDocsPageFolderIndexBehavior(data);
+    if (data.hidden === true || folderIndexBehavior === "hidden") {
+      const descendant = findFirstVisibleDocsChildSlug(childDir, childSlugParts);
+      if (descendant) return descendant;
+      continue;
+    }
+
+    return childSlugParts;
+  }
+
+  return undefined;
+}
+
+function buildHiddenFolderRedirects(docsDir: string, entry: string): NextRedirect[] {
+  const redirects: NextRedirect[] = [];
+
+  function scan(dir: string, slugParts: string[]) {
+    if (!existsSync(dir)) return;
+
+    const pageSource = resolveDocsPageSourceFile(dir);
+    if (pageSource) {
+      const data = readDocsPageFrontmatter(pageSource);
+      if (resolveDocsPageFolderIndexBehavior(data) === "hidden") {
+        const destinationSlug = findFirstVisibleDocsChildSlug(dir, slugParts);
+        if (destinationSlug && destinationSlug.join("/") !== slugParts.join("/")) {
+          const source = slugParts.length > 0 ? `/${entry}/${slugParts.join("/")}` : `/${entry}`;
+          const destination =
+            destinationSlug.length > 0
+              ? `/${entry}/${destinationSlug.join("/")}`
+              : `/${entry}`;
+
+          redirects.push({
+            source,
+            destination,
+            permanent: false,
+          });
+        }
+      }
+    }
+
+    for (const name of listSortedDocsChildDirectories(dir)) {
+      scan(join(dir, name), [...slugParts, name]);
+    }
+  }
+
+  scan(docsDir, []);
+  return dedupeRedirects(redirects);
+}
+
 function mergeDocsMarkdownRewrites(
   entry: string,
   mcp: {
@@ -1218,6 +1357,13 @@ function mergeDocsMarkdownRewrites(
     afterFiles: result.afterFiles ?? [],
     fallback: result.fallback ?? [],
   };
+}
+
+function mergeDocsRedirects(
+  autoRedirects: NextRedirect[],
+  redirects: NextRedirect[] | undefined,
+): NextRedirect[] {
+  return dedupeRedirects([...(redirects ?? []), ...autoRedirects]);
 }
 
 // ─── withDocs ───────────────────────────────────────────────────────
@@ -1528,6 +1674,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     {};
   const docsTraceGlob = docsContentDir.replace(/\\/g, "/").replace(/^\.?\//, "") + "/**/*";
   const skillTraceFile = "skill.md";
+  const docsContentRoot = isAbsolute(docsContentDir) ? docsContentDir : join(root, docsContentDir);
 
   if (!isStaticExport) {
     const existingRewrites = nextConfig.rewrites as
@@ -1539,6 +1686,20 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
         typeof existingRewrites === "function" ? await existingRewrites() : existingRewrites;
       return mergeDocsMarkdownRewrites(entry, mcp, agentFeedback, rewrites);
     };
+
+    const autoRedirects = buildHiddenFolderRedirects(docsContentRoot, entry);
+    if (autoRedirects.length > 0) {
+      const existingRedirects = nextConfig.redirects as
+        | NextRedirect[]
+        | (() => NextRedirect[] | Promise<NextRedirect[]>)
+        | undefined;
+
+      nextConfig.redirects = async () => {
+        const redirects =
+          typeof existingRedirects === "function" ? await existingRedirects() : existingRedirects;
+        return mergeDocsRedirects(autoRedirects, redirects);
+      };
+    }
   }
 
   nextConfig.outputFileTracingIncludes = {

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -610,7 +610,7 @@ Set `enabled: false` to hide the toggle or force a single mode.
 
 ## Sidebar and breadcrumb
 
-- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehavior: "hidden"` when the folder landing-page route should still exist but the sidebar should render that folder as a plain label with child links only. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`. A folder landing page can also override both with frontmatter:
+- **sidebar:** `true` (default) or `SidebarConfig` (style, banner, footer, `folderIndexBehavior`, etc.). Use `folderIndexBehavior: "toggle"` when all folder parents should only expand/collapse instead of navigating to their landing page. Use `folderIndexBehavior: "hidden"` when the folder landing-page route should stop acting like a standalone page: the sidebar renders that folder as a plain label with child links only, direct visits to the parent route redirect to the first visible child, and the hidden parent stays out of markdown/search indexing. Use `folderIndexBehaviorOverrides` to do that selectively for specific folder landing-page URLs such as `"/docs/components"`. A folder landing page can also override both with frontmatter:
   ```mdx
   ---
   sidebar:

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -155,6 +155,7 @@ sidebar:
 If you want to remove the parent page from the sidebar entirely while keeping its child pages,
 set `sidebar.folderIndexBehavior: "hidden"` on that folder landing page. In a flat sidebar this
 renders as a plain section label with child links underneath, without a parent navigation target.
+Manual visits to the hidden parent route redirect to its first visible child.
 
 ## Machine-readable markdown routes
 

--- a/website/app/docs/customization/sidebar/page.mdx
+++ b/website/app/docs/customization/sidebar/page.mdx
@@ -83,11 +83,11 @@ sidebar:
 ---
 ```
 
-With `folderIndexBehavior: "hidden"`, the route still exists, but the framework omits the
-landing-page link from the sidebar tree. In the default flat sidebar, that gives you a label-only
-parent row with a plain list of children underneath. For example, a `Sending Messages` section can
-stay available at `/docs/sending` while the sidebar only shows its child pages like `Send to One
-Person`, `Send to Many People`, and `Track Message Delivery`.
+With `folderIndexBehavior: "hidden"`, the framework omits the landing-page link from the sidebar
+tree and treats the folder like a label-only parent. In the default flat sidebar, that gives you a
+plain list of child links underneath. If someone manually opens the parent route, the framework
+redirects it to the first visible child. Hidden folder landing pages are also left out of the
+machine-readable markdown/search surfaces so they do not keep behaving like standalone docs pages.
 
 If you only want that behavior in selected sections, use
 `sidebar.folderIndexBehaviorOverrides` and key each override by the folder landing-page URL:

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1352,7 +1352,8 @@ Notes:
 - it overrides global `sidebar.folderIndexBehavior`
 - it also overrides `sidebar.folderIndexBehaviorOverrides` for that same folder
 - `folderIndexBehavior: "hidden"` keeps the folder route available but omits the folder index
-  link from the sidebar tree; in flat mode this becomes a label-only group with child links only
+  link from the sidebar tree; in flat mode this becomes a label-only group with child links only,
+  and direct visits to the hidden parent route redirect to the first visible child
 
 **Static OG example** — use `openGraph` and `twitter` in frontmatter to serve a static image instead of the dynamic OG endpoint:
 


### PR DESCRIPTION
- **fix: folderIndexBehaviour overriden by page primitives**
- **chore: format**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hidden folder landing pages being overridden by page primitives. Hidden parents are now excluded from MCP/search/markdown and automatically redirect to the first visible child; child pages stay indexed and routable.

- **Bug Fixes**
  - Honors `sidebar.folderIndexBehavior: "hidden"`:
    - MCP pages omit the hidden folder index while keeping its children (`packages/docs`).
    - Search and markdown lookups skip hidden parents and return 404 for direct markdown requests (`packages/fumadocs`).
    - Next.js adds non-permanent redirects from hidden parent routes to the first visible child, ordered by `order` then name (`packages/next`).
  - Adds tests for MCP, search/markdown, and Next.js redirects; updates docs to reflect redirect behavior.

<sup>Written for commit 1b785377f63c15afce5659060aafe2c41f7950b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

