### PR TITLE
chore: sitemap docs sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ experience for humans, IDEs, and agents without maintaining a pile of routing bo
 - Built-in search with simple, Typesense, Algolia, MCP, and custom provider options
 - Generated API reference from framework route handlers or a hosted OpenAPI JSON document
 - Next.js changelog pages from dated MDX entries
-- Machine-readable docs through `.md` routes, `llms.txt`, `skill.md`, agent discovery, and MCP
+- Machine-readable docs through `.md` routes, `llms.txt`, sitemaps, `skill.md`, agent discovery, and MCP
 - Page-level agent compaction with `docs agent compact` and `agent.compact` defaults
 - Agent and reader-facing docs scoring with `docs doctor --agent` and `docs doctor --site`
 
@@ -99,10 +99,14 @@ Your docs content here.
 
 ## Agent And LLM Surface
 
-The framework exposes machine-readable docs by default in Next.js:
+The framework exposes machine-readable docs in Next.js, with sitemap routes available when
+`sitemap` is enabled:
 
 - `/llms.txt`
 - `/llms-full.txt`
+- `/sitemap.xml`
+- `/sitemap.md`
+- `/.well-known/sitemap.md`
 - `/skill.md`
 - `/.well-known/skill.md`
 - `/.well-known/agent.json`
@@ -117,6 +121,19 @@ The canonical API routes remain available under `/api/docs`, including `/api/doc
 
 For a custom site-specific skill, place `skill.md` at the project root beside `docs.config.ts`.
 When it is missing, the framework serves a generated fallback based on the docs config.
+
+Enable `sitemap` when you also want crawler-friendly XML and agent-friendly Markdown maps:
+
+```ts
+sitemap: {
+  enabled: true,
+  baseUrl: "https://docs.example.com",
+},
+```
+
+For static hosting, run `pnpm exec docs sitemap generate` before your framework build so
+`public/sitemap.xml`, `public/sitemap.md`, `public/.well-known/sitemap.md`, and the internal
+`.farming-labs/sitemap-manifest.json` stay fresh.
 
 ## Agent Compaction
 
@@ -198,6 +215,7 @@ The command checks the agent surface end to end:
 - public agent routes
 - agent discovery spec
 - `llms.txt`
+- `sitemap.xml` / `sitemap.md`
 - `skill.md`
 - MCP
 - search
@@ -216,10 +234,11 @@ pnpm exec docs doctor --agent --url https://docs.example.com
 pnpm exec docs doctor --agent --url https://docs.example.com --json
 ```
 
-Hosted checks request `/.well-known/agent.json`, `/llms.txt`, `/llms-full.txt`, `/skill.md`,
-`/.well-known/skill.md`, one representative `.md` page route, `/mcp`, and `/.well-known/mcp`.
+Hosted checks request `/.well-known/agent.json`, `/llms.txt`, `/llms-full.txt`, sitemap routes,
+`/skill.md`, `/.well-known/skill.md`, one representative `.md` page route, `/mcp`, and
+`/.well-known/mcp`.
 For MCP, the doctor performs an HTTP initialize handshake, checks the session header, and verifies
-the built-in docs tools are exposed. With hosted checks enabled, the agent score is out of `130`
+the built-in docs tools are exposed. With hosted checks enabled, the agent score is out of `135`
 instead of `100`.
 
 `docs doctor --site` focuses on the reader-facing surface instead:
@@ -261,6 +280,7 @@ Use the full docs for feature-specific setup:
 - [Themes](https://docs.farming-labs.dev/docs/customization)
 - [MCP server](https://docs.farming-labs.dev/docs/customization/mcp)
 - [llms.txt](https://docs.farming-labs.dev/docs/customization/llms-txt)
+- [Sitemaps](https://docs.farming-labs.dev/docs/customization/sitemaps)
 - [Agent primitive](https://docs.farming-labs.dev/docs/customization/agent-primitive)
 - [Examples](https://github.com/farming-labs/docs/tree/main/examples)
 

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -130,6 +130,7 @@ describe("inspectAgentReadiness", () => {
       `export default {
   entry: "docs",
   llmsTxt: { enabled: true },
+  sitemap: { enabled: true },
   search: true,
   mcp: { enabled: true },
   feedback: {
@@ -248,6 +249,7 @@ Use this docs site through markdown routes and MCP.
     expect(report.checks.find((check) => check.id === "api-route")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "public-routes")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "agent-discovery")?.status).toBe("pass");
+    expect(report.checks.find((check) => check.id === "sitemap")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "skill")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "feedback")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "metadata")?.status).toBe("pass");
@@ -262,6 +264,7 @@ Use this docs site through markdown routes and MCP.
       `export default {
   entry: "docs",
   llmsTxt: { enabled: true },
+  sitemap: { enabled: true },
   search: true,
   mcp: { enabled: true },
 };`,
@@ -302,6 +305,16 @@ export const { GET, POST } = createDocsAPI({});
         if (url.pathname === "/llms.txt" || url.pathname === "/llms-full.txt") {
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end(`# Docs\n\n${url.pathname}`);
+          return;
+        }
+
+        if (
+          url.pathname === "/sitemap.xml" ||
+          url.pathname === "/sitemap.md" ||
+          url.pathname === "/.well-known/sitemap.md"
+        ) {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end(url.pathname.endsWith(".xml") ? "<urlset></urlset>" : "# Docs Sitemap");
           return;
         }
 
@@ -411,11 +424,12 @@ export const { GET, POST } = createDocsAPI({});
       const report = await inspectAgentReadiness({ url: `http://127.0.0.1:${port}` });
 
       expect(report.url).toBe(`http://127.0.0.1:${port}`);
-      expect(report.maxScore).toBe(130);
+      expect(report.maxScore).toBe(135);
       expect(report.checks.find((check) => check.id === "hosted-agent-discovery")?.status).toBe(
         "pass",
       );
       expect(report.checks.find((check) => check.id === "hosted-llms")?.status).toBe("pass");
+      expect(report.checks.find((check) => check.id === "hosted-sitemap")?.status).toBe("pass");
       expect(report.checks.find((check) => check.id === "hosted-skill")?.status).toBe("pass");
       expect(report.checks.find((check) => check.id === "hosted-markdown")?.status).toBe("pass");
       expect(report.checks.find((check) => check.id === "hosted-mcp")?.status).toBe("pass");
@@ -437,6 +451,7 @@ export const { GET, POST } = createDocsAPI({});
       `export default {
   entry: "docs",
   llmsTxt: { enabled: true },
+  sitemap: { enabled: true },
   search: true,
   mcp: { enabled: true },
   feedback: {
@@ -514,7 +529,7 @@ Use this docs site through markdown routes and MCP.
       process.chdir(tmpDir);
       const report = await inspectAgentReadiness({ url: `http://127.0.0.1:${port}` });
 
-      expect(report.maxScore).toBe(130);
+      expect(report.maxScore).toBe(135);
       expect(report.score).toBeGreaterThanOrEqual(90);
       expect(report.grade).not.toBe("Agent-optimized");
       expect(report.checks.find((check) => check.id === "hosted-agent-discovery")?.status).toBe(

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -14,7 +14,13 @@ import {
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
 } from "../agent.js";
 import { createFilesystemDocsMcpSource, resolveDocsMcpConfig } from "../server.js";
-import type { DocsConfig, DocsMcpConfig } from "../types.js";
+import {
+  DEFAULT_SITEMAP_MD_ROUTE,
+  DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
+  DEFAULT_SITEMAP_XML_ROUTE,
+  resolveDocsSitemapConfig,
+} from "../sitemap.js";
+import type { DocsConfig, DocsMcpConfig, DocsSitemapConfig } from "../types.js";
 import {
   extractNestedObjectLiteral,
   extractTopLevelConfigObject,
@@ -333,6 +339,17 @@ function readTopLevelBooleanProperty(content: string, key: string): boolean | un
   return undefined;
 }
 
+function readObjectBooleanProperty(content: string, key: string): boolean | undefined {
+  const propertyPattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*:\\s*(true|false)(?:\\s|$)`);
+
+  for (const property of splitTopLevelProperties(content)) {
+    const match = property.trim().match(propertyPattern);
+    if (match) return match[1] === "true";
+  }
+
+  return undefined;
+}
+
 function resolveFeatureEnabled(
   config: DocsConfig | undefined,
   content: string,
@@ -353,6 +370,27 @@ function resolveFeatureEnabled(
 
   const enabled = readBooleanProperty(block, "enabled");
   return enabled ?? true;
+}
+
+function readSitemapConfigFromStatic(content: string): boolean | DocsSitemapConfig | undefined {
+  const topLevelBoolean = readTopLevelBooleanProperty(content, "sitemap");
+  if (typeof topLevelBoolean === "boolean") return topLevelBoolean;
+
+  const block = extractNestedObjectLiteral(content, ["sitemap"]);
+  if (!block) return undefined;
+
+  const config: DocsSitemapConfig = {};
+  const enabled = readObjectBooleanProperty(block, "enabled");
+  const routePrefix = block.match(/\broutePrefix\s*:\s*["'`]([^"'`]+)["'`]/)?.[1];
+  const baseUrl = block.match(/\bbaseUrl\s*:\s*["'`]([^"'`]+)["'`]/)?.[1];
+  const manifestPath = block.match(/\bmanifestPath\s*:\s*["'`]([^"'`]+)["'`]/)?.[1];
+
+  if (typeof enabled === "boolean") config.enabled = enabled;
+  if (routePrefix) config.routePrefix = routePrefix;
+  if (baseUrl) config.baseUrl = baseUrl;
+  if (manifestPath) config.manifestPath = manifestPath;
+
+  return config;
 }
 
 function resolveStaticExport(config: DocsConfig | undefined, content: string): boolean {
@@ -534,7 +572,7 @@ function detectRouteSurface(
         apiDetail: "Next static export disables /api/docs and the shared agent endpoints.",
         publicMounted: false,
         publicDetail:
-          "Public .md, llms.txt, skill.md, and agent discovery routes depend on /api/docs.",
+          "Public .md, llms.txt, sitemap, skill.md, and agent discovery routes depend on /api/docs.",
       };
     }
 
@@ -1270,6 +1308,41 @@ async function probeMcpRoute(
   }
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function readDiscoveryRoute(value: unknown): string | undefined {
+  return typeof value === "string" && value.startsWith("/") ? value : undefined;
+}
+
+function hostedSitemapRoutes(discoveryBody: unknown): {
+  enabled: boolean;
+  routes: string[];
+} {
+  const sitemap = asRecord(asRecord(discoveryBody)?.sitemap);
+
+  if (sitemap?.enabled === false) {
+    return { enabled: false, routes: [] };
+  }
+
+  const xml = asRecord(sitemap?.xml);
+  const markdown = asRecord(sitemap?.markdown);
+  const routes = [
+    xml?.enabled === false
+      ? undefined
+      : (readDiscoveryRoute(xml?.route) ?? DEFAULT_SITEMAP_XML_ROUTE),
+    markdown?.enabled === false
+      ? undefined
+      : (readDiscoveryRoute(markdown?.route) ?? DEFAULT_SITEMAP_MD_ROUTE),
+    markdown?.enabled === false
+      ? undefined
+      : (readDiscoveryRoute(markdown?.wellKnownRoute) ?? DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE),
+  ].filter((route): route is string => typeof route === "string");
+
+  return { enabled: true, routes: Array.from(new Set(routes)) };
+}
+
 async function buildHostedAgentChecks(
   url: string,
   pages: Array<{ url: string }>,
@@ -1328,6 +1401,51 @@ async function buildHostedAgentChecks(
         : "Verify deployed /llms.txt and /llms-full.txt routes return non-empty text.",
     ),
   );
+
+  const sitemapRoutes = hostedSitemapRoutes(discovery.body);
+  if (sitemapRoutes.enabled && sitemapRoutes.routes.length > 0) {
+    const sitemap = await Promise.all(
+      sitemapRoutes.routes.map((route) => probeTextRoute(baseUrl, route)),
+    );
+    const sitemapPassed = sitemap.filter((result) => result.ok).length;
+    checks.push(
+      makeCheck(
+        "hosted-sitemap",
+        "Hosted sitemap",
+        sitemapPassed === sitemap.length ? "pass" : sitemapPassed > 0 ? "warn" : "fail",
+        sitemapPassed === sitemap.length ? 5 : sitemapPassed > 0 ? 3 : 0,
+        5,
+        sitemap.map((result) => result.detail).join(" "),
+        sitemapPassed === sitemap.length
+          ? undefined
+          : `Verify deployed sitemap routes return non-empty text: ${sitemapRoutes.routes.join(", ")}.`,
+      ),
+    );
+  } else if (sitemapRoutes.enabled) {
+    checks.push(
+      makeCheck(
+        "hosted-sitemap",
+        "Hosted sitemap",
+        "warn",
+        0,
+        5,
+        "The hosted discovery spec reports sitemap support but did not expose sitemap routes.",
+        "Check sitemap.xml and sitemap.markdown config so at least one sitemap route is enabled.",
+      ),
+    );
+  } else {
+    checks.push(
+      makeCheck(
+        "hosted-sitemap",
+        "Hosted sitemap",
+        "warn",
+        0,
+        5,
+        "The hosted discovery spec reports sitemap routes as disabled.",
+        "Enable sitemap in docs.config when agents and crawlers should discover canonical URLs and freshness metadata.",
+      ),
+    );
+  }
 
   const skill = await Promise.all([
     probeTextRoute(baseUrl, DEFAULT_SKILL_MD_ROUTE),
@@ -1537,6 +1655,9 @@ export async function inspectAgentReadiness(
       defaultName: siteTitle,
     },
   );
+  const sitemapConfig = resolveDocsSitemapConfig(
+    config?.sitemap ?? readSitemapConfigFromStatic(configContent) ?? false,
+  );
   const feedbackRoute = DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = `${feedbackRoute}/schema`;
 
@@ -1587,7 +1708,7 @@ export async function inspectAgentReadiness(
       routeSurface.apiDetail,
       routeSurface.apiMounted
         ? undefined
-        : "Wire the framework docs API route so /api/docs can serve markdown, llms.txt, skill.md, and discovery responses.",
+        : "Wire the framework docs API route so /api/docs can serve markdown, llms.txt, sitemap, skill.md, and discovery responses.",
     ),
   );
 
@@ -1601,7 +1722,7 @@ export async function inspectAgentReadiness(
       routeSurface.publicDetail,
       routeSurface.publicMounted
         ? undefined
-        : "Add the framework public forwarder so /.well-known/*, /llms.txt, /skill.md, /mcp, and .md routes resolve from the shared docs API.",
+        : "Add the framework public forwarder so /.well-known/*, /llms.txt, /sitemap.xml, /sitemap.md, /skill.md, /mcp, and .md routes resolve from the shared docs API.",
     ),
   );
 
@@ -1627,8 +1748,8 @@ export async function inspectAgentReadiness(
           "llms",
           "llms.txt discovery",
           "pass",
-          10,
-          10,
+          5,
+          5,
           `Enabled via ${DEFAULT_LLMS_TXT_ROUTE} and ${DEFAULT_LLMS_FULL_TXT_ROUTE}.`,
         )
       : makeCheck(
@@ -1636,9 +1757,30 @@ export async function inspectAgentReadiness(
           "llms.txt discovery",
           "warn",
           0,
-          10,
+          5,
           `${DEFAULT_LLMS_TXT_ROUTE} and ${DEFAULT_LLMS_FULL_TXT_ROUTE} are disabled in docs config.`,
           "Enable llmsTxt so agents and GEO crawlers can discover the docs index and full context surfaces.",
+        ),
+  );
+
+  checks.push(
+    sitemapConfig.enabled
+      ? makeCheck(
+          "sitemap",
+          "Sitemap discovery",
+          "pass",
+          5,
+          5,
+          `Enabled via ${sitemapConfig.xml.route}, ${sitemapConfig.markdown.route}, and ${sitemapConfig.markdown.wellKnownRoute}.`,
+        )
+      : makeCheck(
+          "sitemap",
+          "Sitemap discovery",
+          "warn",
+          0,
+          5,
+          "Generated sitemap routes are disabled in docs config.",
+          "Enable sitemap so crawlers and agents can discover canonical docs URLs, semantic sections, and lastmod freshness metadata.",
         ),
   );
 

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -2781,7 +2781,7 @@ ${cfg.entry}/                   # Markdown content
   quickstart/page.md
 server/
   api/docs.ts                   # Page data, search, and AI chat API
-  middleware/docs-public.ts     # llms.txt, .well-known, .md, and MCP aliases
+  middleware/docs-public.ts     # llms.txt, sitemap, .well-known, .md, and MCP aliases
 pages/
   ${cfg.entry}/[[...slug]].vue   # Docs catch-all page
 docs.config.ts

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -20,6 +20,7 @@ Useful routes:
 
 - Agent discovery spec: `http://127.0.0.1:3000/api/docs/agent/spec`
 - Site skill: `http://127.0.0.1:3000/skill.md` or `http://127.0.0.1:3000/.well-known/skill.md`
+- Sitemaps: `http://127.0.0.1:3000/sitemap.xml`, `http://127.0.0.1:3000/sitemap.md`, or `http://127.0.0.1:3000/.well-known/sitemap.md`
 - MCP: `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`
@@ -31,11 +32,13 @@ Useful routes:
 Useful command:
 
 ```bash
+pnpm --dir examples/next exec docs sitemap generate --config docs.config.tsx
 pnpm --dir examples/next exec docs agent compact installation --config docs.config.tsx
 ```
 
-The agent discovery spec also advertises the root `skill.md` route, this Skills pack through
-`npx skills add farming-labs/docs`, and recommends the `getting-started` skill for first-run setup.
+The agent discovery spec also advertises the sitemap routes, the root `skill.md` route, this Skills
+pack through `npx skills add farming-labs/docs`, and recommends the `getting-started` skill for
+first-run setup.
 
 ---
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -396,6 +396,7 @@ What it checks:
 - public agent routes
 - agent discovery spec
 - `llms.txt`
+- `sitemap.xml` and `sitemap.md`
 - `skill.md`
 - MCP
 - search
@@ -409,6 +410,7 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 - `/.well-known/agent.json`
 - `/llms.txt`
 - `/llms-full.txt`
+- sitemap routes from the discovery spec, usually `/sitemap.xml`, `/sitemap.md`, and `/.well-known/sitemap.md`
 - `/skill.md`
 - `/.well-known/skill.md`
 - one representative `.md` page route, such as `/docs.md`
@@ -417,7 +419,10 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 
 For hosted MCP, the command performs a Streamable HTTP initialize handshake, checks for
 `mcp-session-id`, calls `tools/list`, and expects `list_pages`, `get_navigation`, `search_docs`,
-and `read_page`. Hosted checks raise the agent max score from `100` to `130`.
+and `read_page`. Hosted checks raise the agent max score from `100` to `135`.
+
+Hosted JSON check IDs include `hosted-agent-discovery`, `hosted-llms`, `hosted-sitemap`,
+`hosted-skill`, `hosted-markdown`, and `hosted-mcp`.
 
 Expected shape of the output:
 
@@ -464,10 +469,10 @@ pnpm --dir website exec docs doctor --agent --config docs.config.tsx
 When the user chooses **Existing project**, the CLI detects (or prompts for) framework, then theme (including **Create your own theme** → prompts for theme name, scaffolds `themes/<name>.ts` and `themes/<name>.css`), path aliases, entry path (default `docs`; Enter to accept), optional API reference scaffold, optional i18n scaffolding, and global CSS. If API reference is enabled and the user does not pass `--api-route-root`, the CLI detects a sensible default route root (usually `api`) and shows it as the default in the prompt. Generated files:
 
 - **Next.js:** `docs.config.ts`, `next.config.ts`, `app/global.css`, `app/layout.tsx`, `app/docs/layout.tsx`, sample MDX pages; installs `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/next`; can start dev server. If API reference is enabled, the CLI also writes `app/api-reference/[[...slug]]/route.ts` (or `src/app/...`).
-- **TanStack Start:** `docs.config.ts`, `src/lib/docs.server.ts`, `src/lib/docs.functions.ts`, `src/routes/<entry>/index.tsx`, `src/routes/<entry>/$.tsx`, `src/routes/api/docs.ts`, one `src/routes/$.ts` public docs forwarder for `/llms.txt`, `.well-known`, `.md`, and MCP, optional `src/routes/api-reference.index.ts` + `src/routes/api-reference.$.ts`, updates `src/routes/__root.tsx`, updates `vite.config.ts`, and wires theme CSS into the selected global stylesheet; installs `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/tanstack-start`.
-- **SvelteKit:** `src/lib/docs.config.ts`, `src/lib/docs.server.ts`, `src/routes/docs/*`, `src/routes/api/docs/+server.ts`, one `src/hooks.server.ts` public docs forwarder for `/llms.txt`, `.well-known`, `.md`, and MCP, optional `src/routes/api-reference/+server.ts` + `src/routes/api-reference/[...slug]/+server.ts`, `src/app.css`, `docs/*.md`; installs svelte + svelte-theme packages.
-- **Astro:** `src/lib/docs.config.ts`, `src/lib/docs.server.ts`, `src/pages/**`, `src/pages/api/docs.ts`, one `src/middleware.ts` public docs forwarder for `/llms.txt`, `.well-known`, `.md`, and MCP, optional `src/pages/api-reference/index.ts` + `src/pages/api-reference/[...slug].ts`, `docs/*.md`; installs astro + astro-theme packages.
-- **Nuxt:** `docs.config.ts`, `nuxt.config.ts`, `server/api/docs.ts`, `server/middleware/docs-public.ts` for `/llms.txt`, `.well-known`, `.md`, and MCP forwarding, optional `server/routes/api-reference/index.ts` + `server/routes/api-reference/[...slug].ts`, `pages/docs/[...slug].vue`, `docs/*.md`; installs nuxt + nuxt-theme packages.
+- **TanStack Start:** `docs.config.ts`, `src/lib/docs.server.ts`, `src/lib/docs.functions.ts`, `src/routes/<entry>/index.tsx`, `src/routes/<entry>/$.tsx`, `src/routes/api/docs.ts`, one `src/routes/$.ts` public docs forwarder for `/llms.txt`, sitemap routes, `.well-known`, `.md`, and MCP, optional `src/routes/api-reference.index.ts` + `src/routes/api-reference.$.ts`, updates `src/routes/__root.tsx`, updates `vite.config.ts`, and wires theme CSS into the selected global stylesheet; installs `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/tanstack-start`.
+- **SvelteKit:** `src/lib/docs.config.ts`, `src/lib/docs.server.ts`, `src/routes/docs/*`, `src/routes/api/docs/+server.ts`, one `src/hooks.server.ts` public docs forwarder for `/llms.txt`, sitemap routes, `.well-known`, `.md`, and MCP, optional `src/routes/api-reference/+server.ts` + `src/routes/api-reference/[...slug]/+server.ts`, `src/app.css`, `docs/*.md`; installs svelte + svelte-theme packages.
+- **Astro:** `src/lib/docs.config.ts`, `src/lib/docs.server.ts`, `src/pages/**`, `src/pages/api/docs.ts`, one `src/middleware.ts` public docs forwarder for `/llms.txt`, sitemap routes, `.well-known`, `.md`, and MCP, optional `src/pages/api-reference/index.ts` + `src/pages/api-reference/[...slug].ts`, `docs/*.md`; installs astro + astro-theme packages.
+- **Nuxt:** `docs.config.ts`, `nuxt.config.ts`, `server/api/docs.ts`, `server/middleware/docs-public.ts` for `/llms.txt`, sitemap routes, `.well-known`, `.md`, and MCP forwarding, optional `server/routes/api-reference/index.ts` + `server/routes/api-reference/[...slug].ts`, `pages/docs/[...slug].vue`, `docs/*.md`; installs nuxt + nuxt-theme packages.
 
 **Create your own theme:** If the user selects this, the CLI prompts for a theme name (default `my-theme`; Enter to accept), then creates `themes/<name>.ts` and `themes/<name>.css` and wires them in `docs.config` and global CSS. See the `creating-themes` skill for the API.
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -487,7 +487,7 @@ feedback: {
 Default behavior:
 
 - `GET /.well-known/agent.json` is the preferred public agent discovery document, with `/.well-known/agent` as fallback and `/api/docs/agent/spec` as the canonical framework route
-- the discovery document includes site identity, locale config, capability flags, search, markdown routes, `llms.txt`, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
+- the discovery document includes site identity, locale config, capability flags, search, markdown routes, `llms.txt`, sitemap routes, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
 - `GET /skill.md` serves the root `skill.md` file when present, `GET /.well-known/skill.md` is the fallback alias, and `GET /api/docs?format=skill` is the shared API format
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Eleven built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-bor
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, `llms.txt` routes, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, `llms.txt` routes, sitemap routes, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -384,6 +384,7 @@ What it checks:
 - public agent route wiring
 - agent discovery spec
 - `llms.txt`
+- `sitemap.xml` and `sitemap.md`
 - `skill.md`
 - MCP
 - search
@@ -499,6 +500,7 @@ The hosted pass probes:
 - `/.well-known/agent.json`
 - `/llms.txt`
 - `/llms-full.txt`
+- sitemap routes from the discovery spec, usually `/sitemap.xml`, `/sitemap.md`, and `/.well-known/sitemap.md`
 - `/skill.md`
 - `/.well-known/skill.md`
 - one representative page markdown route, such as `/docs.md`
@@ -513,9 +515,10 @@ For MCP, the doctor performs a Streamable HTTP `initialize` request, checks for 
 - `search_docs`
 - `read_page`
 
-Hosted checks raise the agent report from `100` possible points to `130` possible points. The JSON
+Hosted checks raise the agent report from `100` possible points to `135` possible points. The JSON
 report also includes the normalized `url` field and hosted check IDs such as
-`hosted-agent-discovery`, `hosted-llms`, `hosted-skill`, `hosted-markdown`, and `hosted-mcp`.
+`hosted-agent-discovery`, `hosted-llms`, `hosted-sitemap`, `hosted-skill`, `hosted-markdown`, and
+`hosted-mcp`.
 
 Use this form after deploying, in preview-deployment CI, or any time a site looks healthy locally
 but an agent cannot discover the public routes. A hosted failure usually means the deployment is
@@ -871,7 +874,7 @@ When you choose **Existing project**, the CLI does the following (framework-spec
        - `src/routes/{entry}/index.tsx` — Docs index route
        - `src/routes/{entry}/$.tsx` — Catch-all docs route
        - `src/routes/api/docs.ts` — Search and AI API route
-       - `src/routes/$.ts` — Public `llms.txt`, `.well-known`, `.md`, and MCP aliases
+       - `src/routes/$.ts` — Public `llms.txt`, sitemap, `.well-known`, `.md`, and MCP aliases
        - `src/styles/app.css` — Imports Tailwind and theme CSS
        - `docs/page.mdx` — Sample documentation page
        - `docs/installation/page.mdx` — Sample installation guide
@@ -896,7 +899,7 @@ When you choose **Existing project**, the CLI does the following (framework-spec
        - `src/routes/docs/[...slug]/+page.svelte` — Dynamic page component
        - `src/routes/docs/+page.svelte` — Generated when i18n is enabled
        - `src/routes/api/docs/+server.ts` — Search and AI API route
-       - `src/hooks.server.ts` — Public `llms.txt`, `.well-known`, `.md`, and MCP aliases
+       - `src/hooks.server.ts` — Public `llms.txt`, sitemap, `.well-known`, `.md`, and MCP aliases
        - `src/app.css` — Theme CSS import
        - `docs/page.md` — Sample documentation page
        - `docs/installation/page.md` — Sample installation guide
@@ -918,7 +921,7 @@ When you choose **Existing project**, the CLI does the following (framework-spec
        - `src/pages/{entry}/index.astro` — Docs index page
        - `src/pages/{entry}/[...slug].astro` — Dynamic page component
        - `src/pages/api/{entry}.ts` — API route for search and AI
-       - `src/middleware.ts` — Public `llms.txt`, `.well-known`, `.md`, and MCP aliases
+       - `src/middleware.ts` — Public `llms.txt`, sitemap, `.well-known`, `.md`, and MCP aliases
        - `astro.config.mjs` — Astro config with SSR enabled
        - `docs/page.md` — Sample documentation page
        - `docs/installation/page.md` — Sample installation guide
@@ -938,7 +941,7 @@ When you choose **Existing project**, the CLI does the following (framework-spec
        - `docs.config.ts` — Full config with your selected theme
        - `nuxt.config.ts` — Nuxt config with theme CSS and server assets
        - `server/api/docs.ts` — docs data, search, AI, and page loading
-       - `server/middleware/docs-public.ts` — public `llms.txt`, `.well-known`, `.md`, and MCP aliases
+       - `server/middleware/docs-public.ts` — public `llms.txt`, sitemap, `.well-known`, `.md`, and MCP aliases
        - `pages/docs/[[...slug]].vue` — Catch-all page component that handles the docs index and nested docs routes
        - `docs/page.md` — Sample documentation page
        - `docs/installation/page.md` — Sample installation guide

--- a/website/app/docs/configuration/agent.md
+++ b/website/app/docs/configuration/agent.md
@@ -17,6 +17,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
    - `ai`
    - `mcp`
    - `llmsTxt`
+   - `sitemap`
    - `apiReference`
    - `staticExport`
    - `i18n`
@@ -34,6 +35,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
   - `agent.compact` for defaults used by `docs agent compact`
   - `mcp` for the built-in MCP server
   - `llmsTxt` for crawler-friendly site summaries
+  - `sitemap` for XML and Markdown maps with canonical URLs and freshness dates
   - markdown routes for page-level machine-readable content
 - When they ask about generated API docs, use `apiReference`.
 - When they ask about static hosting, mention `staticExport: true`.
@@ -55,6 +57,7 @@ Use this machine-oriented page when the user needs implementation guidance for `
 - Use [/docs/customization/agent-primitive](/docs/customization/agent-primitive) when the user wants `.md` routes, hidden `<Agent>` content, or sibling `agent.md` overrides.
 - Use [/docs/customization/mcp](/docs/customization/mcp) when they want machine-readable access through the built-in MCP server.
 - Use [/docs/customization/llms-txt](/docs/customization/llms-txt) when they need crawler-friendly summaries for AI systems.
+- Use [/docs/customization/sitemaps](/docs/customization/sitemaps) when they need `sitemap.xml`, `sitemap.md`, static export files, or `lastmod` behavior.
 - Use [/docs/customization/ai-chat](/docs/customization/ai-chat) when they are configuring Ask AI or retrieval-backed chat.
 - Use [/docs/customization/page-actions](/docs/customization/page-actions) when they want Copy Markdown or Open in LLM actions.
 - Use [/docs/token-efficiency](/docs/token-efficiency) when they care about retrieval quality, context size, or agent cost.
@@ -63,9 +66,9 @@ Use this machine-oriented page when the user needs implementation guidance for `
 
 1. Confirm the runtime and config file path first.
 2. Verify `entry`, `contentDir`, `nav`, and `theme` before discussing advanced features.
-3. Move to `search`, `ai`, `mcp`, `pageActions`, or `llmsTxt` only after the base project shape is correct.
+3. Move to `search`, `ai`, `mcp`, `pageActions`, `llmsTxt`, or `sitemap` only after the base project shape is correct.
 4. Use customization and theme pages once routing and content structure are stable.
-5. Use markdown routes, `agent.compact`, MCP, and token-efficiency docs when the user is optimizing for agents or machine-readable access.
+5. Use markdown routes, sitemaps, `agent.compact`, MCP, and token-efficiency docs when the user is optimizing for agents or machine-readable access.
 
 ## Output style
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1176,9 +1176,9 @@ Agents should discover the configured routes first with `GET /.well-known/agent.
 `GET /.well-known/agent` is the fallback public alias, and `GET /api/docs/agent/spec` is the
 canonical framework route. Generated projects wire all three to the same JSON. The spec includes
 site identity, locale config, capability flags, the search endpoint, markdown route pattern and
-`Accept: text/markdown` contract, API and public `llms.txt` routes, root `skill.md` metadata,
-Skills CLI install metadata, MCP public/well-known endpoints and enabled tools, and the active agent
-feedback schema and submit endpoints.
+`Accept: text/markdown` contract, API and public `llms.txt` routes, sitemap routes, root
+`skill.md` metadata, Skills CLI install metadata, MCP public/well-known endpoints and enabled tools,
+and the active agent feedback schema and submit endpoints.
 
 ```ts title="docs.config.ts"
 export default defineDocs({
@@ -1201,7 +1201,7 @@ Default behavior:
 - `GET /api/docs/agent/spec` returns the canonical framework discovery document
 - `GET /skill.md` serves a root `skill.md` file when present, and otherwise returns a generated fallback
 - `GET /.well-known/skill.md` and `GET /api/docs?format=skill` return the same skill document
-- the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, `skills.file`, `skills.route`, and the `llms.txt` defaults
+- the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, `skills.file`, `skills.route`, the `llms.txt` defaults, and sitemap routes when enabled
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler is still the source of truth

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -61,11 +61,12 @@ The spec is generated from `docs.config` and includes:
 
 - site title, description, docs entry, and base URL
 - configured locales and the `lang`/`locale` query parameters
-- capability flags for markdown, MCP, search, feedback, skills, and `llms.txt`
+- capability flags for markdown, MCP, search, feedback, skills, `llms.txt`, and sitemap
 - shared docs API route
 - search endpoint and query parameter
 - markdown route patterns
 - `llms.txt` and `llms-full.txt` routes
+- `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` routes when enabled
 - `skill.md` route, well-known alias, API format, and root file convention
 - Skills CLI install command and recommended skill metadata
 - MCP enabled state, endpoint, server name, version, and tool toggles
@@ -84,7 +85,8 @@ You are reading this docs site as an implementation agent.
 Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
 is unavailable, fall back to `/.well-known/agent`, then `/api/docs/agent/spec`. Use that JSON as the
 source of truth for the docs entry path, markdown route pattern, search endpoint, MCP endpoint,
-`llms.txt` routes, `skill.md`, skills install command, locale handling, and feedback endpoints.
+`llms.txt` routes, `sitemap.xml` / `sitemap.md` routes, `skill.md`, skills install command, locale
+handling, and feedback endpoints.
 
 Recommended bootstrap flow:
 
@@ -92,11 +94,12 @@ Recommended bootstrap flow:
 2. Read `spec.skills.route` or `spec.skills.wellKnown` when a concise site skill is useful.
 3. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page first.
-5. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
-6. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
+6. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
+7. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the
-spec.
+Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
+in the spec.
 </Agent>
 ```
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -81,7 +81,8 @@ You are reading this docs site as an implementation agent.
 Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
 is unavailable, fall back to `/.well-known/agent`. Use that JSON as the source of truth for the docs
 entry path, markdown route pattern, search endpoint, MCP endpoints, `llms.txt` routes, skills install
-command, `skill.md` route, locale handling, and feedback endpoints.
+command, `sitemap.xml` / `sitemap.md` routes, `skill.md` route, locale handling, and feedback
+endpoints.
 
 Recommended bootstrap flow:
 
@@ -89,11 +90,12 @@ Recommended bootstrap flow:
 2. Read `spec.skills.route` or `spec.skills.wellKnown` when you want the concise site skill.
 3. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read relevant docs pages as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page first.
-5. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
-6. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
+6. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
+7. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the
-spec.
+Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
+in the spec.
 </Agent>
 ```
 
@@ -216,6 +218,7 @@ Agents should fetch it before choosing a transport. It tells them:
 - which markdown URL pattern to use for page reads
 - where to fetch `llms.txt` and `llms-full.txt` content, including the default public URLs and the
   public `/.well-known` aliases when available
+- where to fetch `sitemap.xml`, `sitemap.md`, and the `/.well-known/sitemap.md` alias when sitemap is enabled
 - where to fetch the `skill.md` document for this site
 - how to install the published Skills pack and which skill is recommended first
 - whether MCP is enabled, which public/well-known endpoint to call, and which tools are available
@@ -229,7 +232,8 @@ The skill document is available at `GET /skill.md`, with `GET /.well-known/skill
 well-known alias and `GET /api/docs?format=skill` as the shared API format. Put a `skill.md` file at
 the project root, beside `docs.config.ts`, when you want custom site-specific instructions. If that
 file is missing, the framework generates a short fallback from config that points agents to
-markdown, search, MCP, `llms.txt`, feedback, and the reusable Skills CLI install command.
+markdown, search, MCP, `llms.txt`, sitemap routes, feedback, and the reusable Skills CLI install
+command.
 
 ## Choosing Between Them
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -107,7 +107,7 @@ also expose the crawler-friendly public aliases:
 - `GET /llms-full.txt` — default full-content route
 - `GET /.well-known/llms.txt`
 - `GET /.well-known/llms-full.txt`
-- `GET /.well-known/agent.json` for the preferred agent discovery spec that references those `llms.txt` routes
+- `GET /.well-known/agent.json` for the preferred agent discovery spec that references those `llms.txt` routes and the sitemap routes when enabled
 - `GET /.well-known/agent` as the fallback agent discovery alias
 
 Those aliases rewrite to the same shared API output, so there is still only one content pipeline.

--- a/website/app/docs/customization/sitemaps/page.mdx
+++ b/website/app/docs/customization/sitemaps/page.mdx
@@ -329,3 +329,13 @@ In CI, use `--check` to fail when generated static output is stale:
 ```bash title="terminal"
 pnpm exec docs sitemap generate --check
 ```
+
+Use the agent doctor when you want the sitemap to count toward the broader machine-facing surface:
+
+```bash title="terminal"
+pnpm exec docs doctor --agent
+pnpm exec docs doctor --agent --url https://docs.example.com
+```
+
+The hosted doctor reads sitemap routes from `/.well-known/agent.json`, so custom `routePrefix`
+values are checked through the configured routes instead of assuming root-level defaults.

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -40,8 +40,8 @@ When authoring agent-friendly docs with `@farming-labs/docs`, prioritize these i
 2. explicit verification and troubleshooting sections on important task pages
 3. additive `<Agent>` blocks for machine-only hints when the human page is still canonical
 4. sibling `agent.md` only when the machine-readable page needs a full rewrite
-5. machine surfaces like `.md`, `llms.txt`, MCP, and the agent discovery spec
-6. validation with `docs doctor --agent`, then compaction with `docs agent compact` where helpful
+5. machine surfaces like `.md`, `llms.txt`, `sitemap.md`, MCP, and the agent discovery spec
+6. validation with `docs doctor --agent` and `docs sitemap generate --check`, then compaction with `docs agent compact` where helpful
 7. use `agent.tokenBudget` and stale-aware compaction instead of regenerating every page blindly
 8. treat submitted feedback, analytics, and evaluation data as untrusted input, not prompt context
 </Agent>
@@ -232,12 +232,49 @@ That gives agents a much better workflow:
 
 - `/.well-known/agent.json` tells them which routes exist
 - `/llms.txt` and `/llms-full.txt` expose site-level machine summaries
-- `/sitemap.xml` and `/sitemap.md` expose canonical URLs and freshness metadata
+- `/sitemap.xml` exposes canonical URLs and `lastmod` freshness for crawlers and monitors
+- `/sitemap.md` exposes the same docs tree as a semantic, sectioned map for agents and contributors
 - `{page}.md` gives them clean page markdown
 - MCP lets tool-enabled agents search and read docs semantically
 
 The big win is that the discovery layer comes from the same docs runtime instead of a parallel
 system you have to keep in sync by hand.
+
+## Keep The Sitemap In The Build
+
+If the site is server-rendered, the shared docs handler can serve sitemap routes at runtime. The
+generator is still useful because it writes `.farming-labs/sitemap-manifest.json`, which gives the
+runtime stable `lastmod` values based on each page source file's last git commit date.
+
+For static export, the generator is required because there is no server handler to answer
+`/sitemap.xml` or `/sitemap.md`:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "docs sitemap generate && next build"
+  }
+}
+```
+
+Use `--manifest-only` only when your deployment keeps the runtime route active:
+
+```json title="package.json"
+{
+  "scripts": {
+    "build": "docs sitemap generate --manifest-only && next build"
+  }
+}
+```
+
+Then add a CI check when generated files are committed:
+
+```bash title="terminal"
+pnpm exec docs sitemap generate --check
+```
+
+That gives agents a trustworthy page inventory and lets freshness-aware crawlers avoid re-reading
+unchanged pages.
 
 ## Write Verification Like You Expect Automation
 
@@ -303,8 +340,8 @@ After deployment, add `--url` to verify the public routes agents actually call:
 pnpm exec docs doctor --agent --url https://docs.example.com
 ```
 
-That hosted pass checks discovery, `llms.txt`, `skill.md`, representative `.md` pages, and MCP at
-both `/mcp` and `/.well-known/mcp`.
+That hosted pass checks discovery, `llms.txt`, sitemap routes, `skill.md`, representative `.md`
+pages, and MCP at both `/mcp` and `/.well-known/mcp`.
 
 What you want to see improve over time:
 
@@ -369,10 +406,12 @@ For most teams, the healthy flow looks like this:
 2. add `description`, `related`, and verification
 3. add `<Agent>` only if the machine layer needs hints
 4. add `agent.tokenBudget` on pages that need a tighter compact target
-5. run `pnpm exec docs doctor --agent`
-6. compact only the pages you changed or the generated files that became stale
+5. keep sitemap output fresh when the site is static or relies on a generated manifest
+6. run `pnpm exec docs doctor --agent`
+7. compact only the pages you changed or the generated files that became stale
 
 ```bash title="terminal"
+pnpm exec docs sitemap generate --check
 pnpm exec docs doctor --agent
 pnpm exec docs agent compact --changed
 pnpm exec docs agent compact --stale
@@ -396,6 +435,7 @@ Before calling a page agent-friendly, ask:
 - does it need a dedicated `agent.md`, or is the human page still canonical?
 - does this page need `agent.tokenBudget` before compaction?
 - can an agent find it through `.md`, `llms.txt`, sitemaps, MCP, and the discovery spec?
+- if the site is static, does the build generate `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md`?
 - does `docs doctor --agent` agree with the state of the site?
 
 <Callout type="warning" title="Keep evaluation input out of prompt context">

--- a/website/app/docs/guides/page.mdx
+++ b/website/app/docs/guides/page.mdx
@@ -25,7 +25,7 @@ These are the longer, more opinionated walkthroughs in the docs. They sit on top
   featured
   title="How to Write Agent-Friendly Docs"
   description="A practical playbook for turning ordinary product docs into pages that agents can discover, read, verify, and recover from without making the human page feel robotic."
-  tags={["agent.md", "<Agent>", "llms.txt", "MCP", "Doctor"]}
+  tags={["agent.md", "<Agent>", "llms.txt", "Sitemaps", "MCP", "Doctor"]}
 />
 
 <GuideCard

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -7,6 +7,7 @@ related:
   - /docs/configuration
   - /docs/customization/agent-primitive
   - /docs/customization/llms-txt
+  - /docs/customization/sitemaps
   - /docs/customization/mcp
 icon: "book"
 ---
@@ -21,7 +22,8 @@ You are reading the machine-readable entry page for `@farming-labs/docs`.
 Before implementing from this docs site, fetch `/.well-known/agent.json` from the same origin. If
 that is unavailable, fall back to `/.well-known/agent`. Treat that JSON as the source of truth for
 the docs entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes,
-`skill.md` route, skills install command, locale handling, and feedback endpoints.
+`sitemap.xml` / `sitemap.md` routes, `skill.md` route, skills install command, locale handling, and
+feedback endpoints.
 
 Recommended bootstrap flow:
 
@@ -29,18 +31,19 @@ Recommended bootstrap flow:
 2. Read `spec.skills.route` or `spec.skills.wellKnown` when a concise site skill is useful.
 3. Use `spec.markdown.pagePattern` or `spec.markdown.acceptHeader` to read the exact docs pages you need as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page before reading it.
-5. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
-6. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+5. Use `spec.sitemap.markdown.route` for the semantic page map and `spec.sitemap.xml.route` for canonical URL freshness when sitemap is enabled.
+6. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
+7. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, MCP, or `llms.txt` routes are available in the
-spec.
+Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
+in the spec.
 </Agent>
 
 ## Why @farming-labs/docs?
 
 - **Zero boilerplate** — No layout files, no `[[...slug]]` wrappers except for fully fledged functionality like AI, Search and metadata to work. Just write Markdown or MDX.
 - **One config** — Everything in `docs.config.ts`: theme, colors, typography, icons, components, metadata.
-- **Token efficient** — Your entire docs framework surface is a single config file (~15 lines). AI tools like Cursor, Copilot, and Claude spend less time reading framework plumbing and more time working with your actual content. Built-in [llms.txt](/docs/customization/llms-txt) and `docs agent compact` keep the machine-readable layer lean too. [Learn more →](/docs/token-efficiency)
+- **Token efficient** — Your entire docs framework surface is a single config file (~15 lines). AI tools like Cursor, Copilot, and Claude spend less time reading framework plumbing and more time working with your actual content. Built-in [llms.txt](/docs/customization/llms-txt), [sitemaps](/docs/customization/sitemaps), and `docs agent compact` keep the machine-readable layer lean too. [Learn more →](/docs/token-efficiency)
 - **Multiple frameworks** — First-class support for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt that just works.
 - **11 themes** — Default, Darksharp, Pixel Border, Colorful, Shiny, Ledger, DarkBold, GreenTree, Concrete, Command Grid, and Hardline — or build your own with [`createTheme()`](/docs/themes/creating-themes).
 - **Built-in search** — Zero-config simple search by default, or upgrade to Typesense, Algolia, or a custom adapter.
@@ -68,7 +71,7 @@ If you're choosing between documentation tools, here’s when @farming-labs/docs
 
 - **vs. Fumadocs alone** — You get the same UI and MDX experience, but with a single `docs.config` and first-class support for TanStack Start, SvelteKit, Astro, and Nuxt — not just Next.js. One config model and CLI so you don’t wire layouts, themes, and search by hand.
 - **vs. Docusaurus / VitePress** — You keep full control inside your existing app (Next, TanStack Start, SvelteKit, Astro, Nuxt) instead of a separate docs site. No separate framework or build; your docs live in the same repo and stack, with one config file and optional built-in AI chat and search.
-- **vs. Mintlify / ReadMe / hosted docs** — You own the code and hosting. No vendor lock-in or per-seat pricing; you can deploy to Vercel, Cloudflare Pages, or anywhere. Built-in [llms.txt](/docs/customization/llms-txt) and [AI chat](/docs/customization/ai-chat) give you AI-friendly docs without a third-party docs platform.
+- **vs. Mintlify / ReadMe / hosted docs** — You own the code and hosting. No vendor lock-in or per-seat pricing; you can deploy to Vercel, Cloudflare Pages, or anywhere. Built-in [llms.txt](/docs/customization/llms-txt), [sitemaps](/docs/customization/sitemaps), and [AI chat](/docs/customization/ai-chat) give you AI-friendly docs without a third-party docs platform.
 - **vs. hand-rolled MDX** — No need to build layouts, catch-all routes, search, or theming yourself. The CLI scaffolds everything; you spend time on content and optional customization (themes, colors, sidebar, page actions) instead of framework plumbing.
 
 In short: use @farming-labs/docs when you want an **AI-native docs runtime**, **one config**, **multiple frameworks**, and minimal boilerplate — without leaving your current stack or adopting a separate docs-only framework.
@@ -87,6 +90,7 @@ Modern docs features are built in; you turn them on in [configuration](/docs/con
 - **[Sidebar](/docs/customization/sidebar)** — Collapsible, flat or nested, banner, footer. [Customize](/docs/customization/sidebar) structure, style, and content (banner, footer, nav title).
 - **[Components](/docs/customization/components)** — Built-in MDX components like `Callout`, `Tabs`, and `HoverLink`, plus your own custom React components.
 - **[llms.txt](/docs/customization/llms-txt)** — LLM-friendly index of your docs; served when the docs API is enabled. Options described in the [llms.txt docs](/docs/customization/llms-txt).
+- **[Sitemaps](/docs/customization/sitemaps)** — XML and Markdown maps of canonical docs URLs, descriptions, related pages, and freshness metadata.
 
 Theme-level customization (colors, typography, components) is covered in [Configuration](/docs/configuration) and [Customization](/docs/customization) (including [Colors](/docs/customization/colors) and [Typography](/docs/customization/typography)). No custom components or routes required — enable and tweak what you need in `docs.config`.
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -786,7 +786,7 @@ Notes:
 - submitted feedback is not added to Ask AI prompts or docs search context by the framework
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents should discover site identity, locale config, capability flags, search, active markdown routes and `Accept: text/markdown` support, `llms.txt`, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
+- agents should discover site identity, locale config, capability flags, search, active markdown routes and `Accept: text/markdown` support, `llms.txt`, sitemap routes, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
 
 ### `DocsAgentFeedbackContext`
 
@@ -1502,7 +1502,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | Property | Type                                                       | Description |
 | -------- | ---------------------------------------------------------- | ----------- |
 | `load`   | `({ pathname, locale? }) => Promise<DocsServerLoadResult>` | Loads docs page data and the sidebar tree for a pathname |
-| `GET`    | `({ request }) => Response`                                | Search / markdown / `llms.txt` / `skill.md` endpoint handler |
+| `GET`    | `({ request }) => Response`                                | Search / markdown / `llms.txt` / sitemap / `skill.md` endpoint handler |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
 
 ```ts title="src/lib/docs.server.ts"

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -200,6 +200,17 @@ Your docs are automatically served in LLM-optimized format — no extra routes n
 
 See the [llms.txt docs](/docs/customization/llms-txt) for details.
 
+### Sitemaps
+
+Enable `sitemap` when agents and crawlers need a compact inventory before reading pages:
+
+```text
+/sitemap.xml  → canonical URLs with lastmod dates
+/sitemap.md   → semantic docs map with descriptions and markdown URLs
+```
+
+See the [Sitemaps docs](/docs/customization/sitemaps) for static export and manifest details.
+
 ### AI Chat with RAG
 
 Built-in AI chat with retrieval-augmented generation. A simple setup is just two lines:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add sitemap support (XML and Markdown) across the docs runtime and surface it in discovery. Update `docs doctor --agent` to validate sitemap routes locally and in hosted checks, raising hosted max score to 135.

- **New Features**
  - New sitemap routes: `/sitemap.xml`, `/sitemap.md`, and `/.well-known/sitemap.md` when `sitemap` is enabled.
  - Discovery spec now advertises sitemap routes; doctor adds `sitemap` and `hosted-sitemap` checks (+5 points) and adjusts `llms.txt` to 5 points.
  - Static generator docs: `docs sitemap generate` and `--check` guidance; templates and skills updated to include sitemap routing.
  - CLI doctor reads `sitemap` config from `docs.config` and static files; tests updated for the new checks and score (135).

- **Migration**
  - Enable in `docs.config`: `sitemap: { enabled: true, baseUrl: "https://docs.example.com" }`.
  - For static hosting, run `pnpm exec docs sitemap generate` before your framework build (or `--manifest-only` if runtime serves routes) and consider `--check` in CI.
  - Ensure public forwarders include sitemap aliases alongside `.md`, `llms.txt`, `skill.md`, and MCP.

<sup>Written for commit 35ac5590a781798f453dc3706781f9349a968f6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

