### PR TITLE
feat: improve performant search

### DIFF
--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -1002,6 +1002,7 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `maxResults`         | `number`                                             | `5`                           | Number of doc pages to include as RAG context           |
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
+| `onActions`          | `(data: DocsAskAIActionData) => void \| Promise<void>` | —                             | Callback for copy, like, and dislike response actions   |
 | `packageName`        | `string`                                             | inferred from docs context    | Optional package-name override for import examples       |
 | `docsUrl`            | `string`                                             | —                             | Base URL the AI uses for links                          |
 | `loader`             | `string`                                             | `"shimmer-dots"`              | Loading indicator variant (`"shimmer-dots"`, `"circular"`, `"dots"`, `"typing"`, `"wave"`, `"bars"`, `"pulse"`, `"pulse-dot"`, `"terminal"`, `"text-blink"`, `"text-shimmer"`, `"loading-dots"`) |

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -1002,7 +1002,7 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `maxResults`         | `number`                                             | `5`                           | Number of doc pages to include as RAG context           |
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
-| `packageName`        | `string`                                             | —                             | Package name the AI uses in import examples             |
+| `packageName`        | `string`                                             | inferred from docs context    | Optional package-name override for import examples       |
 | `docsUrl`            | `string`                                             | —                             | Base URL the AI uses for links                          |
 | `loader`             | `string`                                             | `"shimmer-dots"`              | Loading indicator variant (`"shimmer-dots"`, `"circular"`, `"dots"`, `"typing"`, `"wave"`, `"bars"`, `"pulse"`, `"pulse-dot"`, `"terminal"`, `"text-blink"`, `"text-shimmer"`, `"loading-dots"`) |
 | `loadingComponent`   | `(props: { name: string }) => ReactNode`             | —                             | Custom loading component (overrides `loader`, Next.js only) |

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -33,11 +33,13 @@ import path from "node:path";
 import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
+  buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -733,21 +735,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return index;
   }
 
-  function searchByQuery(query: string, ctx: ReturnType<typeof resolveContextFromPath>) {
-    const index = getSearchIndex(ctx);
-    return index
-      .map((page) => {
-        const titleMatch = page.title.toLowerCase().includes(query) ? 10 : 0;
-        const words = query.split(/\s+/);
-        const contentMatch = words.reduce((score, word) => {
-          return score + (page.content.toLowerCase().includes(word) ? 1 : 0);
-        }, 0);
-        return { ...page, score: titleMatch + contentMatch };
-      })
-      .filter((r) => r.score > 0)
-      .sort((a, b) => b.score - a.score);
-  }
-
   // ─── llms.txt content builder ────────────────────────────────
   const llmsSiteTitle =
     typeof (config as Record<string, unknown>).nav === "object" &&
@@ -980,12 +967,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   function buildDefaultSystemPrompt(): string {
     const lines = [
       `You are a helpful documentation assistant${projectName ? ` for ${projectName}` : ""}.`,
-      "Answer questions based on the provided documentation context.",
+      "Answer only from the provided documentation context.",
+      "Prefer exact code/config snippets from the context when the question asks how to implement something.",
+      "Cite the relevant documentation URL when you use a source.",
+      "Use only URLs exactly as they appear in the context; do not invent placeholder domains.",
+      'Never use placeholder package names or imports such as "your-auth-library", "your-package", "your-sdk", "replace-me", or "example-library". If the exact package or import is not in the context, do not include an import snippet.',
       "Be concise and accurate. If the answer is not in the context, say so honestly.",
       "Use markdown formatting for code examples and links.",
     ];
     if (packageName) {
-      lines.push(`When showing import examples, always use "${packageName}" as the package name.`);
+      lines.push(
+        `When showing import examples, use "${packageName}" as the package name and prefer exact imports copied from the documentation context.`,
+      );
     }
     if (docsUrl) {
       lines.push(
@@ -1205,7 +1198,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         maxResults,
       },
     });
-    const scored = searchByQuery(lastUserMessage.content.toLowerCase(), ctx).slice(0, maxResults);
+    const retrieval = await buildDocsAskAIContext({
+      pages: getSearchIndex(ctx),
+      query: lastUserMessage.content,
+      search: resolveSearchRequestConfig(config.search, context.request.url),
+      locale: ctx.locale,
+      pathname: requestUrl.searchParams.get("pathname") ?? undefined,
+      siteTitle: llmsTitle,
+      baseUrl: requestUrl.origin,
+      limit: maxResults,
+    });
+    const scored = retrieval.results;
     await emitTrace({
       type: "retrieval.result",
       name: "docs-index",
@@ -1225,18 +1228,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const promptStartedAt = Date.now();
     const promptStartedAtIso = new Date().toISOString();
     const promptSpanId = createDocsAgentTraceId("span");
-    const contextParts = scored.map(
-      (doc) =>
-        `## ${doc.title}\nURL: ${doc.url}\n${doc.description ? `Description: ${doc.description}\n` : ""}\n${doc.content}`,
-    );
-    const ragContext = contextParts.join("\n\n---\n\n");
+    const ragContext = retrieval.context;
 
     const systemPrompt = aiConfig.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+    const packageHintsPrompt = formatDocsAskAIPackageHints(retrieval.packageHints, packageName);
+    const fullSystemPrompt = [systemPrompt, packageHintsPrompt].filter(Boolean).join("\n\n");
     const systemMessage: ChatMessage = {
       role: "system",
       content: ragContext
-        ? `${systemPrompt}\n\n---\n\nDocumentation context:\n\n${ragContext}`
-        : systemPrompt,
+        ? `${fullSystemPrompt}\n\n---\n\nDocumentation context:\n\n${ragContext}`
+        : fullSystemPrompt,
     };
 
     const llmMessages: ChatMessage[] = [

--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -25,6 +25,7 @@ const ALL_ANALYTICS_EVENTS = [
   "ai_close",
   "ai_question",
   "ai_response",
+  "ai_feedback",
   "ai_error",
   "ai_clear",
   "page_action_copy_markdown",

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -131,6 +131,8 @@ export type {
   OpenDocsProvider,
   GithubConfig,
   AIConfig,
+  DocsAskAIActionData,
+  DocsAskAIActionType,
   DocsAskAIFeedbackConfig,
   DocsAskAIFeedbackData,
   DocsAskAIFeedbackMessage,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -81,11 +81,14 @@ export {
 } from "./agent.js";
 export {
   buildDocsSearchDocuments,
+  buildDocsAskAIContext,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
   createMcpSearchAdapter,
   createSimpleSearchAdapter,
   createTypesenseSearchAdapter,
+  formatDocsAskAIPackageHints,
+  inferDocsAskAIPackageHints,
   performDocsSearch,
   resolveSearchRequestConfig,
 } from "./search.js";
@@ -128,6 +131,10 @@ export type {
   OpenDocsProvider,
   GithubConfig,
   AIConfig,
+  DocsAskAIFeedbackConfig,
+  DocsAskAIFeedbackData,
+  DocsAskAIFeedbackMessage,
+  DocsAskAIFeedbackValue,
   OrderingItem,
   LastUpdatedConfig,
   ReadingTimeConfig,

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -446,6 +446,56 @@ pnpm add @farming-labs/docs
     expect(context.context).toContain("pnpm add @farming-labs/docs");
   });
 
+  it("keeps duplicate heading titles on the same page when URL hashes differ", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Plugins",
+          url: "/docs/plugins",
+          content: "Configure server and client plugins.",
+          rawContent: `# Plugins
+
+## Configure
+
+Server plugin setup.
+
+## Configure
+
+Client plugin setup.
+`,
+        },
+      ],
+      query: "configure plugins",
+      limit: 2,
+      search: createCustomSearchAdapter({
+        name: "duplicate-headings",
+        async search() {
+          return [
+            {
+              id: "server-configure",
+              url: "/docs/plugins#configure",
+              content: "Plugins — Configure",
+              type: "heading",
+              section: "Configure",
+            },
+            {
+              id: "client-configure",
+              url: "/docs/plugins#configure-1",
+              content: "Plugins — Configure",
+              type: "heading",
+              section: "Configure",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(context.results.map((result) => result.url)).toEqual([
+      "/docs/plugins#configure",
+      "/docs/plugins#configure-1",
+    ]);
+  });
+
   it("supplements stale external search results with local section ranking", async () => {
     const context = await buildDocsAskAIContext({
       pages: [

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DocsSearchAdapterContext } from "./types.js";
 import {
+  buildDocsAskAIContext,
   buildDocsSearchDocuments,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
@@ -82,6 +83,39 @@ Second section.
 
     expect(documents.find((item) => item.type === "page")?.content).not.toContain("!");
     expect(documents.find((item) => item.section === "Flow")?.content).toContain("Flow chart");
+  });
+
+  it("keeps fenced code searchable in section documents", () => {
+    const documents = buildDocsSearchDocuments([
+      {
+        title: "Doctor",
+        url: "/docs/doctor",
+        content: "Validate docs readiness.",
+        rawContent: `import { Callout } from "@/components/callout";
+
+# Doctor
+
+## Remote URL
+
+Run the doctor against a deployed site:
+
+\`\`\`bash
+docs doctor --url https://docs.example.com
+\`\`\`
+
+\`\`\`ts
+import { betterAuth } from "better-auth";
+export const auth = betterAuth({});
+\`\`\`
+`,
+      },
+    ]);
+
+    const sectionContent = documents.find((item) => item.section === "Remote URL")?.content;
+    expect(sectionContent).toContain("docs doctor --url https://docs.example.com");
+    expect(sectionContent).toContain('import { betterAuth } from "better-auth";');
+    expect(sectionContent).toContain("export const auth = betterAuth({});");
+    expect(sectionContent).not.toContain("@/components/callout");
   });
 });
 
@@ -284,6 +318,214 @@ Your page is now available at \`/docs/my-page\`.
     expect(results[0]?.description).not.toContain("```");
     expect(results[0]?.description).not.toContain("`");
     expect(results[0]?.description).not.toContain("|");
+  });
+
+  it("ignores question stopwords and punctuation when ranking natural-language queries", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "AI Chat",
+          url: "/docs/ai-chat",
+          content: "suggestedQuestions: What themes are available?",
+          rawContent: `# AI Chat
+
+## Suggested Questions
+
+\`\`\`ts
+suggestedQuestions: ["What themes are available?"]
+\`\`\`
+`,
+        },
+        {
+          title: "Customize",
+          url: "/docs/customize",
+          content: "Nine built-in themes are available.",
+          rawContent: `# Customize
+
+## Available Themes
+
+Nine built-in themes are available: fumadocs, darksharp, pixel-border, colorful, shiny, darkbold, greentree, hardline, and concrete.
+`,
+        },
+      ],
+      query: "What themes are available?",
+    });
+
+    expect(results[0]).toMatchObject({
+      url: "/docs/customize#available-themes",
+      section: "Available Themes",
+    });
+  });
+});
+
+describe("buildDocsAskAIContext", () => {
+  it("uses section search and preserves code blocks for the model context", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Doctor",
+          url: "/docs/doctor",
+          description: "Validate docs readiness before shipping.",
+          content: "Validate docs readiness.",
+          rawContent: `# Doctor
+
+## Local Checks
+
+Run local checks before publishing.
+
+## Remote URL
+
+Run the doctor against a hosted site:
+
+\`\`\`bash
+docs doctor --url https://docs.example.com
+\`\`\`
+
+\`\`\`ts
+import { betterAuth } from "better-auth";
+\`\`\`
+`,
+        },
+      ],
+      query: "docs doctor --url",
+      limit: 1,
+    });
+
+    expect(context.results[0]).toMatchObject({
+      url: "/docs/doctor#remote-url",
+      section: "Remote URL",
+    });
+    expect(context.context).toContain("URL: /docs/doctor#remote-url");
+    expect(context.context).toContain("```bash");
+    expect(context.context).toContain("docs doctor --url https://docs.example.com");
+    expect(context.context).toContain('import { betterAuth } from "better-auth";');
+    expect(context.packageHints.packages).toContain("better-auth");
+    expect(context.packageHints.imports).toContain('import { betterAuth } from "better-auth";');
+    expect(context.context).not.toContain("Local Checks");
+  });
+
+  it("hydrates custom search results with local page content", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Installation",
+          url: "/docs/installation",
+          content: "Install the package.",
+          rawContent: `# Installation
+
+## Package Manager
+
+\`\`\`bash
+pnpm add @farming-labs/docs
+\`\`\`
+`,
+        },
+      ],
+      query: "install",
+      search: createCustomSearchAdapter({
+        name: "custom",
+        async search() {
+          return [
+            {
+              id: "custom-install",
+              url: "/docs/installation#package-manager",
+              content: "Installation — Package Manager",
+              type: "heading",
+              section: "Package Manager",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(context.searchResults.some((result) => result.id === "custom-install")).toBe(true);
+    expect(context.results[0]).toMatchObject({
+      url: "/docs/installation#package-manager",
+      section: "Package Manager",
+    });
+    expect(context.context).toContain("pnpm add @farming-labs/docs");
+  });
+
+  it("supplements stale external search results with local section ranking", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "AI Chat",
+          url: "/docs/getting-started/ai-native",
+          content: "suggestedQuestions: What themes are available?",
+          rawContent: `# AI Chat
+
+## Suggested Questions
+
+\`\`\`ts
+suggestedQuestions: ["What themes are available?"]
+\`\`\`
+`,
+        },
+        {
+          title: "Customize",
+          url: "/docs/customize",
+          content: "Nine built-in themes are available.",
+          rawContent: `# Customize
+
+## Available Themes
+
+Nine built-in themes are available: default, colorful, concrete, darkbold,
+darksharp, hardline, ledger, minimal, and shiny.
+`,
+        },
+      ],
+      query: "What themes are available?",
+      limit: 1,
+      search: createCustomSearchAdapter({
+        name: "stale",
+        async search() {
+          return [
+            {
+              id: "stale-suggested-questions",
+              url: "/docs/getting-started/ai-native#suggested-questions",
+              content: "AI Chat — Suggested Questions",
+              type: "heading",
+              section: "Suggested Questions",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(context.results[0]).toMatchObject({
+      url: "/docs/customize#available-themes",
+      section: "Available Themes",
+    });
+    expect(context.context).toContain("Nine built-in themes are available");
+  });
+
+  it("uses absolute context URLs when a request base URL is provided", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Customize",
+          url: "/docs/customize",
+          content: "Nine built-in themes are available.",
+          rawContent: `# Customize
+
+## Available Themes
+
+Nine built-in themes are available.
+`,
+        },
+      ],
+      query: "available themes",
+      baseUrl: "https://docs.example.com/api/docs",
+      limit: 1,
+    });
+
+    expect(context.results[0]?.url).toBe(
+      "https://docs.example.com/docs/customize#available-themes",
+    );
+    expect(context.context).toContain(
+      "URL: https://docs.example.com/docs/customize#available-themes",
+    );
   });
 });
 

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -402,7 +402,7 @@ function getSearchResultKey(result: DocsSearchResult): string {
   }
 
   return `${normalizeUrlPathname(result.url)}#${normalizeWhitespace(
-    result.section ?? hash,
+    hash || result.section || "",
   ).toLowerCase()}`;
 }
 
@@ -1479,7 +1479,7 @@ export async function buildDocsAskAIContext(options: {
   const results = formattedResults
     .filter((result) => result.section || !sectionResultPaths.has(normalizeUrlPathname(result.url)))
     .filter((result) => {
-      const key = `${normalizeUrlPathname(result.url)}#${result.section ?? ""}`;
+      const key = getSearchResultKey(result);
       if (seen.has(key)) return false;
       seen.add(key);
       return result.contextContent.length > 0;

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -18,6 +18,39 @@ const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_MCP_PROTOCOL_VERSION = "2025-11-25";
 const syncedIndexes = new Set<string>();
 const ALGOLIA_MAX_RECORD_BYTES = 9_500;
+const DEFAULT_ASK_AI_CONTEXT_CHARS = 24_000;
+const DEFAULT_ASK_AI_RESULT_CHARS = 6_000;
+const SEARCH_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "can",
+  "do",
+  "does",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "the",
+  "this",
+  "to",
+  "use",
+  "what",
+  "when",
+  "where",
+  "which",
+  "with",
+]);
 
 interface ResolvedDocsSearchConfig {
   enabled: boolean;
@@ -27,11 +60,30 @@ interface ResolvedDocsSearchConfig {
   raw?: DocsSearchConfig;
 }
 
+export interface DocsAskAIContextResult extends DocsSearchResult {
+  title: string;
+  contextContent: string;
+}
+
+export interface DocsAskAIContext {
+  context: string;
+  results: DocsAskAIContextResult[];
+  searchResults: DocsSearchResult[];
+  packageHints: DocsAskAIPackageHints;
+}
+
+export interface DocsAskAIPackageHints {
+  packages: string[];
+  imports: string[];
+  installCommands: string[];
+}
+
 function stripMarkdownText(content: string): string {
-  return content
-    .replace(/```[\s\S]*?```/g, "")
-    .replace(/~~~[\s\S]*?~~~/g, "")
-    .replace(/^(import|export)\s.*$/gm, "")
+  return removeMdxModuleLinesOutsideFences(content)
+    .replace(/```[^\n]*\n([\s\S]*?)```/g, "$1")
+    .replace(/```([\s\S]*?)```/g, "$1")
+    .replace(/~~~[^\n]*\n([\s\S]*?)~~~/g, "$1")
+    .replace(/~~~([\s\S]*?)~~~/g, "$1")
     .replace(/<[^>]+\/>/g, "")
     .replace(/<\/?[A-Z][^>]*>/g, "")
     .replace(/<\/?[a-z][^>]*>/g, "")
@@ -69,6 +121,329 @@ function normalizeMcpSsePayload(body: string) {
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function tokenizeSearchQuery(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}@/_:.-]+/gu, " ")
+        .split(/\s+/)
+        .map((word) => word.replace(/^[^\p{L}\p{N}@]+|[^\p{L}\p{N}]+$/gu, ""))
+        .filter((word) => word.length > 1 && !SEARCH_STOP_WORDS.has(word)),
+    ),
+  );
+}
+
+function normalizeUrlPathname(value: string): string {
+  try {
+    return new URL(value, "https://docs.local").pathname.replace(/\/+$/, "") || "/";
+  } catch {
+    return value.split(/[?#]/)[0]?.replace(/\/+$/, "") || "/";
+  }
+}
+
+function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
+  if (!baseUrl) return value;
+
+  try {
+    return new URL(value, baseUrl).toString();
+  } catch {
+    return value;
+  }
+}
+
+function getAskAIPageContent(page: DocsSearchSourcePage): string {
+  return page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent ?? page.content;
+}
+
+function removeMdxModuleLinesOutsideFences(content: string): string {
+  let inFence = false;
+
+  return content
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+        inFence = !inFence;
+        return true;
+      }
+
+      return inFence || !/^(import|export)\s/.test(trimmed);
+    })
+    .join("\n");
+}
+
+function cleanAskAIContextMarkdown(content: string): string {
+  return removeMdxModuleLinesOutsideFences(content)
+    .replace(/<[^>]+\/>/g, "")
+    .replace(/<\/?[A-Z][^>]*>/g, "")
+    .replace(/<\/?[a-z][^>]*>/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function packageRootFromSpecifier(specifier: string): string | null {
+  if (
+    !specifier ||
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    specifier.startsWith("@/") ||
+    specifier.startsWith("~/") ||
+    specifier.startsWith("#")
+  ) {
+    return null;
+  }
+
+  const parts = specifier.split("/").filter(Boolean);
+  if (parts.length === 0) return null;
+  if (parts[0]?.startsWith("@")) {
+    return parts.length > 1 ? `${parts[0]}/${parts[1]}` : null;
+  }
+  return parts[0];
+}
+
+function cleanPackageToken(token: string): string | null {
+  const trimmed = token
+    .trim()
+    .replace(/^["'`]+|["'`,;]+$/g, "")
+    .replace(/\\$/g, "");
+
+  if (!trimmed || trimmed.startsWith("-") || /^[A-Z_][A-Z0-9_]*=/.test(trimmed)) return null;
+  if (/^(npm|pnpm|yarn|bun|install|add|i|x|dlx|run|exec)$/.test(trimmed)) return null;
+
+  const withoutVersion = trimmed.startsWith("@")
+    ? trimmed.replace(/^(@[^/]+\/[^@]+)@.+$/, "$1")
+    : trimmed.replace(/^([^@]+)@.+$/, "$1");
+
+  return packageRootFromSpecifier(withoutVersion);
+}
+
+export function inferDocsAskAIPackageHints(content: string): DocsAskAIPackageHints {
+  const packages = new Set<string>();
+  const imports = new Set<string>();
+  const installCommands = new Set<string>();
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const importSpecifier = trimmed.match(
+      /^(?:import|export)\s+(?:type\s+)?[\s\S]*?\s+from\s+["']([^"']+)["']/,
+    )?.[1];
+    const bareImportSpecifier = trimmed.match(/^import\s+["']([^"']+)["']/)?.[1];
+    const requireSpecifier = trimmed.match(/require\(["']([^"']+)["']\)/)?.[1];
+    const specifier = importSpecifier ?? bareImportSpecifier ?? requireSpecifier;
+    const packageName = specifier ? packageRootFromSpecifier(specifier) : null;
+
+    if (packageName) {
+      packages.add(packageName);
+      if (/^(?:import|export)\s/.test(trimmed)) {
+        imports.add(trimmed);
+      }
+    }
+
+    const installMatch = trimmed.match(
+      /^(?:npm\s+(?:install|i)|pnpm\s+add|yarn\s+add|bun\s+add)\s+(.+)$/,
+    );
+    if (!installMatch) continue;
+
+    const commandPackages = installMatch[1]
+      .split(/\s+/)
+      .map(cleanPackageToken)
+      .filter((value): value is string => Boolean(value));
+
+    if (commandPackages.length > 0) {
+      installCommands.add(trimmed);
+      for (const name of commandPackages) packages.add(name);
+    }
+  }
+
+  return {
+    packages: Array.from(packages).slice(0, 8),
+    imports: Array.from(imports).slice(0, 12),
+    installCommands: Array.from(installCommands).slice(0, 8),
+  };
+}
+
+export function formatDocsAskAIPackageHints(
+  hints: DocsAskAIPackageHints,
+  packageName?: string,
+): string | undefined {
+  const packages = packageName
+    ? Array.from(new Set([packageName, ...hints.packages]))
+    : hints.packages;
+
+  if (packages.length === 0 && hints.imports.length === 0 && hints.installCommands.length === 0) {
+    return undefined;
+  }
+
+  const lines = ["Package and import hints inferred from the retrieved documentation context:"];
+
+  if (packages.length > 0) {
+    lines.push(`- Package names found in install/import examples: ${packages.join(", ")}`);
+  }
+
+  if (hints.imports.length > 0) {
+    lines.push(
+      `- Exact import lines found in context: ${hints.imports.map((line) => `\`${line}\``).join("; ")}`,
+    );
+  }
+
+  if (hints.installCommands.length > 0) {
+    lines.push(
+      `- Exact install commands found in context: ${hints.installCommands
+        .map((line) => `\`${line}\``)
+        .join("; ")}`,
+    );
+  }
+
+  lines.push(
+    "Use these exact package names, install commands, and import lines when relevant. Do not replace them with placeholders.",
+  );
+
+  return lines.join("\n");
+}
+
+function clampText(value: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars).trimEnd()}...`;
+}
+
+function extractHeadingText(line: string): { level: number; text: string } | null {
+  const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+  if (!match) return null;
+  return {
+    level: match[1].length,
+    text: normalizeWhitespace(match[2].replace(/[`*_~]/g, "")),
+  };
+}
+
+function extractSectionMarkdown(content: string, section?: string): string {
+  if (!section) return content;
+
+  const target = normalizeWhitespace(section).toLowerCase();
+  const lines = content.split("\n");
+  let start = -1;
+  let level = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const heading = extractHeadingText(lines[i]);
+    if (!heading) continue;
+
+    if (heading.text.toLowerCase() === target) {
+      start = i;
+      level = heading.level;
+      break;
+    }
+  }
+
+  if (start === -1) return content;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const heading = extractHeadingText(lines[i]);
+    if (heading && heading.level <= level) {
+      end = i;
+      break;
+    }
+  }
+
+  return lines.slice(start, end).join("\n");
+}
+
+function findPageForSearchResult(
+  pages: DocsSearchSourcePage[],
+  result: DocsSearchResult,
+): DocsSearchSourcePage | undefined {
+  const resultPath = normalizeUrlPathname(result.url);
+  return pages.find((page) => normalizeUrlPathname(page.url) === resultPath);
+}
+
+function inferResultTitle(result: DocsSearchResult, page?: DocsSearchSourcePage): string {
+  if (page) return page.title;
+
+  const content = stripHtml(result.content).trim();
+  const title = content.split("—")[0]?.trim();
+  return title || result.url;
+}
+
+function formatAskAIContextResult(options: {
+  result: DocsSearchResult;
+  page?: DocsSearchSourcePage;
+  maxChars: number;
+  baseUrl?: string;
+}): DocsAskAIContextResult {
+  const { result, page, maxChars, baseUrl } = options;
+  const title = inferResultTitle(result, page);
+  const section = result.section;
+  const rawContent = page
+    ? extractSectionMarkdown(getAskAIPageContent(page), section)
+    : [result.content, result.description].filter(Boolean).join("\n\n");
+  const contextContent = clampText(cleanAskAIContextMarkdown(rawContent), maxChars);
+
+  return {
+    ...result,
+    url: resolveAskAIContextUrl(result.url, baseUrl),
+    title,
+    contextContent,
+  };
+}
+
+function getSearchResultKey(result: DocsSearchResult): string {
+  let hash = "";
+
+  try {
+    hash = new URL(result.url, "https://docs.local").hash.replace(/^#/, "");
+  } catch {
+    hash = result.url.split("#")[1]?.split(/[?&]/)[0] ?? "";
+  }
+
+  return `${normalizeUrlPathname(result.url)}#${normalizeWhitespace(
+    result.section ?? hash,
+  ).toLowerCase()}`;
+}
+
+function mergeSearchResults(...groups: DocsSearchResult[][]): DocsSearchResult[] {
+  const seen = new Set<string>();
+  const results: DocsSearchResult[] = [];
+
+  for (const group of groups) {
+    for (const result of group) {
+      const key = getSearchResultKey(result);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(result);
+    }
+  }
+
+  return results;
+}
+
+function shouldSupplementAskAIWithSimpleSearch(search: ResolvedDocsSearchConfig): boolean {
+  return search.enabled && search.provider !== "simple";
+}
+
+function rankAskAIContextResult(query: string, result: DocsAskAIContextResult): number {
+  return scoreDocument(query, {
+    id: result.id,
+    url: result.url,
+    title: result.title,
+    content: result.contextContent,
+    description: result.description,
+    type: result.type,
+    section: result.section,
+  });
+}
+
+function buildAskAIContextBlock(result: DocsAskAIContextResult): string {
+  const lines = [`## ${result.title}`, `URL: ${result.url}`];
+  if (result.section) lines.push(`Section: ${result.section}`);
+  if (result.description) lines.push(`Search snippet: ${result.description}`);
+  lines.push("", result.contextContent);
+  return lines.join("\n").trim();
 }
 
 function makeDocumentId(url: string, suffix: string): string {
@@ -174,15 +549,17 @@ export function buildDocsSearchDocuments(
 }
 
 function scoreDocument(query: string, document: DocsSearchDocument): number {
-  const q = query.toLowerCase().trim();
+  const q = normalizeWhitespace(query.toLowerCase().replace(/[?!.,;:]+$/g, ""));
   if (!q) return 0;
 
-  const words = Array.from(new Set(q.split(/\s+/).filter(Boolean)));
+  const words = tokenizeSearchQuery(q);
   const title = document.title.toLowerCase();
   const section = document.section?.toLowerCase() ?? "";
   const description = document.description?.toLowerCase() ?? "";
   const content = document.content.toLowerCase();
   const url = document.url.toLowerCase();
+  const titleTokens = tokenizeSearchQuery(title);
+  const sectionTokens = tokenizeSearchQuery(section);
 
   let score = 0;
 
@@ -236,6 +613,19 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
     }
 
     if (matched) matchedWords += 1;
+  }
+
+  if (words.length > 1) {
+    if (sectionTokens.length > 0 && words.every((word) => sectionTokens.includes(word))) {
+      score += 30;
+    }
+    if (
+      document.type === "page" &&
+      titleTokens.length > 0 &&
+      words.every((word) => titleTokens.includes(word))
+    ) {
+      score += 24;
+    }
   }
 
   if (matchedWords === words.length && words.length > 1) score += 20;
@@ -1013,6 +1403,116 @@ export async function performDocsSearch(options: {
   } catch {
     return createSimpleSearchAdapter().search(query, context);
   }
+}
+
+export async function buildDocsAskAIContext(options: {
+  pages: DocsSearchSourcePage[];
+  query: string;
+  search?: boolean | DocsSearchConfig;
+  locale?: string;
+  pathname?: string;
+  siteTitle?: string;
+  baseUrl?: string;
+  limit?: number;
+  maxContextChars?: number;
+  maxResultChars?: number;
+}): Promise<DocsAskAIContext> {
+  const limit = options.limit ?? 5;
+  const searchLimit = Math.max(limit * 2, limit);
+  const initialSearch = options.search === false ? true : options.search;
+  const initialSearchConfig = normalizeDocsSearchConfig(initialSearch);
+  const primarySearch = initialSearchConfig.enabled ? initialSearch : true;
+  const primarySearchConfig = normalizeDocsSearchConfig(primarySearch);
+  const primarySearchResults = await performDocsSearch({
+    pages: options.pages,
+    query: options.query,
+    search: primarySearch,
+    locale: options.locale,
+    pathname: options.pathname,
+    siteTitle: options.siteTitle,
+    limit: searchLimit,
+  });
+  const localSearchResults = shouldSupplementAskAIWithSimpleSearch(primarySearchConfig)
+    ? await performDocsSearch({
+        pages: options.pages,
+        query: options.query,
+        search: {
+          provider: "simple",
+          enabled: true,
+          chunking: primarySearchConfig.chunking,
+          maxResults: searchLimit,
+        },
+        locale: options.locale,
+        pathname: options.pathname,
+        siteTitle: options.siteTitle,
+        limit: searchLimit,
+      })
+    : [];
+  const searchResults = mergeSearchResults(primarySearchResults, localSearchResults);
+
+  const seen = new Set<string>();
+  const maxResultChars = options.maxResultChars ?? DEFAULT_ASK_AI_RESULT_CHARS;
+  const rankedResults = searchResults
+    .map((result, index) => {
+      const page = findPageForSearchResult(options.pages, result);
+      const formatted = formatAskAIContextResult({
+        result,
+        page,
+        maxChars: maxResultChars,
+        baseUrl: options.baseUrl,
+      });
+
+      return {
+        result,
+        formatted,
+        index,
+        rank: rankAskAIContextResult(options.query, formatted),
+      };
+    })
+    .sort((a, b) => b.rank - a.rank || a.index - b.index);
+  const formattedResults = rankedResults.map((item) => item.formatted);
+  const sectionResultPaths = new Set(
+    formattedResults
+      .filter((result) => result.section)
+      .map((result) => normalizeUrlPathname(result.url)),
+  );
+  const results = formattedResults
+    .filter((result) => result.section || !sectionResultPaths.has(normalizeUrlPathname(result.url)))
+    .filter((result) => {
+      const key = `${normalizeUrlPathname(result.url)}#${result.section ?? ""}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return result.contextContent.length > 0;
+    })
+    .slice(0, limit);
+
+  const maxContextChars = options.maxContextChars ?? DEFAULT_ASK_AI_CONTEXT_CHARS;
+  const blocks: string[] = [];
+  let usedChars = 0;
+
+  for (const result of results) {
+    const block = buildAskAIContextBlock(result);
+    const separatorChars = blocks.length === 0 ? 0 : "\n\n---\n\n".length;
+    if (usedChars + separatorChars + block.length > maxContextChars) {
+      const remaining = maxContextChars - usedChars - separatorChars;
+      if (remaining > 400) {
+        blocks.push(clampText(block, remaining));
+      }
+      break;
+    }
+
+    blocks.push(block);
+    usedChars += separatorChars + block.length;
+  }
+
+  const context = blocks.join("\n\n---\n\n");
+
+  return {
+    context,
+    results: results.slice(0, blocks.length),
+    searchResults: rankedResults.map((item) => item.result),
+    packageHints: inferDocsAskAIPackageHints(context),
+  };
 }
 
 export function createCustomSearchAdapter(

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -35,11 +35,14 @@ export {
 } from "./mcp.js";
 export {
   buildDocsSearchDocuments,
+  buildDocsAskAIContext,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
   createMcpSearchAdapter,
   createSimpleSearchAdapter,
   createTypesenseSearchAdapter,
+  formatDocsAskAIPackageHints,
+  inferDocsAskAIPackageHints,
   performDocsSearch,
   resolveSearchRequestConfig,
 } from "./search.js";
@@ -76,6 +79,10 @@ export type {
   DocsSearchResult,
   DocsSearchSourcePage,
   McpDocsSearchConfig,
+  DocsAskAIFeedbackConfig,
+  DocsAskAIFeedbackData,
+  DocsAskAIFeedbackMessage,
+  DocsAskAIFeedbackValue,
   DocsAnalyticsConfig,
   DocsAnalyticsEvent,
   DocsAnalyticsEventInput,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -716,6 +716,7 @@ export type DocsAnalyticsEventType =
   | "ai_close"
   | "ai_question"
   | "ai_response"
+  | "ai_feedback"
   | "ai_error"
   | "ai_clear"
   | "page_action_copy_markdown"
@@ -743,6 +744,7 @@ export type DocsAnalyticsEventType =
 export interface DocsAnalyticsInput {
   query?: string;
   question?: string;
+  feedbackValue?: string;
   feedbackComment?: string;
   content?: string;
 }
@@ -1158,6 +1160,40 @@ export interface GithubConfig {
   directory?: string;
 }
 
+export type DocsAskAIFeedbackValue = "like" | "dislike";
+
+export interface DocsAskAIFeedbackMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface DocsAskAIFeedbackData {
+  value: DocsAskAIFeedbackValue;
+  question: string;
+  answer: string;
+  messageId?: string;
+  messageIndex?: number;
+  model?: string;
+  surface?: string;
+  url?: string;
+  path?: string;
+  messages?: DocsAskAIFeedbackMessage[];
+}
+
+export interface DocsAskAIFeedbackConfig {
+  /**
+   * Whether to show response rating controls after each completed Ask AI answer.
+   * @default true
+   */
+  enabled?: boolean;
+  /** Label for the positive rating button. @default "Helpful" */
+  positiveLabel?: string;
+  /** Label for the negative rating button. @default "Not helpful" */
+  negativeLabel?: string;
+  /** Called when a user rates an Ask AI response. */
+  onFeedback?: (data: DocsAskAIFeedbackData) => void | Promise<void>;
+}
+
 /**
  * Configuration for "Ask AI" — a RAG-powered chat that lets users
  * ask questions about the documentation content.
@@ -1427,8 +1463,8 @@ export interface AIConfig {
   aiLabel?: string;
 
   /**
-   * The npm package name used in import examples.
-   * The AI will use this in code snippets instead of generic placeholders.
+   * Optional npm package-name override used in import examples.
+   * Ask AI normally infers package names and exact imports from retrieved docs context.
    *
    * @example
    * ```ts
@@ -1515,6 +1551,28 @@ export interface AIConfig {
    * ```
    */
   loadingComponent?: (props: { name: string }) => unknown;
+
+  /**
+   * Response rating controls for generated Ask AI answers.
+   *
+   * Set to `false` to hide the buttons. Pass an object to customize labels
+   * and receive callback payloads with the question, answer, model, and UI surface.
+   *
+   * @default true
+   *
+   * @example
+   * ```ts
+   * ai: {
+   *   enabled: true,
+   *   feedback: {
+   *     onFeedback(data) {
+   *       console.log(data.value, data.question, data.answer);
+   *     },
+   *   },
+   * }
+   * ```
+   */
+  feedback?: boolean | DocsAskAIFeedbackConfig;
 }
 
 /**

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1161,10 +1161,26 @@ export interface GithubConfig {
 }
 
 export type DocsAskAIFeedbackValue = "like" | "dislike";
+export type DocsAskAIActionType = "copy" | DocsAskAIFeedbackValue;
 
 export interface DocsAskAIFeedbackMessage {
   role: "user" | "assistant";
   content: string;
+}
+
+export interface DocsAskAIActionData {
+  type: DocsAskAIActionType;
+  value?: DocsAskAIFeedbackValue;
+  question: string;
+  answer: string;
+  messageId?: string;
+  messageIndex?: number;
+  model?: string;
+  surface?: string;
+  url?: string;
+  path?: string;
+  messages?: DocsAskAIFeedbackMessage[];
+  copied?: boolean;
 }
 
 export interface DocsAskAIFeedbackData {
@@ -1573,6 +1589,25 @@ export interface AIConfig {
    * ```
    */
   feedback?: boolean | DocsAskAIFeedbackConfig;
+
+  /**
+   * Called when a user clicks an Ask AI response action.
+   *
+   * `data.type` is `"copy"`, `"like"`, or `"dislike"`.
+   *
+   * @example
+   * ```ts
+   * ai: {
+   *   enabled: true,
+   *   onActions(data) {
+   *     if (data.type === "copy") console.log("Copied", data.answer);
+   *     if (data.type === "like") console.log("Helpful", data.question);
+   *     if (data.type === "dislike") console.log("Not helpful", data.question);
+   *   },
+   * }
+   * ```
+   */
+  onActions?: (data: DocsAskAIActionData) => void | Promise<void>;
 }
 
 /**

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -24,7 +24,12 @@ import {
 import { createPortal } from "react-dom";
 import { highlight } from "sugar-high";
 import { emitClientAnalyticsEvent } from "./client-analytics.js";
-import type { DocsAskAIFeedbackData, DocsAskAIFeedbackValue } from "@farming-labs/docs";
+import type {
+  DocsAskAIActionData,
+  DocsAskAIActionType,
+  DocsAskAIFeedbackData,
+  DocsAskAIFeedbackValue,
+} from "@farming-labs/docs";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -47,6 +52,7 @@ interface ChatMessage {
 type AIModelOption = { id: string; label: string };
 
 interface DocsWindowHooks extends Window {
+  __fdOnAIActions__?: (data: DocsAskAIActionData) => void | Promise<void>;
   __fdOnAIFeedback__?: (data: DocsAskAIFeedbackData) => void | Promise<void>;
 }
 
@@ -66,13 +72,14 @@ function getLastUserQuestion(messages: ChatMessage[], assistantIndex: number): s
   return "";
 }
 
-function buildFeedbackPayload(options: {
-  value: DocsAskAIFeedbackValue;
+function buildActionPayload(options: {
+  type: DocsAskAIActionType;
   message: ChatMessage;
   messages: ChatMessage[];
   index: number;
   surface: string;
-}): DocsAskAIFeedbackData {
+  copied?: boolean;
+}): DocsAskAIActionData {
   const location =
     typeof window !== "undefined"
       ? {
@@ -82,7 +89,8 @@ function buildFeedbackPayload(options: {
       : {};
 
   return {
-    value: options.value,
+    type: options.type,
+    value: options.type === "like" || options.type === "dislike" ? options.type : undefined,
     question: getLastUserQuestion(options.messages, options.index),
     answer: options.message.content,
     messageId: options.message.id,
@@ -92,8 +100,41 @@ function buildFeedbackPayload(options: {
     messages: options.messages
       .slice(0, options.index + 1)
       .map((message) => ({ role: message.role, content: message.content })),
+    copied: options.copied,
     ...location,
   };
+}
+
+function toFeedbackPayload(data: DocsAskAIActionData): DocsAskAIFeedbackData | null {
+  if (data.type !== "like" && data.type !== "dislike") return null;
+
+  return {
+    value: data.type,
+    question: data.question,
+    answer: data.answer,
+    messageId: data.messageId,
+    messageIndex: data.messageIndex,
+    model: data.model,
+    surface: data.surface,
+    url: data.url,
+    path: data.path,
+    messages: data.messages,
+  };
+}
+
+function emitAskAIAction(data: DocsAskAIActionData) {
+  if (typeof window === "undefined") return;
+
+  try {
+    const result = (window as DocsWindowHooks).__fdOnAIActions__?.(data);
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      void (result as Promise<void>).catch(() => {});
+    }
+  } catch {}
+
+  try {
+    window.dispatchEvent(new CustomEvent("fd:ai-action", { detail: data }));
+  } catch {}
 }
 
 function emitAskAIFeedback(data: DocsAskAIFeedbackData, analytics?: boolean) {
@@ -682,13 +723,15 @@ function AIFeedbackControls({
   onSelect,
 }: {
   value?: DocsAskAIFeedbackValue;
-  onCopy: () => void;
+  onCopy: () => boolean | Promise<boolean>;
   onSelect: (value: DocsAskAIFeedbackValue) => void;
 }) {
   const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(() => {
+  const handleCopy = useCallback(async () => {
+    const didCopy = await onCopy();
+    if (!didCopy) return;
+
     setCopied(true);
-    onCopy();
     window.setTimeout(() => setCopied(false), 1500);
   }, [onCopy]);
 
@@ -942,22 +985,37 @@ function AIChat({
         itemIndex === index ? updatedMessage : item,
       );
       setMessages(updatedMessages);
-      emitAskAIFeedback(
-        buildFeedbackPayload({
-          value,
-          message: updatedMessage,
-          messages: updatedMessages,
-          index,
-          surface,
-        }),
-        analytics,
-      );
+      const actionPayload = buildActionPayload({
+        type: value,
+        message: updatedMessage,
+        messages: updatedMessages,
+        index,
+        surface,
+      });
+      emitAskAIAction(actionPayload);
+
+      const feedbackPayload = toFeedbackPayload(actionPayload);
+      if (feedbackPayload) emitAskAIFeedback(feedbackPayload, analytics);
     },
     [analytics, messages, setMessages, surface],
   );
-  const handleCopyMessage = useCallback((message: ChatMessage) => {
-    void copyTextToClipboard(message.content);
-  }, []);
+  const handleCopyMessage = useCallback(
+    async (message: ChatMessage, index: number) => {
+      const copied = await copyTextToClipboard(message.content);
+      emitAskAIAction(
+        buildActionPayload({
+          type: "copy",
+          message,
+          messages,
+          index,
+          surface,
+          copied,
+        }),
+      );
+      return copied;
+    },
+    [messages, surface],
+  );
 
   return (
     <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
@@ -1002,7 +1060,7 @@ function AIChat({
                         !(isStreaming && i === messages.length - 1) && (
                           <AIFeedbackControls
                             value={msg.feedback}
-                            onCopy={() => handleCopyMessage(msg)}
+                            onCopy={() => handleCopyMessage(msg, i)}
                             onSelect={(value) => handleFeedback(msg, i, value)}
                           />
                         )}
@@ -1837,22 +1895,37 @@ function FullModalAIChat({
         itemIndex === index ? updatedMessage : item,
       );
       setMessages(updatedMessages);
-      emitAskAIFeedback(
-        buildFeedbackPayload({
-          value,
-          message: updatedMessage,
-          messages: updatedMessages,
-          index,
-          surface: "full-modal",
-        }),
-        analytics,
-      );
+      const actionPayload = buildActionPayload({
+        type: value,
+        message: updatedMessage,
+        messages: updatedMessages,
+        index,
+        surface: "full-modal",
+      });
+      emitAskAIAction(actionPayload);
+
+      const feedbackPayload = toFeedbackPayload(actionPayload);
+      if (feedbackPayload) emitAskAIFeedback(feedbackPayload, analytics);
     },
     [analytics, messages, setMessages],
   );
-  const handleCopyMessage = useCallback((message: ChatMessage) => {
-    void copyTextToClipboard(message.content);
-  }, []);
+  const handleCopyMessage = useCallback(
+    async (message: ChatMessage, index: number) => {
+      const copied = await copyTextToClipboard(message.content);
+      emitAskAIAction(
+        buildActionPayload({
+          type: "copy",
+          message,
+          messages,
+          index,
+          surface: "full-modal",
+          copied,
+        }),
+      );
+      return copied;
+    },
+    [messages],
+  );
 
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -1901,7 +1974,7 @@ function FullModalAIChat({
                           !(isStreaming && i === messages.length - 1) && (
                             <AIFeedbackControls
                               value={msg.feedback}
-                              onCopy={() => handleCopyMessage(msg)}
+                              onCopy={() => handleCopyMessage(msg, i)}
                               onSelect={(value) => handleFeedback(msg, i, value)}
                             />
                           )}

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -1055,15 +1055,13 @@ function AIChat({
                         }
                         dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
                       />
-                      {feedbackEnabled &&
-                        !msg.isError &&
-                        !(isStreaming && i === messages.length - 1) && (
-                          <AIFeedbackControls
-                            value={msg.feedback}
-                            onCopy={() => handleCopyMessage(msg, i)}
-                            onSelect={(value) => handleFeedback(msg, i, value)}
-                          />
-                        )}
+                      {feedbackEnabled && !msg.isError && !isStreaming && (
+                        <AIFeedbackControls
+                          value={msg.feedback}
+                          onCopy={() => handleCopyMessage(msg, i)}
+                          onSelect={(value) => handleFeedback(msg, i, value)}
+                        />
+                      )}
                     </>
                   ) : loadingComponentHtml ? (
                     <div dangerouslySetInnerHTML={{ __html: loadingComponentHtml }} />
@@ -1971,7 +1969,7 @@ function FullModalAIChat({
                         {msg.role === "assistant" &&
                           feedbackEnabled &&
                           !msg.isError &&
-                          !(isStreaming && i === messages.length - 1) && (
+                          !isStreaming && (
                             <AIFeedbackControls
                               value={msg.feedback}
                               onCopy={() => handleCopyMessage(msg, i)}

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -17,11 +17,14 @@ import {
   useEffect,
   useRef,
   useCallback,
+  type Dispatch,
   type KeyboardEvent as ReactKeyboardEvent,
+  type SetStateAction,
 } from "react";
 import { createPortal } from "react-dom";
 import { highlight } from "sugar-high";
 import { emitClientAnalyticsEvent } from "./client-analytics.js";
+import type { DocsAskAIFeedbackData, DocsAskAIFeedbackValue } from "@farming-labs/docs";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -35,9 +38,129 @@ interface SearchResult {
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
+  id?: string;
+  model?: string;
+  feedback?: DocsAskAIFeedbackValue;
+  isError?: boolean;
 }
 
 type AIModelOption = { id: string; label: string };
+
+interface DocsWindowHooks extends Window {
+  __fdOnAIFeedback__?: (data: DocsAskAIFeedbackData) => void | Promise<void>;
+}
+
+let aiMessageId = 0;
+
+function createAIMessageId(): string {
+  aiMessageId += 1;
+  return `ai_${Date.now().toString(36)}_${aiMessageId.toString(36)}`;
+}
+
+function getLastUserQuestion(messages: ChatMessage[], assistantIndex: number): string {
+  for (let i = assistantIndex - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message?.role === "user") return message.content;
+  }
+
+  return "";
+}
+
+function buildFeedbackPayload(options: {
+  value: DocsAskAIFeedbackValue;
+  message: ChatMessage;
+  messages: ChatMessage[];
+  index: number;
+  surface: string;
+}): DocsAskAIFeedbackData {
+  const location =
+    typeof window !== "undefined"
+      ? {
+          url: window.location.href,
+          path: window.location.pathname,
+        }
+      : {};
+
+  return {
+    value: options.value,
+    question: getLastUserQuestion(options.messages, options.index),
+    answer: options.message.content,
+    messageId: options.message.id,
+    messageIndex: options.index,
+    model: options.message.model,
+    surface: options.surface,
+    messages: options.messages
+      .slice(0, options.index + 1)
+      .map((message) => ({ role: message.role, content: message.content })),
+    ...location,
+  };
+}
+
+function emitAskAIFeedback(data: DocsAskAIFeedbackData, analytics?: boolean) {
+  if (analytics) {
+    emitClientAnalyticsEvent({
+      type: "ai_feedback",
+      input: {
+        question: data.question,
+        feedbackValue: data.value,
+      },
+      properties: {
+        value: data.value,
+        surface: data.surface,
+        model: data.model,
+        questionLength: data.question.length,
+        answerLength: data.answer.length,
+        messageIndex: data.messageIndex,
+      },
+    });
+  }
+
+  if (typeof window === "undefined") return;
+
+  try {
+    const result = (window as DocsWindowHooks).__fdOnAIFeedback__?.(data);
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      void (result as Promise<void>).catch(() => {});
+    }
+  } catch {}
+
+  try {
+    window.dispatchEvent(new CustomEvent("fd:ai-feedback", { detail: data }));
+  } catch {}
+}
+
+function fallbackCopyText(text: string): boolean {
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    document.execCommand("copy");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (!text) return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return fallbackCopyText(text);
+  }
+}
 
 // ─── Markdown renderer ──────────────────────────────────────────────
 
@@ -247,6 +370,77 @@ function XIcon() {
     >
       <path d="M18 6 6 18" />
       <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+function ThumbsUpIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M7 10v12" />
+      <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+    </svg>
+  );
+}
+
+function ThumbsDownIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M17 14V2" />
+      <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
+    </svg>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 6 9 17l-5-5" />
     </svg>
   );
 }
@@ -482,6 +676,60 @@ function ModelSelector({
   );
 }
 
+function AIFeedbackControls({
+  value,
+  onCopy,
+  onSelect,
+}: {
+  value?: DocsAskAIFeedbackValue;
+  onCopy: () => void;
+  onSelect: (value: DocsAskAIFeedbackValue) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    setCopied(true);
+    onCopy();
+    window.setTimeout(() => setCopied(false), 1500);
+  }, [onCopy]);
+
+  return (
+    <div className="fd-ai-feedback" role="group" aria-label="Rate this Ask AI response">
+      <button
+        type="button"
+        className="fd-ai-feedback-btn"
+        data-copied={copied ? "true" : undefined}
+        aria-label={copied ? "Copied response" : "Copy response"}
+        title={copied ? "Copied" : "Copy response"}
+        onClick={handleCopy}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
+      <button
+        type="button"
+        className="fd-ai-feedback-btn"
+        data-active={value === "like"}
+        aria-pressed={value === "like"}
+        aria-label="Helpful"
+        title="Helpful"
+        onClick={() => onSelect("like")}
+      >
+        <ThumbsUpIcon />
+      </button>
+      <button
+        type="button"
+        className="fd-ai-feedback-btn"
+        data-active={value === "dislike"}
+        aria-pressed={value === "dislike"}
+        aria-label="Not helpful"
+        title="Not helpful"
+        onClick={() => onSelect("dislike")}
+      >
+        <ThumbsDownIcon />
+      </button>
+    </div>
+  );
+}
+
 // ─── Shared AI Chat Component ───────────────────────────────────────
 
 function AIChat({
@@ -499,11 +747,12 @@ function AIChat({
   models,
   defaultModelId,
   analytics,
+  feedbackEnabled = true,
   surface = "chat",
 }: {
   api: string;
   messages: ChatMessage[];
-  setMessages: (m: ChatMessage[]) => void;
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   aiInput: string;
   setAiInput: (v: string) => void;
   isStreaming: boolean;
@@ -515,6 +764,7 @@ function AIChat({
   models?: AIModelOption[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
   surface?: string;
 }) {
   const label = aiLabel || "AI";
@@ -541,9 +791,15 @@ function AIChat({
       if (!question.trim() || isStreaming) return;
       const userMessage: ChatMessage = { role: "user", content: question };
       const newMessages = [...messages, userMessage];
+      const assistantMessage: ChatMessage = {
+        role: "assistant",
+        content: "",
+        id: createAIMessageId(),
+        model: effectiveModelId,
+      };
       setAiInput("");
       setIsStreaming(true);
-      setMessages([...newMessages, { role: "assistant", content: "" }]);
+      setMessages([...newMessages, assistantMessage]);
       const startedAt = Date.now();
 
       if (analytics) {
@@ -574,7 +830,7 @@ function AIChat({
             const err = await res.json();
             errMsg = err.error || errMsg;
           } catch {}
-          setMessages([...newMessages, { role: "assistant", content: errMsg }]);
+          setMessages([...newMessages, { ...assistantMessage, content: errMsg, isError: true }]);
           setIsStreaming(false);
           if (analytics) {
             emitClientAnalyticsEvent({
@@ -610,14 +866,14 @@ function AIChat({
                 const content = json.choices?.[0]?.delta?.content;
                 if (content) {
                   assistantContent += content;
-                  setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+                  setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
                 }
               } catch {}
             }
           }
         }
         if (assistantContent)
-          setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+          setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
         if (analytics) {
           emitClientAnalyticsEvent({
             type: "ai_response",
@@ -633,7 +889,11 @@ function AIChat({
       } catch {
         setMessages([
           ...newMessages,
-          { role: "assistant", content: "Failed to connect. Please try again." },
+          {
+            ...assistantMessage,
+            content: "Failed to connect. Please try again.",
+            isError: true,
+          },
         ]);
         if (analytics) {
           emitClientAnalyticsEvent({
@@ -673,6 +933,31 @@ function AIChat({
   };
 
   const canSend = !!(aiInput.trim() && !isStreaming);
+  const handleFeedback = useCallback(
+    (message: ChatMessage, index: number, value: DocsAskAIFeedbackValue) => {
+      if (message.feedback === value) return;
+
+      const updatedMessage = { ...message, feedback: value };
+      const updatedMessages = messages.map((item, itemIndex) =>
+        itemIndex === index ? updatedMessage : item,
+      );
+      setMessages(updatedMessages);
+      emitAskAIFeedback(
+        buildFeedbackPayload({
+          value,
+          message: updatedMessage,
+          messages: updatedMessages,
+          index,
+          surface,
+        }),
+        analytics,
+      );
+    },
+    [analytics, messages, setMessages, surface],
+  );
+  const handleCopyMessage = useCallback((message: ChatMessage) => {
+    void copyTextToClipboard(message.content);
+  }, []);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
@@ -705,12 +990,23 @@ function AIChat({
               ) : (
                 <div className="fd-ai-bubble-ai">
                   {msg.content ? (
-                    <div
-                      className={
-                        isStreaming && i === messages.length - 1 ? "fd-ai-streaming" : undefined
-                      }
-                      dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
-                    />
+                    <>
+                      <div
+                        className={
+                          isStreaming && i === messages.length - 1 ? "fd-ai-streaming" : undefined
+                        }
+                        dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+                      />
+                      {feedbackEnabled &&
+                        !msg.isError &&
+                        !(isStreaming && i === messages.length - 1) && (
+                          <AIFeedbackControls
+                            value={msg.feedback}
+                            onCopy={() => handleCopyMessage(msg)}
+                            onSelect={(value) => handleFeedback(msg, i, value)}
+                          />
+                        )}
+                    </>
                   ) : loadingComponentHtml ? (
                     <div dangerouslySetInnerHTML={{ __html: loadingComponentHtml }} />
                   ) : (
@@ -795,6 +1091,7 @@ export function DocsSearchDialog({
   models,
   defaultModelId,
   analytics = false,
+  feedbackEnabled = true,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -806,6 +1103,7 @@ export function DocsSearchDialog({
   models?: AIModelOption[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const [tab, setTab] = useState<"search" | "ai">("search");
   const [searchQuery, setSearchQuery] = useState("");
@@ -1064,6 +1362,7 @@ export function DocsSearchDialog({
             models={models}
             defaultModelId={effectiveModelId}
             analytics={analytics}
+            feedbackEnabled={feedbackEnabled}
             surface="ai-dialog"
           />
         )}
@@ -1140,6 +1439,7 @@ export function FloatingAIChat({
   models,
   defaultModelId,
   analytics = false,
+  feedbackEnabled = true,
 }: {
   api?: string;
   position?: FloatingPosition;
@@ -1152,6 +1452,7 @@ export function FloatingAIChat({
   models?: AIModelOption[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -1224,6 +1525,7 @@ export function FloatingAIChat({
         models={models}
         defaultModelId={defaultModelId}
         analytics={analytics}
+        feedbackEnabled={feedbackEnabled}
       />
     );
   }
@@ -1266,7 +1568,10 @@ export function FloatingAIChat({
             aiLabel={aiLabel}
             loaderVariant={loaderVariant}
             loadingComponentHtml={loadingComponentHtml}
+            models={models}
+            defaultModelId={defaultModelId}
             analytics={analytics}
+            feedbackEnabled={feedbackEnabled}
             surface="floating"
           />
         </div>
@@ -1340,13 +1645,14 @@ function FullModalAIChat({
   models,
   defaultModelId,
   analytics,
+  feedbackEnabled = true,
 }: {
   api: string;
   isOpen: boolean;
   setIsOpen: (v: boolean) => void;
   closeAI: (trigger: "button" | "escape" | "overlay") => void;
   messages: ChatMessage[];
-  setMessages: (m: ChatMessage[]) => void;
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   aiInput: string;
   setAiInput: (v: string) => void;
   isStreaming: boolean;
@@ -1360,6 +1666,7 @@ function FullModalAIChat({
   models?: AIModelOption[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const label = aiLabel || "AI";
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1390,9 +1697,15 @@ function FullModalAIChat({
       if (!question.trim() || isStreaming) return;
       const userMessage: ChatMessage = { role: "user", content: question };
       const newMessages = [...messages, userMessage];
+      const assistantMessage: ChatMessage = {
+        role: "assistant",
+        content: "",
+        id: createAIMessageId(),
+        model: effectiveModelId,
+      };
       setAiInput("");
       setIsStreaming(true);
-      setMessages([...newMessages, { role: "assistant", content: "" }]);
+      setMessages([...newMessages, assistantMessage]);
       const startedAt = Date.now();
 
       if (analytics) {
@@ -1423,7 +1736,7 @@ function FullModalAIChat({
             const err = await res.json();
             errMsg = err.error || errMsg;
           } catch {}
-          setMessages([...newMessages, { role: "assistant", content: errMsg }]);
+          setMessages([...newMessages, { ...assistantMessage, content: errMsg, isError: true }]);
           setIsStreaming(false);
           if (analytics) {
             emitClientAnalyticsEvent({
@@ -1459,14 +1772,14 @@ function FullModalAIChat({
                 const content = json.choices?.[0]?.delta?.content;
                 if (content) {
                   assistantContent += content;
-                  setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+                  setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
                 }
               } catch {}
             }
           }
         }
         if (assistantContent)
-          setMessages([...newMessages, { role: "assistant", content: assistantContent }]);
+          setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
         if (analytics) {
           emitClientAnalyticsEvent({
             type: "ai_response",
@@ -1482,7 +1795,11 @@ function FullModalAIChat({
       } catch {
         setMessages([
           ...newMessages,
-          { role: "assistant", content: "Failed to connect. Please try again." },
+          {
+            ...assistantMessage,
+            content: "Failed to connect. Please try again.",
+            isError: true,
+          },
         ]);
         if (analytics) {
           emitClientAnalyticsEvent({
@@ -1511,6 +1828,31 @@ function FullModalAIChat({
 
   const canSend = !!(aiInput.trim() && !isStreaming);
   const showSuggestions = messages.length === 0 && !isStreaming;
+  const handleFeedback = useCallback(
+    (message: ChatMessage, index: number, value: DocsAskAIFeedbackValue) => {
+      if (message.feedback === value) return;
+
+      const updatedMessage = { ...message, feedback: value };
+      const updatedMessages = messages.map((item, itemIndex) =>
+        itemIndex === index ? updatedMessage : item,
+      );
+      setMessages(updatedMessages);
+      emitAskAIFeedback(
+        buildFeedbackPayload({
+          value,
+          message: updatedMessage,
+          messages: updatedMessages,
+          index,
+          surface: "full-modal",
+        }),
+        analytics,
+      );
+    },
+    [analytics, messages, setMessages],
+  );
+  const handleCopyMessage = useCallback((message: ChatMessage) => {
+    void copyTextToClipboard(message.content);
+  }, []);
 
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -1546,12 +1888,24 @@ function FullModalAIChat({
                   </div>
                   <div className="fd-ai-fm-msg-content">
                     {msg.content ? (
-                      <div
-                        className={
-                          isStreaming && i === messages.length - 1 ? "fd-ai-streaming" : undefined
-                        }
-                        dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
-                      />
+                      <>
+                        <div
+                          className={
+                            isStreaming && i === messages.length - 1 ? "fd-ai-streaming" : undefined
+                          }
+                          dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+                        />
+                        {msg.role === "assistant" &&
+                          feedbackEnabled &&
+                          !msg.isError &&
+                          !(isStreaming && i === messages.length - 1) && (
+                            <AIFeedbackControls
+                              value={msg.feedback}
+                              onCopy={() => handleCopyMessage(msg)}
+                              onSelect={(value) => handleFeedback(msg, i, value)}
+                            />
+                          )}
+                      </>
                     ) : loadingComponentHtml ? (
                       <div dangerouslySetInnerHTML={{ __html: loadingComponentHtml }} />
                     ) : (
@@ -1739,6 +2093,7 @@ export function AIModalDialog({
   models,
   defaultModelId,
   analytics = false,
+  feedbackEnabled = true,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -1750,6 +2105,7 @@ export function AIModalDialog({
   models?: AIModelOption[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [aiInput, setAiInput] = useState("");
@@ -1833,6 +2189,7 @@ export function AIModalDialog({
           models={models}
           defaultModelId={defaultModelId}
           analytics={analytics}
+          feedbackEnabled={feedbackEnabled}
           surface="modal"
         />
 

--- a/packages/fumadocs/src/client-analytics.test.ts
+++ b/packages/fumadocs/src/client-analytics.test.ts
@@ -13,6 +13,7 @@ const CLIENT_ANALYTICS_EVENTS = [
   "ai_close",
   "ai_question",
   "ai_response",
+  "ai_feedback",
   "ai_error",
   "ai_clear",
   "page_action_copy_markdown",

--- a/packages/fumadocs/src/docs-ai-features.tsx
+++ b/packages/fumadocs/src/docs-ai-features.tsx
@@ -35,6 +35,7 @@ interface DocsAIFeaturesProps {
   models?: { id: string; label: string }[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }
 
 export function DocsAIFeatures({
@@ -51,6 +52,7 @@ export function DocsAIFeatures({
   models,
   defaultModelId,
   analytics = false,
+  feedbackEnabled = true,
 }: DocsAIFeaturesProps) {
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
@@ -67,6 +69,7 @@ export function DocsAIFeatures({
         models={models}
         defaultModelId={defaultModelId}
         analytics={analytics}
+        feedbackEnabled={feedbackEnabled}
       />
     );
   }
@@ -82,6 +85,7 @@ export function DocsAIFeatures({
         models={models}
         defaultModelId={defaultModelId}
         analytics={analytics}
+        feedbackEnabled={feedbackEnabled}
       />
     );
   }
@@ -99,6 +103,7 @@ export function DocsAIFeatures({
       models={models}
       defaultModelId={defaultModelId}
       analytics={analytics}
+      feedbackEnabled={feedbackEnabled}
     />
   );
 }
@@ -112,6 +117,7 @@ function SearchModeAI({
   models,
   defaultModelId,
   analytics,
+  feedbackEnabled,
 }: {
   api: string;
   suggestedQuestions?: string[];
@@ -121,6 +127,7 @@ function SearchModeAI({
   models?: { id: string; label: string }[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -184,6 +191,7 @@ function SearchModeAI({
       models={models}
       defaultModelId={defaultModelId}
       analytics={analytics}
+      feedbackEnabled={feedbackEnabled}
     />
   );
 }
@@ -197,6 +205,7 @@ function SidebarIconModeAI({
   models,
   defaultModelId,
   analytics,
+  feedbackEnabled,
 }: {
   api: string;
   suggestedQuestions?: string[];
@@ -206,6 +215,7 @@ function SidebarIconModeAI({
   models?: { id: string; label: string }[];
   defaultModelId?: string;
   analytics?: boolean;
+  feedbackEnabled?: boolean;
 }) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
@@ -269,6 +279,7 @@ function SidebarIconModeAI({
         models={models}
         defaultModelId={defaultModelId}
         analytics={analytics}
+        feedbackEnabled={feedbackEnabled}
       />
       <AIModalDialog
         open={aiOpen}
@@ -281,6 +292,7 @@ function SidebarIconModeAI({
         models={models}
         defaultModelId={defaultModelId}
         analytics={analytics}
+        feedbackEnabled={feedbackEnabled}
       />
     </>
   );

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1079,6 +1079,92 @@ Install the framework with pnpm.
     }
   });
 
+  it("infers package guidance from Ask AI context so examples avoid placeholder imports", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-package-prompt-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Installation"
+---
+
+# Installation
+
+Install Better Auth with pnpm.
+
+\`\`\`ts
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+\`\`\`
+`,
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("data: {}\n\n", {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+        },
+      }),
+    ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        rootDir,
+        entry: "docs",
+        ai: {
+          enabled: true,
+          apiKey: "test-key",
+          baseUrl: "https://llm.example/v1",
+          model: "test-model",
+          docsUrl: "https://docs.example.com",
+        },
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How do I create the auth instance?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+
+      const init = vi.mocked(globalThis.fetch).mock.calls[0]?.[1];
+      const upstreamBody = JSON.parse(String(init?.body)) as {
+        messages?: Array<{ role?: string; content?: string }>;
+      };
+      const systemMessage = upstreamBody.messages?.find((message) => message.role === "system");
+      expect(systemMessage?.content).toContain(
+        'Never use placeholder package names or imports such as "your-auth-library"',
+      );
+      expect(systemMessage?.content).toContain(
+        "Package and import hints inferred from the retrieved documentation context",
+      );
+      expect(systemMessage?.content).toContain(
+        "Package names found in install/import examples: better-auth",
+      );
+      expect(systemMessage?.content).toContain('import { betterAuth } from "better-auth";');
+      expect(systemMessage?.content).toContain("https://docs.example.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("keeps upstream Ask AI fetch error details out of API responses", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-fetch-error-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -51,7 +51,12 @@ import {
   resolveDocsMcpConfig,
   type DocsMcpPage,
 } from "@farming-labs/docs/server";
-import { performDocsSearch, resolveSearchRequestConfig } from "@farming-labs/docs";
+import {
+  buildDocsAskAIContext,
+  formatDocsAskAIPackageHints,
+  performDocsSearch,
+  resolveSearchRequestConfig,
+} from "@farming-labs/docs";
 import type {
   DocsMcpConfig,
   DocsSearchConfig,
@@ -83,6 +88,10 @@ interface AIOptions {
   model?: string | AIModelConfig;
   providers?: Record<string, AIProviderConfig>;
   systemPrompt?: string;
+  /** Package name the AI should use in import examples. */
+  packageName?: string;
+  /** Public docs URL the AI should use for absolute links. */
+  docsUrl?: string;
   /** Default baseUrl when no per-model provider is configured. */
   baseUrl?: string;
   /** Default apiKey when no per-model provider is configured. */
@@ -676,6 +685,10 @@ function readAIConfig(root: string): AIOptions {
         const systemPromptMatch = content.match(
           /ai\s*:\s*\{[^}]*systemPrompt\s*:\s*["'`]([^"'`]+)["'`]/s,
         );
+        const packageNameMatch = content.match(
+          /ai\s*:\s*\{[^}]*packageName\s*:\s*["'`]([^"'`]+)["'`]/s,
+        );
+        const docsUrlMatch = content.match(/ai\s*:\s*\{[^}]*docsUrl\s*:\s*["'`]([^"'`]+)["'`]/s);
 
         return {
           enabled: true,
@@ -684,6 +697,8 @@ function readAIConfig(root: string): AIOptions {
           apiKey: apiKeyMatch?.[1] ? process.env[apiKeyMatch[1]] : undefined,
           maxResults: maxResultsMatch ? parseInt(maxResultsMatch[1], 10) : undefined,
           systemPrompt: systemPromptMatch?.[1],
+          packageName: packageNameMatch?.[1],
+          docsUrl: docsUrlMatch?.[1],
         };
       } catch {
         // fall through
@@ -1546,7 +1561,32 @@ function toYamlString(value: string): string {
 
 // ─── AI Chat (RAG) ─────────────────────────────────────────────────
 
-const DEFAULT_SYSTEM_PROMPT = `You are a helpful documentation assistant. Answer questions based on the provided documentation context. Be concise and accurate. If the answer is not in the context, say so honestly. Use markdown formatting for code examples and links.`;
+function buildDefaultSystemPrompt(aiConfig: AIOptions): string {
+  const lines = [
+    "You are a helpful documentation assistant.",
+    "Answer only from the provided documentation context.",
+    "Prefer exact code/config snippets from the context when the question asks how to implement something.",
+    "Cite the relevant documentation URL when you use a source.",
+    "Use only URLs exactly as they appear in the context; do not invent placeholder domains.",
+    'Never use placeholder package names or imports such as "your-auth-library", "your-package", "your-sdk", "replace-me", or "example-library". If the exact package or import is not in the context, do not include an import snippet.',
+    "Be concise and accurate. If the answer is not in the context, say so honestly.",
+    "Use markdown formatting for code examples and links.",
+  ];
+
+  if (aiConfig.packageName) {
+    lines.push(
+      `When showing import examples, use "${aiConfig.packageName}" as the package name and prefer exact imports copied from the documentation context.`,
+    );
+  }
+
+  if (aiConfig.docsUrl) {
+    lines.push(
+      `When linking to documentation pages, use "${aiConfig.docsUrl}" as the base URL (e.g. ${aiConfig.docsUrl}/docs/get-started).`,
+    );
+  }
+
+  return lines.join(" ");
+}
 
 interface ChatMessage {
   role: "user" | "assistant" | "system";
@@ -1601,6 +1641,7 @@ async function handleAskAI(
   request: Request,
   indexes: DocsSearchSourcePage[],
   aiConfig: AIOptions,
+  search: boolean | DocsSearchConfig | undefined,
   analytics?: boolean | DocsAnalyticsConfig,
   observability?: boolean | DocsObservabilityConfig,
   analyticsContext: { locale?: string } = {},
@@ -1755,7 +1796,6 @@ async function handleAskAI(
     },
   });
 
-  // Use the in-memory index for fast context retrieval
   const retrievalStartedAt = Date.now();
   const retrievalStartedAtIso = new Date().toISOString();
   const retrievalSpanId = createDocsAgentTraceId("span");
@@ -1772,19 +1812,17 @@ async function handleAskAI(
       indexSize: indexes.length,
     },
   });
-  const scored = indexes
-    .map((doc) => {
-      const q = query.toLowerCase();
-      const titleMatch = doc.title.toLowerCase().includes(q) ? 10 : 0;
-      const contentWords = q.split(/\s+/);
-      const contentMatch = contentWords.reduce((score, word) => {
-        return score + (doc.content.toLowerCase().includes(word) ? 1 : 0);
-      }, 0);
-      return { ...doc, score: titleMatch + contentMatch };
-    })
-    .filter((d) => d.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, maxResults);
+  const retrieval = await buildDocsAskAIContext({
+    pages: indexes,
+    query,
+    search,
+    locale: analyticsContext.locale,
+    pathname: url.searchParams.get("pathname") ?? undefined,
+    siteTitle: "Documentation",
+    baseUrl: url.origin,
+    limit: maxResults,
+  });
+  const scored = retrieval.results;
   await emitTrace({
     type: "retrieval.result",
     name: "docs-index",
@@ -1807,19 +1845,20 @@ async function handleAskAI(
   const promptStartedAt = Date.now();
   const promptStartedAtIso = new Date().toISOString();
   const promptSpanId = createDocsAgentTraceId("span");
-  const contextParts = scored.map(
-    (doc) =>
-      `## ${doc.title}\nURL: ${doc.url}\n${doc.description ? `Description: ${doc.description}\n` : ""}\n${doc.content}`,
-  );
-  const context = contextParts.join("\n\n---\n\n");
+  const context = retrieval.context;
 
   // ── Build LLM messages ─────────────────────────────────────────
-  const systemPrompt = aiConfig.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+  const systemPrompt = aiConfig.systemPrompt ?? buildDefaultSystemPrompt(aiConfig);
+  const packageHintsPrompt = formatDocsAskAIPackageHints(
+    retrieval.packageHints,
+    aiConfig.packageName,
+  );
+  const fullSystemPrompt = [systemPrompt, packageHintsPrompt].filter(Boolean).join("\n\n");
   const systemMessage: ChatMessage = {
     role: "system",
     content: context
-      ? `${systemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
-      : systemPrompt,
+      ? `${fullSystemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
+      : fullSystemPrompt,
   };
 
   const llmMessages: ChatMessage[] = [
@@ -2795,9 +2834,17 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       const ctx = resolveContextFromRequest(request);
-      return handleAskAI(request, getIndexes(ctx), aiConfig, analytics, observability, {
-        locale: ctx.locale,
-      });
+      return handleAskAI(
+        request,
+        getIndexes(ctx),
+        aiConfig,
+        resolveSearchRequestConfig(searchConfig, request.url),
+        analytics,
+        observability,
+        {
+          locale: ctx.locale,
+        },
+      );
     },
   };
 }

--- a/packages/fumadocs/src/docs-client-hooks.tsx
+++ b/packages/fumadocs/src/docs-client-hooks.tsx
@@ -7,18 +7,21 @@ import type {
   CodeBlockCopyData,
   DocsAnalyticsConfig,
   DocsAnalyticsEvent,
+  DocsAskAIActionData,
   DocsAskAIFeedbackData,
   DocsFeedbackData,
 } from "@farming-labs/docs";
 
 type CopyHandler = (data: CodeBlockCopyData) => void;
 type FeedbackHandler = (data: DocsFeedbackData) => void | Promise<void>;
+type AIActionHandler = (data: DocsAskAIActionData) => void | Promise<void>;
 type AIFeedbackHandler = (data: DocsAskAIFeedbackData) => void | Promise<void>;
 type AnalyticsHandler = (event: DocsAnalyticsEvent) => void | Promise<void>;
 
 interface DocsWindowHooks extends Window {
   __fdOnCopyClick__?: CopyHandler;
   __fdOnFeedback__?: FeedbackHandler;
+  __fdOnAIActions__?: AIActionHandler;
   __fdOnAIFeedback__?: AIFeedbackHandler;
   __fdAnalytics__?: AnalyticsHandler;
   __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
@@ -115,16 +118,19 @@ function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
 export function DocsClientHooks({
   onCopyClick,
   onFeedback,
+  onAIActions,
   onAIFeedback,
   analytics,
 }: {
   onCopyClick?: CopyHandler;
   onFeedback?: FeedbackHandler;
+  onAIActions?: AIActionHandler;
   onAIFeedback?: AIFeedbackHandler;
   analytics?: boolean | DocsAnalyticsConfig;
 }) {
   useWindowHook("__fdOnCopyClick__", onCopyClick);
   useWindowHook("__fdOnFeedback__", onFeedback);
+  useWindowHook("__fdOnAIActions__", onAIActions);
   useWindowHook("__fdOnAIFeedback__", onAIFeedback);
   useAnalyticsHook(analytics);
   useCodeCopyAnalytics(analytics);

--- a/packages/fumadocs/src/docs-client-hooks.tsx
+++ b/packages/fumadocs/src/docs-client-hooks.tsx
@@ -7,16 +7,19 @@ import type {
   CodeBlockCopyData,
   DocsAnalyticsConfig,
   DocsAnalyticsEvent,
+  DocsAskAIFeedbackData,
   DocsFeedbackData,
 } from "@farming-labs/docs";
 
 type CopyHandler = (data: CodeBlockCopyData) => void;
 type FeedbackHandler = (data: DocsFeedbackData) => void | Promise<void>;
+type AIFeedbackHandler = (data: DocsAskAIFeedbackData) => void | Promise<void>;
 type AnalyticsHandler = (event: DocsAnalyticsEvent) => void | Promise<void>;
 
 interface DocsWindowHooks extends Window {
   __fdOnCopyClick__?: CopyHandler;
   __fdOnFeedback__?: FeedbackHandler;
+  __fdOnAIFeedback__?: AIFeedbackHandler;
   __fdAnalytics__?: AnalyticsHandler;
   __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
 }
@@ -112,14 +115,17 @@ function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
 export function DocsClientHooks({
   onCopyClick,
   onFeedback,
+  onAIFeedback,
   analytics,
 }: {
   onCopyClick?: CopyHandler;
   onFeedback?: FeedbackHandler;
+  onAIFeedback?: AIFeedbackHandler;
   analytics?: boolean | DocsAnalyticsConfig;
 }) {
   useWindowHook("__fdOnCopyClick__", onCopyClick);
   useWindowHook("__fdOnFeedback__", onFeedback);
+  useWindowHook("__fdOnAIFeedback__", onAIFeedback);
   useAnalyticsHook(analytics);
   useCodeCopyAnalytics(analytics);
 

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -913,6 +913,11 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const aiSuggestedQuestions = aiConfig?.suggestedQuestions;
   const aiLabel = aiConfig?.aiLabel;
   const aiLoaderVariant = aiConfig?.loader;
+  const aiFeedbackEnabled =
+    aiConfig?.feedback === false ||
+    (typeof aiConfig?.feedback === "object" && aiConfig.feedback.enabled === false)
+      ? false
+      : true;
   const aiLoadingComponentHtml =
     typeof aiConfig?.loadingComponent === "function"
       ? serializeIcon(aiConfig.loadingComponent({ name: aiLabel || "AI" }))
@@ -1022,6 +1027,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
               models={aiModels}
               defaultModelId={aiDefaultModelId}
               analytics={analyticsEnabled}
+              feedbackEnabled={aiFeedbackEnabled}
             />
           </Suspense>
         )}

--- a/packages/fumadocs/styles/ai.css
+++ b/packages/fumadocs/styles/ai.css
@@ -337,6 +337,48 @@
   animation: fd-ai-msg-in 300ms ease-out;
 }
 
+.fd-ai-feedback {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--color-fd-border, #1f1f2e) 70%, transparent);
+}
+
+.fd-ai-feedback-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: var(--radius, 6px);
+  background: transparent;
+  color: var(--color-fd-muted-foreground, #71717a);
+  cursor: pointer;
+  transition:
+    background 150ms,
+    border-color 150ms,
+    color 150ms;
+}
+
+.fd-ai-feedback-btn:hover {
+  color: var(--color-fd-foreground, #e4e4e7);
+  background: var(--color-fd-accent, rgba(255, 255, 255, 0.06));
+}
+
+.fd-ai-feedback-btn[data-active="true"] {
+  color: var(--color-fd-primary, #6366f1);
+  border-color: color-mix(in srgb, var(--color-fd-primary, #6366f1) 40%, transparent);
+  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 10%, transparent);
+}
+
+.fd-ai-feedback-btn[data-copied="true"] {
+  color: var(--color-fd-primary, #6366f1);
+  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 10%, transparent);
+}
+
 @keyframes fd-ai-msg-in {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }

--- a/packages/next/src/client-callbacks.tsx
+++ b/packages/next/src/client-callbacks.tsx
@@ -52,6 +52,7 @@ export default function DocsClientCallbacks(props?: { apiReferencePrimaryServerU
           ? docsConfig.ai.feedback.onFeedback
           : undefined
       }
+      onAIActions={docsConfig.ai?.onActions}
     />
   );
 }

--- a/packages/next/src/client-callbacks.tsx
+++ b/packages/next/src/client-callbacks.tsx
@@ -47,6 +47,11 @@ export default function DocsClientCallbacks(props?: { apiReferencePrimaryServerU
           ? docsConfig.feedback.onFeedback
           : undefined
       }
+      onAIFeedback={
+        docsConfig.ai?.feedback && typeof docsConfig.ai.feedback === "object"
+          ? docsConfig.ai.feedback.onFeedback
+          : undefined
+      }
     />
   );
 }

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -20,11 +20,13 @@ import matter from "gray-matter";
 import { eventHandler, getRequestURL, readRawBody } from "h3";
 import {
   applySidebarFolderIndexBehavior,
+  buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsMcpRequest,
@@ -722,21 +724,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return index;
   }
 
-  function searchByQuery(query: string, ctx: ReturnType<typeof resolveContextFromPath>) {
-    const index = getSearchIndex(ctx);
-    return index
-      .map((page) => {
-        const titleMatch = page.title.toLowerCase().includes(query) ? 10 : 0;
-        const words = query.split(/\s+/);
-        const contentMatch = words.reduce((score, word) => {
-          return score + (page.content.toLowerCase().includes(word) ? 1 : 0);
-        }, 0);
-        return { ...page, score: titleMatch + contentMatch };
-      })
-      .filter((r) => r.score > 0)
-      .sort((a, b) => b.score - a.score);
-  }
-
   // ─── llms.txt content builder ────────────────────────────────
   const llmsSiteTitle =
     typeof (config as Record<string, unknown>).nav === "object" &&
@@ -969,12 +956,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   function buildDefaultSystemPrompt(): string {
     const lines = [
       `You are a helpful documentation assistant${projectName ? ` for ${projectName}` : ""}.`,
-      "Answer questions based on the provided documentation context.",
+      "Answer only from the provided documentation context.",
+      "Prefer exact code/config snippets from the context when the question asks how to implement something.",
+      "Cite the relevant documentation URL when you use a source.",
+      "Use only URLs exactly as they appear in the context; do not invent placeholder domains.",
+      'Never use placeholder package names or imports such as "your-auth-library", "your-package", "your-sdk", "replace-me", or "example-library". If the exact package or import is not in the context, do not include an import snippet.',
       "Be concise and accurate. If the answer is not in the context, say so honestly.",
       "Use markdown formatting for code examples and links.",
     ];
     if (packageName) {
-      lines.push(`When showing import examples, always use "${packageName}" as the package name.`);
+      lines.push(
+        `When showing import examples, use "${packageName}" as the package name and prefer exact imports copied from the documentation context.`,
+      );
     }
     if (docsUrl) {
       lines.push(
@@ -1192,7 +1185,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         maxResults,
       },
     });
-    const scored = searchByQuery(lastUserMessage.content.toLowerCase(), ctx).slice(0, maxResults);
+    const retrieval = await buildDocsAskAIContext({
+      pages: getSearchIndex(ctx),
+      query: lastUserMessage.content,
+      search: resolveSearchRequestConfig(config.search, context.request.url),
+      locale: ctx.locale,
+      pathname: requestUrl.searchParams.get("pathname") ?? undefined,
+      siteTitle: llmsTitle,
+      baseUrl: requestUrl.origin,
+      limit: maxResults,
+    });
+    const scored = retrieval.results;
     await emitTrace({
       type: "retrieval.result",
       name: "docs-index",
@@ -1212,18 +1215,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const promptStartedAt = Date.now();
     const promptStartedAtIso = new Date().toISOString();
     const promptSpanId = createDocsAgentTraceId("span");
-    const contextParts = scored.map(
-      (doc) =>
-        `## ${doc.title}\nURL: ${doc.url}\n${doc.description ? `Description: ${doc.description}\n` : ""}\n${doc.content}`,
-    );
-    const ragContext = contextParts.join("\n\n---\n\n");
+    const ragContext = retrieval.context;
 
     const systemPrompt = aiConfig.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+    const packageHintsPrompt = formatDocsAskAIPackageHints(retrieval.packageHints, packageName);
+    const fullSystemPrompt = [systemPrompt, packageHintsPrompt].filter(Boolean).join("\n\n");
     const systemMessage: ChatMessage = {
       role: "system",
       content: ragContext
-        ? `${systemPrompt}\n\n---\n\nDocumentation context:\n\n${ragContext}`
-        : systemPrompt,
+        ? `${fullSystemPrompt}\n\n---\n\nDocumentation context:\n\n${ragContext}`
+        : fullSystemPrompt,
     };
 
     const llmMessages: ChatMessage[] = [

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -33,11 +33,13 @@ import path from "node:path";
 import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
+  buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -742,21 +744,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return index;
   }
 
-  function searchByQuery(query: string, ctx: ReturnType<typeof resolveContextFromPath>) {
-    const index = getSearchIndex(ctx);
-    return index
-      .map((page) => {
-        const titleMatch = page.title.toLowerCase().includes(query) ? 10 : 0;
-        const words = query.split(/\s+/);
-        const contentMatch = words.reduce((score, word) => {
-          return score + (page.content.toLowerCase().includes(word) ? 1 : 0);
-        }, 0);
-        return { ...page, score: titleMatch + contentMatch };
-      })
-      .filter((r) => r.score > 0)
-      .sort((a, b) => b.score - a.score);
-  }
-
   // ─── llms.txt content builder ────────────────────────────────
   const llmsSiteTitle =
     typeof (config as Record<string, unknown>).nav === "object" &&
@@ -988,12 +975,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   function buildDefaultSystemPrompt(): string {
     const lines = [
       `You are a helpful documentation assistant${projectName ? ` for ${projectName}` : ""}.`,
-      "Answer questions based on the provided documentation context.",
+      "Answer only from the provided documentation context.",
+      "Prefer exact code/config snippets from the context when the question asks how to implement something.",
+      "Cite the relevant documentation URL when you use a source.",
+      "Use only URLs exactly as they appear in the context; do not invent placeholder domains.",
+      'Never use placeholder package names or imports such as "your-auth-library", "your-package", "your-sdk", "replace-me", or "example-library". If the exact package or import is not in the context, do not include an import snippet.',
       "Be concise and accurate. If the answer is not in the context, say so honestly.",
       "Use markdown formatting for code examples and links.",
     ];
     if (packageName) {
-      lines.push(`When showing import examples, always use "${packageName}" as the package name.`);
+      lines.push(
+        `When showing import examples, use "${packageName}" as the package name and prefer exact imports copied from the documentation context.`,
+      );
     }
     if (docsUrl) {
       lines.push(
@@ -1213,7 +1206,17 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         maxResults,
       },
     });
-    const scored = searchByQuery(lastUserMessage.content.toLowerCase(), ctx).slice(0, maxResults);
+    const retrieval = await buildDocsAskAIContext({
+      pages: getSearchIndex(ctx),
+      query: lastUserMessage.content,
+      search: resolveSearchRequestConfig(config.search, event.request.url),
+      locale: ctx.locale,
+      pathname: requestUrl.searchParams.get("pathname") ?? undefined,
+      siteTitle: llmsTitle,
+      baseUrl: requestUrl.origin,
+      limit: maxResults,
+    });
+    const scored = retrieval.results;
     await emitTrace({
       type: "retrieval.result",
       name: "docs-index",
@@ -1233,18 +1236,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const promptStartedAt = Date.now();
     const promptStartedAtIso = new Date().toISOString();
     const promptSpanId = createDocsAgentTraceId("span");
-    const contextParts = scored.map(
-      (doc) =>
-        `## ${doc.title}\nURL: ${doc.url}\n${doc.description ? `Description: ${doc.description}\n` : ""}\n${doc.content}`,
-    );
-    const context = contextParts.join("\n\n---\n\n");
+    const context = retrieval.context;
 
     const systemPrompt = aiConfig.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+    const packageHintsPrompt = formatDocsAskAIPackageHints(retrieval.packageHints, packageName);
+    const fullSystemPrompt = [systemPrompt, packageHintsPrompt].filter(Boolean).join("\n\n");
     const systemMessage: ChatMessage = {
       role: "system",
       content: context
-        ? `${systemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
-        : systemPrompt,
+        ? `${fullSystemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
+        : fullSystemPrompt,
     };
 
     const llmMessages: ChatMessage[] = [

--- a/packages/tanstack-start/src/react.tsx
+++ b/packages/tanstack-start/src/react.tsx
@@ -58,6 +58,11 @@ export function TanstackDocsPage({
             ? (config.feedback as FeedbackConfig).onFeedback
             : undefined
         }
+        onAIFeedback={
+          config.ai?.feedback && typeof config.ai.feedback === "object"
+            ? config.ai.feedback.onFeedback
+            : undefined
+        }
       />
       <TanstackDocsLayout
         config={config}

--- a/packages/tanstack-start/src/react.tsx
+++ b/packages/tanstack-start/src/react.tsx
@@ -63,6 +63,7 @@ export function TanstackDocsPage({
             ? config.ai.feedback.onFeedback
             : undefined
         }
+        onAIActions={config.ai?.onActions}
       />
       <TanstackDocsLayout
         config={config}

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -3,11 +3,13 @@ import path from "node:path";
 import matter from "gray-matter";
 import {
   applySidebarFolderIndexBehavior,
+  buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
@@ -708,21 +710,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     return index;
   }
 
-  function searchByQuery(query: string, ctx: ReturnType<typeof resolveContextFromPath>) {
-    const index = getSearchIndex(ctx);
-    return index
-      .map((page) => {
-        const titleMatch = page.title.toLowerCase().includes(query) ? 10 : 0;
-        const words = query.split(/\s+/);
-        const contentMatch = words.reduce((score, word) => {
-          return score + (page.content.toLowerCase().includes(word) ? 1 : 0);
-        }, 0);
-        return { ...page, score: titleMatch + contentMatch };
-      })
-      .filter((result) => result.score > 0)
-      .sort((a, b) => b.score - a.score);
-  }
-
   const llmsSiteTitle =
     typeof config.nav === "object" && typeof config.nav?.title === "string"
       ? config.nav.title
@@ -945,12 +932,18 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   function buildDefaultSystemPrompt(): string {
     const lines = [
       `You are a helpful documentation assistant${projectName ? ` for ${projectName}` : ""}.`,
-      "Answer questions based on the provided documentation context.",
+      "Answer only from the provided documentation context.",
+      "Prefer exact code/config snippets from the context when the question asks how to implement something.",
+      "Cite the relevant documentation URL when you use a source.",
+      "Use only URLs exactly as they appear in the context; do not invent placeholder domains.",
+      'Never use placeholder package names or imports such as "your-auth-library", "your-package", "your-sdk", "replace-me", or "example-library". If the exact package or import is not in the context, do not include an import snippet.',
       "Be concise and accurate. If the answer is not in the context, say so honestly.",
       "Use markdown formatting for code examples and links.",
     ];
     if (packageName) {
-      lines.push(`When showing import examples, always use "${packageName}" as the package name.`);
+      lines.push(
+        `When showing import examples, use "${packageName}" as the package name and prefer exact imports copied from the documentation context.`,
+      );
     }
     if (docsUrl) {
       lines.push(
@@ -1169,7 +1162,17 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         maxResults,
       },
     });
-    const scored = searchByQuery(lastUserMessage.content.toLowerCase(), ctx).slice(0, maxResults);
+    const retrieval = await buildDocsAskAIContext({
+      pages: getSearchIndex(ctx),
+      query: lastUserMessage.content,
+      search: resolveSearchRequestConfig(config.search, event.request.url),
+      locale: ctx.locale,
+      pathname: requestUrl.searchParams.get("pathname") ?? undefined,
+      siteTitle: llmsTitle,
+      baseUrl: requestUrl.origin,
+      limit: maxResults,
+    });
+    const scored = retrieval.results;
     await emitTrace({
       type: "retrieval.result",
       name: "docs-index",
@@ -1189,18 +1192,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const promptStartedAt = Date.now();
     const promptStartedAtIso = new Date().toISOString();
     const promptSpanId = createDocsAgentTraceId("span");
-    const contextParts = scored.map(
-      (doc) =>
-        `## ${doc.title}\nURL: ${doc.url}\n${doc.description ? `Description: ${doc.description}\n` : ""}\n${doc.content}`,
-    );
-    const context = contextParts.join("\n\n---\n\n");
+    const context = retrieval.context;
 
     const systemPrompt = aiConfig.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+    const packageHintsPrompt = formatDocsAskAIPackageHints(retrieval.packageHints, packageName);
+    const fullSystemPrompt = [systemPrompt, packageHintsPrompt].filter(Boolean).join("\n\n");
     const systemMessage: ChatMessage = {
       role: "system",
       content: context
-        ? `${systemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
-        : systemPrompt,
+        ? `${fullSystemPrompt}\n\n---\n\nDocumentation context:\n\n${context}`
+        : fullSystemPrompt,
     };
 
     const llmMessages: ChatMessage[] = [

--- a/skills/farming-labs/ask-ai/SKILL.md
+++ b/skills/farming-labs/ask-ai/SKILL.md
@@ -174,26 +174,32 @@ Number of search results used as context for the AI. More = more context, higher
 
 ### feedback
 
-Like/dislike buttons shown after a completed Ask AI answer.
+Copy, like, and dislike action row shown after a completed Ask AI answer. Set `feedback: false` to
+hide the row.
 
 | Type | Default |
 | ---- | ------- |
 | `boolean \| { enabled?: boolean; onFeedback?: (data) => void \| Promise<void> }` | `true` |
 
+### onActions
+
+Single callback for copy, like, and dislike actions. Use `data.type` to branch.
+
 ```ts
 ai: {
   enabled: true,
-  feedback: {
-    onFeedback(data) {
-      console.log(data.value, data.question, data.answer, data.model);
-    },
+  onActions(data) {
+    if (data.type === "copy") console.log("Copied", data.answer);
+    if (data.type === "like") console.log("Helpful", data.question);
+    if (data.type === "dislike") console.log("Not helpful", data.question);
   },
 }
 ```
 
-The callback receives the rating value, question, answer, model, UI surface, URL/path, and visible
-chat messages up to that answer. The client also dispatches `fd:ai-feedback` and emits
-`ai_feedback` when analytics is enabled.
+The callback receives the action type, question, answer, model, UI surface, URL/path, visible chat
+messages up to that answer, and `copied` for copy actions. Like/dislike also dispatch the legacy
+`fd:ai-feedback` browser event and emit `ai_feedback` when analytics is enabled. All actions
+dispatch `fd:ai-action`.
 
 ### Retrieval quality
 

--- a/skills/farming-labs/ask-ai/SKILL.md
+++ b/skills/farming-labs/ask-ai/SKILL.md
@@ -172,9 +172,52 @@ Number of search results used as context for the AI. More = more context, higher
 | ---- | ------- |
 | `number` | `5` |
 
+### feedback
+
+Like/dislike buttons shown after a completed Ask AI answer.
+
+| Type | Default |
+| ---- | ------- |
+| `boolean \| { enabled?: boolean; onFeedback?: (data) => void \| Promise<void> }` | `true` |
+
+```ts
+ai: {
+  enabled: true,
+  feedback: {
+    onFeedback(data) {
+      console.log(data.value, data.question, data.answer, data.model);
+    },
+  },
+}
+```
+
+The callback receives the rating value, question, answer, model, UI surface, URL/path, and visible
+chat messages up to that answer. The client also dispatches `fd:ai-feedback` and emits
+`ai_feedback` when analytics is enabled.
+
+### Retrieval quality
+
+Ask AI uses the configured docs search pipeline before building model context, including simple
+search, Typesense, Algolia, MCP search, or custom adapters. The model context is hydrated from the
+matched local page/section, preserves fenced code blocks for commands and config snippets, and
+infers package names plus exact import lines from the retrieved context.
+
 ### aiLabel
 
 Label for the AI button (e.g. "DocsBot", "Ask AI").
+
+### packageName
+
+Optional package-name override for unusual docs where install/import examples do not mention the
+main package clearly. Most projects should leave this unset because Ask AI infers package names and
+exact imports from retrieved docs context.
+
+```ts
+ai: {
+  enabled: true,
+  packageName: "@farming-labs/docs",
+}
+```
 
 ---
 

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -346,6 +346,60 @@ ai: {
 }
 ```
 
+### Retrieval Quality
+
+Ask AI uses the same configured docs search pipeline as the search API. If you configure simple
+search, Typesense, Algolia, MCP search, or a custom search adapter, Ask AI uses those results before
+building the model context.
+
+The context passed to the model is hydrated from the local docs page or matching section, preserving
+fenced code blocks so install commands, config snippets, and examples can be quoted accurately.
+
+```ts title="docs.config.ts"
+import { createCustomSearchAdapter } from "@farming-labs/docs";
+
+export default defineDocs({
+  search: createCustomSearchAdapter({
+    name: "my-index",
+    async search(query) {
+      const results = await fetch("https://search.example.com/docs", {
+        method: "POST",
+        body: JSON.stringify(query),
+      }).then((res) => res.json());
+
+      return results;
+    },
+  }),
+  ai: {
+    enabled: true,
+  },
+});
+```
+
+### `feedback`
+
+Completed Ask AI responses show like/dislike buttons by default. Use `feedback.onFeedback` to send
+ratings to your own analytics, data warehouse, or issue triage pipeline.
+
+| Type                                             | Default |
+| ------------------------------------------------ | ------- |
+| `boolean \| { enabled?: boolean; onFeedback?: (data) => void \| Promise<void> }` | `true` |
+
+```ts title="docs.config.ts"
+ai: {
+  enabled: true,
+  feedback: {
+    onFeedback(data) {
+      console.log(data.value, data.question, data.answer, data.model);
+    },
+  },
+}
+```
+
+The callback receives `value` (`"like"` or `"dislike"`), `question`, `answer`, `model`, `surface`,
+`url`, `path`, and the visible chat messages up to that answer. The UI also dispatches a
+`fd:ai-feedback` browser event and emits an `ai_feedback` analytics event when analytics is enabled.
+
 ### `suggestedQuestions`
 
 Pre-filled suggested questions shown in the AI chat when the conversation is empty. Clicking one fills the input and submits automatically.
@@ -382,13 +436,15 @@ ai: {
 
 ### `packageName`
 
-The npm package name used in code examples. The AI will use this in import snippets instead of generic placeholders.
+Optional package-name override for unusual docs where install/import examples do not mention the
+main package clearly. Most projects should leave this unset: Ask AI infers package names, install
+commands, and exact import lines from the retrieved docs context.
 
 | Type     | Default |
 | -------- | ------- |
-| `string` | —       |
+| `string` | inferred from docs context |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   packageName: "@farming-labs/docs",
@@ -539,7 +595,6 @@ export default defineDocs({
     floatingStyle: "full-modal",
     model: "gpt-4o-mini",
     aiLabel: "DocsBot",
-    packageName: "@farming-labs/docs",
     docsUrl: "https://docs.farming-labs.dev",
     maxResults: 5,
     suggestedQuestions: [

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -378,27 +378,39 @@ export default defineDocs({
 
 ### `feedback`
 
-Completed Ask AI responses show like/dislike buttons by default. Use `feedback.onFeedback` to send
-ratings to your own analytics, data warehouse, or issue triage pipeline.
+Completed Ask AI responses show copy, like, and dislike actions by default. Set `feedback: false`
+to hide the action row.
 
-| Type                                             | Default |
-| ------------------------------------------------ | ------- |
+| Type | Default |
+| ---- | ------- |
 | `boolean \| { enabled?: boolean; onFeedback?: (data) => void \| Promise<void> }` | `true` |
+
+### `onActions`
+
+Single callback for Ask AI response actions. Use `data.type` to handle `"copy"`, `"like"`, and
+`"dislike"` from one place.
 
 ```ts title="docs.config.ts"
 ai: {
   enabled: true,
-  feedback: {
-    onFeedback(data) {
-      console.log(data.value, data.question, data.answer, data.model);
-    },
+  onActions(data) {
+    if (data.type === "copy") {
+      console.log("Copied AI response", data.answer);
+    }
+
+    if (data.type === "like" || data.type === "dislike") {
+      console.log(data.type, data.question, data.answer, data.model);
+    }
   },
 }
 ```
 
-The callback receives `value` (`"like"` or `"dislike"`), `question`, `answer`, `model`, `surface`,
-`url`, `path`, and the visible chat messages up to that answer. The UI also dispatches a
-`fd:ai-feedback` browser event and emits an `ai_feedback` analytics event when analytics is enabled.
+The callback receives `type`, `question`, `answer`, `model`, `surface`, `url`, `path`, and the
+visible chat messages up to that answer. Copy actions also include `copied`. Like/dislike actions
+also include `value` for compatibility with `feedback.onFeedback`.
+
+Like/dislike still dispatch the legacy `fd:ai-feedback` browser event and emit an `ai_feedback`
+analytics event when analytics is enabled. All three actions dispatch `fd:ai-action`.
 
 ### `suggestedQuestions`
 

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -64,30 +64,57 @@ interface DocsAnalyticsEvent {
 }
 ```
 
-## Events
+## Event Types
 
-Client events:
+Analytics events describe product usage: what a person or agent did, which surface they used, and
+whether the action completed.
 
-- `page_view`
-- `search_open`, `search_close`, `search_query`, `search_result_click`, `search_error`
-- `ai_open`, `ai_close`, `ai_question`, `ai_response`, `ai_error`, `ai_clear`
-- `page_action_copy_markdown`, `page_action_open_docs_menu`, `page_action_open_docs`
-- `code_block_copy`
-- `feedback_select`, `feedback_submit`, `feedback_error`
+### Client Events
 
-Server and agent-surface events:
+| Event                            | Meaning                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `page_view`                      | A docs page was viewed in the browser.                                  |
+| `search_open`                    | The search UI was opened.                                               |
+| `search_close`                   | The search UI was closed.                                               |
+| `search_query`                   | A search query was submitted or changed enough to run search.           |
+| `search_result_click`            | A search result was selected.                                           |
+| `search_error`                   | Client-side search failed.                                              |
+| `ai_open`                        | The Ask AI UI was opened.                                               |
+| `ai_close`                       | The Ask AI UI was closed.                                               |
+| `ai_question`                    | A user submitted a question to Ask AI from the client UI.                |
+| `ai_response`                    | The Ask AI UI received a successful response.                            |
+| `ai_feedback`                    | A user rated a completed Ask AI answer with the response feedback buttons. |
+| `ai_error`                       | The Ask AI UI encountered an error.                                     |
+| `ai_clear`                       | The Ask AI conversation was cleared.                                    |
+| `page_action_copy_markdown`      | The Copy Markdown page action was used.                                 |
+| `page_action_open_docs_menu`     | The Open in LLM/Open docs page-action menu was opened.                  |
+| `page_action_open_docs`          | A destination in the Open in LLM/Open docs menu was selected.           |
+| `code_block_copy`                | A code block copy button was clicked.                                   |
+| `feedback_select`                | A feedback rating or option was selected.                               |
+| `feedback_submit`                | Feedback was submitted successfully.                                    |
+| `feedback_error`                 | Feedback submission failed.                                             |
 
-- `api_search`
-- `api_ai_request`, `api_ai_response`, `api_ai_error`
-- `agent_read`
-- `markdown_request`, `llms_request`, `skill_request`
-- `agent_spec_request`, `agent_feedback_schema`, `agent_feedback_submit`, `agent_feedback_error`
-- `mcp_request`, `mcp_tool`
+### Server And Agent-Surface Events
 
-`agent_read` fires when a page is read through the machine-readable surface: `/docs/page.md`,
-`/docs/page` with `Accept: text/markdown`, `GET /api/docs?format=markdown&path=page`, or MCP
-`read_page`. Its `properties.delivery` value is `md_route`, `accept_header`, `api_format`, or
-`mcp_tool`.
+| Event                           | Meaning                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `api_search`                    | The docs API handled a search request.                                  |
+| `api_ai_request`                | The docs API accepted an Ask AI request.                                |
+| `api_ai_response`               | The docs API returned a successful Ask AI response.                     |
+| `api_ai_error`                  | The docs API rejected or failed an Ask AI request.                      |
+| `agent_read`                    | A page was read through a machine-readable docs surface.                |
+| `markdown_request`              | A markdown route or API markdown request was served.                    |
+| `llms_request`                  | `/llms.txt` or `/llms-full.txt` was requested.                          |
+| `skill_request`                 | An Agent Skills file or skill index was requested.                      |
+| `agent_spec_request`            | The agent-facing docs spec endpoint was requested.                      |
+| `agent_feedback_schema`         | The agent feedback schema endpoint was requested.                       |
+| `agent_feedback_submit`         | Agent feedback was submitted successfully.                              |
+| `agent_feedback_error`          | Agent feedback submission failed.                                       |
+| `mcp_request`                   | The MCP endpoint received a request.                                    |
+| `mcp_tool`                      | An MCP tool call was handled, such as `search_docs` or `read_page`.     |
+
+`agent_read` includes `properties.delivery` so you can see how the page was read: `md_route`,
+`accept_header`, `api_format`, or `mcp_tool`.
 
 ## Input Privacy
 

--- a/website/app/docs/customization/observability/page.mdx
+++ b/website/app/docs/customization/observability/page.mdx
@@ -124,33 +124,43 @@ Example tool event:
 
 ## Trace Events
 
-Ask AI events:
+Observability events describe runtime steps inside an agent run. They are span-like: use
+`traceId` to group a run, `spanId` to identify a step, and `parentSpanId` to connect child steps to
+their parent.
 
-- `run.start` — an Ask AI run started
-- `user.input` — a user message was accepted for the run
-- `retrieval.query` — docs retrieval started
-- `retrieval.result` — docs retrieval finished with measurable result counts
-- `retrieval.error` — docs retrieval failed
-- `prompt.build` — the system/context prompt was built
-- `model.call` — the model request started
-- `model.response` — the model returned response headers successfully
-- `model.stream` — a streaming model response was handed back to the client
-- `model.error` — the model request failed or returned an error status
-- `agent.final` — the final agent response handoff was reached
-- `run.error` — the run finished unsuccessfully
-- `run.end` — the run finished
+### Ask AI Events
 
-MCP tool events:
+| Event              | Meaning                                                               |
+| ------------------ | --------------------------------------------------------------------- |
+| `run.start`        | A new Ask AI run started. This is the root span for the request.       |
+| `user.input`       | The latest user message was accepted and summarized into safe counts. |
+| `retrieval.query`  | Docs retrieval started for the user question.                         |
+| `retrieval.result` | Docs retrieval completed and produced measurable result counts.       |
+| `retrieval.error`  | Docs retrieval failed before the model call could use the context.    |
+| `prompt.build`     | The system prompt and retrieved docs context were assembled.          |
+| `model.call`       | The outbound model request started.                                   |
+| `model.response`   | The model provider returned successful response headers.              |
+| `model.stream`     | A streaming model response was handed back to the client.             |
+| `model.error`      | The model request failed, threw, or returned an error status.         |
+| `agent.final`      | The final response handoff was reached after a successful model call. |
+| `run.error`        | The run ended unsuccessfully.                                         |
+| `run.end`          | The run ended, either successfully or after an error.                 |
 
-- `tool.call` — an MCP tool started
-- `tool.result` — an MCP tool completed successfully
-- `tool.error` — an MCP tool returned an error result or threw
+### MCP Tool Events
 
-Generic runtime events:
+| Event         | Meaning                                                           |
+| ------------- | ----------------------------------------------------------------- |
+| `tool.call`   | An MCP tool call started, such as `search_docs` or `read_page`.   |
+| `tool.result` | An MCP tool completed successfully and returned a result.         |
+| `tool.error`  | An MCP tool returned an error result or threw during execution.   |
 
-- `retry` — a retry attempt was recorded
-- `timeout` — a step timed out
-- `error` — a generic run-level error was recorded
+### Generic Runtime Events
+
+| Event     | Meaning                                                               |
+| --------- | --------------------------------------------------------------------- |
+| `retry`   | A retry attempt was recorded for a failed or unstable step.           |
+| `timeout` | A step timed out before it could complete.                            |
+| `error`   | A generic run-level error was recorded outside a more specific event. |
 
 Built-in trace events avoid raw user-authored text. They use lengths, counts, route names, model
 IDs, status codes, and content sizes so they are safer to aggregate.

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1173,6 +1173,7 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
 | `feedback`           | `boolean \| DocsAskAIFeedbackConfig`                 | `true`                        | Like/dislike rating controls for completed answers      |
+| `onActions`          | `(data: DocsAskAIActionData) => void \| Promise<void>` | —                             | Callback for copy, like, and dislike response actions   |
 | `packageName`        | `string`                                             | inferred from docs context    | Optional package-name override for import examples       |
 | `docsUrl`            | `string`                                             | —                             | Base URL the AI uses for links                          |
 | `loader`             | `string`                                             | `"shimmer-dots"`              | Loading indicator variant (`"shimmer-dots"`, `"circular"`, `"dots"`, `"typing"`, `"wave"`, `"bars"`, `"pulse"`, `"pulse-dot"`, `"terminal"`, `"text-blink"`, `"text-shimmer"`, `"loading-dots"`) |

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1172,7 +1172,8 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `maxResults`         | `number`                                             | `5`                           | Number of doc pages to include as RAG context           |
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
-| `packageName`        | `string`                                             | —                             | Package name the AI uses in import examples             |
+| `feedback`           | `boolean \| DocsAskAIFeedbackConfig`                 | `true`                        | Like/dislike rating controls for completed answers      |
+| `packageName`        | `string`                                             | inferred from docs context    | Optional package-name override for import examples       |
 | `docsUrl`            | `string`                                             | —                             | Base URL the AI uses for links                          |
 | `loader`             | `string`                                             | `"shimmer-dots"`              | Loading indicator variant (`"shimmer-dots"`, `"circular"`, `"dots"`, `"typing"`, `"wave"`, `"bars"`, `"pulse"`, `"pulse-dot"`, `"terminal"`, `"text-blink"`, `"text-shimmer"`, `"loading-dots"`) |
 | `loadingComponent`   | `(props: { name: string }) => ReactNode`             | —                             | Custom loading component (overrides `loader`, Next.js only) |

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -255,6 +255,11 @@ export default defineDocs({
       defaultModel: "gpt-4o-mini",
     },
     aiLabel: "DocsBot",
+    feedback: {
+      onFeedback(data) {
+        console.log("[@farming-labs/docs:ask-ai-feedback]", data);
+      },
+    },
     suggestedQuestions: [
       "How do I get started?",
       "How do I create my own theme?",

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -255,10 +255,8 @@ export default defineDocs({
       defaultModel: "gpt-4o-mini",
     },
     aiLabel: "DocsBot",
-    feedback: {
-      onFeedback(data) {
-        console.log("[@farming-labs/docs:ask-ai-feedback]", data);
-      },
+    onActions(data) {
+      console.log("[@farming-labs/docs:ask-ai-action]", data);
     },
     suggestedQuestions: [
       "How do I get started?",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up docs search and builds better Ask AI answers by creating context from search results while preserving fenced code. Adds unified `onActions`, optional like/dislike feedback, and package-aware example hints across frameworks.

- **New Features**
  - Added `buildDocsAskAIContext` to hydrate model context from configured search (`simple`, `Typesense`, `Algolia`, `MCP`, or custom), including section content and fenced code.
  - Unified actions via `onActions` and client hook `__fdOnAIActions__`; optional `feedback` UI (toggle or handle with `__fdOnAIFeedback__`); new analytics event `ai_feedback`.
  - Package guidance via `formatDocsAskAIPackageHints` and `inferDocsAskAIPackageHints`; supports `packageName` and `docsUrl`. Exposed in `@farming-labs/docs` and wired through `fumadocs`, `next`, `astro`, `nuxt`, `svelte`, and `tanstack-start`.

- **Refactors**
  - Centralized search pipeline and removed duplicated server search; added stop-words and tuned scoring/limits; kept fenced code searchable in section docs.
  - Updated UI and styles for feedback; exported new types/APIs; expanded tests and docs.

<sup>Written for commit 71dc983deb8de3621c33b569a0a30e79e39e6785. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

