### PR TITLE
chore: security ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "simple-git": "^3.36.0",
       "serialize-javascript": "^7.0.3",
       "svgo": "^4.0.1",
+      "fast-uri": "3.1.2",
       "rollup": "^4.59.0",
       "tar": "^7.5.11",
       "readdir-glob>minimatch": "^5.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   simple-git: ^3.36.0
   serialize-javascript: ^7.0.3
   svgo: ^4.0.1
+  fast-uri: 3.1.2
   rollup: ^4.59.0
   tar: ^7.5.11
   readdir-glob>minimatch: ^5.1.8
@@ -4766,8 +4767,8 @@ packages:
   fast-npm-meta@1.2.1:
     resolution: {integrity: sha512-vTHOCEbzcbQEfYL0sPzcz+HF5asxoy60tPBVaiYzsCfuyhbXZCSqXL+LgPGV22nuAYimoGMeDpywMQB4aOw8HQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -10975,7 +10976,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12105,7 +12106,7 @@ snapshots:
 
   fast-npm-meta@1.2.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin `fast-uri@3.1.2` as a direct dependency and add a lockfile override so all transitive users resolve to the patched version, clearing Security CI findings. The lockfile is updated to replace `fast-uri@3.1.0` with `3.1.2` across dependencies.

<sup>Written for commit 0bcfc5c65eeed24a96aaea9c137804872987d754. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

