### PR TITLE
chore: add sitemap docs

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -11,11 +11,11 @@ Skills are organized under **`farming-labs/`** and divided by topic. Use the ski
 | Skill | Path | When to use |
 | ----- | ---- | ----------- |
 | **Getting started** | [farming-labs/getting-started](./farming-labs/getting-started/SKILL.md) | Setup, init, manual install, theme CSS, defineDocs, packages by framework. |
-| **CLI** | [farming-labs/cli](./farming-labs/cli/SKILL.md) | Scaffolding: `init`, `upgrade`, `--template`, `--name`, `--theme`, `--framework`, package manager commands. |
+| **CLI** | [farming-labs/cli](./farming-labs/cli/SKILL.md) | Scaffolding and commands: `init`, `upgrade`, `sitemap generate`, `--template`, `--name`, `--theme`, `--framework`, package manager commands. |
 | **Creating themes** | [farming-labs/creating-themes](./farming-labs/creating-themes/SKILL.md) | Build and share themes: `createTheme()`, `extendTheme()`, publish as npm, CSS overrides. |
 | **Ask AI** | [farming-labs/ask-ai](./farming-labs/ask-ai/SKILL.md) | RAG-powered AI chat: mode, floatingStyle, providers, models, suggestedQuestions, apiKey. |
 | **Page actions** | [farming-labs/page-actions](./farming-labs/page-actions/SKILL.md) | Copy Markdown and Open in LLM: copyMarkdown, openDocs, providers, urlTemplate. |
-| **Configuration** | [farming-labs/configuration](./farming-labs/configuration/SKILL.md) | docs.config.ts: entry, theme, staticExport, sidebar, github, metadata, og, etc. |
+| **Configuration** | [farming-labs/configuration](./farming-labs/configuration/SKILL.md) | docs.config.ts: entry, theme, staticExport, sidebar, github, sitemap, metadata, og, etc. |
 
 Full index and per-skill install paths: **[farming-labs/README.md](./farming-labs/README.md)**.
 

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -5,7 +5,7 @@ This folder contains [Agent Skills](https://skills.sh/) (conforming to the [Agen
 Each skill is a separate directory with a `SKILL.md` file. Use the skill that matches the task
 (getting started, CLI, creating themes, Ask AI, page actions, or configuration, including search
 adapters, changelog setup, human page feedback, `agent.compact`, agent discovery/spec routes,
-`skill.md`, agent feedback endpoints, API reference, MCP, `llms.txt`, and machine-readable markdown
+`skill.md`, agent feedback endpoints, API reference, MCP, `llms.txt`, sitemaps, and machine-readable markdown
 routes with embedded `Agent` blocks, generated or hand-written `agent.md` overrides, or
 `Accept: text/markdown` negotiation).
 
@@ -44,11 +44,11 @@ The agent discovery spec also advertises the root `skill.md` route, this Skills 
 | Skill | Path | When to use |
 | ----- | ---- | ----------- |
 | **Getting started** | [getting-started](./getting-started/SKILL.md) | Setting up docs, init, manual install, theme CSS, docs.config, packages by framework, generated changelog pages in Next.js, machine-readable markdown routes with `Agent` blocks or `agent.md` overrides, and API reference wiring from local routes or a hosted OpenAPI JSON. |
-| **CLI** | [cli](./cli/SKILL.md) | Scaffolding and commands: init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), `init` / `upgrade` / `doctor` / `agent compact` / `mcp`, hosted `doctor --agent --url`, `--template`, `--name`, `--theme`, `--entry`, `--api-reference`, `--framework`, `--config`, package manager commands. |
+| **CLI** | [cli](./cli/SKILL.md) | Scaffolding and commands: init flow (existing vs fresh), Create your own theme, optional defaults (Enter to accept), `init` / `upgrade` / `doctor` / `agent compact` / `sitemap generate` / `mcp`, hosted `doctor --agent --url`, `--template`, `--name`, `--theme`, `--entry`, `--api-reference`, `--framework`, `--config`, package manager commands. |
 | **Creating themes** | [creating-themes](./creating-themes/SKILL.md) | Building a custom theme with `createTheme()`, `extendTheme()`, `ui.components` defaults like `HoverLink`, publishing as npm, CSS overrides. |
 | **Ask AI** | [ask-ai](./ask-ai/SKILL.md) | Enabling and configuring the RAG-powered AI chat: mode, floatingStyle, providers, models, suggestedQuestions, apiKey. |
 | **Page actions** | [page-actions](./page-actions/SKILL.md) | Copy Markdown and Open in LLM buttons: copyMarkdown, openDocs, providers, urlTemplate, `{url}.md` markdown route patterns, position, alignment, and provider defaults. |
-| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, `agent.compact`, human page feedback, agent feedback endpoints, metadata, og, `mcp`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
+| **Configuration** | [configuration](./configuration/SKILL.md) | docs.config.ts options: entry, theme, staticExport, sidebar, breadcrumb, github, components, `search`, `changelog`, `agent.compact`, human page feedback, agent feedback endpoints, metadata, og, `mcp`, `sitemap`, built-in markdown routes with `Agent` blocks or `agent.md`, and `apiReference` including remote `specUrl` support. |
 
 ---
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, compact agent docs, sync external search indexes, and run MCP for docs. Use when running init, upgrade, doctor, agent compact, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, compact agent docs, generate sitemaps, sync external search indexes, and run MCP for docs. Use when running init, upgrade, doctor, agent compact, sitemap generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
@@ -8,7 +8,7 @@ description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, co
 The `@farming-labs/docs` CLI scaffolds, upgrades, audits agent and reader readiness, compacts
 page-level agent docs, syncs external search indexes, and can run the built-in MCP server for
 documentation projects. Use this skill when the user asks about CLI commands, init, upgrade,
-`doctor`, `agent compact`, search sync, mcp, or scaffolding.
+`doctor`, `agent compact`, `sitemap generate`, search sync, mcp, or scaffolding.
 
 ---
 
@@ -223,6 +223,64 @@ Then verify:
 
 - MCP: `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`
 - Search: `http://127.0.0.1:3000/api/docs?query=session`
+
+---
+
+## Sitemap generate
+
+Use `sitemap generate` when the user wants static sitemap files, `lastmod` freshness metadata, or
+CI validation for generated sitemap output.
+
+```bash
+pnpm exec docs sitemap generate
+pnpm exec docs sitemap generate --config src/lib/docs.config.ts
+pnpm exec docs sitemap generate --manifest-only
+pnpm exec docs sitemap generate --check
+```
+
+Behavior:
+
+- reads `docs.config.ts[x]` by default, or the path passed with `--config`
+- scans docs content using `entry` and `contentDir`
+- writes `.farming-labs/sitemap-manifest.json`
+- writes public sitemap files by default: `sitemap.xml`, `sitemap.md`, and `.well-known/sitemap.md`
+- writes to `static/` for SvelteKit and `public/` for other frameworks
+- resolves `lastmod` from `git log -1` for each page source path, falling back to filesystem mtime
+- preserves `generatedAt` when the comparable manifest content has not changed
+
+Flags:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--config <path>` | Use a custom docs config path. |
+| `--manifest-only` | Only write `.farming-labs/sitemap-manifest.json`. |
+| `--public` | Explicitly write public sitemap files; this is already the default unless `--manifest-only` is set. |
+| `--check` | Fail when generated output is stale. |
+
+Build script examples:
+
+```json
+{
+  "scripts": {
+    "build": "docs sitemap generate --config src/lib/docs.config.ts && astro build"
+  }
+}
+```
+
+```json
+{
+  "scripts": {
+    "build": "docs sitemap generate --manifest-only && next build"
+  }
+}
+```
+
+For normal published apps, package scripts can call `docs` because the installed package exposes
+the bin. In this repo while dogfooding unpublished workspace builds, call the built CLI file
+directly after `@farming-labs/docs` has been built if the package bin is not available.
+
+Use the `configuration` skill or `/docs/customization/sitemaps` for `sitemap` config options and
+output examples.
 
 ---
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configuration
-description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, readingTime, agent.compact, metadata, og, apiReference, MCP, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
+description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, readingTime, agent.compact, metadata, og, apiReference, MCP, sitemap, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
 ---
 
 # @farming-labs/docs — Configuration
@@ -50,6 +50,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `changelog` | `boolean \| ChangelogConfig` | `false` | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp` | `boolean \| DocsMcpConfig` | enabled | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false` | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON document |
+| `sitemap` | `boolean \| DocsSitemapConfig` | `false` | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
 | `metadata` | `DocsMetadata` | — | SEO: titleTemplate, description, etc. |
 | `og` | `OGConfig` | — | Dynamic Open Graph images |
 
@@ -146,6 +147,66 @@ Call out content negotiation when relevant: in Next.js, `/docs/<slug>` remains t
 for browsers, but agents/scripts can send `Accept: text/markdown` to the same URL and receive the
 machine-readable markdown representation without appending `.md`. In other adapters, use
 `/docs/<slug>.md` or the API format route.
+
+---
+
+## Sitemaps
+
+Use `sitemap` when the project should expose crawler-friendly XML and agent-friendly Markdown maps
+of the docs tree.
+
+```ts
+sitemap: {
+  enabled: true,
+  baseUrl: "https://docs.example.com",
+},
+```
+
+Default routes:
+
+- `/sitemap.xml`
+- `/sitemap.md`
+- `/.well-known/sitemap.md`
+- `/api/docs?format=sitemap-xml`
+- `/api/docs?format=sitemap-md`
+
+Static generation:
+
+```bash
+pnpm exec docs sitemap generate
+pnpm exec docs sitemap generate --config src/lib/docs.config.ts
+pnpm exec docs sitemap generate --manifest-only
+pnpm exec docs sitemap generate --check
+```
+
+Behavior:
+
+- `docs sitemap generate` writes `.farming-labs/sitemap-manifest.json` plus public sitemap files by default
+- SvelteKit public output goes to `static/`; other adapters use `public/`
+- `--manifest-only` writes only the manifest for server-rendered apps that serve routes at runtime
+- `--public` is an explicit spelling of the default public-file behavior
+- `--check` fails when generated sitemap output is stale
+- `lastmod` uses each page source file's last git commit date first, then filesystem mtime
+- `routePrefix: "/docs-map"` moves all sitemap routes to `/docs-map/sitemap.xml`, `/docs-map/sitemap.md`, and `/docs-map/.well-known/sitemap.md`
+- there is no separate well-known route config; the route prefix applies to all sitemap routes together
+
+Useful config:
+
+```ts
+sitemap: {
+  routePrefix: "/docs-map",
+  baseUrl: "https://docs.example.com",
+  xml: { includeLastmod: true },
+  markdown: {
+    includeDescriptions: true,
+    includeLastmod: true,
+    linkTarget: "both",
+  },
+},
+```
+
+Use `/docs/customization/sitemaps` when the user needs output examples or static export details.
+Use the `cli` skill when they ask about command syntax.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI"
-description: "Scaffold, upgrade, compact agent docs, sync search, and run MCP"
+description: "Scaffold, upgrade, compact agent docs, generate sitemaps, sync search, and run MCP"
 icon: "terminal"
 order: 2
 ---
@@ -15,6 +15,7 @@ The `@farming-labs/docs` CLI has a few main jobs:
 - **`doctor`** — audit local docs readiness and optional hosted agent routes
 - **`mcp`** — run the built-in docs MCP server over stdio for local clients and IDE agents
 - **`search sync`** — push docs content into an external search index like Typesense or Algolia
+- **`sitemap generate`** — write sitemap metadata plus static `sitemap.xml` and `sitemap.md` files
 
 If you only need the common commands, start here. The framework-specific output and generated file lists are further down this page.
 
@@ -203,6 +204,42 @@ ALGOLIA_APP_ID=your-app-id
 ALGOLIA_ADMIN_API_KEY=your-admin-key
 ALGOLIA_SEARCH_API_KEY=your-search-key
 ```
+
+### Generate sitemaps
+
+Use `sitemap generate` when you want static `sitemap.xml` and `sitemap.md` files, or when a
+server-rendered deployment needs a generated manifest with reliable `lastmod` dates.
+
+```bash title="terminal"
+pnpm exec docs sitemap generate
+```
+
+By default the command writes:
+
+- `.farming-labs/sitemap-manifest.json`
+- `public/sitemap.xml`
+- `public/sitemap.md`
+- `public/.well-known/sitemap.md`
+
+SvelteKit writes the public files under `static/` instead of `public/`. Use `--config` when your
+config lives outside the project root:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate --config src/lib/docs.config.ts
+```
+
+Useful flags:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--config <path>` | Use a custom docs config path. |
+| `--manifest-only` | Write only `.farming-labs/sitemap-manifest.json`. Useful for server-rendered apps that serve sitemap routes through the runtime. |
+| `--public` | Explicitly write public sitemap files. This is already the default unless `--manifest-only` is set. |
+| `--check` | Fail if the generated manifest or public sitemap files are stale. |
+
+The generator resolves `lastmod` from each page source file's last git commit date, then falls back
+to filesystem modified time. See [Sitemaps](/docs/customization/sitemaps) for route config, static
+export setup, and output examples.
 
 ### Compact page-level agent docs
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -136,6 +136,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |
+| `sitemap`     | `boolean \| DocsSitemapConfig` | `false`         | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
 | `i18n`        | `DocsI18nConfig`               | —               | Query-param locale support and locale switcher     |
 | `metadata`    | `DocsMetadata`                 | —               | SEO metadata template                              |
 | `og`          | `OGConfig`                     | —               | Dynamic Open Graph images (see [API Reference](/docs/reference#ogconfig)) |
@@ -191,6 +192,51 @@ related:
 ```
 
 See [Agent Primitive](/docs/customization/agent-primitive) for the page-level authoring model.
+
+## Sitemaps
+
+Use `sitemap` when you want both crawler-friendly XML and agent-friendly Markdown maps of your docs:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  sitemap: {
+    enabled: true,
+    baseUrl: "https://docs.example.com",
+  },
+});
+```
+
+Default routes:
+
+- `/sitemap.xml`
+- `/sitemap.md`
+- `/.well-known/sitemap.md`
+- `/api/docs?format=sitemap-xml`
+- `/api/docs?format=sitemap-md`
+
+For static export, run the generator before your framework build:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate
+```
+
+The command writes `.farming-labs/sitemap-manifest.json` plus public sitemap files. It uses each
+page source file's last git commit date for `lastmod`, with filesystem modified time as a fallback.
+
+Use `routePrefix` to move all sitemap routes together:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  sitemap: {
+    routePrefix: "/docs-map",
+  },
+});
+```
+
+That generates `/docs-map/sitemap.xml`, `/docs-map/sitemap.md`, and
+`/docs-map/.well-known/sitemap.md`. See [Sitemaps](/docs/customization/sitemaps) for static export,
+manifest, `lastmod`, and output examples.
 
 ## Static export
 

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -23,5 +23,6 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[Observability](/docs/customization/observability)** — Trace Ask AI and MCP runs with span IDs, timing, status, previews, and errors
 - **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio, `/mcp`, and `/.well-known/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
+- **[Sitemaps](/docs/customization/sitemaps)** — Generate `sitemap.xml` and `sitemap.md` for crawlers, agents, and static exports
 
 All customization happens through the `theme` and top-level config options in `docs.config.ts`.

--- a/website/app/docs/customization/sitemaps/page.mdx
+++ b/website/app/docs/customization/sitemaps/page.mdx
@@ -1,0 +1,331 @@
+---
+title: "Sitemaps"
+description: "Generate sitemap.xml and sitemap.md for crawlers, agents, and static exports"
+icon: "file"
+order: 5.85
+related:
+  - /docs/customization/llms-txt
+  - /docs/customization/agent-primitive
+  - /docs/customization/mcp
+  - /docs/configuration
+  - /docs/cli
+---
+
+# Sitemaps
+
+Generate both a standard `sitemap.xml` and a semantic `sitemap.md` from the same docs source. The
+XML file gives search crawlers a canonical URL list with freshness dates. The Markdown file gives
+agents, contributors, and automation a readable map of the docs tree with titles, descriptions,
+markdown URLs, last-updated dates, and related pages.
+
+<Agent>
+Use this page when the task is to enable or troubleshoot generated sitemaps.
+
+Default public routes:
+- `/sitemap.xml`
+- `/sitemap.md`
+- `/.well-known/sitemap.md`
+
+Static export command:
+- `pnpm exec docs sitemap generate`
+
+The command writes `.farming-labs/sitemap-manifest.json` plus public sitemap files unless
+`--manifest-only` is used. Lastmod dates come from `git log -1` for each page source path first,
+then filesystem mtime as a fallback.
+</Agent>
+
+## Quick Start
+
+Enable sitemaps in `docs.config.ts`:
+
+```ts title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  sitemap: {
+    enabled: true,
+    baseUrl: "https://docs.example.com",
+  },
+});
+```
+
+That exposes these routes through the same docs server wrapper and public forwarding layer:
+
+- `GET /sitemap.xml`
+- `GET /sitemap.md`
+- `GET /.well-known/sitemap.md`
+- `GET /api/docs?format=sitemap-xml`
+- `GET /api/docs?format=sitemap-md`
+
+Next.js `withDocs()` adds the public rewrites automatically. TanStack Start, SvelteKit, Astro, and
+Nuxt use the same generated public forwarder that already handles `.md`, `llms.txt`, `.well-known`,
+and MCP routes.
+
+## Static Export
+
+For static hosting, run the generator before your framework build:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate
+```
+
+The command writes:
+
+- `.farming-labs/sitemap-manifest.json`
+- `public/sitemap.xml`
+- `public/sitemap.md`
+- `public/.well-known/sitemap.md`
+
+SvelteKit uses `static/` instead of `public/`.
+
+`docs sitemap generate` is enough for static output. The `--public` flag is only an explicit spelling
+for the default behavior. Use `--manifest-only` when a server-rendered app only needs the generated
+manifest for accurate `lastmod` values and should keep the public route handled by the runtime.
+
+```bash title="terminal"
+pnpm exec docs sitemap generate --manifest-only
+```
+
+Use a custom config path for adapters whose config lives outside the project root:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate --config src/lib/docs.config.ts
+```
+
+Common build scripts:
+
+<Tabs items={["Next.js", "Astro", "SvelteKit", "TanStack Start", "Nuxt"]}>
+  <Tab value="Next.js">
+    ```json title="package.json"
+    {
+      "scripts": {
+        "build": "docs sitemap generate --manifest-only && next build"
+      }
+    }
+    ```
+
+    For `output: "export"`, drop `--manifest-only` so `public/sitemap.xml` and `public/sitemap.md`
+    are written before `next build`.
+  </Tab>
+  <Tab value="Astro">
+    ```json title="package.json"
+    {
+      "scripts": {
+        "build": "docs sitemap generate --config src/lib/docs.config.ts && astro build"
+      }
+    }
+    ```
+  </Tab>
+  <Tab value="SvelteKit">
+    ```json title="package.json"
+    {
+      "scripts": {
+        "build": "docs sitemap generate --config src/lib/docs.config.ts && vite build"
+      }
+    }
+    ```
+  </Tab>
+  <Tab value="TanStack Start">
+    ```json title="package.json"
+    {
+      "scripts": {
+        "build": "docs sitemap generate && vite build"
+      }
+    }
+    ```
+  </Tab>
+  <Tab value="Nuxt">
+    ```json title="package.json"
+    {
+      "scripts": {
+        "build": "docs sitemap generate && nuxt build"
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+When you dogfood unpublished workspace packages, you may need to call the built CLI file directly
+after building the package. Published apps should use `docs` in package scripts or `pnpm exec docs`
+from the terminal.
+
+## What `lastmod` Means
+
+`lastmod` is the last known content update date for a page. It appears as `<lastmod>` in
+`sitemap.xml` and as `Last updated:` in `sitemap.md`.
+
+The CLI resolves dates in this order:
+
+1. the last git commit date for the page source file
+2. the filesystem modified date for the page source file
+3. no date, if neither source is available
+
+Git dates are preferred because they are stable across machines and CI runs. Filesystem dates are a
+fallback for new files, generated content, or projects that are not in a git checkout.
+
+Freshness is useful because crawlers and agents can:
+
+- detect pages that changed since the last crawl
+- prioritize recently edited documentation
+- avoid re-reading stable pages unnecessarily
+- show contributors where docs may have gone stale
+
+If you do not want freshness dates, disable them per output:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  sitemap: {
+    xml: {
+      includeLastmod: false,
+    },
+    markdown: {
+      includeLastmod: false,
+    },
+  },
+});
+```
+
+## Route Prefix
+
+Use `routePrefix` when you want the sitemap routes under a custom prefix:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  sitemap: {
+    enabled: true,
+    routePrefix: "/docs-map",
+    baseUrl: "https://docs.example.com",
+  },
+});
+```
+
+This generates:
+
+- `/docs-map/sitemap.xml`
+- `/docs-map/sitemap.md`
+- `/docs-map/.well-known/sitemap.md`
+
+There is no separate well-known route setting. The prefix applies to all sitemap routes together so
+adapters only need one forwarding rule.
+
+## Configuration Reference
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  sitemap: {
+    enabled: true,
+    routePrefix: "",
+    baseUrl: "https://docs.example.com",
+    manifestPath: ".farming-labs/sitemap-manifest.json",
+    xml: {
+      enabled: true,
+      includeLastmod: true,
+    },
+    markdown: {
+      enabled: true,
+      includeDescriptions: true,
+      includeLastmod: true,
+      linkTarget: "both",
+    },
+  },
+});
+```
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `sitemap` | `boolean \| DocsSitemapConfig` | `false` | Enable or configure sitemap routes. |
+| `sitemap.enabled` | `boolean` | `true` when `sitemap` is an object | Disable without removing the object. |
+| `sitemap.routePrefix` | `string` | `""` | Prefix all public sitemap routes. |
+| `sitemap.baseUrl` | `string` | request origin at runtime, `llmsTxt.baseUrl` in the CLI | Absolute base URL for XML `<loc>` values. |
+| `sitemap.manifestPath` | `string` | `.farming-labs/sitemap-manifest.json` | Internal generated manifest path. |
+| `sitemap.xml` | `boolean \| SitemapXmlConfig` | enabled | Enable or configure `sitemap.xml`. |
+| `sitemap.xml.includeLastmod` | `boolean` | `true` | Include `<lastmod>` when a page date is known. |
+| `sitemap.markdown` | `boolean \| SitemapMarkdownConfig` | enabled | Enable or configure `sitemap.md`. |
+| `sitemap.markdown.includeDescriptions` | `boolean` | `true` | Include page descriptions in the Markdown sitemap. |
+| `sitemap.markdown.includeLastmod` | `boolean` | `true` | Include `Last updated:` lines when a page date is known. |
+| `sitemap.markdown.linkTarget` | `"html" \| "markdown" \| "both"` | `"both"` | Choose whether list items link to HTML pages, Markdown pages, or both. |
+
+## Output Examples
+
+### `sitemap.xml`
+
+```xml title="sitemap.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://docs.example.com/docs</loc>
+    <lastmod>2026-05-08</lastmod>
+  </url>
+  <url>
+    <loc>https://docs.example.com/docs/installation</loc>
+    <lastmod>2026-05-08</lastmod>
+  </url>
+</urlset>
+```
+
+### `sitemap.md`
+
+```markdown title="sitemap.md"
+# Example Docs Sitemap
+
+Base URL: https://docs.example.com
+Docs entry: /docs
+Generated: 2026-05-08
+
+## Overview
+
+- [Introduction](/docs)
+  Markdown: /docs.md
+  Description: Start here
+  Last updated: 2026-05-08
+
+## Installation
+
+- [Installation](/docs/installation)
+  Markdown: /docs/installation.md
+  Description: Install the docs framework
+  Last updated: 2026-05-08
+  Related: /docs/configuration
+```
+
+### Manifest
+
+```json title=".farming-labs/sitemap-manifest.json"
+{
+  "version": 1,
+  "generatedAt": "2026-05-08T00:00:00.000Z",
+  "baseUrl": "https://docs.example.com",
+  "entry": "docs",
+  "siteTitle": "Example Docs",
+  "pages": [
+    {
+      "url": "/docs/installation",
+      "absoluteUrl": "https://docs.example.com/docs/installation",
+      "markdownUrl": "/docs/installation.md",
+      "title": "Installation",
+      "description": "Install the docs framework",
+      "sourcePath": "docs/installation/page.mdx",
+      "lastmod": "2026-05-08",
+      "lastmodSource": "git",
+      "related": ["/docs/configuration"]
+    }
+  ]
+}
+```
+
+## Verification
+
+After enabling the feature, check the public routes:
+
+```bash title="terminal"
+curl "http://127.0.0.1:3000/sitemap.xml"
+curl "http://127.0.0.1:3000/sitemap.md"
+curl "http://127.0.0.1:3000/.well-known/sitemap.md"
+```
+
+In CI, use `--check` to fail when generated static output is stale:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate --check
+```

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -5,6 +5,7 @@ related:
   - /docs/guides
   - /docs/customization/agent-primitive
   - /docs/customization/llms-txt
+  - /docs/customization/sitemaps
   - /docs/customization/mcp
   - /docs/configuration
   - /docs/cli
@@ -212,6 +213,10 @@ export default defineDocs({
     enabled: true,
     baseUrl: "https://docs.example.com",
   },
+  sitemap: {
+    enabled: true,
+    baseUrl: "https://docs.example.com",
+  },
   mcp: {
     enabled: true,
   },
@@ -227,6 +232,7 @@ That gives agents a much better workflow:
 
 - `/.well-known/agent.json` tells them which routes exist
 - `/llms.txt` and `/llms-full.txt` expose site-level machine summaries
+- `/sitemap.xml` and `/sitemap.md` expose canonical URLs and freshness metadata
 - `{page}.md` gives them clean page markdown
 - MCP lets tool-enabled agents search and read docs semantically
 
@@ -251,6 +257,7 @@ Example:
 - Open `http://localhost:3000/docs`
 - Fetch `http://localhost:3000/docs.md`
 - Fetch `http://localhost:3000/.well-known/agent.json`
+- Fetch `http://localhost:3000/sitemap.md`
 
 ## Troubleshooting
 
@@ -388,7 +395,7 @@ Before calling a page agent-friendly, ask:
 - should this page get an additive `<Agent>` block?
 - does it need a dedicated `agent.md`, or is the human page still canonical?
 - does this page need `agent.tokenBudget` before compaction?
-- can an agent find it through `.md`, `llms.txt`, MCP, and the discovery spec?
+- can an agent find it through `.md`, `llms.txt`, sitemaps, MCP, and the discovery spec?
 - does `docs doctor --agent` agree with the state of the site?
 
 <Callout type="warning" title="Keep evaluation input out of prompt context">
@@ -403,7 +410,7 @@ can technically crawl. You are publishing docs they can actually work with.
 ## Read Next
 
 - [Agent Primitive](/docs/customization/agent-primitive) for `Agent` blocks and sibling `agent.md`
-- [llms.txt](/docs/customization/llms-txt) for the discovery layer
+- [llms.txt](/docs/customization/llms-txt) and [Sitemaps](/docs/customization/sitemaps) for the discovery layer
 - [MCP Server](/docs/customization/mcp) for tool-enabled retrieval
 - [CLI](/docs/cli#agent-compact) for `docs agent compact`
 - [CLI](/docs/cli#doctor) for `docs doctor --agent`

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -224,6 +224,10 @@ export default defineDocs({
     siteDescription:
       "An AI-native documentation framework for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt.",
   },
+  sitemap: {
+    enabled: true,
+    baseUrl: "https://docs.farming-labs.dev",
+  },
   og: {
     enabled: true,
     type: "dynamic",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "pnpm prisma generate && pnpm -C .. build && pnpm --dir ../examples/next build && pnpm --dir ../examples/tanstack-start build && pnpm --dir ../examples/nuxt build && pnpm --dir ../examples/astro build && pnpm --dir ../examples/sveltekit build && next build",
+    "build": "pnpm prisma generate && pnpm -C .. build && pnpm --dir ../examples/next build && pnpm --dir ../examples/tanstack-start build && pnpm --dir ../examples/nuxt build && pnpm --dir ../examples/astro build && pnpm --dir ../examples/sveltekit build && node ../packages/docs/dist/cli/index.mjs sitemap generate --config docs.config.tsx --manifest-only && next build",
     "start": "next start",
     "postinstall": "prisma generate"
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds sitemap docs and examples for generating `sitemap.xml` and `sitemap.md`, including the new `sitemap generate` CLI flow and `sitemap` config. This helps teams ship crawler- and agent-friendly sitemaps with proper lastmod dates and static export support.

- **New Features**
  - New Sitemaps guide at `/docs/customization/sitemaps` with XML/Markdown outputs, `lastmod` behavior, `routePrefix`, manifest format, and examples.
  - CLI docs: added `sitemap generate` usage and flags (`--config`, `--manifest-only`, `--public`, `--check`) with build script samples.
  - Configuration docs: added `sitemap` option to `docs.config.ts` plus default routes (`/sitemap.xml`, `/sitemap.md`, `/.well-known/sitemap.md`) and API endpoints.
  - Skills updated: `cli` and `configuration` skills now cover `sitemap generate` and `sitemap` config; indexes point to the new content.
  - Website enabled sitemaps in `website/docs.config.tsx` and runs the CLI with `--manifest-only` in the build script.
  - Cross-links added in guides and customization index to surface the sitemaps docs.

<sup>Written for commit 3fd0d8fec5ffef431203af2dfb3e237e487da54a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

