### PR TITLE
feat: llms.txt port includes .md route

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -67,6 +67,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
+  toDocsMarkdownUrl,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -809,7 +810,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     llmsTxt += `## Pages\n\n`;
     for (const page of pages) {
-      llmsTxt += `- [${page.title}](${llmsBaseUrl}${page.url})`;
+      llmsTxt += `- [${page.title}](${llmsBaseUrl}${toDocsMarkdownUrl(page.url)})`;
       if (page.description) llmsTxt += `: ${page.description}`;
       llmsTxt += `\n`;
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -421,12 +421,26 @@ description: "Start here"
 Welcome to the docs.
 `,
     );
+    mkdirSync(join(rootDir, "app", "docs", "installation"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "How to install"
+---
+
+# Installation
+
+Install the package.
+`,
+    );
     writeFileSync(
       join(rootDir, "docs.config.ts"),
       `export default {
   llmsTxt: {
     enabled: true,
     siteTitle: "Alias Docs",
+    baseUrl: "https://docs.example.com",
   },
 };`,
     );
@@ -443,6 +457,11 @@ Welcome to the docs.
     expect(llmsApi.status).toBe(200);
     expect(llmsApi.headers.get("content-type")).toContain("text/plain");
     expect(llmsApiText).toContain("# Alias Docs");
+    expect(llmsApiText).toContain("- [Introduction](https://docs.example.com/docs.md): Start here");
+    expect(llmsApiText).toContain(
+      "- [Installation](https://docs.example.com/docs/installation.md): How to install",
+    );
+    expect(llmsApiText).not.toContain("(https://docs.example.com/docs/installation):");
 
     for (const path of ["/llms.txt", "/.well-known/llms.txt"]) {
       const response = await GET(new Request(`http://localhost${path}`));

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -37,6 +37,7 @@ import {
   resolveDocsI18n,
   resolveDocsLocale,
   resolvePageSidebarFolderIndexBehavior,
+  toDocsMarkdownUrl,
   createDocsSitemapResponse,
   resolveDocsSitemapConfig,
 } from "@farming-labs/docs";
@@ -2387,7 +2388,7 @@ function generateLlmsTxt(
   if (siteDescription) llmsTxt += `> ${siteDescription}\n\n`;
   llmsTxt += `## Pages\n\n`;
   for (const page of indexes) {
-    llmsTxt += `- [${page.title}](${baseUrl}${page.url})`;
+    llmsTxt += `- [${page.title}](${baseUrl}${toDocsMarkdownUrl(page.url)})`;
     if (page.description) llmsTxt += `: ${page.description}`;
     llmsTxt += `\n`;
   }

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -56,6 +56,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
+  toDocsMarkdownUrl,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -798,7 +799,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     llmsTxt += `## Pages\n\n`;
     for (const page of pages) {
-      llmsTxt += `- [${page.title}](${llmsBaseUrl}${page.url})`;
+      llmsTxt += `- [${page.title}](${llmsBaseUrl}${toDocsMarkdownUrl(page.url)})`;
       if (page.description) llmsTxt += `: ${page.description}`;
       llmsTxt += `\n`;
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -67,6 +67,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
+  toDocsMarkdownUrl,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -818,7 +819,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     llmsTxt += `## Pages\n\n`;
     for (const page of pages) {
-      llmsTxt += `- [${page.title}](${llmsBaseUrl}${page.url})`;
+      llmsTxt += `- [${page.title}](${llmsBaseUrl}${toDocsMarkdownUrl(page.url)})`;
       if (page.description) llmsTxt += `: ${page.description}`;
       llmsTxt += `\n`;
 

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -37,6 +37,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
+  toDocsMarkdownUrl,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -784,7 +785,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     llmsTxt += "## Pages\n\n";
     for (const page of pages) {
-      llmsTxt += `- [${page.title}](${llmsBaseUrl}${page.url})`;
+      llmsTxt += `- [${page.title}](${llmsBaseUrl}${toDocsMarkdownUrl(page.url)})`;
       if (page.description) llmsTxt += `: ${page.description}`;
       llmsTxt += "\n";
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -116,6 +116,12 @@ The agent discovery spec also advertises `defaultTxt: "/llms.txt"` and
 own framework-specific routes. TanStack Start, SvelteKit, Astro, and Nuxt can use the shared API
 query routes directly when they do not want to add the public aliases.
 
+The compact `llms.txt` listing links to each page's markdown route by default, for example
+`/docs/installation.md` instead of `/docs/installation`. That gives agents a direct path to the
+machine-readable page and keeps the root index aligned with AFDocs-style checks. `llms-full.txt`
+still includes the canonical page URL in its `URL:` line because the content is already embedded in
+that file.
+
 When you also want crawlers and AI agents to see an explicit access policy, publish
 `/robots.txt` with `docs robots generate`. The generated policy allows the public `llms.txt`
 aliases along with docs, markdown, sitemap, skill, MCP, and agent discovery routes.
@@ -133,9 +139,9 @@ aliases along with docs, markdown, sitemap, skill, MCP, and agent discovery rout
 
 ## Pages
 
-- [Introduction](https://docs.example.com/docs): Getting started guide
-- [Installation](https://docs.example.com/docs/installation): How to install
-- [Configuration](https://docs.example.com/docs/configuration): Config reference
+- [Introduction](https://docs.example.com/docs.md): Getting started guide
+- [Installation](https://docs.example.com/docs/installation.md): How to install
+- [Configuration](https://docs.example.com/docs/configuration.md): Config reference
 ```
 
 ### `/api/docs?format=llms-full`

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -233,7 +233,7 @@ export default defineDocs({
 That gives agents a much better workflow:
 
 - `/.well-known/agent.json` tells them which routes exist
-- `/llms.txt` and `/llms-full.txt` expose site-level machine summaries
+- `/llms.txt` links directly to page markdown routes, while `/llms-full.txt` exposes full machine-readable context
 - `/sitemap.xml` exposes canonical URLs and `lastmod` freshness for crawlers and monitors
 - `/sitemap.md` exposes the same docs tree as a semantic, sectioned map for agents and contributors
 - `spec.robots.route` points agents to the static crawl policy, usually `/robots.txt`
@@ -505,7 +505,7 @@ Before calling a page agent-friendly, ask:
 - should this page get an additive `<Agent>` block?
 - does it need a dedicated `agent.md`, or is the human page still canonical?
 - does this page need `agent.tokenBudget` before compaction?
-- can an agent find it through `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt`, sitemaps, `robots.txt`, MCP, and the discovery spec?
+- can an agent find it through `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt` markdown links, sitemaps, `robots.txt`, MCP, and the discovery spec?
 - do canonical `Signature-Agent` reads use the existing `/api/docs` handler instead of a custom wrapper route?
 - if the adapter preloads content, is the sitemap manifest bundled so JSON-LD freshness stays stable?
 - if the site is static, does the build generate `sitemap.xml`, `sitemap.md`, `/.well-known/sitemap.md`, and `robots.txt`?

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -91,7 +91,7 @@ Modern docs features are built in; you turn them on in [configuration](/docs/con
 - **[Page actions](/docs/customization/page-actions)** — Copy Markdown, open in ChatGPT/other tools. [Customize](/docs/customization/page-actions) which actions appear and their options.
 - **[Sidebar](/docs/customization/sidebar)** — Collapsible, flat or nested, banner, footer. [Customize](/docs/customization/sidebar) structure, style, and content (banner, footer, nav title).
 - **[Components](/docs/customization/components)** — Built-in MDX components like `Callout`, `Tabs`, and `HoverLink`, plus your own custom React components.
-- **[llms.txt](/docs/customization/llms-txt)** — LLM-friendly index of your docs; served when the docs API is enabled. Options described in the [llms.txt docs](/docs/customization/llms-txt).
+- **[llms.txt](/docs/customization/llms-txt)** — LLM-friendly index whose page links point directly to markdown routes. Options described in the [llms.txt docs](/docs/customization/llms-txt).
 - **[Sitemaps](/docs/customization/sitemaps)** — XML and Markdown maps of canonical docs URLs, descriptions, related pages, and freshness metadata.
 - **Robots.txt** — Generate an agent-friendly crawl policy with `docs robots generate`. Configure defaults from [Configuration](/docs/configuration) and see the command in [CLI](/docs/cli).
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
`llms.txt` now links to each docs page’s `.md` route (e.g., `/docs/installation.md`) instead of the canonical URL. This gives agents a direct machine-readable path; `llms-full.txt` remains unchanged.

- **New Features**
  - Use `toDocsMarkdownUrl` from `@farming-labs/docs` when generating `llms.txt` links.
  - Applied across `packages/astro`, `packages/nuxt`, `packages/svelte`, `packages/tanstack-start`, and the `packages/fumadocs` API.
  - Tests added in `packages/fumadocs/src/docs-api.test.ts` for `.md` links and `baseUrl`.
  - Docs updated to state `llms.txt` links point to markdown routes.

<sup>Written for commit 228bdf2c8b151b29c9f709921cc5c7f81abe91a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

