### PR TITLE
feat: llms.txt default opt-in

### DIFF
--- a/examples/next/app/api/docs/route.ts
+++ b/examples/next/app/api/docs/route.ts
@@ -8,6 +8,7 @@ export const { GET, POST } = createDocsAPI({
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
+  llmsTxt: docsConfig.llmsTxt,
   search: docsConfig.search,
   ai: docsConfig.ai,
   analytics: docsConfig.analytics,

--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -24,9 +24,11 @@ const showLastModified = !!data.lastModified;
 
 const llmsTxtEnabled = (() => {
   const cfg = config?.llmsTxt;
+  if (cfg === undefined) return true;
   if (cfg === true) return true;
+  if (cfg === false) return false;
   if (typeof cfg === "object" && cfg !== null) return cfg.enabled !== false;
-  return false;
+  return true;
 })();
 
 const copyMarkdownEnabled = (() => {

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2456,7 +2456,6 @@ export interface DocsConfig {
    * @example
    * ```ts
    * llmsTxt: {
-   *   enabled: true,
    *   baseUrl: "https://docs.example.com",
    * }
    * ```

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -499,6 +499,71 @@ Install the package.
     }
   });
 
+  it("serves llms.txt by default when llmsTxt is omitted", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-default-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "getting-started"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "getting-started", "page.mdx"),
+      `---
+title: "Getting Started"
+description: "First steps"
+---
+
+# Getting Started
+
+Start here.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `export default {
+  nav: {
+    title: "Default Docs",
+  },
+};`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    const response = await GET(new Request("http://localhost/llms.txt"));
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    expect(text).toContain("# Default Docs");
+    expect(text).toContain("- [Getting Started](/docs/getting-started.md): First steps");
+  });
+
+  it("honors llmsTxt opt-out in the shared docs api handler", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-disabled-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `export default {
+  llmsTxt: false,
+};`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    const response = await GET(new Request("http://localhost/llms.txt"));
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("Not Found");
+  });
+
   it("serves a root skill.md file before falling back to generated skill content", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-root-skill-route-"));
     tempDirs.push(rootDir);
@@ -1630,7 +1695,7 @@ title: "Home"
       markdownRoutes: true,
       agentMdOverrides: true,
       agentBlocks: true,
-      llms: false,
+      llms: true,
       skills: true,
       mcp: false,
       search: false,
@@ -1646,7 +1711,7 @@ title: "Home"
       rootPage: "/guides.md",
     });
     expect(spec.llms).toEqual({
-      enabled: false,
+      enabled: true,
       defaultTxt: "/llms.txt",
       defaultFull: "/llms-full.txt",
       txt: "/api/docs?format=llms",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -135,6 +135,8 @@ interface DocsAPIOptions {
   feedback?: boolean | FeedbackConfig;
   /** MCP configuration used for the agent discovery spec. */
   mcp?: boolean | DocsMcpConfig;
+  /** llms.txt configuration. Enabled by default; set false to opt out. */
+  llmsTxt?: boolean | LlmsTxtOptions;
   /** Sitemap configuration used for sitemap.xml and sitemap.md. */
   sitemap?: boolean | DocsSitemapConfig;
   /** Robots.txt generation policy used for the agent discovery spec. */
@@ -2272,6 +2274,7 @@ async function handleAskAI(
 // ─── llms.txt generation ────────────────────────────────────────────
 
 interface LlmsTxtOptions {
+  enabled?: boolean;
   siteTitle?: string;
   siteDescription?: string;
   baseUrl?: string;
@@ -2283,11 +2286,25 @@ function readLlmsTxtConfig(root: string): LlmsTxtOptions & { enabled: boolean } 
     if (fs.existsSync(configPath)) {
       try {
         const content = fs.readFileSync(configPath, "utf-8");
+        const navTitleMatch = content.match(/nav\s*:\s*\{[^}]*title\s*:\s*["']([^"']+)["']/s);
 
-        if (!content.includes("llmsTxt")) return { enabled: false };
+        if (!content.includes("llmsTxt")) {
+          return {
+            enabled: true,
+            siteTitle: navTitleMatch?.[1],
+          };
+        }
 
         const isBoolTrue = /llmsTxt\s*:\s*true/.test(content);
-        if (isBoolTrue) return { enabled: true };
+        if (isBoolTrue) {
+          return {
+            enabled: true,
+            siteTitle: navTitleMatch?.[1],
+          };
+        }
+
+        const isBoolFalse = /llmsTxt\s*:\s*false/.test(content);
+        if (isBoolFalse) return { enabled: false };
 
         const enabledMatch = content.match(/llmsTxt\s*:\s*\{[^}]*enabled\s*:\s*(true|false)/s);
         if (enabledMatch && enabledMatch[1] === "false") return { enabled: false };
@@ -2300,8 +2317,6 @@ function readLlmsTxtConfig(root: string): LlmsTxtOptions & { enabled: boolean } 
           /llmsTxt\s*:\s*\{[^}]*siteDescription\s*:\s*["']([^"']+)["']/s,
         );
 
-        const navTitleMatch = content.match(/nav\s*:\s*\{[^}]*title\s*:\s*["']([^"']+)["']/s);
-
         return {
           enabled: true,
           baseUrl: baseUrlMatch?.[1],
@@ -2313,7 +2328,23 @@ function readLlmsTxtConfig(root: string): LlmsTxtOptions & { enabled: boolean } 
       }
     }
   }
-  return { enabled: false };
+  return { enabled: true };
+}
+
+function resolveLlmsTxtConfig(
+  input: boolean | LlmsTxtOptions | undefined,
+  fallback: LlmsTxtOptions & { enabled: boolean },
+): LlmsTxtOptions & { enabled: boolean } {
+  if (input === undefined) return fallback;
+  if (typeof input === "boolean") {
+    return input ? { ...fallback, enabled: true } : { enabled: false };
+  }
+
+  return {
+    ...fallback,
+    ...input,
+    enabled: input.enabled ?? true,
+  };
 }
 
 function readSitemapConfig(root: string): boolean | DocsSitemapConfig | undefined {
@@ -2449,7 +2480,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const searchConfig = options?.search;
 
   // Read llms.txt config
-  const llmsConfig = readLlmsTxtConfig(root);
+  const llmsConfig = resolveLlmsTxtConfig(options?.llmsTxt, readLlmsTxtConfig(root));
   const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
   const robotsConfig = options?.robots ?? readRobotsConfig(root);
   const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
@@ -2850,6 +2881,18 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       const llmsFormat = resolveLlmsTxtFormat(url);
+      if (llmsFormat === "llms" || llmsFormat === "llms-full") {
+        if (!llmsConfig.enabled) {
+          return new Response("Not Found", {
+            status: 404,
+            headers: {
+              "Content-Type": "text/plain; charset=utf-8",
+              "X-Robots-Tag": "noindex",
+            },
+          });
+        }
+      }
+
       if (llmsFormat === "llms") {
         await emitDocsAnalyticsEvent(analytics, {
           type: "llms_request",

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -114,6 +114,35 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.pageActionsPosition).toBe("below-title");
   });
 
+  it("enables llms.txt footer links by default", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.llmsTxtEnabled).toBe(true);
+  });
+
+  it("honors llmsTxt opt-out for footer links", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      llmsTxt: false,
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.llmsTxtEnabled).toBe(false);
+  });
+
   it("passes Schema.org structured data through to DocsPageClient", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -929,7 +929,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const readingTimeWordsPerMinute = readingTimeOptions.wordsPerMinute ?? 220;
 
   // llms.txt config
-  const llmsTxtEnabled = resolveBool(config.llmsTxt);
+  const llmsTxtEnabled = resolveEnabledByDefault(config.llmsTxt);
   const feedbackConfig = resolveFeedbackConfig(config.feedback);
 
   // Serialize provider icons to HTML strings so they survive the
@@ -1141,6 +1141,12 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
 /** Resolve `boolean | { enabled?: boolean }` to a simple boolean. */
 function resolveBool(v: boolean | { enabled?: boolean } | undefined): boolean {
   if (v === undefined) return false;
+  if (typeof v === "boolean") return v;
+  return v.enabled !== false;
+}
+
+function resolveEnabledByDefault(v: boolean | { enabled?: boolean } | undefined): boolean {
+  if (v === undefined) return true;
   if (typeof v === "boolean") return v;
   return v.enabled !== false;
 }

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -273,6 +273,12 @@ function resolveBool(value: boolean | { enabled?: boolean } | undefined): boolea
   return value.enabled !== false;
 }
 
+function resolveEnabledByDefault(value: boolean | { enabled?: boolean } | undefined): boolean {
+  if (value === undefined) return true;
+  if (typeof value === "boolean") return value;
+  return value.enabled !== false;
+}
+
 function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
   const defaults = {
     enabled: false,
@@ -373,7 +379,7 @@ export function TanstackDocsLayout({
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
   const readingTimeEnabled = resolveReadingTimeOptions(config.readingTime).enabled;
 
-  const llmsTxtEnabled = resolveBool(config.llmsTxt);
+  const llmsTxtEnabled = resolveEnabledByDefault(config.llmsTxt);
   const feedbackConfig = resolveFeedbackConfig(config.feedback);
   const staticExport = !!(config as { staticExport?: boolean }).staticExport;
 

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -618,6 +618,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(route).not.toContain("resolveNextProjectRoot");
     expect(route).not.toContain("rootDir,");
     expect(route).toContain("changelog: docsConfig.changelog");
+    expect(route).toContain("llmsTxt: docsConfig.llmsTxt");
     expect(route).toContain("search: docsConfig.search");
     expect(route).toContain("ai: docsConfig.ai");
   });

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -104,6 +104,7 @@ export const { GET, POST } = createDocsAPI({
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
+  llmsTxt: docsConfig.llmsTxt,
   sitemap: docsConfig.sitemap,
   search: docsConfig.search,
   analytics: docsConfig.analytics,

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -85,9 +85,11 @@ const showLastModified = computed(() => !!props.data.lastModified);
 
 const llmsTxtEnabled = computed(() => {
   const cfg = props.config?.llmsTxt;
+  if (cfg === undefined) return true;
   if (cfg === true) return true;
+  if (cfg === false) return false;
   if (typeof cfg === "object" && cfg !== null) return (cfg as { enabled?: boolean }).enabled !== false;
-  return false;
+  return true;
 });
 
 const entry = computed(() => (props.data.entry as string) ?? (props.config?.entry as string) ?? "docs");

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -55,9 +55,11 @@
 
   let llmsTxtEnabled = $derived.by(() => {
     const cfg = config?.llmsTxt;
+    if (cfg === undefined) return true;
     if (cfg === true) return true;
+    if (cfg === false) return false;
     if (typeof cfg === "object" && cfg !== null) return cfg.enabled !== false;
-    return false;
+    return true;
   });
 
   let copyMarkdownEnabled = $derived.by(() => {

--- a/website/app/api/docs/route.ts
+++ b/website/app/api/docs/route.ts
@@ -8,6 +8,7 @@ export const { GET, POST } = createDocsAPI({
   changelog: docsConfig.changelog,
   feedback: docsConfig.feedback,
   mcp: docsConfig.mcp,
+  llmsTxt: docsConfig.llmsTxt,
   search: docsConfig.search,
   analytics: docsConfig.analytics,
   observability: docsConfig.observability,

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -133,6 +133,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `pageActions` | `PageActionsConfig`            | —               | Copy Markdown, Open in LLM buttons                 |
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
+| `llmsTxt`     | `boolean \| LlmsTxtConfig`     | `true`          | Generated `/llms.txt` and `/llms-full.txt` with markdown page links |
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -7,7 +7,7 @@ order: 5.8
 
 # llms.txt
 
-Serve <HoverLink href="https://llmstxt.org" title="llms.txt" description="An open convention for exposing website content to language models in a predictable, crawlable text format." linkLabel="Read the llms.txt spec" external><code>llms.txt</code></HoverLink> content through your existing docs API and the default public aliases. Just enable it in your config.
+Serve <HoverLink href="https://llmstxt.org" title="llms.txt" description="An open convention for exposing website content to language models in a predictable, crawlable text format." linkLabel="Read the llms.txt spec" external><code>llms.txt</code></HoverLink> content through your existing docs API and the default public aliases. It is enabled by default.
 
 ## What is llms.txt?
 
@@ -27,9 +27,11 @@ The shared API handler remains the source of truth:
 
 ## Quick Start
 
+No config is required for the default routes. Add `llmsTxt` only when you want to customize the
+public base URL, title, description, or explicitly opt out.
+
 ```ts title="docs.config.ts"
 llmsTxt: {
-  enabled: true,
   baseUrl: "https://docs.example.com",
 }
 ```
@@ -42,7 +44,7 @@ aliases do not need one route file per URL.
 
 ## Configuration Reference
 
-All options go inside the `llmsTxt` object in `docs.config.ts`:
+All options go inside the optional `llmsTxt` object in `docs.config.ts`:
 
 ```ts title="docs.config.ts"
 export default defineDocs({
@@ -58,7 +60,7 @@ Enable or disable llms.txt generation.
 
 | Type      | Default |
 | --------- | ------- |
-| `boolean` | `false` |
+| `boolean` | `true`  |
 
 ### `llmsTxt.baseUrl`
 
@@ -70,7 +72,6 @@ Base URL prepended to all page links in the generated files.
 
 ```ts title="llmstxt-baseurl.ts"
 llmsTxt: {
-  enabled: true,
   baseUrl: "https://docs.example.com",
 }
 ```
@@ -174,7 +175,7 @@ Full page content here...
 
 ## Footer Links
 
-When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to the public `/llms.txt` and `/llms-full.txt` routes.
+Because `llms.txt` is enabled by default, `llms.txt` and `llms-full.txt` links automatically appear in the page footer next to "Edit on GitHub", pointing to the public `/llms.txt` and `/llms-full.txt` routes.
 
 ## Full Example
 
@@ -182,7 +183,6 @@ When enabled, `llms.txt` and `llms-full.txt` links automatically appear in the p
 export default defineDocs({
   entry: "docs",
   llmsTxt: {
-    enabled: true,
     baseUrl: "https://docs.example.com",
     siteTitle: "My Project Docs",
     siteDescription: "Comprehensive documentation for My Project",

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -212,7 +212,6 @@ import { defineDocs } from "@farming-labs/docs";
 export default defineDocs({
   entry: "docs",
   llmsTxt: {
-    enabled: true,
     baseUrl: "https://docs.example.com",
   },
   sitemap: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default-enable llms.txt in the shared docs API and layouts, with opt-out support. Sites now serve `/llms.txt` and `/llms-full.txt` and show footer links by default.

- **New Features**
  - Serve `/llms.txt` and `/llms-full.txt` by default; `llmsTxt: false` returns 404 with `X-Robots-Tag: noindex`.
  - Footer links to both files are on by default across layouts; honors `llmsTxt: false`.
  - Added `llmsTxt` to the docs API and passed through Next route handlers and examples.
  - Auto-fill `siteTitle` from `nav.title` when not provided; discovery spec now reports `llms: true` by default.

- **Migration**
  - No changes required for most apps.
  - To disable, set `llmsTxt: false` in `docs.config.ts`.
  - If you previously set `enabled: true`, you can remove it and keep any other `llmsTxt` fields.

<sup>Written for commit 1de23d452a0c423e3c79958446231706ca3552b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

