### PR TITLE
fix: add sidebar icons for analytics pages

### DIFF
--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -31,6 +31,8 @@ import {
   Copy,
   Check,
   ArrowUpRight,
+  ChartNoAxesColumn,
+  Activity,
 } from "lucide-react";
 import { SidebarThemeToggle } from "@/components/sidebar-theme-toggle";
 import { Callout } from "@/components/ui/callout";
@@ -136,6 +138,8 @@ export default defineDocs({
     copy: <Copy size={16} />,
     check: <Check size={16} />,
     arrowUpRight: <ArrowUpRight size={16} />,
+    "chart-no-axes-column": <ChartNoAxesColumn size={16} />,
+    activity: <Activity size={16} />,
   },
   github: {
     url: "https://github.com/farming-labs/docs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `ChartNoAxesColumn` and `Activity` icons from `lucide-react` to the docs sidebar config for analytics pages. Fixes missing sidebar icons by mapping `"chart-no-axes-column"` and `"activity"` to 16px icons.

<sup>Written for commit e4a60d7a7d9b0b211107a7f518de84501416ac87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

