### PR TITLE
feat: add automatic markdown alternate links for docs pages

### DIFF
--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -1,5 +1,6 @@
 ---
 import DocsPage from "./DocsPage.astro";
+import { toDocsMarkdownUrl } from "@farming-labs/docs";
 
 const { data, config = null } = Astro.props;
 
@@ -71,6 +72,10 @@ const openDocsProviders = (() => {
 })();
 
 const pathname = Astro.url.pathname;
+const pageUrl = typeof data.url === "string" ? data.url : pathname;
+const markdownAlternateHref = config?.staticExport
+  ? null
+  : toDocsMarkdownUrl(pageUrl, { locale: data.locale });
 const githubFileUrl = config?.github && data.editOnGithub ? data.editOnGithub : null;
 
 const pageActionsPosition = (() => {
@@ -141,6 +146,7 @@ const htmlWithoutFirstH1 = (data.html || "").replace(/<h1[^>]*>[\s\S]*?<\/h1>\s*
 <head>
   <title>{data.title}{titleSuffix}</title>
   {data.description && <meta name="description" content={data.description} />}
+  {markdownAlternateHref && <link rel="alternate" type="text/markdown" href={markdownAlternateHref} />}
 </head>
 
 <DocsPage

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -154,6 +154,7 @@ export interface DocsServer {
   load: (pathname: string) => Promise<{
     tree: ReturnType<typeof loadDocsNavTree>;
     flatPages: PageNode[];
+    url: string;
     title: string;
     description?: string;
     html: string;
@@ -710,6 +711,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return {
       tree,
       flatPages,
+      url: currentUrl,
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDocsLlmsTxtFormat,
   resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
+  toDocsMarkdownUrl,
 } from "./agent.js";
 
 describe("agent route helpers", () => {
@@ -121,6 +122,18 @@ describe("agent route helpers", () => {
       new Request("https://example.com/blog?format=markdown&path=install"),
     );
     expect(hijackRoute).toBeNull();
+  });
+
+  it("builds per-page markdown alternate URLs", () => {
+    expect(toDocsMarkdownUrl("/docs")).toBe("/docs.md");
+    expect(toDocsMarkdownUrl("/docs/install")).toBe("/docs/install.md");
+    expect(toDocsMarkdownUrl("/docs/install.md")).toBe("/docs/install.md");
+    expect(toDocsMarkdownUrl("/docs/install?ref=sidebar", { locale: "fr" })).toBe(
+      "/docs/install.md?ref=sidebar&lang=fr",
+    );
+    expect(toDocsMarkdownUrl("/docs/install?lang=es", { locale: "fr" })).toBe(
+      "/docs/install.md?lang=es",
+    );
   });
 
   it("renders agent-specific markdown documents", () => {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -90,6 +90,17 @@ export function normalizeDocsUrlPath(value: string): string {
   return normalized.replace(/\/+$/, "");
 }
 
+export function toDocsMarkdownUrl(url: string, options: { locale?: string } = {}): string {
+  const [withoutHash, hash = ""] = url.split("#", 2);
+  const [pathname, query = ""] = withoutHash.split("?", 2);
+  const normalizedPath = normalizeDocsUrlPath(pathname || "/");
+  const markdownPath = normalizedPath.endsWith(".md") ? normalizedPath : `${normalizedPath}.md`;
+  const params = new URLSearchParams(query);
+  if (options.locale && !params.has("lang")) params.set("lang", options.locale);
+  const search = params.toString();
+  return `${markdownPath}${search ? `?${search}` : ""}${hash ? `#${hash}` : ""}`;
+}
+
 export function isDocsAgentDiscoveryRequest(url: URL): boolean {
   const pathname = normalizeDocsUrlPath(url.pathname);
   if (pathname === DEFAULT_DOCS_API_ROUTE && url.searchParams.get("agent")?.trim() === "spec") {

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1085,6 +1085,7 @@ export function tanstackDocsIndexRouteTemplate(opts: TanstackRouteTemplateOption
   const entryUrl = `/${opts.entry.replace(/^\/+|\/+$/g, "")}`;
   return `\
 import { createFileRoute } from "@tanstack/react-router";
+import { toDocsMarkdownUrl } from "@farming-labs/docs";
 import { TanstackDocsPage } from "@farming-labs/tanstack-start/react";
 import { loadDocPage } from "${tanstackDocsFunctionsImport(opts)}";
 import docsConfig from "${tanstackDocsConfigImport(opts.filePath)}";
@@ -1092,6 +1093,9 @@ import docsConfig from "${tanstackDocsConfigImport(opts.filePath)}";
 export const Route = createFileRoute("${entryUrl}/")({
   loader: () => loadDocPage({ data: { pathname: "${entryUrl}" } }),
   head: ({ loaderData }) => ({
+    links: loaderData && !docsConfig.staticExport
+      ? [{ rel: "alternate", type: "text/markdown", href: toDocsMarkdownUrl(loaderData.url, { locale: loaderData.locale }) }]
+      : [],
     meta: [
       { title: loaderData ? \`\${loaderData.title} – ${opts.projectName}\` : "${opts.projectName}" },
       ...(loaderData?.description
@@ -1116,7 +1120,7 @@ export function tanstackDocsCatchAllRouteTemplate(opts: TanstackRouteTemplateOpt
     : relativeImport(opts.filePath, "src/lib/docs.server.ts");
   return `\
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import { isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsPublicGetRequest, toDocsMarkdownUrl } from "@farming-labs/docs";
 import { TanstackDocsPage } from "@farming-labs/tanstack-start/react";
 import { loadDocPage } from "${tanstackDocsFunctionsImport(opts)}";
 import { docsServer } from "${serverImport}";
@@ -1150,6 +1154,9 @@ export const Route = createFileRoute("${entryUrl}/$")({
     }
   },
   head: ({ loaderData }) => ({
+    links: loaderData && !docsConfig.staticExport
+      ? [{ rel: "alternate", type: "text/markdown", href: toDocsMarkdownUrl(loaderData.url, { locale: loaderData.locale }) }]
+      : [],
     meta: [
       { title: loaderData ? \`\${loaderData.title} – ${opts.projectName}\` : "${opts.projectName}" },
       ...(loaderData?.description

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -78,6 +78,7 @@ export {
   resolveDocsLlmsTxtFormat,
   resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
+  toDocsMarkdownUrl,
 } from "./agent.js";
 export {
   DEFAULT_SITEMAP_MANIFEST_PATH,

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createDocsLayout } from "./docs-layout.js";
+import { createDocsLayout, createPageMetadata } from "./docs-layout.js";
 
 function findDocsPageClientProps(node: unknown): Record<string, unknown> | null {
   if (!node || typeof node !== "object") return null;
@@ -56,6 +56,20 @@ function findDocsLayoutTree(node: unknown): Record<string, unknown> | null {
 
   return children ? findDocsLayoutTree(children) : null;
 }
+
+describe("createPageMetadata", () => {
+  it("preserves the active locale in markdown alternate links", () => {
+    const metadata = createPageMetadata(
+      { entry: "docs" },
+      { title: "Installation", description: "Install the framework" },
+      undefined,
+      "/docs/installation",
+      { locale: "fr" },
+    ) as { alternates?: { types?: Record<string, string> } };
+
+    expect(metadata.alternates?.types?.["text/markdown"]).toBe("/docs/installation.md?lang=fr");
+  });
+});
 
 describe("createDocsLayout pageActions", () => {
   let tmpDir: string;

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -12,6 +12,7 @@ import {
   resolveDocsAgentMdxContent,
   resolveDocsAnalyticsConfig,
   resolvePageSidebarFolderIndexBehavior,
+  toDocsMarkdownUrl,
 } from "@farming-labs/docs";
 import type {
   DocsConfig,
@@ -605,7 +606,7 @@ export function createDocsMetadata(config: DocsConfig) {
  * ```ts
  * export function generateMetadata({ params }) {
  *   const page = getPage(params.slug);
- *   return createPageMetadata(docsConfig, page.data);
+ *   return createPageMetadata(docsConfig, page.data, undefined, page.url);
  * }
  * ```
  */
@@ -613,11 +614,20 @@ export function createPageMetadata(
   config: DocsConfig,
   page: Pick<PageFrontmatter, "title" | "description" | "ogImage" | "openGraph" | "twitter">,
   baseUrl?: string,
+  url?: string,
 ) {
   const result: Record<string, unknown> = {
     title: page.title,
     ...(page.description ? { description: page.description } : {}),
   };
+
+  if (url && !(config as { staticExport?: boolean }).staticExport) {
+    result.alternates = {
+      types: {
+        "text/markdown": toDocsMarkdownUrl(url),
+      },
+    };
+  }
 
   if (config.og?.enabled !== false) {
     const openGraph = buildPageOpenGraph(page, config.og, baseUrl);

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -606,7 +606,7 @@ export function createDocsMetadata(config: DocsConfig) {
  * ```ts
  * export function generateMetadata({ params }) {
  *   const page = getPage(params.slug);
- *   return createPageMetadata(docsConfig, page.data, undefined, page.url);
+ *   return createPageMetadata(docsConfig, page.data, undefined, page.url, { locale });
  * }
  * ```
  */
@@ -615,6 +615,7 @@ export function createPageMetadata(
   page: Pick<PageFrontmatter, "title" | "description" | "ogImage" | "openGraph" | "twitter">,
   baseUrl?: string,
   url?: string,
+  options: { locale?: string } = {},
 ) {
   const result: Record<string, unknown> = {
     title: page.title,
@@ -624,7 +625,7 @@ export function createPageMetadata(
   if (url && !(config as { staticExport?: boolean }).staticExport) {
     result.alternates = {
       types: {
-        "text/markdown": toDocsMarkdownUrl(url),
+        "text/markdown": toDocsMarkdownUrl(url, { locale: options.locale }),
       },
     };
   }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -73,6 +73,11 @@
       "types": "./dist/mdx-plugins/remark-og.d.mts",
       "import": "./dist/mdx-plugins/remark-og.mjs",
       "default": "./dist/mdx-plugins/remark-og.mjs"
+    },
+    "./mdx-plugins/remark-markdown-alternate": {
+      "types": "./dist/mdx-plugins/remark-markdown-alternate.d.mts",
+      "import": "./dist/mdx-plugins/remark-markdown-alternate.mjs",
+      "default": "./dist/mdx-plugins/remark-markdown-alternate.mjs"
     }
   },
   "scripts": {

--- a/packages/next/src/changelog.tsx
+++ b/packages/next/src/changelog.tsx
@@ -557,10 +557,15 @@ export function createNextChangelogStaticParams(entries: GeneratedChangelogEntry
 
 export function createNextChangelogIndexMetadata(config: DocsConfig): Metadata {
   const changelog = resolveChangelogConfig(config.changelog);
-  return createPageMetadata(config, {
-    title: changelog.title,
-    description: changelog.description,
-  }) as Metadata;
+  return createPageMetadata(
+    config,
+    {
+      title: changelog.title,
+      description: changelog.description,
+    },
+    undefined,
+    getListingUrl(config),
+  ) as Metadata;
 }
 
 export function createNextChangelogEntryMetadata(
@@ -576,15 +581,25 @@ export function createNextChangelogEntryMetadata(
 
     if (!entry) {
       const changelog = resolveChangelogConfig(config.changelog);
-      return createPageMetadata(config, {
-        title: changelog.title,
-        description: changelog.description,
-      }) as Metadata;
+      return createPageMetadata(
+        config,
+        {
+          title: changelog.title,
+          description: changelog.description,
+        },
+        undefined,
+        getListingUrl(config),
+      ) as Metadata;
     }
 
-    return createPageMetadata(config, {
-      title: entry.title,
-      description: entry.description,
-    }) as Metadata;
+    return createPageMetadata(
+      config,
+      {
+        title: entry.title,
+        description: entry.description,
+      },
+      undefined,
+      `${getListingUrl(config)}/${entry.slug}`,
+    ) as Metadata;
   };
 }

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -301,6 +301,8 @@ function createDocsWorkspaceAliases(): Record<string, string> {
     "@farming-labs/next/mdx-plugins/remark-heading":
       "./packages/next/src/mdx-plugins/remark-heading.ts",
     "@farming-labs/next/mdx-plugins/remark-og": "./packages/next/src/mdx-plugins/remark-og.ts",
+    "@farming-labs/next/mdx-plugins/remark-markdown-alternate":
+      "./packages/next/src/mdx-plugins/remark-markdown-alternate.ts",
     "@farming-labs/theme": "./packages/fumadocs/src/index.ts",
     "@farming-labs/theme/api": "./packages/fumadocs/src/docs-api.ts",
     "@farming-labs/theme/client-hooks": "./packages/fumadocs/src/docs-client-hooks.tsx",
@@ -1628,6 +1630,10 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   if (ogEndpoint) {
     remarkPlugins.push(["@farming-labs/next/mdx-plugins/remark-og", { endpoint: ogEndpoint }]);
   }
+  remarkPlugins.push([
+    "@farming-labs/next/mdx-plugins/remark-markdown-alternate",
+    { entry, appDir, contentDir: docsContentDir, enabled: !isStaticExport },
+  ]);
   remarkPlugins.push(
     ["remark-mdx-frontmatter", { name: "metadata" }],
     "@farming-labs/next/mdx-plugins/remark-heading",
@@ -1721,6 +1727,14 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
           "client-callbacks.mjs",
         ),
         "@farming-labs/next/layout": join(workspaceRoot, "packages", "next", "dist", "layout.mjs"),
+        "@farming-labs/next/mdx-plugins/remark-markdown-alternate": join(
+          workspaceRoot,
+          "packages",
+          "next",
+          "dist",
+          "mdx-plugins",
+          "remark-markdown-alternate.mjs",
+        ),
         "@farming-labs/theme$": join(workspaceRoot, "packages", "fumadocs", "dist", "index.mjs"),
         "@farming-labs/theme/api": join(
           workspaceRoot,

--- a/packages/next/src/mdx-plugins/remark-markdown-alternate.test.ts
+++ b/packages/next/src/mdx-plugins/remark-markdown-alternate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import remarkMarkdownAlternate from "./remark-markdown-alternate.js";
+
+describe("remarkMarkdownAlternate", () => {
+  it("adds a text/markdown alternate URL for docs page routes", () => {
+    const tree = {
+      children: [{ type: "yaml", value: 'title: "Install"' }],
+    };
+    const transform = remarkMarkdownAlternate({ entry: "docs", contentDir: "app/docs" });
+
+    transform(tree, { path: "/repo/app/docs/install/page.mdx" });
+
+    expect(tree.children[0]?.value).toContain("alternates:");
+    expect(tree.children[0]?.value).toContain('text/markdown: "/docs/install.md"');
+  });
+
+  it("adds root docs markdown alternate URLs", () => {
+    const tree = {
+      children: [{ type: "yaml", value: 'title: "Docs"' }],
+    };
+    const transform = remarkMarkdownAlternate({ entry: "docs", contentDir: "app/docs" });
+
+    transform(tree, { path: "/repo/app/docs/page.mdx" });
+
+    expect(tree.children[0]?.value).toContain('text/markdown: "/docs.md"');
+  });
+
+  it("handles relative source paths", () => {
+    const tree = {
+      children: [{ type: "yaml", value: 'title: "Quickstart"' }],
+    };
+    const transform = remarkMarkdownAlternate({ entry: "docs", contentDir: "app/docs" });
+
+    transform(tree, { path: "app/docs/quickstart/page.md" });
+
+    expect(tree.children[0]?.value).toContain('text/markdown: "/docs/quickstart.md"');
+  });
+
+  it("does not overwrite custom alternates", () => {
+    const tree = {
+      children: [
+        {
+          type: "yaml",
+          value: 'title: "Install"\nalternates:\n  canonical: "/custom"',
+        },
+      ],
+    };
+    const transform = remarkMarkdownAlternate({ entry: "docs", contentDir: "app/docs" });
+
+    transform(tree, { path: "/repo/app/docs/install/page.mdx" });
+
+    expect(tree.children[0]?.value).not.toContain("text/markdown");
+  });
+});

--- a/packages/next/src/mdx-plugins/remark-markdown-alternate.ts
+++ b/packages/next/src/mdx-plugins/remark-markdown-alternate.ts
@@ -1,0 +1,104 @@
+import { toDocsMarkdownUrl } from "@farming-labs/docs";
+
+interface RemarkMarkdownAlternateOptions {
+  entry?: string;
+  appDir?: string;
+  contentDir?: string;
+  enabled?: boolean;
+}
+
+interface MarkdownNode {
+  type: string;
+  value?: string;
+}
+
+interface VFileLike {
+  path?: string;
+  history?: string[];
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+/g, "/");
+}
+
+function normalizeSegment(value: string | undefined, fallback: string): string {
+  return (value ?? fallback).replace(/^\/+|\/+$/g, "") || fallback;
+}
+
+function escapeYamlString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function routeFromSourcePath(
+  filePath: string,
+  options: RemarkMarkdownAlternateOptions,
+): string | null {
+  const normalized = `/${normalizePath(filePath).replace(/^\/+/, "")}`;
+  if (!/\/page\.mdx?$/.test(normalized)) return null;
+
+  const entry = normalizeSegment(options.entry, "docs");
+  const candidates = [
+    options.contentDir,
+    options.appDir ? `${options.appDir}/${entry}` : undefined,
+    `src/app/${entry}`,
+    `app/${entry}`,
+  ]
+    .filter(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+    )
+    .map((candidate) => normalizePath(candidate).replace(/^\/+|\/+$/g, ""));
+
+  for (const candidate of candidates) {
+    const marker = `/${candidate}/`;
+    const markerIndex = normalized.lastIndexOf(marker);
+    if (markerIndex === -1) continue;
+
+    const relativePath = normalized.slice(markerIndex + marker.length);
+    if (!relativePath.endsWith("page.mdx") && !relativePath.endsWith("page.md")) continue;
+
+    const slug = relativePath.replace(/\/?page\.mdx?$/, "").replace(/^\/+|\/+$/g, "");
+    return slug ? `/${entry}/${slug}` : `/${entry}`;
+  }
+
+  return null;
+}
+
+function getFilePath(file?: VFileLike): string | undefined {
+  return file?.path ?? file?.history?.[0];
+}
+
+function hasAlternates(yaml: string): boolean {
+  return /^\s*alternates\s*:/m.test(yaml);
+}
+
+function alternateYaml(url: string): string {
+  return [
+    "alternates:",
+    "  types:",
+    `    text/markdown: "${escapeYamlString(toDocsMarkdownUrl(url))}"`,
+  ].join("\n");
+}
+
+export default function remarkMarkdownAlternate(options: RemarkMarkdownAlternateOptions = {}) {
+  return (tree: { children: MarkdownNode[] }, file?: VFileLike) => {
+    if (options.enabled === false) return;
+
+    const filePath = getFilePath(file);
+    if (!filePath) return;
+
+    const route = routeFromSourcePath(filePath, options);
+    if (!route) return;
+
+    const yamlNode = tree.children.find((node) => node.type === "yaml");
+    if (yamlNode?.value) {
+      if (hasAlternates(yamlNode.value)) return;
+      yamlNode.value += `\n${alternateYaml(route)}`;
+      return;
+    }
+
+    tree.children.unshift({
+      type: "yaml",
+      value: alternateYaml(route),
+    });
+  };
+}

--- a/packages/next/tsdown.config.ts
+++ b/packages/next/tsdown.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     "src/mdx-plugins/rehype-toc.ts",
     "src/mdx-plugins/rehype-code.ts",
     "src/mdx-plugins/remark-og.ts",
+    "src/mdx-plugins/remark-markdown-alternate.ts",
   ],
   format: "esm",
   dts: true,

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -2,6 +2,7 @@
 import { computed, ref, onMounted, onUnmounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useHead } from "#app";
+import { toDocsMarkdownUrl } from "@farming-labs/docs";
 import DocsPage from "./DocsPage.vue";
 
 const DEFAULT_OPEN_PROVIDERS = [
@@ -12,6 +13,7 @@ const DEFAULT_OPEN_PROVIDERS = [
 const props = defineProps<{
   data: {
     title: string;
+    url?: string;
     description?: string;
     html: string;
     rawMarkdown?: string;
@@ -88,6 +90,12 @@ const llmsTxtEnabled = computed(() => {
 });
 
 const entry = computed(() => (props.data.entry as string) ?? (props.config?.entry as string) ?? "docs");
+const pageUrl = computed(() =>
+  props.data.url ?? `/${entry.value}${props.data.slug ? `/${props.data.slug}` : ""}`,
+);
+const markdownAlternateHref = computed(() =>
+  props.config?.staticExport ? null : toDocsMarkdownUrl(pageUrl.value, { locale: props.data.locale }),
+);
 
 const copyMarkdownEnabled = computed(() => {
   const pa = props.config?.pageActions as Record<string, unknown> | undefined;
@@ -227,6 +235,10 @@ useHead({
   title: () => `${props.data.title}${titleSuffix.value}`,
   meta: () =>
     metaDescription.value ? [{ name: "description", content: metaDescription.value }] : [],
+  link: () =>
+    markdownAlternateHref.value
+      ? [{ rel: "alternate", type: "text/markdown", href: markdownAlternateHref.value }]
+      : [],
 });
 
 function handleCopyPage() {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -142,6 +142,7 @@ export interface DocsServer {
   load: (pathname: string) => Promise<{
     tree: ReturnType<typeof loadDocsNavTree>;
     flatPages: PageNode[];
+    url: string;
     title: string;
     description?: string;
     html: string;
@@ -700,6 +701,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return {
       tree,
       flatPages,
+      url: currentUrl,
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -1,6 +1,7 @@
 <script>
   import DocsPage from "./DocsPage.svelte";
   import { onMount, onDestroy } from "svelte";
+  import { toDocsMarkdownUrl } from "@farming-labs/docs";
 
   const DEFAULT_OPEN_PROVIDERS = [
     { name: "ChatGPT", urlTemplate: "https://chatgpt.com/?hints=search&q=Read+{mdxUrl},+I+want+to+ask+questions+about+it." },
@@ -28,6 +29,14 @@
 
   let tocStyle = $derived(
     (config?.theme?.ui?.layout?.toc?.style === "directional") ? "directional" : "default"
+  );
+
+  let pageUrl = $derived(
+    data.url ?? `/${data.entry ?? config?.entry ?? "docs"}${data.slug ? `/${data.slug}` : ""}`
+  );
+
+  let markdownAlternateHref = $derived(
+    config?.staticExport ? null : toDocsMarkdownUrl(pageUrl, { locale: data.locale })
   );
 
   let breadcrumbEnabled = $derived.by(() => {
@@ -313,6 +322,9 @@
   <title>{data.title}{titleSuffix}</title>
   {#if data.description}
     <meta name="description" content={data.description} />
+  {/if}
+  {#if markdownAlternateHref}
+    <link rel="alternate" type="text/markdown" href={markdownAlternateHref} />
   {/if}
 </svelte:head>
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -163,6 +163,7 @@ export interface DocsServer {
   load: (event: UnifiedLoadEvent) => Promise<{
     tree: ReturnType<typeof loadDocsNavTree>;
     flatPages: PageNode[];
+    url: string;
     title: string;
     description?: string;
     html: string;
@@ -720,6 +721,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return {
       tree,
       flatPages,
+      url: currentUrl,
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       html,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -117,6 +117,7 @@ function safeUrlOrigin(value: string): string {
 export interface DocsServerLoadResult {
   tree: ReturnType<typeof loadDocsNavTree>;
   flatPages: PageNode[];
+  url: string;
   title: string;
   description?: string;
   rawContent: string;
@@ -689,6 +690,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     return {
       tree,
       flatPages,
+      url: currentUrl,
       title: (data.title as string) ?? fallbackTitle,
       description: data.description as string | undefined,
       rawContent: content,

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds automatic text/markdown alternate links for docs pages across frameworks to improve discoverability and agent tooling, without changing page URLs or content. Alternates now preserve the active locale when present.

- **New Features**
  - Added `toDocsMarkdownUrl` in `@farming-labs/docs` to build `.md` URLs (preserves query/hash; appends `lang` when missing).
  - Astro, Nuxt, and Svelte themes emit `<link rel="alternate" type="text/markdown">` for docs pages when not `staticExport`, preserving the current locale.
  - Next.js: added `@farming-labs/next/mdx-plugins/remark-markdown-alternate` to inject markdown alternates via frontmatter; enabled by `withDocs`, skipped if custom `alternates` exist.
  - `@farming-labs/theme` `createPageMetadata` now sets `alternates.types["text/markdown"]` when a page `url` is provided and not `staticExport`, preserving locale.
  - TanStack Start templates add the alternate link in `head` using `loaderData.url` and `loaderData.locale` when not `staticExport`.
  - Docs servers (`astro`, `nuxt`, `svelte`, `tanstack-start`) now include `url` in load results.

- **Migration**
  - If you have a custom docs server or loader, include `url` in the returned page data.
  - To disable alternates: set `staticExport: true` in docs config, or pass `{ enabled: false }` to the Next remark plugin.

<sup>Written for commit 714de85f1f92512342d7e0164dfc696c8526f037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

