### PR TITLE
feat: use mcp flag for ai capability

### DIFF
--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -1000,6 +1000,7 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `baseUrl`            | `string`                                             | `"https://api.openai.com/v1"` | OpenAI-compatible API base URL                          |
 | `apiKey`             | `string`                                             | `process.env.OPENAI_API_KEY`  | API key for the LLM provider                            |
 | `maxResults`         | `number`                                             | `5`                           | Number of doc pages to include as RAG context           |
+| `useMcp`             | `boolean \| DocsAskAIMcpConfig`                      | `false`                       | Route Ask AI retrieval through MCP `search_docs` without changing the search API |
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
 | `feedback`           | `boolean \| DocsAskAIFeedbackConfig`                 | `true`                        | Copy, like, and dislike action row for completed answers |

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -50,6 +50,7 @@ import {
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -61,7 +62,7 @@ import {
   resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
-import type { DocsAgentTraceEventInput } from "@farming-labs/docs";
+import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
   resolveDocsMcpConfig,
@@ -99,6 +100,7 @@ interface AIConfigObj {
   baseUrl?: string;
   apiKey?: string;
   maxResults?: number;
+  useMcp?: boolean | DocsAskAIMcpConfig;
   suggestedQuestions?: string[];
   aiLabel?: string;
   packageName?: string;
@@ -1201,7 +1203,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const retrieval = await buildDocsAskAIContext({
       pages: getSearchIndex(ctx),
       query: lastUserMessage.content,
-      search: resolveSearchRequestConfig(config.search, context.request.url),
+      search: resolveAskAISearchRequestConfig({
+        search: config.search,
+        useMcp: aiConfig.useMcp,
+        mcpEndpoint: mcpConfig.route,
+        mcpEnabled: mcpConfig.enabled,
+        mcpSearchEnabled: mcpConfig.tools.searchDocs,
+        requestUrl: context.request.url,
+      }),
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -90,6 +90,7 @@ export {
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   performDocsSearch,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
 export type { GeneratedAgentProvenance, GeneratedAgentSourceKind } from "./agent-provenance.js";
@@ -148,6 +149,7 @@ export type {
   DocsAgentFeedbackData,
   FeedbackConfig,
   AgentFeedbackConfig,
+  DocsAskAIMcpConfig,
   DocsSearchAdapter,
   DocsSearchAdapterContext,
   DocsSearchAdapterFactory,

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -1,6 +1,7 @@
 import type {
   AlgoliaDocsSearchConfig,
   CustomDocsSearchConfig,
+  DocsAskAIMcpConfig,
   DocsSearchAdapter,
   DocsSearchAdapterFactory,
   DocsSearchAdapterContext,
@@ -1091,6 +1092,41 @@ export function resolveSearchRequestConfig(
     ...search,
     endpoint: new URL(search.endpoint, requestUrl).toString(),
   };
+}
+
+export function resolveAskAISearchRequestConfig(options: {
+  search: boolean | DocsSearchConfig | undefined;
+  useMcp?: boolean | DocsAskAIMcpConfig;
+  mcpEndpoint?: string;
+  mcpEnabled?: boolean;
+  mcpSearchEnabled?: boolean;
+  requestUrl?: string;
+}): boolean | DocsSearchConfig | undefined {
+  if (!options.useMcp) {
+    return resolveSearchRequestConfig(options.search, options.requestUrl);
+  }
+
+  if (typeof options.useMcp === "object") {
+    return resolveSearchRequestConfig(
+      {
+        ...options.useMcp,
+        provider: "mcp",
+      },
+      options.requestUrl,
+    );
+  }
+
+  if (options.mcpEnabled === false || options.mcpSearchEnabled === false || !options.mcpEndpoint) {
+    return resolveSearchRequestConfig(options.search, options.requestUrl);
+  }
+
+  return resolveSearchRequestConfig(
+    {
+      provider: "mcp",
+      endpoint: options.mcpEndpoint,
+    },
+    options.requestUrl,
+  );
 }
 
 export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchAdapter {

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -44,6 +44,7 @@ export {
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   performDocsSearch,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
 export {
@@ -73,6 +74,7 @@ export type {
   DocsSearchAdapter,
   DocsSearchAdapterContext,
   DocsSearchAdapterFactory,
+  DocsAskAIMcpConfig,
   DocsSearchConfig,
   DocsSearchDocument,
   DocsSearchQuery,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1069,6 +1069,10 @@ export interface McpDocsSearchConfig {
   chunking?: DocsSearchChunkingConfig;
 }
 
+export type DocsAskAIMcpConfig = Omit<McpDocsSearchConfig, "provider"> & {
+  provider?: "mcp";
+};
+
 export interface CustomDocsSearchConfig {
   provider: "custom";
   enabled?: boolean;
@@ -1443,6 +1447,28 @@ export interface AIConfig {
    * @default 5
    */
   maxResults?: number;
+
+  /**
+   * Route Ask AI retrieval through the configured MCP `search_docs` tool.
+   *
+   * - `true` uses the MCP server this docs site already exposes at `mcp.route`
+   *   (default `/api/docs/mcp`)
+   * - an object can point Ask AI at another Streamable HTTP MCP endpoint
+   *
+   * This only affects Ask AI retrieval. The normal docs search API still uses
+   * the top-level `search` config.
+   *
+   * @default false
+   *
+   * @example
+   * ```ts
+   * ai: {
+   *   enabled: true,
+   *   useMcp: true,
+   * }
+   * ```
+   */
+  useMcp?: boolean | DocsAskAIMcpConfig;
 
   /**
    * Pre-filled suggested questions shown in the AI chat when empty.

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -2268,4 +2268,407 @@ Welcome to the docs.
       vi.restoreAllMocks();
     }
   });
+
+  it.each([
+    {
+      label: "default MCP route",
+      mcp: undefined,
+      endpoint: "http://localhost/api/docs/mcp",
+    },
+    {
+      label: "custom MCP route",
+      mcp: { route: "/custom/docs/mcp" },
+      endpoint: "http://localhost/custom/docs/mcp",
+    },
+  ])("routes Ask AI retrieval through the $label when ai.useMcp is enabled", async (scenario) => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-ai-use-mcp-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+
+    process.chdir(rootDir);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              serverInfo: { name: "docs-mcp", version: "1.0.0" },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              "mcp-session-id": "session-1",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    results: [
+                      {
+                        id: "mcp-ask-ai-1",
+                        url: "/docs/introduction",
+                        content: "Introduction - Ask AI MCP result",
+                        description: "Returned from MCP search_docs for Ask AI.",
+                        type: "heading",
+                        section: "Ask AI",
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response("data: {}\n\n", {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        }),
+      ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        entry: "docs",
+        ai: {
+          enabled: true,
+          apiKey: "test-key",
+          baseUrl: "https://llm.example/v1",
+          model: "test-model",
+          useMcp: true,
+        },
+        mcp: scenario.mcp,
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How does Ask AI use MCP?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe(scenario.endpoint);
+      expect(vi.mocked(globalThis.fetch).mock.calls[1]?.[0]).toBe(scenario.endpoint);
+      expect(vi.mocked(globalThis.fetch).mock.calls[2]?.[0]).toBe(scenario.endpoint);
+      expect(vi.mocked(globalThis.fetch).mock.calls[3]?.[0]).toBe(
+        "https://llm.example/v1/chat/completions",
+      );
+
+      const upstreamInit = vi.mocked(globalThis.fetch).mock.calls[3]?.[1];
+      const upstreamBody = JSON.parse(String(upstreamInit?.body)) as {
+        messages?: Array<{ role?: string; content?: string }>;
+      };
+      const systemMessage = upstreamBody.messages?.find((message) => message.role === "system");
+      expect(systemMessage?.content).toContain("Returned from MCP search_docs for Ask AI.");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("supports a custom Ask AI MCP endpoint with headers and tool name", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-ai-use-mcp-custom-endpoint-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+
+    process.chdir(rootDir);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              serverInfo: { name: "remote-docs-mcp", version: "1.0.0" },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              "mcp-session-id": "remote-session-1",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    results: [
+                      {
+                        id: "remote-mcp-ask-ai-1",
+                        url: "/docs/remote",
+                        content: "Remote MCP result",
+                        description: "Returned from a custom MCP endpoint.",
+                        type: "page",
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response("data: {}\n\n", {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        }),
+      ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        entry: "docs",
+        ai: {
+          enabled: true,
+          apiKey: "test-key",
+          baseUrl: "https://llm.example/v1",
+          model: "test-model",
+          useMcp: {
+            endpoint: "https://docs.example.com/mcp",
+            headers: {
+              Authorization: "Bearer docs-mcp-token",
+            },
+            toolName: "custom_search_docs",
+          },
+        },
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How does custom MCP work?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe("https://docs.example.com/mcp");
+      expect(vi.mocked(globalThis.fetch).mock.calls[1]?.[0]).toBe("https://docs.example.com/mcp");
+
+      const initializeInit = vi.mocked(globalThis.fetch).mock.calls[0]?.[1];
+      expect(initializeInit?.headers).toMatchObject({
+        Authorization: "Bearer docs-mcp-token",
+      });
+
+      const toolInit = vi.mocked(globalThis.fetch).mock.calls[1]?.[1];
+      expect(toolInit?.headers).toMatchObject({
+        Authorization: "Bearer docs-mcp-token",
+        "mcp-session-id": "remote-session-1",
+      });
+      expect(JSON.parse(String(toolInit?.body))).toMatchObject({
+        method: "tools/call",
+        params: {
+          name: "custom_search_docs",
+        },
+      });
+
+      const upstreamInit = vi.mocked(globalThis.fetch).mock.calls[3]?.[1];
+      const upstreamBody = JSON.parse(String(upstreamInit?.body)) as {
+        messages?: Array<{ role?: string; content?: string }>;
+      };
+      const systemMessage = upstreamBody.messages?.find((message) => message.role === "system");
+      expect(systemMessage?.content).toContain("Returned from a custom MCP endpoint.");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("uses a real custom MCP endpoint for Ask AI retrieval before generation", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-ai-real-mcp-endpoint-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "guides"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "guides", "page.mdx"),
+      `---
+title: "MCP Integration"
+description: "Use MCP retrieval for Ask AI."
+---
+
+# MCP Integration
+
+Ask AI should retrieve this exact MCP Actual Retrieval Token from the real MCP handler.
+`,
+    );
+
+    process.chdir(rootDir);
+
+    const mcpHandlers = createDocsMCPAPI({
+      rootDir,
+      entry: "docs",
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(request.url);
+
+      if (url.href === "https://docs.example.com/mcp") {
+        if (request.method === "POST") return mcpHandlers.POST(request);
+        if (request.method === "DELETE") return mcpHandlers.DELETE(request);
+        return mcpHandlers.GET(request);
+      }
+
+      if (url.href === "https://llm.example/v1/chat/completions") {
+        return new Response("data: {}\n\n", {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch request: ${url.href}`);
+    }) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        rootDir,
+        entry: "docs",
+        ai: {
+          enabled: true,
+          apiKey: "test-key",
+          baseUrl: "https://llm.example/v1",
+          model: "test-model",
+          useMcp: {
+            endpoint: "https://docs.example.com/mcp",
+            headers: {
+              Authorization: "Bearer docs-mcp-token",
+            },
+          },
+        },
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How do I use MCP retrieval?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+
+      const calls = vi.mocked(globalThis.fetch).mock.calls.map(([input, init]) => ({
+        request: input instanceof Request ? input : new Request(input, init),
+        init,
+      }));
+      const mcpCalls = calls.filter(
+        ({ request }) => request.url === "https://docs.example.com/mcp",
+      );
+      expect(mcpCalls.map(({ request }) => request.method)).toEqual(["POST", "POST", "DELETE"]);
+      expect(new Headers(mcpCalls[0]?.init?.headers).get("authorization")).toBe(
+        "Bearer docs-mcp-token",
+      );
+      expect(new Headers(mcpCalls[1]?.init?.headers).get("mcp-session-id")).toEqual(
+        expect.any(String),
+      );
+      expect(JSON.parse(String(mcpCalls[1]?.init?.body))).toMatchObject({
+        method: "tools/call",
+        params: {
+          name: "search_docs",
+        },
+      });
+
+      const llmCall = calls.find(
+        ({ request }) => request.url === "https://llm.example/v1/chat/completions",
+      );
+      expect(llmCall).toBeDefined();
+      const upstreamBody = JSON.parse(String(llmCall?.init?.body)) as {
+        messages?: Array<{ role?: string; content?: string }>;
+      };
+      const systemMessage = upstreamBody.messages?.find((message) => message.role === "system");
+      expect(systemMessage?.content).toContain("MCP Actual Retrieval Token");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -55,9 +55,11 @@ import {
   buildDocsAskAIContext,
   formatDocsAskAIPackageHints,
   performDocsSearch,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "@farming-labs/docs";
 import type {
+  DocsAskAIMcpConfig,
   DocsMcpConfig,
   DocsSearchConfig,
   DocsSearchSourcePage,
@@ -97,6 +99,7 @@ interface AIOptions {
   /** Default apiKey when no per-model provider is configured. */
   apiKey?: string;
   maxResults?: number;
+  useMcp?: boolean | DocsAskAIMcpConfig;
 }
 
 interface DocsAPIOptions {
@@ -682,6 +685,7 @@ function readAIConfig(root: string): AIOptions {
         // Match `apiKey: process.env.SOME_VAR` and resolve it at runtime
         const apiKeyMatch = content.match(/ai\s*:\s*\{[^}]*apiKey\s*:\s*process\.env\.(\w+)/s);
         const maxResultsMatch = content.match(/ai\s*:\s*\{[^}]*maxResults\s*:\s*(\d+)/s);
+        const useMcpMatch = content.match(/ai\s*:\s*\{[^}]*useMcp\s*:\s*(true|false)/s);
         const systemPromptMatch = content.match(
           /ai\s*:\s*\{[^}]*systemPrompt\s*:\s*["'`]([^"'`]+)["'`]/s,
         );
@@ -696,6 +700,7 @@ function readAIConfig(root: string): AIOptions {
           baseUrl: baseUrlMatch?.[1],
           apiKey: apiKeyMatch?.[1] ? process.env[apiKeyMatch[1]] : undefined,
           maxResults: maxResultsMatch ? parseInt(maxResultsMatch[1], 10) : undefined,
+          useMcp: useMcpMatch ? useMcpMatch[1] === "true" : undefined,
           systemPrompt: systemPromptMatch?.[1],
           packageName: packageNameMatch?.[1],
           docsUrl: docsUrlMatch?.[1],
@@ -2838,7 +2843,14 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         request,
         getIndexes(ctx),
         aiConfig,
-        resolveSearchRequestConfig(searchConfig, request.url),
+        resolveAskAISearchRequestConfig({
+          search: searchConfig,
+          useMcp: aiConfig.useMcp,
+          mcpEndpoint: mcpConfig.route,
+          mcpEnabled: mcpConfig.enabled,
+          mcpSearchEnabled: mcpConfig.tools.searchDocs,
+          requestUrl: request.url,
+        }),
         analytics,
         observability,
         {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -39,6 +39,7 @@ import {
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -50,7 +51,7 @@ import {
   resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
-import type { DocsAgentTraceEventInput } from "@farming-labs/docs";
+import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
   resolveDocsMcpConfig,
@@ -88,6 +89,7 @@ interface AIConfigObj {
   baseUrl?: string;
   apiKey?: string;
   maxResults?: number;
+  useMcp?: boolean | DocsAskAIMcpConfig;
   suggestedQuestions?: string[];
   aiLabel?: string;
   packageName?: string;
@@ -1188,7 +1190,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const retrieval = await buildDocsAskAIContext({
       pages: getSearchIndex(ctx),
       query: lastUserMessage.content,
-      search: resolveSearchRequestConfig(config.search, context.request.url),
+      search: resolveAskAISearchRequestConfig({
+        search: config.search,
+        useMcp: aiConfig.useMcp,
+        mcpEndpoint: mcpConfig.route,
+        mcpEnabled: mcpConfig.enabled,
+        mcpSearchEnabled: mcpConfig.tools.searchDocs,
+        requestUrl: context.request.url,
+      }),
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -50,6 +50,7 @@ import {
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -61,7 +62,7 @@ import {
   resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
-import type { DocsAgentTraceEventInput } from "@farming-labs/docs";
+import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
   resolveDocsMcpConfig,
@@ -99,6 +100,7 @@ interface AIConfigObj {
   baseUrl?: string;
   apiKey?: string;
   maxResults?: number;
+  useMcp?: boolean | DocsAskAIMcpConfig;
   suggestedQuestions?: string[];
   aiLabel?: string;
   packageName?: string;
@@ -1209,7 +1211,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const retrieval = await buildDocsAskAIContext({
       pages: getSearchIndex(ctx),
       query: lastUserMessage.content,
-      search: resolveSearchRequestConfig(config.search, event.request.url),
+      search: resolveAskAISearchRequestConfig({
+        search: config.search,
+        useMcp: aiConfig.useMcp,
+        mcpEndpoint: mcpConfig.route,
+        mcpEnabled: mcpConfig.enabled,
+        mcpSearchEnabled: mcpConfig.tools.searchDocs,
+        requestUrl: event.request.url,
+      }),
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -20,6 +20,7 @@ import {
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
+  resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtFormat,
@@ -31,7 +32,7 @@ import {
   resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
-import type { DocsAgentTraceEventInput } from "@farming-labs/docs";
+import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
 import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
@@ -63,6 +64,7 @@ interface AIConfigObj {
   baseUrl?: string;
   apiKey?: string;
   maxResults?: number;
+  useMcp?: boolean | DocsAskAIMcpConfig;
   suggestedQuestions?: string[];
   aiLabel?: string;
   packageName?: string;
@@ -1165,7 +1167,14 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const retrieval = await buildDocsAskAIContext({
       pages: getSearchIndex(ctx),
       query: lastUserMessage.content,
-      search: resolveSearchRequestConfig(config.search, event.request.url),
+      search: resolveAskAISearchRequestConfig({
+        search: config.search,
+        useMcp: aiConfig.useMcp,
+        mcpEndpoint: mcpConfig.route,
+        mcpEnabled: mcpConfig.enabled,
+        mcpSearchEnabled: mcpConfig.tools.searchDocs,
+        requestUrl: event.request.url,
+      }),
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,

--- a/skills/farming-labs/ask-ai/SKILL.md
+++ b/skills/farming-labs/ask-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-ai
-description: Configure the Ask AI (RAG-powered AI chat) in @farming-labs/docs. Use when enabling AI chat, setting mode (search vs floating), floatingStyle (panel, modal, popover, full-modal), position, providers, models, suggestedQuestions, apiKey, systemPrompt, maxResults, feedback, or onActions. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt, and env vars.
+description: Configure the Ask AI (RAG-powered AI chat) in @farming-labs/docs. Use when enabling AI chat, setting mode (search vs floating), floatingStyle (panel, modal, popover, full-modal), position, providers, models, suggestedQuestions, apiKey, systemPrompt, maxResults, useMcp, feedback, or onActions. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt, and env vars.
 ---
 
 # @farming-labs/docs — Ask AI (AI Chat)
@@ -207,6 +207,17 @@ Ask AI uses the configured docs search pipeline before building model context, i
 search, Typesense, Algolia, MCP search, or custom adapters. The model context is hydrated from the
 matched local page/section, preserves fenced code blocks for commands and config snippets, and
 infers package names plus exact import lines from the retrieved context.
+
+Use `ai.useMcp: true` when only Ask AI should retrieve through the built-in MCP `search_docs` tool
+while the normal docs search API keeps its own provider. `true` uses `mcp.route` (default
+`/api/docs/mcp`) from the MCP server the docs site already exposes. If a project sets
+`mcp: { route: "/custom/docs/mcp" }`, `useMcp: true` follows that route automatically. Pass
+`{ endpoint: "https://docs.example.com/mcp", headers: { Authorization: "Bearer ..." } }` only for a
+hosted or external MCP endpoint. MCP handles retrieval only; `model`, `apiKey`, `baseUrl`, or
+`providers` still control the LLM generation request. Custom MCP endpoints must support Streamable
+HTTP MCP, return an `mcp-session-id` on `initialize`, and expose a search tool (default
+`search_docs`; override with `toolName` if needed). If MCP is disabled or `search_docs` is turned
+off, Ask AI falls back to the normal top-level `search` config.
 
 ### aiLabel
 

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -346,6 +346,76 @@ ai: {
 }
 ```
 
+### `useMcp`
+
+Route Ask AI retrieval through the MCP server your docs site already exposes, without changing the
+normal docs search API.
+
+| Type | Default |
+| ---- | ------- |
+| `boolean \| DocsAskAIMcpConfig` | `false` |
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  ai: {
+    enabled: true,
+    useMcp: true,
+  },
+});
+```
+
+`useMcp: true` uses the built-in docs MCP server and calls its `search_docs` tool to retrieve Ask AI
+context. By default that is the canonical `mcp.route` at `/api/docs/mcp`; if you configure
+`mcp.route`, Ask AI uses that route automatically:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  mcp: {
+    route: "/custom/docs/mcp",
+  },
+  ai: {
+    enabled: true,
+    useMcp: true,
+  },
+});
+```
+
+Pass an object only when Ask AI should use a hosted or external MCP endpoint instead of this site's
+own MCP route. MCP handles retrieval only; the `model`, `apiKey`, `baseUrl`, or `providers` config
+still controls the LLM generation request.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  ai: {
+    enabled: true,
+    model: "gpt-4o-mini",
+    apiKey: process.env.OPENAI_API_KEY,
+    useMcp: {
+      endpoint: "https://docs.example.com/mcp",
+      headers: {
+        Authorization: `Bearer ${process.env.DOCS_MCP_TOKEN}`,
+      },
+    },
+  },
+});
+```
+
+If your top-level `search` config already uses `provider: "mcp"`, Ask AI follows that automatically.
+Use `ai.useMcp` when only Ask AI should route retrieval through MCP.
+
+`DocsAskAIMcpConfig` accepts the MCP search options (`endpoint`, `headers`, `toolName`,
+`protocolVersion`, `maxResults`, and `enabled`). If MCP is disabled or `search_docs` is turned off,
+Ask AI falls back to the normal top-level `search` config.
+
+End-to-end, Ask AI does two server-side calls:
+
+1. Retrieve docs context from `search_docs` on the configured MCP endpoint.
+2. Send the prompt plus retrieved context to the configured OpenAI-compatible model endpoint.
+
+So a custom MCP endpoint must support Streamable HTTP MCP, return an `mcp-session-id` on
+`initialize`, expose a search tool (default `search_docs`), and return results with `url`,
+`content`, optional `description`, and optional `section`.
+
 ### Retrieval Quality
 
 Ask AI uses the same configured docs search pipeline as the search API. If you configure simple

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -241,6 +241,57 @@ export default defineDocs({
 });
 ```
 
+For Ask AI only, keep the top-level search provider as-is and enable MCP retrieval in the AI config.
+This uses the MCP server the docs site already exposes:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  ai: {
+    enabled: true,
+    useMcp: true,
+  },
+});
+```
+
+If you changed the canonical MCP route, `useMcp: true` follows it automatically:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  mcp: {
+    route: "/custom/docs/mcp",
+  },
+  ai: {
+    enabled: true,
+    useMcp: true,
+  },
+});
+```
+
+For a hosted or external MCP endpoint, configure the endpoint on `ai.useMcp` instead. This does not
+replace your LLM provider config; the MCP endpoint retrieves docs context, then Ask AI still sends
+the final prompt to your configured model provider.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  ai: {
+    enabled: true,
+    model: "gpt-4o-mini",
+    apiKey: process.env.OPENAI_API_KEY,
+    useMcp: {
+      endpoint: "https://docs.example.com/mcp",
+      headers: {
+        Authorization: `Bearer ${process.env.DOCS_MCP_TOKEN}`,
+      },
+      toolName: "search_docs",
+    },
+  },
+});
+```
+
+The custom MCP endpoint must support Streamable HTTP MCP, return an `mcp-session-id` on
+`initialize`, and expose a search tool that returns docs results. The default tool name is
+`search_docs`; override `toolName` only if your server uses a different name.
+
 For local self-hosted setups, relative MCP endpoints like `/mcp` and `/.well-known/mcp` are
 supported. The canonical `/api/docs/mcp` route remains available too. The built-in `search_docs`
 tool automatically falls back to simple search internally when it detects that same-route loop, so

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1170,6 +1170,7 @@ RAG-powered AI chat. See [Ask AI](/docs/customization/ai-chat) for usage guide.
 | `baseUrl`            | `string`                                             | `"https://api.openai.com/v1"` | OpenAI-compatible API base URL                          |
 | `apiKey`             | `string`                                             | `process.env.OPENAI_API_KEY`  | API key for the LLM provider                            |
 | `maxResults`         | `number`                                             | `5`                           | Number of doc pages to include as RAG context           |
+| `useMcp`             | `boolean \| DocsAskAIMcpConfig`                      | `false`                       | Route Ask AI retrieval through MCP `search_docs` without changing the search API |
 | `suggestedQuestions` | `string[]`                                           | —                             | Pre-filled questions shown when chat is empty           |
 | `aiLabel`            | `string`                                             | `"AI"`                        | Display name for the AI assistant                       |
 | `feedback`           | `boolean \| DocsAskAIFeedbackConfig`                 | `true`                        | Copy, like, and dislike action row for completed answers |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `ai.useMcp` to route Ask AI retrieval through MCP `search_docs` without changing the normal search API, plus a resolver to wire it into all servers. This enables using the built-in docs MCP route or a custom MCP endpoint for retrieval before LLM generation.

- New Features
  - Added `ai.useMcp` (boolean or `DocsAskAIMcpConfig`) to `@farming-labs/docs` so Ask AI retrieves via MCP; supports built-in `mcp.route` or custom `endpoint/headers/toolName`, with fallback to the top‑level `search` when MCP is disabled.
  - Introduced `resolveAskAISearchRequestConfig` and integrated it into `astro`, `nuxt`, `svelte`, `tanstack-start` servers and the `fumadocs` API; exported `DocsAskAIMcpConfig` in types.
  - Updated docs and examples (AI chat, MCP, reference, skill) with usage; added tests covering default/custom MCP routes, custom endpoints with headers/tool name, and end‑to‑end retrieval via a live MCP handler.

<sup>Written for commit 4a55cc8edf5981d970eccffc2e8cc3085d631b8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

