### PR TITLE
feat: sitemap xml/md

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "docs sitemap generate --config src/lib/docs.config.ts && astro build",
+    "build": "pnpm --dir ../.. --filter @farming-labs/docs run build && node ../../packages/docs/dist/cli/index.mjs sitemap generate --config src/lib/docs.config.ts && astro build",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "docs sitemap generate --config src/lib/docs.config.ts && astro build",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/examples/astro/src/lib/docs.config.ts
+++ b/examples/astro/src/lib/docs.config.ts
@@ -88,6 +88,7 @@ export default defineDocs({
     submitLabel: "Submit",
   },
   llmsTxt: { enabled: true, baseUrl: "https://docs.farming-labs.dev" },
+  sitemap: { enabled: true, baseUrl: "https://docs.farming-labs.dev" },
   lastUpdated: { enabled: true, position: "below-title" },
   themeToggle: { enabled: true, default: "dark" },
   breadcrumb: { enabled: true },

--- a/examples/astro/src/lib/docs.server.ts
+++ b/examples/astro/src/lib/docs.server.ts
@@ -4,9 +4,9 @@ import config from "./docs.config";
 const contentFiles = import.meta.glob(
   ["/docs/**/*.{md,mdx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"],
   {
-  query: "?raw",
-  import: "default",
-  eager: true,
+    query: "?raw",
+    import: "default",
+    eager: true,
   },
 ) as Record<string, string>;
 

--- a/examples/astro/src/lib/docs.server.ts
+++ b/examples/astro/src/lib/docs.server.ts
@@ -1,11 +1,14 @@
 import { createDocsServer } from "@farming-labs/astro/server";
 import config from "./docs.config";
 
-const contentFiles = import.meta.glob(["/docs/**/*.{md,mdx}", "/skill.md"], {
+const contentFiles = import.meta.glob(
+  ["/docs/**/*.{md,mdx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"],
+  {
   query: "?raw",
   import: "default",
   eager: true,
-}) as Record<string, string>;
+  },
+) as Record<string, string>;
 
 export const { load, GET, POST, MCP } = createDocsServer({
   ...config,

--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -20,7 +20,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
 
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsPublicGetRequest(docsEntry, context.url, context.request)
+    isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap })
   ) {
     return GET({ request: context.request });
   }

--- a/examples/sveltekit/src/hooks.server.js
+++ b/examples/sveltekit/src/hooks.server.js
@@ -19,7 +19,7 @@ export async function handle({ event, resolve }) {
 
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsPublicGetRequest(docsEntry, event.url, event.request)
+    isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap })
   ) {
     return GET({ url: event.url, request: event.request });
   }

--- a/examples/sveltekit/src/lib/docs.server.ts
+++ b/examples/sveltekit/src/lib/docs.server.ts
@@ -3,11 +3,14 @@ import { env } from "$env/dynamic/private";
 import config from "./docs.config";
 
 // preload for production
-const contentFiles = import.meta.glob(["/docs/**/*.{md,mdx,svx}", "/skill.md"], {
+const contentFiles = import.meta.glob(
+  ["/docs/**/*.{md,mdx,svx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"],
+  {
   query: "?raw",
   import: "default",
   eager: true,
-}) as Record<string, string>;
+  },
+) as Record<string, string>;
 
 export const { load, GET, POST, MCP } = createDocsServer({
   ...config,

--- a/examples/sveltekit/src/lib/docs.server.ts
+++ b/examples/sveltekit/src/lib/docs.server.ts
@@ -6,9 +6,9 @@ import config from "./docs.config";
 const contentFiles = import.meta.glob(
   ["/docs/**/*.{md,mdx,svx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"],
   {
-  query: "?raw",
-  import: "default",
-  eager: true,
+    query: "?raw",
+    import: "default",
+    eager: true,
   },
 ) as Record<string, string>;
 

--- a/examples/tanstack-start/src/routes/$.ts
+++ b/examples/tanstack-start/src/routes/$.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
+import docsConfig from "../../docs.config";
 
 const docsEntry = "docs";
 
@@ -18,7 +19,10 @@ async function handlePublicDocsRequest(request: Request) {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request)) {
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsPublicGetRequest(docsEntry, url, request, { sitemap: docsConfig.sitemap })
+  ) {
     return docsServer.GET({ request });
   }
 

--- a/packages/astro/src/content.ts
+++ b/packages/astro/src/content.ts
@@ -49,6 +49,8 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   icon?: string;
+  sourcePath?: string;
+  lastModified?: string;
   content: string;
   rawContent: string;
   agentContent?: string;
@@ -109,6 +111,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         icon: data.icon as string | undefined,
+        sourcePath: full.replace(/\\/g, "/"),
+        lastModified: stat.mtime.toISOString(),
         content: stripMarkdown(humanRawContent),
         rawContent: humanRawContent,
         ...(pageAgentRawContent !== humanRawContent

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -48,7 +48,6 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
@@ -62,12 +61,12 @@ import {
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
-  resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
+  readDocsSitemapManifest,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -35,6 +35,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
@@ -47,6 +48,8 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
@@ -829,6 +832,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -860,6 +864,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -873,6 +878,19 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         },
       );
     }
+
+    const sitemapResponse = createDocsSitemapResponse({
+      request: context.request,
+      sitemap: config.sitemap,
+      entry,
+      siteTitle: llmsTitle,
+      baseUrl: llmsBaseUrl || url.origin,
+      pages: getSearchIndex(ctx),
+      manifest:
+        readDocsSitemapManifestFromContentMap(preloaded) ??
+        readDocsSitemapManifest(rootDir, config.sitemap),
+    });
+    if (sitemapResponse) return sitemapResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -69,6 +69,22 @@ describe("agent route helpers", () => {
     expect(
       isDocsPublicGetRequest(
         "docs",
+        new URL("https://example.com/sitemap.xml"),
+        new Request("https://example.com/sitemap.xml"),
+        { sitemap: true },
+      ),
+    ).toBe(true);
+    expect(
+      isDocsPublicGetRequest(
+        "docs",
+        new URL("https://example.com/docs/sitemap.md"),
+        new Request("https://example.com/docs/sitemap.md"),
+        { sitemap: { routePrefix: "/docs" } },
+      ),
+    ).toBe(true);
+    expect(
+      isDocsPublicGetRequest(
+        "docs",
         new URL("https://example.com/api/docs?format=llms"),
         new Request("https://example.com/api/docs?format=llms"),
       ),
@@ -188,6 +204,7 @@ describe("agent route helpers", () => {
         },
       },
       llms: { enabled: true, siteTitle: "Docs" },
+      sitemap: true,
     });
 
     expect(spec.api.agentSpecDefault).toBe("/.well-known/agent.json");
@@ -199,5 +216,7 @@ describe("agent route helpers", () => {
     expect(spec.skills.api).toBe("/api/docs?format=skill");
     expect(spec.skills.generatedFallback).toBe(true);
     expect(spec.mcp.publicEndpoints).toEqual(["/mcp", "/.well-known/mcp"]);
+    expect(spec.sitemap.xml.route).toBe("/sitemap.xml");
+    expect(spec.sitemap.markdown.wellKnownRoute).toBe("/.well-known/sitemap.md");
   });
 });

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -2,6 +2,14 @@ import type { DocsSearchConfig, DocsSearchSourcePage, ResolvedDocsRelatedLink } 
 import type { ResolvedDocsI18n } from "./i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "./mcp.js";
 import { renderDocsRelatedMarkdownLines } from "./related.js";
+import {
+  DEFAULT_SITEMAP_MD_ROUTE,
+  DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
+  DEFAULT_SITEMAP_XML_ROUTE,
+  resolveDocsSitemapConfig,
+  resolveDocsSitemapRequest,
+} from "./sitemap.js";
+import type { DocsSitemapConfig } from "./types.js";
 
 export const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 export const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
@@ -39,6 +47,7 @@ export interface DocsAgentDiscoverySpecOptions {
   mcp: DocsMcpResolvedConfig;
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
+  sitemap?: boolean | DocsSitemapConfig;
   markdown?: {
     acceptHeader?: boolean;
   };
@@ -51,6 +60,7 @@ export interface DocsSkillDocumentOptions {
   mcp: DocsMcpResolvedConfig;
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
+  sitemap?: boolean | DocsSitemapConfig;
   markdown?: {
     acceptHeader?: boolean;
   };
@@ -115,7 +125,12 @@ export function resolveDocsSkillFormat(url: URL): "skill" | null {
   return url.searchParams.get("format")?.trim() === "skill" ? "skill" : null;
 }
 
-export function isDocsPublicGetRequest(entry: string, url: URL, request: Request): boolean {
+export function isDocsPublicGetRequest(
+  entry: string,
+  url: URL,
+  request: Request,
+  options: { sitemap?: boolean | DocsSitemapConfig } = {},
+): boolean {
   const pathname = normalizeDocsUrlPath(url.pathname);
   if (pathname === DEFAULT_DOCS_API_ROUTE || pathname === DEFAULT_MCP_ROUTE) return false;
 
@@ -123,6 +138,7 @@ export function isDocsPublicGetRequest(entry: string, url: URL, request: Request
     isDocsAgentDiscoveryRequest(url) ||
     isDocsSkillRequest(url) ||
     resolveDocsLlmsTxtFormat(url) !== null ||
+    resolveDocsSitemapRequest(url, options.sitemap) !== null ||
     resolveDocsMarkdownRequest(entry, url, request) !== null
   );
 }
@@ -231,6 +247,7 @@ export function renderDocsSkillDocument({
   mcp,
   feedback,
   llms,
+  sitemap,
   markdown,
 }: DocsSkillDocumentOptions): string {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -241,6 +258,7 @@ export function renderDocsSkillDocument({
   const llmsEnabled = llms?.enabled ?? true;
   const searchEnabled = isSearchEnabled(search);
   const feedbackEnabled = feedback?.enabled ?? false;
+  const sitemapConfig = resolveDocsSitemapConfig(sitemap);
   const feedbackRoute = feedback?.route ?? DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const description = truncateSkillDescription(
@@ -290,6 +308,15 @@ export function renderDocsSkillDocument({
     );
   }
 
+  if (sitemapConfig.enabled) {
+    if (sitemapConfig.xml.enabled) {
+      lines.push(`- Use ${sitemapConfig.xml.route} to check canonical page freshness.`);
+    }
+    if (sitemapConfig.markdown.enabled) {
+      lines.push(`- Use ${sitemapConfig.markdown.route} for a semantic docs map.`);
+    }
+  }
+
   if (mcp.enabled) {
     lines.push(
       `- Use ${DEFAULT_MCP_WELL_KNOWN_ROUTE} or ${DEFAULT_MCP_PUBLIC_ROUTE} for MCP tools when your environment supports MCP.`,
@@ -318,6 +345,16 @@ export function renderDocsSkillDocument({
       `- llms-full.txt: ${DEFAULT_LLMS_FULL_TXT_ROUTE}`,
       `- llms well-known aliases: ${DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE}, ${DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE}`,
     );
+  }
+
+  if (sitemapConfig.enabled) {
+    if (sitemapConfig.xml.enabled) lines.push(`- Sitemap XML: ${sitemapConfig.xml.route}`);
+    if (sitemapConfig.markdown.enabled) {
+      lines.push(
+        `- Sitemap Markdown: ${sitemapConfig.markdown.route}`,
+        `- Sitemap well-known alias: ${sitemapConfig.markdown.wellKnownRoute}`,
+      );
+    }
   }
 
   if (mcp.enabled) {
@@ -424,6 +461,7 @@ export function buildDocsAgentDiscoverySpec({
   mcp,
   feedback,
   llms,
+  sitemap,
   markdown,
 }: DocsAgentDiscoverySpecOptions) {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -432,6 +470,7 @@ export function buildDocsAgentDiscoverySpec({
   const feedbackRoute = feedback?.route ?? DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const llmsEnabled = llms?.enabled ?? true;
+  const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms?.baseUrl });
 
   return {
     version: "1",
@@ -458,6 +497,7 @@ export function buildDocsAgentDiscoverySpec({
       skills: true,
       mcp: mcp.enabled,
       search: searchEnabled,
+      sitemap: sitemapConfig.enabled,
       agentFeedback: feedback?.enabled ?? false,
       locales: localesEnabled,
     },
@@ -488,6 +528,23 @@ export function buildDocsAgentDiscoverySpec({
       publicFull: DEFAULT_LLMS_FULL_TXT_ROUTE,
       wellKnownTxt: DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE,
       wellKnownFull: DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
+    },
+    sitemap: {
+      enabled: sitemapConfig.enabled,
+      xml: {
+        enabled: sitemapConfig.xml.enabled,
+        route: sitemapConfig.xml.route,
+        api: `${DEFAULT_DOCS_API_ROUTE}?format=sitemap-xml`,
+        defaultRoute: DEFAULT_SITEMAP_XML_ROUTE,
+      },
+      markdown: {
+        enabled: sitemapConfig.markdown.enabled,
+        route: sitemapConfig.markdown.route,
+        wellKnownRoute: sitemapConfig.markdown.wellKnownRoute,
+        api: `${DEFAULT_DOCS_API_ROUTE}?format=sitemap-md`,
+        defaultRoute: DEFAULT_SITEMAP_MD_ROUTE,
+        defaultWellKnownRoute: DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
+      },
     },
     search: {
       enabled: searchEnabled,

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -133,6 +133,21 @@ async function main() {
     console.error();
     printHelp();
     process.exit(1);
+  } else if (parsedCommand.command === "sitemap" && subcommand === "generate") {
+    const { generateSitemap, parseSitemapGenerateArgs, printSitemapGenerateHelp } =
+      await import("./sitemap.js");
+    const sitemapOptions = parseSitemapGenerateArgs(args.slice(2));
+    if (sitemapOptions.help) {
+      printSitemapGenerateHelp();
+      return;
+    }
+    await generateSitemap(sitemapOptions);
+  } else if (parsedCommand.command === "sitemap") {
+    console.error(pc.red(`Unknown sitemap subcommand: ${subcommand ?? "(missing)"}`));
+    console.error();
+    const { printSitemapGenerateHelp } = await import("./sitemap.js");
+    printSitemapGenerateHelp();
+    process.exit(1);
   } else if (parsedCommand.command === "upgrade") {
     const { upgrade } = await import("./upgrade.js");
     const framework =
@@ -170,6 +185,7 @@ ${pc.dim("Commands:")}
   ${pc.cyan("doctor")}   Inspect and score agent or reader-facing docs quality
   ${pc.cyan("mcp")}      Run the built-in docs MCP server over stdio
   ${pc.cyan("search")}   Search utilities (${pc.dim("sync")} for external indexes)
+  ${pc.cyan("sitemap")}  Sitemap utilities (${pc.dim("generate")} for sitemap XML/Markdown data)
   ${pc.cyan("upgrade")}  Upgrade @farming-labs/* packages to latest (auto-detect or use --framework)
 
 ${pc.dim("Supported frameworks:")}
@@ -234,6 +250,13 @@ ${pc.dim("Options for search sync:")}
   ${pc.cyan("--app-id <id>")}                      Algolia app id (or use ${pc.dim("ALGOLIA_APP_ID")})
   ${pc.cyan("--index-name <name>")}                Algolia index name (default ${pc.dim("docs")})
   ${pc.cyan("--search-api-key <key>")}             Algolia search key (or use ${pc.dim("ALGOLIA_SEARCH_API_KEY")})
+
+${pc.dim("Options for sitemap generate:")}
+  ${pc.cyan("sitemap generate")}                   Generate ${pc.dim(".farming-labs/sitemap-manifest.json")}
+  ${pc.cyan("--public")}                           Also write public ${pc.dim("sitemap.xml")} and ${pc.dim("sitemap.md")} files
+  ${pc.cyan("--manifest-only")}                    Only write the internal sitemap manifest
+  ${pc.cyan("--check")}                            Fail if generated sitemap output is stale
+  ${pc.cyan("--config <path>")}                    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
 
 ${pc.dim("Options for upgrade:")}
   ${pc.cyan("--framework <name>")}  Explicit framework (${pc.dim("next")}, ${pc.dim("tanstack-start")}, ${pc.dim("nuxt")}, ${pc.dim("sveltekit")}, ${pc.dim("astro")}); omit to auto-detect

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -252,8 +252,8 @@ ${pc.dim("Options for search sync:")}
   ${pc.cyan("--search-api-key <key>")}             Algolia search key (or use ${pc.dim("ALGOLIA_SEARCH_API_KEY")})
 
 ${pc.dim("Options for sitemap generate:")}
-  ${pc.cyan("sitemap generate")}                   Generate ${pc.dim(".farming-labs/sitemap-manifest.json")}
-  ${pc.cyan("--public")}                           Also write public ${pc.dim("sitemap.xml")} and ${pc.dim("sitemap.md")} files
+  ${pc.cyan("sitemap generate")}                   Generate sitemap manifest and public ${pc.dim("sitemap.xml")}/${pc.dim("sitemap.md")}
+  ${pc.cyan("--public")}                           Explicitly write public ${pc.dim("sitemap.xml")} and ${pc.dim("sitemap.md")} files
   ${pc.cyan("--manifest-only")}                    Only write the internal sitemap manifest
   ${pc.cyan("--check")}                            Fail if generated sitemap output is stale
   ${pc.cyan("--config <path>")}                    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}

--- a/packages/docs/src/cli/sitemap.test.ts
+++ b/packages/docs/src/cli/sitemap.test.ts
@@ -26,7 +26,7 @@ describe("sitemap cli", () => {
     });
   });
 
-  it("writes a manifest and public files", async () => {
+  it("writes a manifest and public files by default", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default {
@@ -52,7 +52,7 @@ description: "Configure docs"
     );
 
     process.chdir(tmpDir);
-    await generateSitemap({ public: true });
+    await generateSitemap();
 
     const manifestPath = path.join(tmpDir, ".farming-labs", "sitemap-manifest.json");
     expect(existsSync(manifestPath)).toBe(true);
@@ -101,12 +101,43 @@ description: "Configure docs"
     );
 
     process.chdir(tmpDir);
-    await generateSitemap({ public: true });
+    await generateSitemap();
 
     const manifestPath = path.join(tmpDir, ".farming-labs", "sitemap-manifest.json");
     const originalManifest = readFileSync(manifestPath, "utf-8");
 
-    await expect(generateSitemap({ public: true, check: true })).resolves.toBeUndefined();
+    await expect(generateSitemap({ check: true })).resolves.toBeUndefined();
     expect(readFileSync(manifestPath, "utf-8")).toBe(originalManifest);
+  });
+
+  it("can write only the internal manifest", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "docs",
+  sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+};
+`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs", "page.md"),
+      `---
+title: "Home"
+---
+
+# Home
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    await generateSitemap({ manifestOnly: true });
+
+    expect(existsSync(path.join(tmpDir, ".farming-labs", "sitemap-manifest.json"))).toBe(true);
+    expect(existsSync(path.join(tmpDir, "public", "sitemap.xml"))).toBe(false);
+    expect(existsSync(path.join(tmpDir, "public", "sitemap.md"))).toBe(false);
   });
 });

--- a/packages/docs/src/cli/sitemap.test.ts
+++ b/packages/docs/src/cli/sitemap.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { generateSitemap, parseSitemapGenerateArgs } from "./sitemap.js";
+
+describe("sitemap cli", () => {
+  const originalCwd = process.cwd();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "docs-sitemap-"));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("parses generate flags", () => {
+    expect(parseSitemapGenerateArgs(["--config", "src/lib/docs.config.ts", "--public"])).toEqual({
+      configPath: "src/lib/docs.config.ts",
+      public: true,
+    });
+  });
+
+  it("writes a manifest and public files", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "docs",
+  sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+  nav: { title: "Example Docs" },
+};
+`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "docs", "configuration"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs", "configuration", "page.mdx"),
+      `---
+title: "Configuration"
+description: "Configure docs"
+---
+
+# Configuration
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    await generateSitemap({ public: true });
+
+    const manifestPath = path.join(tmpDir, ".farming-labs", "sitemap-manifest.json");
+    expect(existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    expect(manifest.pages[0]).toMatchObject({
+      url: "/docs/configuration",
+      markdownUrl: "/docs/configuration.md",
+      title: "Configuration",
+      lastmodSource: "filesystem",
+    });
+
+    expect(readFileSync(path.join(tmpDir, "public", "sitemap.xml"), "utf-8")).toContain(
+      "<lastmod>",
+    );
+    expect(readFileSync(path.join(tmpDir, "public", "sitemap.md"), "utf-8")).toContain(
+      "Markdown: /docs/configuration.md",
+    );
+    expect(
+      readFileSync(path.join(tmpDir, "public", ".well-known", "sitemap.md"), "utf-8"),
+    ).toContain("# Example Docs Sitemap");
+  });
+
+  it("preserves generatedAt when check output is unchanged", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "docs",
+  sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+  nav: { title: "Example Docs" },
+};
+`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "docs", "configuration"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs", "configuration", "page.mdx"),
+      `---
+title: "Configuration"
+description: "Configure docs"
+---
+
+# Configuration
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    await generateSitemap({ public: true });
+
+    const manifestPath = path.join(tmpDir, ".farming-labs", "sitemap-manifest.json");
+    const originalManifest = readFileSync(manifestPath, "utf-8");
+
+    await expect(generateSitemap({ public: true, check: true })).resolves.toBeUndefined();
+    expect(readFileSync(manifestPath, "utf-8")).toBe(originalManifest);
+  });
+});

--- a/packages/docs/src/cli/sitemap.ts
+++ b/packages/docs/src/cli/sitemap.ts
@@ -264,8 +264,7 @@ export async function generateSitemap(options: SitemapGenerateOptions = {}): Pro
   const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
   const manifestChanged = writeIfChanged(manifestPath, manifestJson, options.check === true);
 
-  const shouldWritePublic =
-    options.public === true || (config?.staticExport === true && options.manifestOnly !== true);
+  const shouldWritePublic = options.manifestOnly !== true;
   const publicWrites: string[] = [];
 
   if (shouldWritePublic) {
@@ -313,7 +312,7 @@ ${pc.dim("Usage:")}
 
 ${pc.dim("Options:")}
   ${pc.cyan("--config <path>")}     Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
-  ${pc.cyan("--public")}            Also write public sitemap.xml and sitemap.md files
+  ${pc.cyan("--public")}            Explicitly write public sitemap.xml and sitemap.md files
   ${pc.cyan("--manifest-only")}     Only write the internal sitemap manifest
   ${pc.cyan("--check")}             Fail if generated output is stale
   ${pc.cyan("-h, --help")}          Show this help message

--- a/packages/docs/src/cli/sitemap.ts
+++ b/packages/docs/src/cli/sitemap.ts
@@ -1,0 +1,320 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+import {
+  buildDocsSitemapManifest,
+  renderDocsSitemapMarkdown,
+  renderDocsSitemapXml,
+  resolveDocsSitemapConfig,
+  type DocsSitemapManifest,
+} from "../sitemap.js";
+import { createFilesystemDocsMcpSource } from "../server.js";
+import type { DocsConfig, DocsSitemapConfig } from "../types.js";
+import {
+  extractNestedObjectLiteral,
+  loadDocsConfigModule,
+  readBooleanProperty,
+  readNavTitle,
+  readStringProperty,
+  readTopLevelStringProperty,
+  resolveDocsConfigPath,
+  resolveDocsContentDir,
+} from "./config.js";
+import { detectFramework } from "./utils.js";
+
+export interface SitemapGenerateOptions {
+  configPath?: string;
+  public?: boolean;
+  manifestOnly?: boolean;
+  check?: boolean;
+}
+
+export interface ParsedSitemapGenerateArgs extends SitemapGenerateOptions {
+  help?: boolean;
+}
+
+function normalizePathSegment(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
+}
+
+function parseInlineFlag(arg: string): { key: string; value?: string } {
+  const [rawKey, value] = arg.slice(2).split("=", 2);
+  return { key: rawKey.trim(), value };
+}
+
+export function parseSitemapGenerateArgs(argv: string[]): ParsedSitemapGenerateArgs {
+  const parsed: ParsedSitemapGenerateArgs = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+
+    if (arg === "--public") {
+      parsed.public = true;
+      continue;
+    }
+
+    if (arg === "--manifest-only") {
+      parsed.manifestOnly = true;
+      continue;
+    }
+
+    if (arg === "--check") {
+      parsed.check = true;
+      continue;
+    }
+
+    if (arg.startsWith("--config=")) {
+      const value = parseInlineFlag(arg).value;
+      if (!value) throw new Error("Missing value for --config.");
+      parsed.configPath = value;
+      continue;
+    }
+
+    if (arg === "--config") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Missing value for --config.");
+      parsed.configPath = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown sitemap generate flag: ${arg}.`);
+  }
+
+  return parsed;
+}
+
+function readLlmsBaseUrlFromConfig(content: string, config?: DocsConfig): string | undefined {
+  if (config?.llmsTxt && typeof config.llmsTxt === "object") return config.llmsTxt.baseUrl;
+  const block = extractNestedObjectLiteral(content, ["llmsTxt"]);
+  return block ? readStringProperty(block, "baseUrl") : undefined;
+}
+
+function readSitemapConfigFromStatic(content: string): boolean | DocsSitemapConfig | undefined {
+  if (/\bsitemap\s*:\s*false/.test(content)) return false;
+  if (/\bsitemap\s*:\s*true/.test(content)) return true;
+
+  const block = extractNestedObjectLiteral(content, ["sitemap"]);
+  if (!block) return undefined;
+
+  return {
+    enabled: readBooleanProperty(block, "enabled") ?? true,
+    routePrefix: readStringProperty(block, "routePrefix"),
+    baseUrl: readStringProperty(block, "baseUrl"),
+    manifestPath: readStringProperty(block, "manifestPath"),
+  };
+}
+
+function resolveConfiguredSitemap(
+  content: string,
+  config?: DocsConfig,
+): boolean | DocsSitemapConfig {
+  if (config?.sitemap !== undefined) return config.sitemap;
+  return readSitemapConfigFromStatic(content) ?? true;
+}
+
+function formatDateOnly(value: string): string | undefined {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function gitLastCommitDate(rootDir: string, sourcePath?: string): string | undefined {
+  if (!sourcePath) return undefined;
+
+  try {
+    const output = execFileSync("git", ["log", "-1", "--format=%cI", "--", sourcePath], {
+      cwd: rootDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return formatDateOnly(output);
+  } catch {
+    return undefined;
+  }
+}
+
+function fileModifiedDate(rootDir: string, sourcePath?: string): string | undefined {
+  if (!sourcePath) return undefined;
+  const fullPath = path.isAbsolute(sourcePath) ? sourcePath : path.join(rootDir, sourcePath);
+  if (!existsSync(fullPath)) return undefined;
+
+  try {
+    return statSync(fullPath).mtime.toISOString().slice(0, 10);
+  } catch {
+    return undefined;
+  }
+}
+
+function writeIfChanged(filePath: string, content: string, check: boolean): boolean {
+  const current = existsSync(filePath) ? readFileSync(filePath, "utf-8") : undefined;
+  if (current === content) return false;
+  if (check) return true;
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+  return true;
+}
+
+function readExistingManifest(filePath: string): DocsSitemapManifest | undefined {
+  if (!existsSync(filePath)) return undefined;
+
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8")) as DocsSitemapManifest;
+  } catch {
+    return undefined;
+  }
+}
+
+function comparableManifest(manifest: DocsSitemapManifest): DocsSitemapManifest {
+  return { ...manifest, generatedAt: "" };
+}
+
+function preserveGeneratedAtWhenUnchanged(
+  manifest: DocsSitemapManifest,
+  existing: DocsSitemapManifest | undefined,
+): DocsSitemapManifest {
+  if (!existing?.generatedAt) return manifest;
+
+  const nextComparable = JSON.stringify(comparableManifest(manifest));
+  const existingComparable = JSON.stringify(comparableManifest(existing));
+  if (nextComparable !== existingComparable) return manifest;
+
+  return { ...manifest, generatedAt: existing.generatedAt };
+}
+
+function resolvePublicDir(rootDir: string): string {
+  const framework = detectFramework(rootDir);
+  if (framework === "sveltekit") return path.join(rootDir, "static");
+  return path.join(rootDir, "public");
+}
+
+function publicFilePath(rootDir: string, route: string): string {
+  return path.join(resolvePublicDir(rootDir), route.replace(/^\/+/, ""));
+}
+
+export async function generateSitemap(options: SitemapGenerateOptions = {}): Promise<void> {
+  const rootDir = process.cwd();
+  const loadedConfigModule = await loadDocsConfigModule(rootDir, options.configPath);
+  const configPath = loadedConfigModule?.path ?? resolveDocsConfigPath(rootDir, options.configPath);
+  const configContent = readFileSync(configPath, "utf-8");
+  const config = loadedConfigModule?.config;
+
+  const entry =
+    normalizePathSegment(config?.entry ?? readTopLevelStringProperty(configContent, "entry") ?? "docs") ||
+    "docs";
+  const contentDir =
+    typeof config?.contentDir === "string"
+      ? config.contentDir
+      : resolveDocsContentDir(rootDir, configContent, entry);
+  const siteTitle =
+    typeof config?.nav?.title === "string"
+      ? config.nav.title
+      : (readNavTitle(configContent) ?? "Documentation");
+  const sitemapInput = resolveConfiguredSitemap(configContent, config);
+  if (sitemapInput === false) {
+    throw new Error("Sitemap generation is disabled by `sitemap: false`.");
+  }
+
+  const baseUrl =
+    (typeof sitemapInput === "object" ? sitemapInput.baseUrl : undefined) ??
+    readLlmsBaseUrlFromConfig(configContent, config);
+  const sitemap = resolveDocsSitemapConfig(sitemapInput, { baseUrl });
+
+  const source = createFilesystemDocsMcpSource({
+    rootDir,
+    entry,
+    contentDir,
+    siteTitle,
+    ordering: config?.ordering,
+  });
+  const pages = await Promise.resolve(source.getPages());
+  if (pages.length === 0) {
+    throw new Error(`No docs content was found under ${contentDir}.`);
+  }
+
+  const builtManifest = buildDocsSitemapManifest({
+    pages,
+    entry,
+    siteTitle,
+    baseUrl: sitemap.baseUrl,
+    resolveLastmod(page) {
+      const gitDate = gitLastCommitDate(rootDir, page.sourcePath);
+      if (gitDate) return { lastmod: gitDate, lastmodSource: "git" };
+
+      const fsDate = fileModifiedDate(rootDir, page.sourcePath);
+      if (fsDate) return { lastmod: fsDate, lastmodSource: "filesystem" };
+
+      return undefined;
+    },
+  });
+
+  const manifestPath = path.resolve(rootDir, sitemap.manifestPath);
+  const manifest = preserveGeneratedAtWhenUnchanged(
+    builtManifest,
+    readExistingManifest(manifestPath),
+  );
+  const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
+  const manifestChanged = writeIfChanged(manifestPath, manifestJson, options.check === true);
+
+  const shouldWritePublic =
+    options.public === true || (config?.staticExport === true && options.manifestOnly !== true);
+  const publicWrites: string[] = [];
+
+  if (shouldWritePublic) {
+    const xml = renderDocsSitemapXml(manifest, {
+      baseUrl: sitemap.baseUrl,
+      includeLastmod: sitemap.xml.includeLastmod,
+    });
+    const markdown = renderDocsSitemapMarkdown(manifest, {
+      baseUrl: sitemap.baseUrl,
+      includeDescriptions: sitemap.markdown.includeDescriptions,
+      includeLastmod: sitemap.markdown.includeLastmod,
+      linkTarget: sitemap.markdown.linkTarget,
+    });
+
+    if (sitemap.xml.enabled) {
+      const filePath = publicFilePath(rootDir, sitemap.xml.route);
+      if (writeIfChanged(filePath, xml, options.check === true)) publicWrites.push(filePath);
+    }
+
+    if (sitemap.markdown.enabled) {
+      for (const route of [sitemap.markdown.route, sitemap.markdown.wellKnownRoute]) {
+        const filePath = publicFilePath(rootDir, route);
+        if (writeIfChanged(filePath, markdown, options.check === true)) publicWrites.push(filePath);
+      }
+    }
+  }
+
+  if (options.check && (manifestChanged || publicWrites.length > 0)) {
+    throw new Error("Sitemap output is stale. Run `docs sitemap generate` to update it.");
+  }
+
+  console.log(pc.green(`Generated sitemap manifest for ${manifest.pages.length} page(s).`));
+  console.log(pc.dim(path.relative(rootDir, manifestPath)));
+  for (const filePath of publicWrites) {
+    console.log(pc.dim(path.relative(rootDir, filePath)));
+  }
+}
+
+export function printSitemapGenerateHelp() {
+  console.log(`
+${pc.bold("docs sitemap generate")} — Generate sitemap metadata and static sitemap files.
+
+${pc.dim("Usage:")}
+  pnpm exec docs ${pc.cyan("sitemap generate")}
+
+${pc.dim("Options:")}
+  ${pc.cyan("--config <path>")}     Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
+  ${pc.cyan("--public")}            Also write public sitemap.xml and sitemap.md files
+  ${pc.cyan("--manifest-only")}     Only write the internal sitemap manifest
+  ${pc.cyan("--check")}             Fail if generated output is stale
+  ${pc.cyan("-h, --help")}          Show this help message
+`);
+}

--- a/packages/docs/src/cli/sitemap.ts
+++ b/packages/docs/src/cli/sitemap.ts
@@ -207,8 +207,9 @@ export async function generateSitemap(options: SitemapGenerateOptions = {}): Pro
   const config = loadedConfigModule?.config;
 
   const entry =
-    normalizePathSegment(config?.entry ?? readTopLevelStringProperty(configContent, "entry") ?? "docs") ||
-    "docs";
+    normalizePathSegment(
+      config?.entry ?? readTopLevelStringProperty(configContent, "entry") ?? "docs",
+    ) || "docs";
   const contentDir =
     typeof config?.contentDir === "string"
       ? config.contentDir

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1127,7 +1127,7 @@ export const Route = createFileRoute("${entryUrl}/$")({
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url);
-        if (isDocsPublicGetRequest(${JSON.stringify(opts.entry)}, url, request)) {
+        if (isDocsPublicGetRequest(${JSON.stringify(opts.entry)}, url, request, { sitemap: docsConfig.sitemap })) {
           return docsServer.GET({ request });
         }
         return undefined;
@@ -1217,7 +1217,7 @@ async function handlePublicDocsRequest(request: Request) {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request)) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request, { sitemap: docsConfig.sitemap })) {
     return docsServer.GET({ request });
   }
 
@@ -1597,7 +1597,7 @@ import { createDocsServer } from "@farming-labs/svelte/server";
 import config from "${configImport}";
 
 // preload for production
-const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx,svx}", "/skill.md"], {
+const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx,svx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"], {
   query: "?raw",
   import: "default",
   eager: true,
@@ -1693,7 +1693,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request)) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap })) {
     return GET({ url: event.url, request: event.request });
   }
 
@@ -1758,7 +1758,7 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request)) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap })) {
     return docsGET({ url: event.url, request: event.request });
   }
 
@@ -2090,7 +2090,7 @@ export function astroDocsServerTemplate(cfg: TemplateConfig): string {
 import { createDocsServer } from "@farming-labs/astro/server";
 import config from "${configImport}";
 
-const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx}", "/skill.md"], {
+const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx}", "/skill.md", "/.farming-labs/sitemap-manifest.json"], {
   query: "?raw",
   import: "default",
   eager: true,
@@ -2236,7 +2236,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request)) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap })) {
     return GET({ request: context.request });
   }
 
@@ -2303,7 +2303,7 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request)) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap })) {
     return docsGET({ request: context.request });
   }
 

--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -26,6 +26,7 @@ export function defineDocs(config: DocsConfig): DocsConfig {
     lastUpdated: config.lastUpdated,
     readingTime: config.readingTime,
     llmsTxt: config.llmsTxt,
+    sitemap: config.sitemap,
     ai: config.ai,
     ordering: config.ordering,
     metadata: config.metadata,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -86,7 +86,6 @@ export {
   DEFAULT_SITEMAP_XML_ROUTE,
   buildDocsSitemapManifest,
   createDocsSitemapResponse,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   renderDocsSitemapMarkdown,
   renderDocsSitemapXml,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -80,6 +80,28 @@ export {
   resolveDocsMarkdownRequest,
 } from "./agent.js";
 export {
+  DEFAULT_SITEMAP_MANIFEST_PATH,
+  DEFAULT_SITEMAP_MD_ROUTE,
+  DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
+  DEFAULT_SITEMAP_XML_ROUTE,
+  buildDocsSitemapManifest,
+  createDocsSitemapResponse,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
+  renderDocsSitemapMarkdown,
+  renderDocsSitemapXml,
+  resolveDocsSitemapConfig,
+  resolveDocsSitemapRequest,
+  toDocsSitemapMarkdownUrl,
+} from "./sitemap.js";
+export type {
+  DocsSitemapFormat,
+  DocsSitemapManifest,
+  DocsSitemapManifestPage,
+  DocsSitemapPageInput,
+  DocsSitemapResolvedConfig,
+} from "./sitemap.js";
+export {
   buildDocsSearchDocuments,
   buildDocsAskAIContext,
   createAlgoliaSearchAdapter,
@@ -96,6 +118,7 @@ export {
 export type { GeneratedAgentProvenance, GeneratedAgentSourceKind } from "./agent-provenance.js";
 export type {
   DocsConfig,
+  DocsSitemapConfig,
   ChangelogConfig,
   ChangelogFrontmatter,
   ApiReferenceConfig,

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -34,6 +34,8 @@ export interface DocsMcpPage {
   description?: string;
   related?: DocsSearchSourcePage["related"];
   icon?: string;
+  sourcePath?: string;
+  lastModified?: string;
   content: string;
   rawContent?: string;
   agentContent?: string;
@@ -196,7 +198,7 @@ export function createFilesystemDocsMcpSource(
     const cached = cache.get("__default__");
     if (cached) return cached;
 
-    const pages = scanFilesystemDocsPages(contentDirAbs, entry);
+    const pages = scanFilesystemDocsPages(contentDirAbs, entry, rootDir);
     cache.set("__default__", pages);
     return pages;
   }
@@ -1037,7 +1039,11 @@ function hasVisibleDescendantFilesystemDocsPage(dir: string): boolean {
   return false;
 }
 
-function scanFilesystemDocsPages(contentDirAbs: string, entry: string): ScannedDocsMcpPage[] {
+function scanFilesystemDocsPages(
+  contentDirAbs: string,
+  entry: string,
+  rootDir: string,
+): ScannedDocsMcpPage[] {
   const pages: Array<ScannedDocsMcpPage & { relatedInput?: unknown }> = [];
 
   function scan(dir: string, slugParts: string[]) {
@@ -1091,6 +1097,8 @@ function scanFilesystemDocsPages(contentDirAbs: string, entry: string): ScannedD
         description: data.description as string | undefined,
         relatedInput: data.related,
         icon: data.icon as string | undefined,
+        sourcePath: path.relative(rootDir, full).replace(/\\/g, "/"),
+        lastModified: stat.mtime.toISOString(),
         content: stripMarkdownForMcp(humanRawContent),
         rawContent: humanRawContent,
         agentFallbackContent: pageAgentContent,
@@ -1270,6 +1278,8 @@ function toSearchSourcePages(pages: DocsMcpPage[]): DocsSearchSourcePage[] {
     url: page.url,
     content: page.agentContent ?? page.agentFallbackContent ?? page.content,
     rawContent: page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent,
+    sourcePath: page.sourcePath,
+    lastModified: page.lastModified,
     agentContent: page.agentContent,
     agentRawContent: page.agentRawContent,
     agentFallbackContent: page.agentFallbackContent,

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -57,6 +57,28 @@ export {
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,
 } from "./prompt-utils.js";
+export {
+  DEFAULT_SITEMAP_MANIFEST_PATH,
+  DEFAULT_SITEMAP_MD_ROUTE,
+  DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
+  DEFAULT_SITEMAP_XML_ROUTE,
+  buildDocsSitemapManifest,
+  createDocsSitemapResponse,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
+  renderDocsSitemapMarkdown,
+  renderDocsSitemapXml,
+  resolveDocsSitemapConfig,
+  resolveDocsSitemapRequest,
+  toDocsSitemapMarkdownUrl,
+} from "./sitemap.js";
+export type {
+  DocsSitemapFormat,
+  DocsSitemapManifest,
+  DocsSitemapManifestPage,
+  DocsSitemapPageInput,
+  DocsSitemapResolvedConfig,
+} from "./sitemap.js";
 export type {
   DocsMcpHttpHandlers,
   DocsMcpNavigationNode,

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -64,7 +64,6 @@ export {
   DEFAULT_SITEMAP_XML_ROUTE,
   buildDocsSitemapManifest,
   createDocsSitemapResponse,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   renderDocsSitemapMarkdown,
   renderDocsSitemapXml,
@@ -72,6 +71,7 @@ export {
   resolveDocsSitemapRequest,
   toDocsSitemapMarkdownUrl,
 } from "./sitemap.js";
+export { readDocsSitemapManifest } from "./sitemap-server.js";
 export type {
   DocsSitemapFormat,
   DocsSitemapManifest,

--- a/packages/docs/src/sitemap-server.ts
+++ b/packages/docs/src/sitemap-server.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { resolveDocsSitemapConfig, type DocsSitemapManifest } from "./sitemap.js";
+import type { DocsSitemapConfig } from "./types.js";
+
+export function readDocsSitemapManifest(
+  rootDir: string,
+  sitemap?: boolean | DocsSitemapConfig,
+): DocsSitemapManifest | null {
+  const resolved = resolveDocsSitemapConfig(sitemap);
+  const manifestPath = path.resolve(rootDir, resolved.manifestPath);
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(manifestPath, "utf-8")) as DocsSitemapManifest;
+  } catch {
+    return null;
+  }
+}

--- a/packages/docs/src/sitemap.test.ts
+++ b/packages/docs/src/sitemap.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocsSitemapManifest,
+  createDocsSitemapResponse,
+  renderDocsSitemapMarkdown,
+  renderDocsSitemapXml,
+  resolveDocsSitemapConfig,
+  resolveDocsSitemapRequest,
+} from "./sitemap.js";
+
+describe("docs sitemap helpers", () => {
+  it("resolves default and prefixed sitemap routes", () => {
+    expect(resolveDocsSitemapConfig(true).xml.route).toBe("/sitemap.xml");
+    expect(resolveDocsSitemapConfig(true).markdown.wellKnownRoute).toBe("/.well-known/sitemap.md");
+
+    const prefixed = resolveDocsSitemapConfig({ routePrefix: "/docs" });
+    expect(prefixed.xml.route).toBe("/docs/sitemap.xml");
+    expect(prefixed.markdown.route).toBe("/docs/sitemap.md");
+    expect(prefixed.markdown.wellKnownRoute).toBe("/docs/.well-known/sitemap.md");
+  });
+
+  it("detects public and API sitemap requests", () => {
+    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"), true)).toBe(
+      "xml",
+    );
+    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.md"), true)).toBe(
+      "markdown",
+    );
+    expect(
+      resolveDocsSitemapRequest(new URL("https://example.com/api/docs?format=sitemap-md"), false),
+    ).toBe("markdown");
+    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"), false)).toBeNull();
+  });
+
+  it("renders XML and Markdown from a manifest", () => {
+    const manifest = buildDocsSitemapManifest({
+      entry: "docs",
+      siteTitle: "Example Docs",
+      baseUrl: "https://docs.example.com",
+      generatedAt: "2026-05-08T12:00:00.000Z",
+      pages: [
+        {
+          url: "/docs/configuration",
+          title: "Configuration",
+          description: "Configure docs.config.ts",
+          lastModified: "2026-05-07T10:00:00.000Z",
+          related: [{ href: "/docs/customization/mcp" }],
+        },
+      ],
+    });
+
+    expect(renderDocsSitemapXml(manifest)).toContain(
+      "<loc>https://docs.example.com/docs/configuration</loc>",
+    );
+    expect(renderDocsSitemapXml(manifest)).toContain("<lastmod>2026-05-07</lastmod>");
+
+    const markdown = renderDocsSitemapMarkdown(manifest);
+    expect(markdown).toContain("# Example Docs Sitemap");
+    expect(markdown).toContain("- [Configuration](/docs/configuration)");
+    expect(markdown).toContain("Markdown: /docs/configuration.md");
+    expect(markdown).toContain("Related: /docs/customization/mcp");
+  });
+
+  it("creates cacheable responses with ETags", async () => {
+    const response = createDocsSitemapResponse({
+      request: new Request("https://docs.example.com/sitemap.xml"),
+      sitemap: true,
+      entry: "docs",
+      pages: [{ url: "/docs", title: "Home", lastmod: "2026-05-08" }],
+    });
+
+    expect(response?.headers.get("content-type")).toContain("application/xml");
+    expect(response?.headers.get("etag")).toBeTruthy();
+    expect(await response?.text()).toContain("<urlset");
+  });
+});

--- a/packages/docs/src/sitemap.test.ts
+++ b/packages/docs/src/sitemap.test.ts
@@ -20,9 +20,7 @@ describe("docs sitemap helpers", () => {
   });
 
   it("detects public and API sitemap requests", () => {
-    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"), true)).toBe(
-      "xml",
-    );
+    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"), true)).toBe("xml");
     expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.md"), true)).toBe(
       "markdown",
     );

--- a/packages/docs/src/sitemap.ts
+++ b/packages/docs/src/sitemap.ts
@@ -141,8 +141,7 @@ export function resolveDocsSitemapConfig(
     manifestPath: objectConfig.manifestPath ?? DEFAULT_SITEMAP_MANIFEST_PATH,
     xml: {
       enabled: xmlEnabled,
-      includeLastmod:
-        typeof xmlConfig === "object" ? (xmlConfig.includeLastmod ?? true) : true,
+      includeLastmod: typeof xmlConfig === "object" ? (xmlConfig.includeLastmod ?? true) : true,
       route: joinRoute(routePrefix, DEFAULT_SITEMAP_XML_ROUTE),
     },
     markdown: {
@@ -151,7 +150,8 @@ export function resolveDocsSitemapConfig(
         typeof markdownConfig === "object" ? (markdownConfig.includeDescriptions ?? true) : true,
       includeLastmod:
         typeof markdownConfig === "object" ? (markdownConfig.includeLastmod ?? true) : true,
-      linkTarget: typeof markdownConfig === "object" ? (markdownConfig.linkTarget ?? "both") : "both",
+      linkTarget:
+        typeof markdownConfig === "object" ? (markdownConfig.linkTarget ?? "both") : "both",
       route: joinRoute(routePrefix, DEFAULT_SITEMAP_MD_ROUTE),
       wellKnownRoute: joinRoute(routePrefix, DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE),
     },
@@ -248,9 +248,7 @@ export function buildDocsSitemapManifest(options: {
   generatedAt?: string;
   resolveLastmod?: (
     page: DocsSitemapPageInput,
-  ) =>
-    | { lastmod?: string; lastmodSource?: DocsSitemapManifestPage["lastmodSource"] }
-    | undefined;
+  ) => { lastmod?: string; lastmodSource?: DocsSitemapManifestPage["lastmodSource"] } | undefined;
 }): DocsSitemapManifest {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const seen = new Set<string>();
@@ -441,7 +439,8 @@ export function createDocsSitemapResponse({
     ETag: hashString(body),
   });
   const lastModified = newestLastmod(nextManifest.pages);
-  if (lastModified) headers.set("Last-Modified", new Date(`${lastModified}T00:00:00.000Z`).toUTCString());
+  if (lastModified)
+    headers.set("Last-Modified", new Date(`${lastModified}T00:00:00.000Z`).toUTCString());
 
   if (request.headers.get("if-none-match") === headers.get("ETag")) {
     return new Response(null, { status: 304, headers });

--- a/packages/docs/src/sitemap.ts
+++ b/packages/docs/src/sitemap.ts
@@ -1,5 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import type { DocsSitemapConfig, ResolvedDocsRelatedLink } from "./types.js";
 
 export const DEFAULT_SITEMAP_XML_ROUTE = "/sitemap.xml";
@@ -359,21 +357,6 @@ export function renderDocsSitemapMarkdown(
   }
 
   return lines.join("\n").replace(/\n{3,}/g, "\n\n");
-}
-
-export function readDocsSitemapManifest(
-  rootDir: string,
-  sitemap?: boolean | DocsSitemapConfig,
-): DocsSitemapManifest | null {
-  const resolved = resolveDocsSitemapConfig(sitemap);
-  const manifestPath = path.resolve(rootDir, resolved.manifestPath);
-  if (!existsSync(manifestPath)) return null;
-
-  try {
-    return JSON.parse(readFileSync(manifestPath, "utf-8")) as DocsSitemapManifest;
-  } catch {
-    return null;
-  }
 }
 
 export function readDocsSitemapManifestFromContentMap(

--- a/packages/docs/src/sitemap.ts
+++ b/packages/docs/src/sitemap.ts
@@ -1,0 +1,451 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { DocsSitemapConfig, ResolvedDocsRelatedLink } from "./types.js";
+
+export const DEFAULT_SITEMAP_XML_ROUTE = "/sitemap.xml";
+export const DEFAULT_SITEMAP_MD_ROUTE = "/sitemap.md";
+export const DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE = "/.well-known/sitemap.md";
+export const DEFAULT_SITEMAP_MANIFEST_PATH = ".farming-labs/sitemap-manifest.json";
+
+export type DocsSitemapFormat = "xml" | "markdown";
+
+export interface DocsSitemapPageInput {
+  slug?: string;
+  url: string;
+  title: string;
+  description?: string;
+  related?: ResolvedDocsRelatedLink[];
+  sourcePath?: string;
+  lastmod?: string;
+  lastModified?: string;
+}
+
+export interface DocsSitemapManifestPage {
+  url: string;
+  absoluteUrl?: string;
+  markdownUrl: string;
+  title: string;
+  description?: string;
+  sourcePath?: string;
+  lastmod?: string;
+  lastmodSource?: "git" | "filesystem" | "frontmatter" | "manifest" | "unknown";
+  related?: string[];
+}
+
+export interface DocsSitemapManifest {
+  version: 1;
+  generatedAt: string;
+  baseUrl?: string;
+  entry: string;
+  siteTitle?: string;
+  pages: DocsSitemapManifestPage[];
+}
+
+export interface DocsSitemapResolvedConfig {
+  enabled: boolean;
+  routePrefix: string;
+  baseUrl?: string;
+  manifestPath: string;
+  xml: {
+    enabled: boolean;
+    includeLastmod: boolean;
+    route: string;
+  };
+  markdown: {
+    enabled: boolean;
+    includeDescriptions: boolean;
+    includeLastmod: boolean;
+    linkTarget: "html" | "markdown" | "both";
+    route: string;
+    wellKnownRoute: string;
+  };
+}
+
+export interface CreateDocsSitemapResponseOptions {
+  request: Request;
+  sitemap?: boolean | DocsSitemapConfig;
+  entry?: string;
+  siteTitle?: string;
+  baseUrl?: string;
+  pages: DocsSitemapPageInput[];
+  manifest?: DocsSitemapManifest | null;
+}
+
+function normalizeUrlPath(value: string): string {
+  const normalized = value.replace(/\/+/g, "/");
+  if (normalized === "/") return normalized;
+  return normalized.replace(/\/+$/, "");
+}
+
+function normalizeRoutePrefix(value?: string): string {
+  if (!value) return "";
+  const normalized = normalizeUrlPath(`/${value.replace(/^\/+|\/+$/g, "")}`);
+  return normalized === "/" ? "" : normalized;
+}
+
+function joinRoute(prefix: string, route: string): string {
+  return normalizeUrlPath(`${prefix}/${route.replace(/^\/+/, "")}`);
+}
+
+function normalizeDateOnly(value?: string): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const dateOnly = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (dateOnly) return dateOnly[1];
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function normalizeBaseUrl(value?: string): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim().replace(/\/+$/, "");
+  return trimmed || undefined;
+}
+
+function isEnabledObject(config: boolean | DocsSitemapConfig | undefined): boolean {
+  if (config === false || config === undefined) return false;
+  if (config === true) return true;
+  return config.enabled !== false;
+}
+
+export function resolveDocsSitemapConfig(
+  sitemap?: boolean | DocsSitemapConfig,
+  defaults: { baseUrl?: string } = {},
+): DocsSitemapResolvedConfig {
+  const objectConfig: DocsSitemapConfig = sitemap && typeof sitemap === "object" ? sitemap : {};
+  const routePrefix = normalizeRoutePrefix(objectConfig.routePrefix);
+  const xmlConfig = objectConfig.xml;
+  const markdownConfig = objectConfig.markdown;
+
+  const xmlEnabled =
+    xmlConfig === false
+      ? false
+      : typeof xmlConfig === "object"
+        ? (xmlConfig.enabled ?? true)
+        : true;
+  const markdownEnabled =
+    markdownConfig === false
+      ? false
+      : typeof markdownConfig === "object"
+        ? (markdownConfig.enabled ?? true)
+        : true;
+
+  return {
+    enabled: isEnabledObject(sitemap),
+    routePrefix,
+    baseUrl: normalizeBaseUrl(objectConfig.baseUrl ?? defaults.baseUrl),
+    manifestPath: objectConfig.manifestPath ?? DEFAULT_SITEMAP_MANIFEST_PATH,
+    xml: {
+      enabled: xmlEnabled,
+      includeLastmod:
+        typeof xmlConfig === "object" ? (xmlConfig.includeLastmod ?? true) : true,
+      route: joinRoute(routePrefix, DEFAULT_SITEMAP_XML_ROUTE),
+    },
+    markdown: {
+      enabled: markdownEnabled,
+      includeDescriptions:
+        typeof markdownConfig === "object" ? (markdownConfig.includeDescriptions ?? true) : true,
+      includeLastmod:
+        typeof markdownConfig === "object" ? (markdownConfig.includeLastmod ?? true) : true,
+      linkTarget: typeof markdownConfig === "object" ? (markdownConfig.linkTarget ?? "both") : "both",
+      route: joinRoute(routePrefix, DEFAULT_SITEMAP_MD_ROUTE),
+      wellKnownRoute: joinRoute(routePrefix, DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE),
+    },
+  };
+}
+
+export function resolveDocsSitemapRequest(
+  url: URL,
+  sitemap?: boolean | DocsSitemapConfig,
+): DocsSitemapFormat | null {
+  const pathname = normalizeUrlPath(url.pathname);
+  const format = url.searchParams.get("format")?.trim();
+
+  if (pathname === "/api/docs") {
+    if (format === "sitemap-xml") return "xml";
+    if (format === "sitemap-md" || format === "sitemap-markdown") return "markdown";
+  }
+
+  const resolved = resolveDocsSitemapConfig(sitemap);
+  if (!resolved.enabled) return null;
+
+  if (resolved.xml.enabled && pathname === resolved.xml.route) return "xml";
+  if (
+    resolved.markdown.enabled &&
+    (pathname === resolved.markdown.route || pathname === resolved.markdown.wellKnownRoute)
+  ) {
+    return "markdown";
+  }
+
+  return null;
+}
+
+export function toDocsSitemapMarkdownUrl(url: string): string {
+  const normalized = normalizeUrlPath(url);
+  return normalized.endsWith(".md") ? normalized : `${normalized}.md`;
+}
+
+function absolutizeUrl(baseUrl: string | undefined, url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  const base = normalizeBaseUrl(baseUrl);
+  return base ? `${base}${url.startsWith("/") ? url : `/${url}`}` : url;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function hashString(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const bytes = new TextEncoder().encode(value);
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return `"fnv1a64-${hash.toString(16).padStart(16, "0")}"`;
+}
+
+function newestLastmod(pages: DocsSitemapManifestPage[]): string | undefined {
+  let newest: string | undefined;
+  for (const page of pages) {
+    const date = normalizeDateOnly(page.lastmod);
+    if (!date) continue;
+    if (!newest || date > newest) newest = date;
+  }
+  return newest;
+}
+
+function titleize(value: string): string {
+  return value.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function sitemapSectionName(entry: string, pageUrl: string): string {
+  const normalizedEntry = `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+  const normalizedUrl = normalizeUrlPath(pageUrl);
+  if (normalizedUrl === normalizedEntry) return "Overview";
+
+  const slug = normalizedUrl.startsWith(`${normalizedEntry}/`)
+    ? normalizedUrl.slice(normalizedEntry.length + 1)
+    : normalizedUrl.replace(/^\/+/, "");
+  const firstSegment = slug.split("/").filter(Boolean)[0];
+  return firstSegment ? titleize(firstSegment) : "Pages";
+}
+
+export function buildDocsSitemapManifest(options: {
+  pages: DocsSitemapPageInput[];
+  entry?: string;
+  siteTitle?: string;
+  baseUrl?: string;
+  generatedAt?: string;
+  resolveLastmod?: (
+    page: DocsSitemapPageInput,
+  ) =>
+    | { lastmod?: string; lastmodSource?: DocsSitemapManifestPage["lastmodSource"] }
+    | undefined;
+}): DocsSitemapManifest {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const seen = new Set<string>();
+  const pages: DocsSitemapManifestPage[] = [];
+
+  for (const page of options.pages) {
+    const url = normalizeUrlPath(page.url);
+    if (seen.has(url)) continue;
+    seen.add(url);
+
+    const resolvedLastmod = options.resolveLastmod?.(page);
+    const fallbackLastmod = normalizeDateOnly(page.lastmod ?? page.lastModified);
+    const lastmod = normalizeDateOnly(resolvedLastmod?.lastmod) ?? fallbackLastmod;
+
+    pages.push({
+      url,
+      absoluteUrl: absolutizeUrl(baseUrl, url),
+      markdownUrl: toDocsSitemapMarkdownUrl(url),
+      title: page.title,
+      description: page.description,
+      sourcePath: page.sourcePath,
+      lastmod,
+      lastmodSource: resolvedLastmod?.lastmodSource ?? (lastmod ? "unknown" : undefined),
+      related: page.related?.map((link) => link.href),
+    });
+  }
+
+  pages.sort((left, right) => left.url.localeCompare(right.url));
+
+  return {
+    version: 1,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    baseUrl,
+    entry: options.entry ?? "docs",
+    siteTitle: options.siteTitle,
+    pages,
+  };
+}
+
+export function renderDocsSitemapXml(
+  manifest: DocsSitemapManifest,
+  options: { baseUrl?: string; includeLastmod?: boolean } = {},
+): string {
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? manifest.baseUrl);
+  const includeLastmod = options.includeLastmod ?? true;
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  ];
+
+  for (const page of manifest.pages) {
+    lines.push("  <url>");
+    lines.push(`    <loc>${escapeXml(page.absoluteUrl ?? absolutizeUrl(baseUrl, page.url))}</loc>`);
+    const lastmod = normalizeDateOnly(page.lastmod);
+    if (includeLastmod && lastmod) lines.push(`    <lastmod>${lastmod}</lastmod>`);
+    lines.push("  </url>");
+  }
+
+  lines.push("</urlset>");
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderDocsSitemapMarkdown(
+  manifest: DocsSitemapManifest,
+  options: {
+    baseUrl?: string;
+    includeDescriptions?: boolean;
+    includeLastmod?: boolean;
+    linkTarget?: "html" | "markdown" | "both";
+  } = {},
+): string {
+  const siteTitle = manifest.siteTitle ?? "Documentation";
+  const includeDescriptions = options.includeDescriptions ?? true;
+  const includeLastmod = options.includeLastmod ?? true;
+  const linkTarget = options.linkTarget ?? "both";
+  const lines = [`# ${siteTitle} Sitemap`, ""];
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? manifest.baseUrl);
+
+  if (baseUrl) lines.push(`Base URL: ${baseUrl}`);
+  lines.push(`Docs entry: /${manifest.entry.replace(/^\/+|\/+$/g, "") || "docs"}`);
+  lines.push(`Generated: ${normalizeDateOnly(manifest.generatedAt) ?? manifest.generatedAt}`, "");
+
+  const groups = new Map<string, DocsSitemapManifestPage[]>();
+  for (const page of manifest.pages) {
+    const sectionName = sitemapSectionName(manifest.entry, page.url);
+    groups.set(sectionName, [...(groups.get(sectionName) ?? []), page]);
+  }
+
+  for (const [sectionName, pages] of groups) {
+    lines.push(`## ${sectionName}`, "");
+
+    for (const page of pages) {
+      const primaryHref = linkTarget === "markdown" ? page.markdownUrl : page.url;
+      lines.push(`- [${page.title}](${primaryHref})`);
+      if (linkTarget === "both" || linkTarget === "markdown") {
+        lines.push(`  Markdown: ${page.markdownUrl}`);
+      }
+      if (includeDescriptions && page.description) {
+        lines.push(`  Description: ${page.description}`);
+      }
+      const lastmod = normalizeDateOnly(page.lastmod);
+      if (includeLastmod && lastmod) lines.push(`  Last updated: ${lastmod}`);
+      if (page.related && page.related.length > 0) {
+        lines.push(`  Related: ${page.related.join(", ")}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+export function readDocsSitemapManifest(
+  rootDir: string,
+  sitemap?: boolean | DocsSitemapConfig,
+): DocsSitemapManifest | null {
+  const resolved = resolveDocsSitemapConfig(sitemap);
+  const manifestPath = path.resolve(rootDir, resolved.manifestPath);
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(manifestPath, "utf-8")) as DocsSitemapManifest;
+  } catch {
+    return null;
+  }
+}
+
+export function readDocsSitemapManifestFromContentMap(
+  contentMap?: Record<string, string> | null,
+): DocsSitemapManifest | null {
+  if (!contentMap) return null;
+  const raw =
+    contentMap[`/${DEFAULT_SITEMAP_MANIFEST_PATH}`] ?? contentMap[DEFAULT_SITEMAP_MANIFEST_PATH];
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as DocsSitemapManifest;
+  } catch {
+    return null;
+  }
+}
+
+export function createDocsSitemapResponse({
+  request,
+  sitemap,
+  entry = "docs",
+  siteTitle,
+  baseUrl,
+  pages,
+  manifest,
+}: CreateDocsSitemapResponseOptions): Response | null {
+  const url = new URL(request.url);
+  const format = resolveDocsSitemapRequest(url, sitemap);
+  if (!format) return null;
+
+  const resolved = resolveDocsSitemapConfig(sitemap, { baseUrl });
+  if (!resolved.enabled) return null;
+  if (format === "xml" && !resolved.xml.enabled) return null;
+  if (format === "markdown" && !resolved.markdown.enabled) return null;
+
+  const nextManifest =
+    manifest ??
+    buildDocsSitemapManifest({
+      pages,
+      entry,
+      siteTitle,
+      baseUrl: resolved.baseUrl ?? url.origin,
+    });
+
+  const responseBaseUrl = resolved.baseUrl ?? nextManifest.baseUrl ?? url.origin;
+  const body =
+    format === "xml"
+      ? renderDocsSitemapXml(nextManifest, {
+          baseUrl: responseBaseUrl,
+          includeLastmod: resolved.xml.includeLastmod,
+        })
+      : renderDocsSitemapMarkdown(nextManifest, {
+          baseUrl: responseBaseUrl,
+          includeDescriptions: resolved.markdown.includeDescriptions,
+          includeLastmod: resolved.markdown.includeLastmod,
+          linkTarget: resolved.markdown.linkTarget,
+        });
+
+  const headers = new Headers({
+    "Content-Type":
+      format === "xml" ? "application/xml; charset=utf-8" : "text/markdown; charset=utf-8",
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    ETag: hashString(body),
+  });
+  const lastModified = newestLastmod(nextManifest.pages);
+  if (lastModified) headers.set("Last-Modified", new Date(`${lastModified}T00:00:00.000Z`).toUTCString());
+
+  if (request.headers.get("if-none-match") === headers.get("ETag")) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  return new Response(body, { headers });
+}

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -873,6 +873,74 @@ export interface LlmsTxtConfig {
   siteDescription?: string;
 }
 
+export interface SitemapXmlConfig {
+  /**
+   * Whether to expose the XML sitemap route.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Include per-page `<lastmod>` entries when a reliable page date is available.
+   * @default true
+   */
+  includeLastmod?: boolean;
+}
+
+export interface SitemapMarkdownConfig {
+  /**
+   * Whether to expose the Markdown sitemap route.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Include page descriptions in the Markdown sitemap.
+   * @default true
+   */
+  includeDescriptions?: boolean;
+  /**
+   * Include per-page freshness dates in the Markdown sitemap.
+   * @default true
+   */
+  includeLastmod?: boolean;
+  /**
+   * Which URL each Markdown list item should primarily link to.
+   * @default "both"
+   */
+  linkTarget?: "html" | "markdown" | "both";
+}
+
+/**
+ * Configuration for generated `/sitemap.xml`, `/sitemap.md`, and
+ * `/.well-known/sitemap.md` routes.
+ */
+export interface DocsSitemapConfig {
+  /**
+   * Whether to enable sitemap routes.
+   * @default true when `sitemap` is an object
+   */
+  enabled?: boolean;
+  /**
+   * Optional route prefix. For example, `"/docs"` generates
+   * `/docs/sitemap.xml`, `/docs/sitemap.md`, and `/docs/.well-known/sitemap.md`.
+   * @default ""
+   */
+  routePrefix?: string;
+  /**
+   * Public site URL used to build absolute XML sitemap URLs.
+   * Falls back to the request origin at runtime or llmsTxt.baseUrl in the CLI.
+   */
+  baseUrl?: string;
+  /**
+   * Internal generated manifest path.
+   * @default ".farming-labs/sitemap-manifest.json"
+   */
+  manifestPath?: string;
+  /** XML sitemap options. */
+  xml?: boolean | SitemapXmlConfig;
+  /** Markdown sitemap options. */
+  markdown?: boolean | SitemapMarkdownConfig;
+}
+
 /**
  * Tool-level toggles for the built-in MCP server.
  *
@@ -926,6 +994,9 @@ export interface DocsSearchSourcePage {
   content: string;
   description?: string;
   related?: ResolvedDocsRelatedLink[];
+  sourcePath?: string;
+  lastModified?: string;
+  lastmod?: string;
   rawContent?: string;
   agentContent?: string;
   agentRawContent?: string;
@@ -2347,6 +2418,20 @@ export interface DocsConfig {
    * @see https://llmstxt.org
    */
   llmsTxt?: boolean | LlmsTxtConfig;
+  /**
+   * Generated XML and Markdown sitemaps for crawlers, agents, and static export.
+   *
+   * @example
+   * ```ts
+   * sitemap: true
+   *
+   * sitemap: {
+   *   routePrefix: "/docs",
+   *   baseUrl: "https://docs.example.com",
+   * }
+   * ```
+   */
+  sitemap?: boolean | DocsSitemapConfig;
   /**
    * Generated changelog pages backed by date-folder MDX entries inside the docs
    * content tree.

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1393,6 +1393,7 @@ title: "Home"
       skills: true,
       mcp: true,
       search: true,
+      sitemap: false,
       agentFeedback: true,
       locales: true,
     });
@@ -1560,6 +1561,7 @@ title: "Home"
       skills: true,
       mcp: false,
       search: false,
+      sitemap: false,
       agentFeedback: false,
       locales: false,
     });

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -34,6 +34,9 @@ import {
   resolveDocsI18n,
   resolveDocsLocale,
   resolvePageSidebarFolderIndexBehavior,
+  createDocsSitemapResponse,
+  readDocsSitemapManifest,
+  resolveDocsSitemapConfig,
 } from "@farming-labs/docs";
 import type {
   ChangelogConfig,
@@ -63,6 +66,7 @@ import type {
   DocsMcpConfig,
   DocsSearchConfig,
   DocsSearchSourcePage,
+  DocsSitemapConfig,
   OrderingItem,
 } from "@farming-labs/docs";
 import { withLangInUrl } from "./i18n.js";
@@ -126,6 +130,8 @@ interface DocsAPIOptions {
   feedback?: boolean | FeedbackConfig;
   /** MCP configuration used for the agent discovery spec. */
   mcp?: boolean | DocsMcpConfig;
+  /** Sitemap configuration used for sitemap.xml and sitemap.md. */
+  sitemap?: boolean | DocsSitemapConfig;
 }
 
 interface DocsMCPAPIOptions {
@@ -222,6 +228,7 @@ interface AgentSpecOptions {
   mcp: ReturnType<typeof resolveDocsMcpConfig>;
   feedback: ResolvedAgentFeedbackConfig;
   llms: LlmsTxtOptions & { enabled: boolean };
+  sitemap?: boolean | DocsSitemapConfig;
 }
 
 interface SkillDocumentOptions extends AgentSpecOptions {}
@@ -349,10 +356,20 @@ function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
   return true;
 }
 
-function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: AgentSpecOptions) {
+function buildAgentSpec({
+  origin,
+  entry,
+  i18n,
+  search,
+  mcp,
+  feedback,
+  llms,
+  sitemap,
+}: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const localesEnabled = i18n !== null;
   const searchEnabled = isSearchEnabled(search);
+  const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms.baseUrl });
 
   return {
     version: "1",
@@ -379,6 +396,7 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       skills: true,
       mcp: mcp.enabled,
       search: searchEnabled,
+      sitemap: sitemapConfig.enabled,
       agentFeedback: feedback.enabled,
       locales: localesEnabled,
     },
@@ -412,6 +430,20 @@ function buildAgentSpec({ origin, entry, i18n, search, mcp, feedback, llms }: Ag
       publicFull: DEFAULT_LLMS_FULL_TXT_ROUTE,
       wellKnownTxt: DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE,
       wellKnownFull: DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
+    },
+    sitemap: {
+      enabled: sitemapConfig.enabled,
+      xml: {
+        enabled: sitemapConfig.xml.enabled,
+        route: sitemapConfig.xml.route,
+        api: `${DEFAULT_DOCS_API_ROUTE}?format=sitemap-xml`,
+      },
+      markdown: {
+        enabled: sitemapConfig.markdown.enabled,
+        route: sitemapConfig.markdown.route,
+        wellKnownRoute: sitemapConfig.markdown.wellKnownRoute,
+        api: `${DEFAULT_DOCS_API_ROUTE}?format=sitemap-md`,
+      },
     },
     search: {
       enabled: searchEnabled,
@@ -1184,6 +1216,8 @@ function scanDocsDir(
             rawContent,
             agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
             url,
+            sourcePath: pageSource.replace(/\\/g, "/"),
+            lastModified: fs.statSync(pageSource).mtime.toISOString(),
             locale,
           });
         }
@@ -1440,11 +1474,13 @@ function renderSkillDocument({
   mcp,
   feedback,
   llms,
+  sitemap,
 }: SkillDocumentOptions): string {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const siteTitle = compactSkillText(llms.siteTitle ?? "Documentation");
   const siteDescription = llms.siteDescription ? compactSkillText(llms.siteDescription) : undefined;
   const searchEnabled = isSearchEnabled(search);
+  const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms.baseUrl });
   const description = truncateSkillDescription(
     `Use ${siteTitle} through markdown routes, llms.txt, agent discovery, search, and MCP when available.`,
   );
@@ -1488,6 +1524,15 @@ function renderSkillDocument({
     );
   }
 
+  if (sitemapConfig.enabled) {
+    if (sitemapConfig.xml.enabled) {
+      lines.push(`- Use ${sitemapConfig.xml.route} to check canonical page freshness.`);
+    }
+    if (sitemapConfig.markdown.enabled) {
+      lines.push(`- Use ${sitemapConfig.markdown.route} for a semantic docs map.`);
+    }
+  }
+
   if (mcp.enabled) {
     lines.push(
       `- Use ${DEFAULT_MCP_WELL_KNOWN_ROUTE} or ${DEFAULT_MCP_PUBLIC_ROUTE} for MCP tools when your environment supports MCP.`,
@@ -1518,6 +1563,16 @@ function renderSkillDocument({
       `- llms-full.txt: ${DEFAULT_LLMS_FULL_TXT_ROUTE}`,
       `- llms well-known aliases: ${DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE}, ${DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE}`,
     );
+  }
+
+  if (sitemapConfig.enabled) {
+    if (sitemapConfig.xml.enabled) lines.push(`- Sitemap XML: ${sitemapConfig.xml.route}`);
+    if (sitemapConfig.markdown.enabled) {
+      lines.push(
+        `- Sitemap Markdown: ${sitemapConfig.markdown.route}`,
+        `- Sitemap well-known alias: ${sitemapConfig.markdown.wellKnownRoute}`,
+      );
+    }
   }
 
   if (mcp.enabled) {
@@ -2216,6 +2271,37 @@ function readLlmsTxtConfig(root: string): LlmsTxtOptions & { enabled: boolean } 
   return { enabled: false };
 }
 
+function readSitemapConfig(root: string): boolean | DocsSitemapConfig | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = path.join(root, `docs.config.${ext}`);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      if (!content.includes("sitemap")) return undefined;
+      if (/sitemap\s*:\s*false/.test(content)) return false;
+      if (/sitemap\s*:\s*true/.test(content)) return true;
+
+      const sitemapBlock = content.match(/sitemap\s*:\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? "";
+      const routePrefix = sitemapBlock.match(/routePrefix\s*:\s*["']([^"']+)["']/)?.[1];
+      const baseUrl = sitemapBlock.match(/baseUrl\s*:\s*["']([^"']+)["']/)?.[1];
+      const manifestPath = sitemapBlock.match(/manifestPath\s*:\s*["']([^"']+)["']/)?.[1];
+      const enabledMatch = sitemapBlock.match(/enabled\s*:\s*(true|false)/);
+
+      return {
+        enabled: enabledMatch ? enabledMatch[1] === "true" : true,
+        routePrefix,
+        baseUrl,
+        manifestPath,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
 function generateLlmsTxt(
   indexes: DocsSearchSourcePage[],
   options: LlmsTxtOptions,
@@ -2288,6 +2374,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
   // Read llms.txt config
   const llmsConfig = readLlmsTxtConfig(root);
+  const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
   const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
     defaultName: llmsConfig.siteTitle ?? "Documentation",
   });
@@ -2510,6 +2597,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             mcp: mcpConfig,
             feedback: agentFeedbackConfig,
             llms: llmsConfig,
+            sitemap: sitemapConfig,
           }),
           {
             headers: {
@@ -2575,6 +2663,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
               mcp: mcpConfig,
               feedback: agentFeedbackConfig,
               llms: llmsConfig,
+              sitemap: sitemapConfig,
             }),
           {
             headers: {
@@ -2585,6 +2674,17 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           },
         );
       }
+
+      const sitemapResponse = createDocsSitemapResponse({
+        request,
+        sitemap: sitemapConfig,
+        entry,
+        siteTitle: llmsConfig.siteTitle ?? "Documentation",
+        baseUrl: llmsConfig.baseUrl ?? url.origin,
+        pages: getIndexes(ctx),
+        manifest: readDocsSitemapManifest(root, sitemapConfig),
+      });
+      if (sitemapResponse) return sitemapResponse;
 
       const markdownRequest = resolveMarkdownRequest(entry, url, request);
 

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -35,7 +35,6 @@ import {
   resolveDocsLocale,
   resolvePageSidebarFolderIndexBehavior,
   createDocsSitemapResponse,
-  readDocsSitemapManifest,
   resolveDocsSitemapConfig,
 } from "@farming-labs/docs";
 import type {
@@ -51,6 +50,7 @@ import type {
 import {
   createDocsMcpHttpHandler,
   createFilesystemDocsMcpSource,
+  readDocsSitemapManifest,
   resolveDocsMcpConfig,
   type DocsMcpPage,
 } from "@farming-labs/docs/server";

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -625,11 +625,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     const nextConfig = withDocs({});
 
     expect(nextConfig.outputFileTracingIncludes).toMatchObject({
-      "/api/docs": [
-        "website/app/docs/**/*",
-        "skill.md",
-        ".farming-labs/sitemap-manifest.json",
-      ],
+      "/api/docs": ["website/app/docs/**/*", "skill.md", ".farming-labs/sitemap-manifest.json"],
       "/api/docs/mcp": ["website/app/docs/**/*"],
     });
   });

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -122,6 +122,15 @@ const DOCS_CONFIG_WITH_CUSTOM_MCP_ROUTE = `export default {
 };
 `;
 
+const DOCS_CONFIG_WITH_SITEMAP = `export default {
+  entry: "docs",
+  sitemap: {
+    enabled: true,
+    routePrefix: "/docs-map",
+  },
+};
+`;
+
 const DOCS_CONFIG_WITH_AGENT_FEEDBACK = `export default {
   entry: "docs",
   feedback: {
@@ -342,6 +351,32 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(acceptPattern.test("application/json, text/markdown;profile=agent;q=0")).toBe(false);
     expect(acceptPattern.test("text/markdown-v2")).toBe(false);
     expect(acceptPattern.test("application/not-text/markdownish")).toBe(false);
+  });
+
+  it("routes sitemap rewrites through the shared docs api handler when enabled", async () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_SITEMAP, "utf-8");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/docs-map/sitemap.xml",
+          destination: "/api/docs?format=sitemap-xml",
+        }),
+        expect.objectContaining({
+          source: "/docs-map/sitemap.md",
+          destination: "/api/docs?format=sitemap-md",
+        }),
+        expect.objectContaining({
+          source: "/docs-map/.well-known/sitemap.md",
+          destination: "/api/docs?format=sitemap-md",
+        }),
+      ]),
+    );
   });
 
   it("redirects hidden folder parents to their first visible child", async () => {
@@ -577,7 +612,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     const nextConfig = withDocs({});
 
     expect(nextConfig.outputFileTracingIncludes).toMatchObject({
-      "/api/docs": ["app/docs/**/*", "skill.md"],
+      "/api/docs": ["app/docs/**/*", "skill.md", ".farming-labs/sitemap-manifest.json"],
       "/api/docs/mcp": ["app/docs/**/*"],
     });
   });
@@ -590,7 +625,11 @@ describe("withDocs (app dir: src/app vs app)", () => {
     const nextConfig = withDocs({});
 
     expect(nextConfig.outputFileTracingIncludes).toMatchObject({
-      "/api/docs": ["website/app/docs/**/*", "skill.md"],
+      "/api/docs": [
+        "website/app/docs/**/*",
+        "skill.md",
+        ".farming-labs/sitemap-manifest.json",
+      ],
       "/api/docs/mcp": ["website/app/docs/**/*"],
     });
   });

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -104,6 +104,7 @@ export const { GET, POST } = createDocsAPI({
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
+  sitemap: docsConfig.sitemap,
   search: docsConfig.search,
   analytics: docsConfig.analytics,
   observability: docsConfig.observability,
@@ -193,6 +194,10 @@ const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 const DEFAULT_SKILL_MD_ROUTE = "/skill.md";
 const DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE = "/.well-known/skill.md";
+const DEFAULT_SITEMAP_XML_ROUTE = "/sitemap.xml";
+const DEFAULT_SITEMAP_MD_ROUTE = "/sitemap.md";
+const DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE = "/.well-known/sitemap.md";
+const DEFAULT_SITEMAP_MANIFEST_PATH = ".farming-labs/sitemap-manifest.json";
 const MARKDOWN_ACCEPT_HEADER_VALUE = [
   "(?:^|.*,\\s*)",
   "text/markdown",
@@ -980,6 +985,53 @@ function normalizeRoutePath(route: string): string {
   return normalized !== "/" ? normalized.replace(/\/+$/, "") : DEFAULT_MCP_ROUTE;
 }
 
+function normalizeRoutePrefix(prefix?: string): string {
+  if (!prefix) return "";
+  const normalized = `/${prefix.replace(/^\/+|\/+$/g, "")}`.replace(/\/+/g, "/");
+  return normalized === "/" ? "" : normalized;
+}
+
+function joinPublicRoute(prefix: string, route: string): string {
+  return `${prefix}/${route.replace(/^\/+/, "")}`.replace(/\/+/g, "/");
+}
+
+function readSitemapConfig(root: string): {
+  enabled: boolean;
+  routePrefix: string;
+} {
+  for (const ext of FILE_EXTS) {
+    const configPath = join(root, `docs.config.${ext}`);
+    if (!existsSync(configPath)) continue;
+
+    try {
+      const content = readFileSync(configPath, "utf-8");
+
+      if (content.match(/sitemap\s*:\s*false/)) {
+        return { enabled: false, routePrefix: "" };
+      }
+
+      if (content.match(/sitemap\s*:\s*true/)) {
+        return { enabled: true, routePrefix: "" };
+      }
+
+      const block = extractObjectLiteral(content, "sitemap");
+      if (!block) continue;
+
+      const enabledMatch = block.match(/enabled\s*:\s*(true|false)/);
+      const routePrefixMatch = block.match(/routePrefix\s*:\s*["']([^"']+)["']/);
+
+      return {
+        enabled: enabledMatch ? enabledMatch[1] !== "false" : true,
+        routePrefix: normalizeRoutePrefix(routePrefixMatch?.[1]),
+      };
+    } catch {
+      return { enabled: false, routePrefix: "" };
+    }
+  }
+
+  return { enabled: false, routePrefix: "" };
+}
+
 function normalizeAgentFeedbackRoute(
   route?: string,
   fallback = DEFAULT_AGENT_FEEDBACK_ROUTE,
@@ -1140,6 +1192,26 @@ function buildSkillMdRewrites(): NextRewrite[] {
     {
       source: DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
       destination: "/api/docs?format=skill",
+    },
+  ];
+}
+
+function buildSitemapRewrites(config: { enabled: boolean; routePrefix: string }): NextRewrite[] {
+  if (!config.enabled) return [];
+  const prefix = config.routePrefix;
+
+  return [
+    {
+      source: joinPublicRoute(prefix, DEFAULT_SITEMAP_XML_ROUTE),
+      destination: "/api/docs?format=sitemap-xml",
+    },
+    {
+      source: joinPublicRoute(prefix, DEFAULT_SITEMAP_MD_ROUTE),
+      destination: "/api/docs?format=sitemap-md",
+    },
+    {
+      source: joinPublicRoute(prefix, DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE),
+      destination: "/api/docs?format=sitemap-md",
     },
   ];
 }
@@ -1324,6 +1396,10 @@ function mergeDocsMarkdownRewrites(
     enabled: boolean;
     route: string;
   },
+  sitemap: {
+    enabled: boolean;
+    routePrefix: string;
+  },
   agentFeedback: {
     enabled: boolean;
     route: string;
@@ -1336,6 +1412,7 @@ function mergeDocsMarkdownRewrites(
     ...buildMcpRewrites(mcp),
     ...buildLlmsTxtRewrites(),
     ...buildSkillMdRewrites(),
+    ...buildSitemapRewrites(sitemap),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
@@ -1410,6 +1487,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   }
 
   const mcp = readMcpConfig(root);
+  const sitemap = readSitemapConfig(root);
   const docsMcpRouteDir = join(root, appDir, "api", "docs", "mcp");
   if (
     mcp.enabled &&
@@ -1674,6 +1752,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     {};
   const docsTraceGlob = docsContentDir.replace(/\\/g, "/").replace(/^\.?\//, "") + "/**/*";
   const skillTraceFile = "skill.md";
+  const sitemapManifestTraceFile = DEFAULT_SITEMAP_MANIFEST_PATH;
   const docsContentRoot = isAbsolute(docsContentDir) ? docsContentDir : join(root, docsContentDir);
 
   if (!isStaticExport) {
@@ -1684,7 +1763,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     nextConfig.rewrites = async () => {
       const rewrites =
         typeof existingRewrites === "function" ? await existingRewrites() : existingRewrites;
-      return mergeDocsMarkdownRewrites(entry, mcp, agentFeedback, rewrites);
+      return mergeDocsMarkdownRewrites(entry, mcp, sitemap, agentFeedback, rewrites);
     };
 
     const autoRedirects = buildHiddenFolderRedirects(docsContentRoot, entry);
@@ -1705,7 +1784,12 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   nextConfig.outputFileTracingIncludes = {
     ...existingTracingIncludes,
     "/api/docs": [
-      ...new Set([...(existingTracingIncludes["/api/docs"] ?? []), docsTraceGlob, skillTraceFile]),
+      ...new Set([
+        ...(existingTracingIncludes["/api/docs"] ?? []),
+        docsTraceGlob,
+        skillTraceFile,
+        sitemapManifestTraceFile,
+      ]),
     ],
     [DEFAULT_MCP_ROUTE]: [
       ...new Set([...(existingTracingIncludes[DEFAULT_MCP_ROUTE] ?? []), docsTraceGlob]),

--- a/packages/nuxt/src/content.ts
+++ b/packages/nuxt/src/content.ts
@@ -49,6 +49,8 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   icon?: string;
+  sourcePath?: string;
+  lastModified?: string;
   content: string;
   rawContent: string;
   agentContent?: string;
@@ -109,6 +111,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         icon: data.icon as string | undefined,
+        sourcePath: full.replace(/\\/g, "/"),
+        lastModified: stat.mtime.toISOString(),
         content: stripMarkdown(humanRawContent),
         rawContent: humanRawContent,
         ...(pageAgentRawContent !== humanRawContent

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -37,7 +37,6 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
@@ -51,12 +50,12 @@ import {
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
-  resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
+  readDocsSitemapManifest,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -22,6 +22,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
@@ -36,6 +37,8 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
@@ -818,6 +821,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -849,6 +853,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -862,6 +867,19 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         },
       );
     }
+
+    const sitemapResponse = createDocsSitemapResponse({
+      request: context.request,
+      sitemap: config.sitemap,
+      entry,
+      siteTitle: llmsTitle,
+      baseUrl: llmsBaseUrl || url.origin,
+      pages: getSearchIndex(ctx),
+      manifest:
+        readDocsSitemapManifestFromContentMap(preloaded) ??
+        readDocsSitemapManifest(rootDir, config.sitemap),
+    });
+    if (sitemapResponse) return sitemapResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
@@ -1691,7 +1709,9 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
 
     if (method === "GET" || method === "HEAD") {
       const request = new Request(url.href, { method, headers });
-      if (!isDocsPublicGetRequest(entry, url, request)) return undefined;
+      if (!isDocsPublicGetRequest(entry, url, request, { sitemap: config.sitemap })) {
+        return undefined;
+      }
 
       const server = await getServer();
       return server.GET({

--- a/packages/svelte/src/content.ts
+++ b/packages/svelte/src/content.ts
@@ -49,6 +49,8 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   icon?: string;
+  sourcePath?: string;
+  lastModified?: string;
   content: string;
   rawContent: string;
   agentContent?: string;
@@ -109,6 +111,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         icon: data.icon as string | undefined,
+        sourcePath: full.replace(/\\/g, "/"),
+        lastModified: stat.mtime.toISOString(),
         content: stripMarkdown(humanRawContent),
         rawContent: humanRawContent,
         ...(pageAgentRawContent !== humanRawContent

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -48,7 +48,6 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
@@ -62,12 +61,12 @@ import {
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
-  resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   createDocsMcpHttpHandler,
+  readDocsSitemapManifest,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -35,6 +35,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
@@ -47,6 +48,8 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
@@ -837,6 +840,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -868,6 +872,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -881,6 +886,19 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         },
       );
     }
+
+    const sitemapResponse = createDocsSitemapResponse({
+      request: event.request,
+      sitemap: config.sitemap,
+      entry,
+      siteTitle: llmsTitle,
+      baseUrl: llmsBaseUrl || event.url.origin,
+      pages: getSearchIndex(ctx),
+      manifest:
+        readDocsSitemapManifestFromContentMap(preloaded) ??
+        readDocsSitemapManifest(rootDir, config.sitemap),
+    });
+    if (sitemapResponse) return sitemapResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, event.url, event.request);
     if (markdownRequest) {

--- a/packages/tanstack-start/src/content.ts
+++ b/packages/tanstack-start/src/content.ts
@@ -49,6 +49,8 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   icon?: string;
+  sourcePath?: string;
+  lastModified?: string;
   content: string;
   rawContent: string;
   agentContent?: string;
@@ -101,6 +103,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         icon: data.icon as string | undefined,
+        sourcePath: full.replace(/\\/g, "/"),
+        lastModified: stat.mtime.toISOString(),
         content: stripMarkdown(humanRawContent),
         rawContent: humanRawContent,
         ...(pageAgentRawContent !== humanRawContent

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -5,6 +5,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
@@ -17,6 +18,8 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
+  readDocsSitemapManifest,
+  readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
   resolvePageSidebarFolderIndexBehavior,
@@ -799,6 +802,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -830,6 +834,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
               siteTitle: llmsTitle,
               siteDescription: llmsDesc,
             },
+            sitemap: config.sitemap,
             markdown: {
               acceptHeader: false,
             },
@@ -843,6 +848,19 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         },
       );
     }
+
+    const sitemapResponse = createDocsSitemapResponse({
+      request: event.request,
+      sitemap: config.sitemap,
+      entry,
+      siteTitle: llmsTitle,
+      baseUrl: llmsBaseUrl || url.origin,
+      pages: getSearchIndex(ctx),
+      manifest:
+        readDocsSitemapManifestFromContentMap(preloaded) ??
+        readDocsSitemapManifest(rootDir, config.sitemap),
+    });
+    if (sitemapResponse) return sitemapResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, event.request);
     if (markdownRequest) {

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -18,7 +18,6 @@ import {
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsSkillDocument,
-  readDocsSitemapManifest,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
@@ -32,11 +31,14 @@ import {
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
-  resolveSidebarFolderIndexBehavior,
   resolveDocsSkillFormat,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
-import { createDocsMcpHttpHandler, resolveDocsMcpConfig } from "@farming-labs/docs/server";
+import {
+  createDocsMcpHttpHandler,
+  readDocsSitemapManifest,
+  resolveDocsMcpConfig,
+} from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
 import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds first-class sitemaps for docs with XML/Markdown routes, a generated manifest, and a CLI to build static files. Improves SEO, cacheability (ETag/Last-Modified), and agent discovery across Next, Astro, SvelteKit, Nuxt, TanStack Start, and Fumadocs.

- **New Features**
  - Sitemap routes: /sitemap.xml, /sitemap.md, and /.well-known/sitemap.md (prefix via `sitemap.routePrefix`); API aliases at `/api/docs?format=sitemap-xml|sitemap-md`.
  - Config: new `sitemap` option (baseUrl, `includeLastmod`, `includeDescriptions`, `linkTarget`, `manifestPath`).
  - CLI: `docs sitemap generate` writes `.farming-labs/sitemap-manifest.json` and public `sitemap.xml`/`sitemap.md`; supports `--manifest-only`, `--check`, `--config`, `--public`; infers lastmod from Git or filesystem and preserves `generatedAt` when unchanged.
  - Runtime: unified handler serves sitemaps with ETag/Last-Modified using preloaded or on-disk manifest; server-only manifest reader; discovery spec and `skill.md` advertise sitemap endpoints; public GET detection includes sitemap routes.
  - Frameworks: integrated in `createDocsServer` and `createDocsAPI`; Next.js adds rewrites for sitemap routes and traces `.farming-labs/sitemap-manifest.json`; examples preload the manifest and pass `config.sitemap` to `isDocsPublicGetRequest`; Astro example runs the local CLI to generate sitemaps during `build`.

- **Migration**
  - Add `sitemap: true` (or an object) to `docs.config.*`; set `baseUrl` for absolute XML links.
  - For static export, run `docs sitemap generate` and commit `.farming-labs/sitemap-manifest.json`.
  - Next.js: no manual rewrites; upgrade and rebuild.

<sup>Written for commit a556956c845e2a96d324afc3102e53a7935a280b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

