### PR TITLE
feat: add robots meta on agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The canonical API routes remain available under `/api/docs`, including `/api/doc
 `/api/docs/mcp`, and `/api/docs/agent/spec`.
 Canonical Next.js markdown reads with `Accept: text/markdown` or `Signature-Agent` are handled by
 that same shared `/api/docs` route, so apps do not need a second markdown-only API wrapper.
+The agent discovery JSON also includes `robots.enabled`, `robots.route`, and
+`robots.defaultRoute` so agents can find the static crawl policy without guessing.
 
 For a custom site-specific skill, place `skill.md` at the project root beside `docs.config.ts`.
 When it is missing, the framework serves a generated fallback based on the docs config.
@@ -244,8 +246,8 @@ pnpm exec docs doctor --agent --url https://docs.example.com --json
 ```
 
 Hosted checks request `/.well-known/agent.json`, `/llms.txt`, `/llms-full.txt`, sitemap routes,
-`/robots.txt`, `/skill.md`, `/.well-known/skill.md`, one representative `.md` page route,
-`/mcp`, and `/.well-known/mcp`.
+the robots route from the discovery spec, `/skill.md`, `/.well-known/skill.md`, one representative
+`.md` page route, `/mcp`, and `/.well-known/mcp`.
 For MCP, the doctor performs an HTTP initialize handshake, checks the session header, and verifies
 the built-in docs tools are exposed. With hosted checks enabled, the agent score is out of `145`
 instead of `105`.

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -836,6 +836,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },
@@ -868,6 +869,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -266,6 +266,7 @@ describe("agent route helpers", () => {
     expect(document).toContain("Base URL: https://docs.example.com");
     expect(document).toContain("/guides.md");
     expect(document).toContain("/.well-known/agent.json");
+    expect(document).toContain("/robots.txt");
     expect(document).toContain("/api/docs?format=skill");
     expect(document).toContain("npx skills add farming-labs/docs");
   });
@@ -288,6 +289,7 @@ describe("agent route helpers", () => {
       },
       llms: { enabled: true, siteTitle: "Docs" },
       sitemap: true,
+      robots: true,
     });
 
     expect(spec.api.agentSpecDefault).toBe("/.well-known/agent.json");
@@ -302,5 +304,11 @@ describe("agent route helpers", () => {
     expect(spec.mcp.publicEndpoints).toEqual(["/mcp", "/.well-known/mcp"]);
     expect(spec.sitemap.xml.route).toBe("/sitemap.xml");
     expect(spec.sitemap.markdown.wellKnownRoute).toBe("/.well-known/sitemap.md");
+    expect(spec.capabilities.robots).toBe(true);
+    expect(spec.robots).toEqual({
+      enabled: true,
+      route: "/robots.txt",
+      defaultRoute: "/robots.txt",
+    });
   });
 });

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1,4 +1,9 @@
-import type { DocsSearchConfig, DocsSearchSourcePage, ResolvedDocsRelatedLink } from "./types.js";
+import type {
+  DocsRobotsConfig,
+  DocsSearchConfig,
+  DocsSearchSourcePage,
+  ResolvedDocsRelatedLink,
+} from "./types.js";
 import type { ResolvedDocsI18n } from "./i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "./mcp.js";
 import { renderDocsRelatedMarkdownLines } from "./related.js";
@@ -24,6 +29,7 @@ export const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
 export const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 export const DEFAULT_SKILL_MD_ROUTE = "/skill.md";
 export const DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE = "/.well-known/skill.md";
+const DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE = "/robots.txt";
 export const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
 
@@ -49,6 +55,7 @@ export interface DocsAgentDiscoverySpecOptions {
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
   sitemap?: boolean | DocsSitemapConfig;
+  robots?: boolean | DocsRobotsConfig;
   markdown?: {
     acceptHeader?: boolean;
     signatureAgentHeader?: boolean;
@@ -63,6 +70,7 @@ export interface DocsSkillDocumentOptions {
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
   sitemap?: boolean | DocsSitemapConfig;
+  robots?: boolean | DocsRobotsConfig;
   markdown?: {
     acceptHeader?: boolean;
     signatureAgentHeader?: boolean;
@@ -286,7 +294,7 @@ export function renderDocsMarkdownNotFound({
 
   lines.push(
     "",
-    "The agent discovery spec is the safest first step because it lists the active markdown, sitemap, search, MCP, and feedback routes for this deployment.",
+    "The agent discovery spec is the safest first step because it lists the active markdown, sitemap, robots, search, MCP, and feedback routes for this deployment.",
   );
 
   return lines.join("\n");
@@ -336,6 +344,7 @@ export function renderDocsSkillDocument({
   feedback,
   llms,
   sitemap,
+  robots,
   markdown,
 }: DocsSkillDocumentOptions): string {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -347,10 +356,11 @@ export function renderDocsSkillDocument({
   const searchEnabled = isSearchEnabled(search);
   const feedbackEnabled = feedback?.enabled ?? false;
   const sitemapConfig = resolveDocsSitemapConfig(sitemap);
+  const robotsEnabled = isRobotsDiscoveryEnabled(robots);
   const feedbackRoute = feedback?.route ?? DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const description = truncateSkillDescription(
-    `Use ${siteTitle} through markdown routes, llms.txt, agent discovery, search, and MCP when available.`,
+    `Use ${siteTitle} through markdown routes, llms.txt, robots.txt, agent discovery, search, and MCP when available.`,
   );
   const markdownAcceptHeader = markdown?.acceptHeader === false ? null : "text/markdown";
   const markdownSignatureAgentHeader =
@@ -413,6 +423,12 @@ export function renderDocsSkillDocument({
     }
   }
 
+  if (robotsEnabled) {
+    lines.push(
+      `- Check ${DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE} for crawler and AI-agent access policy.`,
+    );
+  }
+
   if (mcp.enabled) {
     lines.push(
       `- Use ${DEFAULT_MCP_WELL_KNOWN_ROUTE} or ${DEFAULT_MCP_PUBLIC_ROUTE} for MCP tools when your environment supports MCP.`,
@@ -434,6 +450,10 @@ export function renderDocsSkillDocument({
     `- Markdown root: /${normalizedEntry}.md`,
     `- Markdown pages: /${normalizedEntry}/{slug}.md`,
   );
+
+  if (robotsEnabled) {
+    lines.push(`- Robots policy: ${DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE}`);
+  }
 
   if (llmsEnabled) {
     lines.push(
@@ -558,6 +578,7 @@ export function buildDocsAgentDiscoverySpec({
   feedback,
   llms,
   sitemap,
+  robots,
   markdown,
 }: DocsAgentDiscoverySpecOptions) {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -567,6 +588,7 @@ export function buildDocsAgentDiscoverySpec({
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const llmsEnabled = llms?.enabled ?? true;
   const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms?.baseUrl });
+  const robotsEnabled = isRobotsDiscoveryEnabled(robots);
 
   return {
     version: "1",
@@ -594,6 +616,7 @@ export function buildDocsAgentDiscoverySpec({
       mcp: mcp.enabled,
       search: searchEnabled,
       sitemap: sitemapConfig.enabled,
+      robots: robotsEnabled,
       agentFeedback: feedback?.enabled ?? false,
       locales: localesEnabled,
     },
@@ -643,6 +666,11 @@ export function buildDocsAgentDiscoverySpec({
         defaultRoute: DEFAULT_SITEMAP_MD_ROUTE,
         defaultWellKnownRoute: DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE,
       },
+    },
+    robots: {
+      enabled: robotsEnabled,
+      route: DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE,
+      defaultRoute: DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE,
     },
     search: {
       enabled: searchEnabled,
@@ -732,6 +760,12 @@ function normalizeRequestedMarkdownPath(entry: string, requestedPath: string): s
 function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
   if (search === false) return false;
   if (search && typeof search === "object" && search.enabled === false) return false;
+  return true;
+}
+
+function isRobotsDiscoveryEnabled(robots?: boolean | DocsRobotsConfig): boolean {
+  if (robots === false) return false;
+  if (robots && typeof robots === "object" && robots.enabled === false) return false;
   return true;
 }
 

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -367,7 +367,13 @@ export const { GET, POST } = createDocsAPI({});
       if (req.method === "GET") {
         if (url.pathname === "/.well-known/agent.json") {
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ mcp: { enabled: true }, llms: { enabled: true } }));
+          res.end(
+            JSON.stringify({
+              mcp: { enabled: true },
+              llms: { enabled: true },
+              robots: { enabled: true, route: "/robots.txt" },
+            }),
+          );
           return;
         }
 

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1165,13 +1165,15 @@ async function probeTextRoute(
   }
 }
 
-async function probeRobotsRoute(baseUrl: string): Promise<{
+async function probeRobotsRoute(
+  baseUrl: string,
+  route = DEFAULT_ROBOTS_TXT_ROUTE,
+): Promise<{
   ok: boolean;
   status?: number;
   detail: string;
   body?: string;
 }> {
-  const route = DEFAULT_ROBOTS_TXT_ROUTE;
   const url = joinDoctorUrl(baseUrl, route);
 
   try {
@@ -1438,6 +1440,14 @@ function hostedSitemapRoutes(discoveryBody: unknown): {
   return { enabled: true, routes: Array.from(new Set(routes)) };
 }
 
+function hostedRobotsRoute(discoveryBody: unknown): { enabled: boolean; route: string } {
+  const robots = asRecord(asRecord(discoveryBody)?.robots);
+  return {
+    enabled: robots?.enabled === false ? false : true,
+    route: readDiscoveryRoute(robots?.route) ?? DEFAULT_ROBOTS_TXT_ROUTE,
+  };
+}
+
 async function buildHostedAgentChecks(
   url: string,
   pages: Array<{ url: string }>,
@@ -1542,33 +1552,48 @@ async function buildHostedAgentChecks(
     );
   }
 
-  const robots = await probeRobotsRoute(baseUrl);
-  const robotsAnalysis = robots.body ? analyzeDocsRobotsTxt(robots.body) : undefined;
-  const robotsBlocked = robotsAnalysis?.blocksAgentRoutes || robotsAnalysis?.blocksAiAgents;
-  const robotsComplete = robotsAnalysis?.hasAgentRoutes && robotsAnalysis?.hasAiPolicy;
-  checks.push(
-    makeCheck(
-      "hosted-robots",
-      "Hosted robots.txt",
-      robots.ok && !robotsBlocked && robotsComplete
-        ? "pass"
-        : robots.ok && !robotsBlocked
-          ? "warn"
-          : "fail",
-      robots.ok && !robotsBlocked && robotsComplete ? 5 : robots.ok && !robotsBlocked ? 3 : 0,
-      5,
-      robots.ok
-        ? robotsBlocked
-          ? `${DEFAULT_ROBOTS_TXT_ROUTE} is reachable but blocks ${robotsAnalysis?.blocksAiAgents ? "common AI crawlers" : "agent-readable docs routes"}.`
-          : robotsComplete
-            ? `${robots.detail} It advertises agent-readable routes and common AI crawler policy.`
-            : `${robots.detail} It is missing ${robotsAnalysis?.missingRoutes.length ? `agent routes (${robotsAnalysis.missingRoutes.join(", ")})` : "common AI crawler policy"}.`
-        : robots.detail,
-      robots.ok && !robotsBlocked && robotsComplete
-        ? undefined
-        : "Publish an agent-friendly robots.txt with `docs robots generate`, or append the generated block to the existing file.",
-    ),
-  );
+  const robotsRoute = hostedRobotsRoute(discovery.body);
+  if (robotsRoute.enabled) {
+    const robots = await probeRobotsRoute(baseUrl, robotsRoute.route);
+    const robotsAnalysis = robots.body ? analyzeDocsRobotsTxt(robots.body) : undefined;
+    const robotsBlocked = robotsAnalysis?.blocksAgentRoutes || robotsAnalysis?.blocksAiAgents;
+    const robotsComplete = robotsAnalysis?.hasAgentRoutes && robotsAnalysis?.hasAiPolicy;
+    checks.push(
+      makeCheck(
+        "hosted-robots",
+        "Hosted robots.txt",
+        robots.ok && !robotsBlocked && robotsComplete
+          ? "pass"
+          : robots.ok && !robotsBlocked
+            ? "warn"
+            : "fail",
+        robots.ok && !robotsBlocked && robotsComplete ? 5 : robots.ok && !robotsBlocked ? 3 : 0,
+        5,
+        robots.ok
+          ? robotsBlocked
+            ? `${robotsRoute.route} is reachable but blocks ${robotsAnalysis?.blocksAiAgents ? "common AI crawlers" : "agent-readable docs routes"}.`
+            : robotsComplete
+              ? `${robots.detail} It advertises agent-readable routes and common AI crawler policy.`
+              : `${robots.detail} It is missing ${robotsAnalysis?.missingRoutes.length ? `agent routes (${robotsAnalysis.missingRoutes.join(", ")})` : "common AI crawler policy"}.`
+          : robots.detail,
+        robots.ok && !robotsBlocked && robotsComplete
+          ? undefined
+          : "Publish an agent-friendly robots.txt with `docs robots generate`, or append the generated block to the existing file.",
+      ),
+    );
+  } else {
+    checks.push(
+      makeCheck(
+        "hosted-robots",
+        "Hosted robots.txt",
+        "warn",
+        0,
+        5,
+        "The hosted discovery spec reports robots.txt as disabled.",
+        "Enable robots and publish an agent-friendly robots.txt with `docs robots generate`.",
+      ),
+    );
+  }
 
   const skill = await Promise.all([
     probeTextRoute(baseUrl, DEFAULT_SKILL_MD_ROUTE),

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1324,6 +1324,9 @@ title: "Home"
     locales: ["en", "fr"],
     defaultLocale: "fr",
   },
+  robots: {
+    enabled: true,
+  },
 };`,
     );
 
@@ -1376,6 +1379,7 @@ title: "Home"
         queryParam: string;
         localeParam: string;
       };
+      robots: { enabled: boolean; route: string; defaultRoute: string };
       skills: {
         enabled: boolean;
         file: string;
@@ -1426,6 +1430,7 @@ title: "Home"
       mcp: true,
       search: true,
       sitemap: false,
+      robots: true,
       agentFeedback: true,
       locales: true,
     });
@@ -1462,6 +1467,11 @@ title: "Home"
       method: "GET",
       queryParam: "query",
       localeParam: "lang",
+    });
+    expect(spec.robots).toEqual({
+      enabled: true,
+      route: "/robots.txt",
+      defaultRoute: "/robots.txt",
     });
     expect(spec.skills).toEqual({
       enabled: true,
@@ -1551,6 +1561,7 @@ title: "Home"
       markdown: { acceptHeader: string; pagePattern: string; rootPage: string };
       llms: Record<string, string | boolean>;
       search: { enabled: boolean; endpoint: string; method: string };
+      robots: { enabled: boolean; route: string; defaultRoute: string };
       skills: {
         enabled: boolean;
         file: string;
@@ -1594,6 +1605,7 @@ title: "Home"
       mcp: false,
       search: false,
       sitemap: false,
+      robots: true,
       agentFeedback: false,
       locales: false,
     });
@@ -1617,6 +1629,11 @@ title: "Home"
       enabled: false,
       endpoint: "/api/docs?query={query}",
       method: "GET",
+    });
+    expect(spec.robots).toEqual({
+      enabled: true,
+      route: "/robots.txt",
+      defaultRoute: "/robots.txt",
     });
     expect(spec.skills).toMatchObject({
       enabled: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -67,6 +67,7 @@ import {
 import type {
   DocsAskAIMcpConfig,
   DocsMcpConfig,
+  DocsRobotsConfig,
   DocsSearchConfig,
   DocsSearchSourcePage,
   DocsSitemapConfig,
@@ -135,6 +136,8 @@ interface DocsAPIOptions {
   mcp?: boolean | DocsMcpConfig;
   /** Sitemap configuration used for sitemap.xml and sitemap.md. */
   sitemap?: boolean | DocsSitemapConfig;
+  /** Robots.txt generation policy used for the agent discovery spec. */
+  robots?: boolean | DocsRobotsConfig;
 }
 
 interface DocsMCPAPIOptions {
@@ -165,6 +168,7 @@ const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 const DEFAULT_SKILL_MD_ROUTE = "/skill.md";
 const DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE = "/.well-known/skill.md";
+const DEFAULT_ROBOTS_TXT_ROUTE = "/robots.txt";
 const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
 const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
   type: "object",
@@ -232,6 +236,7 @@ interface AgentSpecOptions {
   feedback: ResolvedAgentFeedbackConfig;
   llms: LlmsTxtOptions & { enabled: boolean };
   sitemap?: boolean | DocsSitemapConfig;
+  robots?: boolean | DocsRobotsConfig;
 }
 
 interface SkillDocumentOptions extends AgentSpecOptions {}
@@ -359,6 +364,12 @@ function isSearchEnabled(search?: boolean | DocsSearchConfig): boolean {
   return true;
 }
 
+function isRobotsDiscoveryEnabled(robots?: boolean | DocsRobotsConfig): boolean {
+  if (robots === false) return false;
+  if (robots && typeof robots === "object" && robots.enabled === false) return false;
+  return true;
+}
+
 function buildAgentSpec({
   origin,
   entry,
@@ -368,11 +379,13 @@ function buildAgentSpec({
   feedback,
   llms,
   sitemap,
+  robots,
 }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const localesEnabled = i18n !== null;
   const searchEnabled = isSearchEnabled(search);
   const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms.baseUrl });
+  const robotsEnabled = isRobotsDiscoveryEnabled(robots);
 
   return {
     version: "1",
@@ -400,6 +413,7 @@ function buildAgentSpec({
       mcp: mcp.enabled,
       search: searchEnabled,
       sitemap: sitemapConfig.enabled,
+      robots: robotsEnabled,
       agentFeedback: feedback.enabled,
       locales: localesEnabled,
     },
@@ -447,6 +461,11 @@ function buildAgentSpec({
         wellKnownRoute: sitemapConfig.markdown.wellKnownRoute,
         api: `${DEFAULT_DOCS_API_ROUTE}?format=sitemap-md`,
       },
+    },
+    robots: {
+      enabled: robotsEnabled,
+      route: DEFAULT_ROBOTS_TXT_ROUTE,
+      defaultRoute: DEFAULT_ROBOTS_TXT_ROUTE,
     },
     search: {
       enabled: searchEnabled,
@@ -1481,14 +1500,16 @@ function renderSkillDocument({
   feedback,
   llms,
   sitemap,
+  robots,
 }: SkillDocumentOptions): string {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const siteTitle = compactSkillText(llms.siteTitle ?? "Documentation");
   const siteDescription = llms.siteDescription ? compactSkillText(llms.siteDescription) : undefined;
   const searchEnabled = isSearchEnabled(search);
   const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms.baseUrl });
+  const robotsEnabled = isRobotsDiscoveryEnabled(robots);
   const description = truncateSkillDescription(
-    `Use ${siteTitle} through markdown routes, llms.txt, agent discovery, search, and MCP when available.`,
+    `Use ${siteTitle} through markdown routes, llms.txt, robots.txt, agent discovery, search, and MCP when available.`,
   );
   const lines = [
     "---",
@@ -1539,6 +1560,10 @@ function renderSkillDocument({
     }
   }
 
+  if (robotsEnabled) {
+    lines.push(`- Check ${DEFAULT_ROBOTS_TXT_ROUTE} for crawler and AI-agent access policy.`);
+  }
+
   if (mcp.enabled) {
     lines.push(
       `- Use ${DEFAULT_MCP_WELL_KNOWN_ROUTE} or ${DEFAULT_MCP_PUBLIC_ROUTE} for MCP tools when your environment supports MCP.`,
@@ -1562,6 +1587,10 @@ function renderSkillDocument({
     `- Markdown root: /${normalizedEntry}.md`,
     `- Markdown pages: /${normalizedEntry}/{slug}.md`,
   );
+
+  if (robotsEnabled) {
+    lines.push(`- Robots policy: ${DEFAULT_ROBOTS_TXT_ROUTE}`);
+  }
 
   if (llms.enabled) {
     lines.push(
@@ -2308,6 +2337,37 @@ function readSitemapConfig(root: string): boolean | DocsSitemapConfig | undefine
   return undefined;
 }
 
+function readRobotsConfig(root: string): boolean | DocsRobotsConfig | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = path.join(root, `docs.config.${ext}`);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      if (!content.includes("robots")) return undefined;
+      if (/robots\s*:\s*false/.test(content)) return false;
+      if (/robots\s*:\s*true/.test(content)) return true;
+
+      const robotsBlock = content.match(/robots\s*:\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? "";
+      const enabledMatch = robotsBlock.match(/enabled\s*:\s*(true|false)/);
+      const pathMatch = robotsBlock.match(/path\s*:\s*["']([^"']+)["']/);
+      const baseUrlMatch = robotsBlock.match(/baseUrl\s*:\s*["']([^"']+)["']/);
+      const aiMatch = robotsBlock.match(/ai\s*:\s*["'](allow|disallow)["']/);
+
+      return {
+        enabled: enabledMatch ? enabledMatch[1] === "true" : true,
+        path: pathMatch?.[1],
+        baseUrl: baseUrlMatch?.[1],
+        ai: aiMatch?.[1] as DocsRobotsConfig["ai"],
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
 function generateLlmsTxt(
   indexes: DocsSearchSourcePage[],
   options: LlmsTxtOptions,
@@ -2381,6 +2441,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   // Read llms.txt config
   const llmsConfig = readLlmsTxtConfig(root);
   const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
+  const robotsConfig = options?.robots ?? readRobotsConfig(root);
   const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
     defaultName: llmsConfig.siteTitle ?? "Documentation",
   });
@@ -2604,6 +2665,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             feedback: agentFeedbackConfig,
             llms: llmsConfig,
             sitemap: sitemapConfig,
+            robots: robotsConfig,
           }),
           {
             headers: {
@@ -2670,6 +2732,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
               feedback: agentFeedbackConfig,
               llms: llmsConfig,
               sitemap: sitemapConfig,
+              robots: robotsConfig,
             }),
           {
             headers: {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -825,6 +825,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },
@@ -857,6 +858,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -844,6 +844,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },
@@ -876,6 +877,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -809,6 +809,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },
@@ -841,6 +842,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
               siteDescription: llmsDesc,
             },
             sitemap: config.sitemap,
+            robots: config.robots,
             markdown: {
               acceptHeader: false,
             },

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -38,9 +38,9 @@ pnpm --dir examples/next exec docs robots generate --config docs.config.tsx
 pnpm --dir examples/next exec docs agent compact installation --config docs.config.tsx
 ```
 
-The agent discovery spec also advertises the sitemap routes, the root `skill.md` route, this Skills
-pack through `npx skills add farming-labs/docs`, and recommends the `getting-started` skill for
-first-run setup.
+The agent discovery spec also advertises the sitemap routes, `robots.route`, the root `skill.md`
+route, this Skills pack through `npx skills add farming-labs/docs`, and recommends the
+`getting-started` skill for first-run setup.
 
 ---
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -443,7 +443,7 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 - `/llms.txt`
 - `/llms-full.txt`
 - sitemap routes from the discovery spec, usually `/sitemap.xml`, `/sitemap.md`, and `/.well-known/sitemap.md`
-- `/robots.txt`
+- the robots route from the discovery spec, usually `/robots.txt`
 - `/skill.md`
 - `/.well-known/skill.md`
 - one representative `.md` page route, such as `/docs.md`

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -235,6 +235,8 @@ Behavior:
 - existing files are preserved unless the user passes `--append` or `--force`
 - generated policy includes docs entry routes, `.md` routes, `llms.txt`, sitemap routes,
   `skill.md`, MCP aliases, agent discovery routes, and common AI crawler user agents
+- the agent discovery JSON advertises `robots.enabled`, `robots.route`, and `robots.defaultRoute`
+  as a pointer to the static policy file
 - `baseUrl` lets the generator include an absolute `Sitemap:` line
 - `docs doctor --agent` validates the resolved robots path and warns when agent routes or common AI
   crawlers are blocked
@@ -520,7 +522,7 @@ feedback: {
 Default behavior:
 
 - `GET /.well-known/agent.json` is the preferred public agent discovery document, with `/.well-known/agent` as fallback and `/api/docs/agent/spec` as the canonical framework route
-- the discovery document includes site identity, locale config, capability flags, search, markdown routes, `llms.txt`, sitemap routes, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
+- the discovery document includes site identity, locale config, capability flags, search, markdown routes, `llms.txt`, sitemap routes, `robots.route`, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
 - `GET /skill.md` serves the root `skill.md` file when present, `GET /.well-known/skill.md` is the fallback alias, and `GET /api/docs?format=skill` is the shared API format
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Eleven built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-bor
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, `llms.txt` routes, sitemap routes, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, `llms.txt` routes, sitemap routes, `robots.route`, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Generated robots.txt** — use `docs robots generate` to write a static policy that allows docs routes, `.md` routes, `llms.txt`, sitemaps, `skill.md`, MCP aliases, agent discovery routes, and common AI crawler user agents. Existing files are preserved by default; use `--append` to add the managed block or `--force` to replace the file.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -542,7 +542,7 @@ The hosted pass probes:
 - `/llms.txt`
 - `/llms-full.txt`
 - sitemap routes from the discovery spec, usually `/sitemap.xml`, `/sitemap.md`, and `/.well-known/sitemap.md`
-- `/robots.txt`
+- the robots route from the discovery spec, usually `/robots.txt`
 - `/skill.md`
 - `/.well-known/skill.md`
 - one representative page markdown route, such as `/docs.md`

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1247,10 +1247,10 @@ Agents should discover the configured routes first with `GET /.well-known/agent.
 canonical framework route. Generated projects wire all three to the same JSON. The spec includes
 site identity, locale config, capability flags, the search endpoint, markdown route pattern,
 `Accept: text/markdown` contract, `Signature-Agent` support, API and public `llms.txt` routes,
-sitemap routes, root `skill.md` metadata, Skills CLI install metadata, MCP public/well-known
-endpoints and enabled tools, and the active agent feedback schema and submit endpoints. Publish
-`/robots.txt` separately with `docs robots generate` when crawlers and AI agents need an explicit
-access policy.
+sitemap routes, the `robots.txt` route, root `skill.md` metadata, Skills CLI install metadata, MCP
+public/well-known endpoints and enabled tools, and the active agent feedback schema and submit
+endpoints. Publish `/robots.txt` with `docs robots generate` when crawlers and AI agents need an
+explicit access policy at the advertised route.
 
 ```ts title="docs.config.ts"
 export default defineDocs({
@@ -1273,7 +1273,7 @@ Default behavior:
 - `GET /api/docs/agent/spec` returns the canonical framework discovery document
 - `GET /skill.md` serves a root `skill.md` file when present, and otherwise returns a generated fallback
 - `GET /.well-known/skill.md` and `GET /api/docs?format=skill` return the same skill document
-- the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, `skills.file`, `skills.route`, the `llms.txt` defaults, and sitemap routes when enabled
+- the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, `skills.file`, `skills.route`, the `llms.txt` defaults, `robots.route`, and sitemap routes when enabled
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
 - the shared `/api/docs` handler is still the source of truth

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -96,11 +96,12 @@ Recommended bootstrap flow:
 3. Use `spec.markdown.pagePattern`, `spec.markdown.acceptHeader`, or `spec.markdown.signatureAgentHeader` to read relevant docs pages as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page first.
 5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
-6. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
-7. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy.
+7. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
+8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
-in the spec.
+Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
+available in the spec.
 </Agent>
 ```
 

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -94,8 +94,8 @@ You are reading this docs site as an implementation agent.
 Before implementing from these docs, fetch `/.well-known/agent.json` from the same origin. If that
 is unavailable, fall back to `/.well-known/agent`. Use that JSON as the source of truth for the docs
 entry path, markdown route pattern, search endpoint, MCP endpoints, `llms.txt` routes, skills install
-command, `sitemap.xml` / `sitemap.md` routes, `skill.md` route, locale handling, and feedback
-endpoints.
+command, `sitemap.xml` / `sitemap.md` routes, `robots.txt` route, `skill.md` route, locale
+handling, and feedback endpoints.
 
 Recommended bootstrap flow:
 
@@ -104,11 +104,12 @@ Recommended bootstrap flow:
 3. Use `spec.markdown.pagePattern`, `spec.markdown.acceptHeader`, or `spec.markdown.signatureAgentHeader` to read relevant docs pages as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page first.
 5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
-6. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
-7. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy.
+7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
+8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
-in the spec.
+Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
+available in the spec.
 </Agent>
 ```
 
@@ -233,21 +234,22 @@ Agents should fetch it before choosing a transport. It tells them:
 - where to fetch `llms.txt` and `llms-full.txt` content, including the default public URLs and the
   public `/.well-known` aliases when available
 - where to fetch `sitemap.xml`, `sitemap.md`, and the `/.well-known/sitemap.md` alias when sitemap is enabled
-- where to fetch the `skill.md` document for this site
+- where to fetch `robots.txt` and the `skill.md` document for this site
 - how to install the published Skills pack and which skill is recommended first
 - whether MCP is enabled, which public/well-known endpoint to call, and which tools are available
 - whether agent feedback is enabled, plus the schema and submit endpoints to use
 
 The generated spec includes `agentSpecDefault: "/.well-known/agent.json"` and
 `agentSpecFallback: "/.well-known/agent"` so downstream integrations do not need to hard-code the
-preference themselves.
+preference themselves. It also includes `robots.route` so agents can find the static crawl policy
+without guessing.
 
 The skill document is available at `GET /skill.md`, with `GET /.well-known/skill.md` as the
 well-known alias and `GET /api/docs?format=skill` as the shared API format. Put a `skill.md` file at
 the project root, beside `docs.config.ts`, when you want custom site-specific instructions. If that
 file is missing, the framework generates a short fallback from config that points agents to
-markdown, search, MCP, `llms.txt`, sitemap routes, feedback, and the reusable Skills CLI install
-command.
+markdown, search, MCP, `llms.txt`, sitemap routes, `robots.txt`, feedback, and the reusable Skills
+CLI install command.
 
 ## Choosing Between Them
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -107,7 +107,7 @@ also expose the crawler-friendly public aliases:
 - `GET /llms-full.txt` — default full-content route
 - `GET /.well-known/llms.txt`
 - `GET /.well-known/llms-full.txt`
-- `GET /.well-known/agent.json` for the preferred agent discovery spec that references those `llms.txt` routes and the sitemap routes when enabled
+- `GET /.well-known/agent.json` for the preferred agent discovery spec that references those `llms.txt` routes, the `robots.txt` route, and the sitemap routes when enabled
 - `GET /.well-known/agent` as the fallback agent discovery alias
 
 Those aliases rewrite to the same shared API output, so there is still only one content pipeline.

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -236,6 +236,7 @@ That gives agents a much better workflow:
 - `/llms.txt` and `/llms-full.txt` expose site-level machine summaries
 - `/sitemap.xml` exposes canonical URLs and `lastmod` freshness for crawlers and monitors
 - `/sitemap.md` exposes the same docs tree as a semantic, sectioned map for agents and contributors
+- `spec.robots.route` points agents to the static crawl policy, usually `/robots.txt`
 - `{page}.md` gives them clean page markdown
 - canonical `{page}` URLs with `Signature-Agent` give agents the same markdown without appending `.md`
 - MCP lets tool-enabled agents search and read docs semantically

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -23,8 +23,8 @@ You are reading the machine-readable entry page for `@farming-labs/docs`.
 Before implementing from this docs site, fetch `/.well-known/agent.json` from the same origin. If
 that is unavailable, fall back to `/.well-known/agent`. Treat that JSON as the source of truth for
 the docs entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes,
-`sitemap.xml` / `sitemap.md` routes, `skill.md` route, skills install command, locale handling,
-`Signature-Agent` support, and feedback endpoints.
+`sitemap.xml` / `sitemap.md` routes, `robots.txt` route, `skill.md` route, skills install command,
+locale handling, `Signature-Agent` support, and feedback endpoints.
 
 Recommended bootstrap flow:
 
@@ -33,12 +33,12 @@ Recommended bootstrap flow:
 3. Use `spec.markdown.pagePattern`, `spec.markdown.acceptHeader`, or `spec.markdown.signatureAgentHeader` to read the exact docs pages you need as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page before reading it.
 5. Use `spec.sitemap.markdown.route` for the semantic page map and `spec.sitemap.xml.route` for canonical URL freshness when sitemap is enabled.
-6. Fetch `/robots.txt` separately when you need to confirm crawler and AI-agent access policy for the public docs surface.
+6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy for the public docs surface.
 7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
 8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, sitemap, MCP, or `llms.txt` routes are available
-in the spec.
+Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
+available in the spec.
 </Agent>
 
 ## Why @farming-labs/docs?

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -300,6 +300,10 @@ aliases, agent discovery routes, and common AI crawler user agents. Existing fil
 default; use `docs robots generate --append` to add or update the managed block, or `--force` to
 replace the file.
 
+The agent discovery JSON advertises this surface as `robots.enabled`, `robots.route`, and
+`robots.defaultRoute`, so agents can find the policy without guessing. The JSON points to the route;
+the actual policy contents still live in the generated static `robots.txt` file.
+
 ### `DocsRobotsRule`
 
 | Property     | Type                 | Description |
@@ -832,7 +836,7 @@ Notes:
 - submitted feedback is not added to Ask AI prompts or docs search context by the framework
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents should discover site identity, locale config, capability flags, search, active markdown routes, `Accept: text/markdown`, `Signature-Agent` support, `llms.txt`, sitemap routes, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
+- agents should discover site identity, locale config, capability flags, search, active markdown routes, `Accept: text/markdown`, `Signature-Agent` support, `llms.txt`, sitemap routes, `robots.txt`, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
 
 ### `DocsAgentFeedbackContext`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose robots.txt in the agent discovery spec and update `docs doctor` to probe the advertised route. Agents can now find the crawl policy reliably instead of guessing `/robots.txt`.

- **New Features**
  - Agent discovery JSON adds `robots.enabled`, `robots.route`, and `robots.defaultRoute` (default `/robots.txt`; enabled by default; disable with `robots: false`).
  - `docs doctor --agent` reads the robots route from discovery, probes it, analyzes policy, and warns if disabled or blocking.
  - `createDocsAPI` reads optional `robots` config; adapters for Astro, Nuxt, Svelte, and TanStack Start forward `config.robots` into discovery.
  - Generated `skill.md` and docs reference the robots route so agents can confirm access policy.
  - Tests and docs updated; no breaking changes.

<sup>Written for commit b165d380060116846f698d4bcccdec0102eb39d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

