### PR TITLE
fix: maintain .md route on agent score

### DIFF
--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -542,8 +542,12 @@ function combinedMarkdownRouteCheck(checks: AgentScoreCheck[]): AgentScoreCheck 
   const strictCheck = checks.find((check) => check.id === STRICT_MARKDOWN_ROUTE_CHECK_ID);
   if (!afDocsCheck && !strictCheck) return undefined;
 
-  const afDocsPercent = afDocsCheck ? scorePercent(afDocsCheck.score, afDocsCheck.maxScore) : undefined;
-  const strictPercent = strictCheck ? scorePercent(strictCheck.score, strictCheck.maxScore) : undefined;
+  const afDocsPercent = afDocsCheck
+    ? scorePercent(afDocsCheck.score, afDocsCheck.maxScore)
+    : undefined;
+  const strictPercent = strictCheck
+    ? scorePercent(strictCheck.score, strictCheck.maxScore)
+    : undefined;
   const values = [afDocsPercent, strictPercent].filter(
     (value): value is number => typeof value === "number",
   );
@@ -575,8 +579,7 @@ function checksForDetails(checks: AgentScoreCheck[]): AgentScoreCheck[] {
   return [
     ...checks.filter(
       (check) =>
-        check.id !== AF_DOCS_MARKDOWN_URL_CHECK_ID &&
-        check.id !== STRICT_MARKDOWN_ROUTE_CHECK_ID,
+        check.id !== AF_DOCS_MARKDOWN_URL_CHECK_ID && check.id !== STRICT_MARKDOWN_ROUTE_CHECK_ID,
     ),
     ...(combined ? [combined] : []),
   ];

--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -125,6 +125,9 @@ const SCORE_SECTION_ID = "score";
 const LEADERBOARD_SECTION_ID = "leaderboard";
 const SELECTED_SITE_PARAM = "site";
 const SCORE_INPUT_PARAM = "url";
+const AF_DOCS_MARKDOWN_URL_CHECK_ID = "afdocs:markdown-url-support";
+const STRICT_MARKDOWN_ROUTE_CHECK_ID = "agent:adjacent-markdown-routes";
+const COMBINED_MARKDOWN_ROUTE_CHECK_ID = "agent:md-routes";
 
 const SCORE_LOADING_STEPS = [
   "Resolving docs site",
@@ -144,7 +147,7 @@ const BREAKDOWN_HELP_ITEMS = [
   {
     title: "Markdown",
     detail:
-      "Checks whether agents can read clean markdown through adjacent .md routes, markdown mirrors, or negotiation.",
+      "Checks whether agents can read clean markdown through .md routes, markdown mirrors, or negotiation.",
   },
   {
     title: "Page Size",
@@ -350,6 +353,17 @@ function scorePercent(score: number, maxScore: number): number {
   return Math.round(Math.max(0, Math.min(1, score / maxScore)) * 100);
 }
 
+function averageScorePercent(values: number[]): number {
+  const valid = values.filter((value) => Number.isFinite(value));
+  if (valid.length === 0) return 0;
+  return Math.round(valid.reduce((total, value) => total + value, 0) / valid.length);
+}
+
+function averageCheckPercent(checks: AgentScoreCheck[]): number | undefined {
+  if (checks.length === 0) return undefined;
+  return averageScorePercent(checks.map((check) => scorePercent(check.score, check.maxScore)));
+}
+
 function displayStatusForCheck(check: AgentScoreCheck): ScoreStatus {
   return statusFromScore(check.score, check.maxScore);
 }
@@ -370,9 +384,19 @@ function extraChecksForStandardCategory(
   checks: AgentScoreCheck[],
 ): AgentScoreCheck[] {
   if (categoryId === "markdown-availability") {
-    return checks.filter((check) => check.id === "agent:adjacent-markdown-routes");
+    return checks.filter((check) => check.id === STRICT_MARKDOWN_ROUTE_CHECK_ID);
   }
   return [];
+}
+
+function averageCategoryWithExtraChecks(
+  categoryScore: number,
+  extraChecks: AgentScoreCheck[],
+): number {
+  const extraPercent = averageCheckPercent(extraChecks);
+  return typeof extraPercent === "number"
+    ? averageScorePercent([categoryScore, extraPercent])
+    : categoryScore;
 }
 
 function buildPinnedStandardBreakdownItem(
@@ -389,12 +413,7 @@ function buildPinnedStandardBreakdownItem(
 
   if (scoredCategory) {
     const categoryScore = scoredCategory.score ?? 0;
-    const extraScore = extraChecks.reduce((total, check) => total + check.score, 0);
-    const extraMaxScore = extraChecks.reduce((total, check) => total + check.maxScore, 0);
-    const score =
-      extraMaxScore > 0
-        ? scorePercent(categoryScore + extraScore, 100 + extraMaxScore)
-        : categoryScore;
+    const score = averageCategoryWithExtraChecks(categoryScore, extraChecks);
     return {
       id: `standard:${definition.id}`,
       title: definition.title,
@@ -463,7 +482,12 @@ function buildPrimaryBreakdownItems(report: AgentScoreReport): BreakdownItem[] {
 
 function groupTitleForCheck(check: AgentScoreCheck): string {
   if (check.id === "framework:mcp") return "MCP";
-  if (check.id === "agent:adjacent-markdown-routes") return "Markdown";
+  if (
+    check.id === STRICT_MARKDOWN_ROUTE_CHECK_ID ||
+    check.id === COMBINED_MARKDOWN_ROUTE_CHECK_ID
+  ) {
+    return "Markdown";
+  }
   if (check.id.startsWith("framework:")) return "Framework surfaces";
   if (check.id.startsWith("afdocs:")) {
     const category = categoryTitleFromCheck(check);
@@ -491,7 +515,7 @@ function groupChecksForDetails(checks: AgentScoreCheck[]): CheckGroup[] {
   const groups: CheckGroup[] = [];
   const byId = new Map<string, CheckGroup>();
 
-  for (const check of checks) {
+  for (const check of checksForDetails(checks)) {
     const title = groupTitleForCheck(check);
     const id = groupIdFromTitle(title) || "agent-probes";
     const existing = byId.get(id);
@@ -507,6 +531,77 @@ function groupChecksForDetails(checks: AgentScoreCheck[]): CheckGroup[] {
   }
 
   return groups;
+}
+
+function stripAfDocsCategoryPrefix(detail: string): string {
+  return detail.replace(/^[^:]+:\s*/, "");
+}
+
+function combinedMarkdownRouteCheck(checks: AgentScoreCheck[]): AgentScoreCheck | undefined {
+  const afDocsCheck = checks.find((check) => check.id === AF_DOCS_MARKDOWN_URL_CHECK_ID);
+  const strictCheck = checks.find((check) => check.id === STRICT_MARKDOWN_ROUTE_CHECK_ID);
+  if (!afDocsCheck && !strictCheck) return undefined;
+
+  const afDocsPercent = afDocsCheck ? scorePercent(afDocsCheck.score, afDocsCheck.maxScore) : undefined;
+  const strictPercent = strictCheck ? scorePercent(strictCheck.score, strictCheck.maxScore) : undefined;
+  const values = [afDocsPercent, strictPercent].filter(
+    (value): value is number => typeof value === "number",
+  );
+  const score = averageScorePercent(values);
+
+  return {
+    id: COMBINED_MARKDOWN_ROUTE_CHECK_ID,
+    title: ".md routes",
+    detail: [
+      afDocsCheck
+        ? `Published markdown URLs: ${stripAfDocsCategoryPrefix(afDocsCheck.detail)}`
+        : undefined,
+      strictCheck ? `Same-path .md routes: ${strictCheck.detail}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    status: statusFromScore(score, 100),
+    score,
+    maxScore: 100,
+    recommendation:
+      score >= PASS_SCORE_RATIO * 100
+        ? undefined
+        : "Serve clean markdown through discoverable .md URLs, preferably matching each docs page route.",
+  };
+}
+
+function checksForDetails(checks: AgentScoreCheck[]): AgentScoreCheck[] {
+  const combined = combinedMarkdownRouteCheck(checks);
+  return [
+    ...checks.filter(
+      (check) =>
+        check.id !== AF_DOCS_MARKDOWN_URL_CHECK_ID &&
+        check.id !== STRICT_MARKDOWN_ROUTE_CHECK_ID,
+    ),
+    ...(combined ? [combined] : []),
+  ];
+}
+
+function groupScorePercent(group: CheckGroup): number {
+  if (group.id === "markdown") {
+    const combined = group.checks.find((check) => check.id === COMBINED_MARKDOWN_ROUTE_CHECK_ID);
+    if (combined) return scorePercent(combined.score, combined.maxScore);
+
+    const afDocsChecks = group.checks.filter((check) => check.id.startsWith("afdocs:"));
+    const adjacentChecks = group.checks.filter(
+      (check) => check.id === STRICT_MARKDOWN_ROUTE_CHECK_ID,
+    );
+    const afDocsPercent = averageCheckPercent(afDocsChecks);
+    const adjacentPercent = averageCheckPercent(adjacentChecks);
+    const values = [afDocsPercent, adjacentPercent].filter(
+      (value): value is number => typeof value === "number",
+    );
+    if (values.length > 0) return averageScorePercent(values);
+  }
+
+  const groupScore = group.checks.reduce((total, check) => total + check.score, 0);
+  const groupMaxScore = group.checks.reduce((total, check) => total + check.maxScore, 0);
+  return scorePercent(groupScore, groupMaxScore);
 }
 
 function usesFarmingLabsDocsFramework(
@@ -1273,8 +1368,8 @@ function HeroSection({
             <code className="font-mono text-black/70 dark:text-white/70">
               docs doctor --agent --url
             </code>{" "}
-            CLI runs, in one click. We probe discovery, llms.txt, sitemap, robots, skill.md,
-            adjacent .md routes, and MCP, then give you a score and a breakdown.
+            CLI runs, in one click. We probe discovery, llms.txt, sitemap, robots, skill.md, .md
+            routes, and MCP, then give you a score and a breakdown.
           </p>
 
           <div className="mt-6 flex font-pixel flex-wrap gap-1.5 sm:gap-2">
@@ -1647,10 +1742,8 @@ function ChecksBreakdown({ checks }: { checks: AgentScoreCheck[] }) {
 
       <ul className="divide-y divide-black/10 dark:divide-white/10">
         {groups.map((group) => {
-          const groupScore = group.checks.reduce((total, check) => total + check.score, 0);
-          const groupMaxScore = group.checks.reduce((total, check) => total + check.maxScore, 0);
-          const groupPercent = scorePercent(groupScore, groupMaxScore);
-          const groupStatus = statusFromScore(groupScore, groupMaxScore);
+          const groupPercent = groupScorePercent(group);
+          const groupStatus = statusFromScore(groupPercent, 100);
           const groupCallout = groupCalloutForId(group.id);
 
           return (

--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -144,7 +144,7 @@ const BREAKDOWN_HELP_ITEMS = [
   {
     title: "Markdown",
     detail:
-      "Checks whether each docs page is available as clean markdown through .md routes or negotiation.",
+      "Checks whether agents can read clean markdown through adjacent .md routes, markdown mirrors, or negotiation.",
   },
   {
     title: "Page Size",
@@ -365,6 +365,16 @@ function categoryTitleFromCheck(check: AgentScoreCheck): string | undefined {
   return check.detail.split(":").at(0)?.trim();
 }
 
+function extraChecksForStandardCategory(
+  categoryId: string,
+  checks: AgentScoreCheck[],
+): AgentScoreCheck[] {
+  if (categoryId === "markdown-availability") {
+    return checks.filter((check) => check.id === "agent:adjacent-markdown-routes");
+  }
+  return [];
+}
+
 function buildPinnedStandardBreakdownItem(
   definition: StandardBreakdownDefinition,
   report: AgentScoreReport,
@@ -372,17 +382,26 @@ function buildPinnedStandardBreakdownItem(
   const checks = report.checks.filter(
     (check) => categoryTitleFromCheck(check) === definition.sourceTitle,
   );
+  const extraChecks = extraChecksForStandardCategory(definition.id, report.checks);
   const scoredCategory = report.standard.categories.find(
     (category) => category.id === definition.id,
   );
 
   if (scoredCategory) {
-    const score = scoredCategory.score ?? 0;
+    const categoryScore = scoredCategory.score ?? 0;
+    const extraScore = extraChecks.reduce((total, check) => total + check.score, 0);
+    const extraMaxScore = extraChecks.reduce((total, check) => total + check.maxScore, 0);
+    const score =
+      extraMaxScore > 0
+        ? scorePercent(categoryScore + extraScore, 100 + extraMaxScore)
+        : categoryScore;
     return {
       id: `standard:${definition.id}`,
       title: definition.title,
       detail: scoredCategory.grade
-        ? `${definition.sourceTitle}: AFDocs category grade ${scoredCategory.grade}.`
+        ? `${definition.sourceTitle}: AFDocs category grade ${scoredCategory.grade}${
+            extraChecks.length > 0 ? ", plus hosted route probes." : "."
+          }`
         : `${definition.sourceTitle}: AFDocs did not score this category on this run.`,
       status: statusFromScore(score, 100),
       score,
@@ -444,6 +463,7 @@ function buildPrimaryBreakdownItems(report: AgentScoreReport): BreakdownItem[] {
 
 function groupTitleForCheck(check: AgentScoreCheck): string {
   if (check.id === "framework:mcp") return "MCP";
+  if (check.id === "agent:adjacent-markdown-routes") return "Markdown";
   if (check.id.startsWith("framework:")) return "Framework surfaces";
   if (check.id.startsWith("afdocs:")) {
     const category = categoryTitleFromCheck(check);
@@ -1253,8 +1273,8 @@ function HeroSection({
             <code className="font-mono text-black/70 dark:text-white/70">
               docs doctor --agent --url
             </code>{" "}
-            CLI runs, in one click. We probe discovery, llms.txt, sitemap, robots, skill.md, .md
-            routes, and MCP, then give you a score and a breakdown.
+            CLI runs, in one click. We probe discovery, llms.txt, sitemap, robots, skill.md,
+            adjacent .md routes, and MCP, then give you a score and a breakdown.
           </p>
 
           <div className="mt-6 flex font-pixel flex-wrap gap-1.5 sm:gap-2">

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -429,12 +429,15 @@ https://docs.farming-labs.dev/score?url=docs.example.com
 ```
 
 The score page runs AFDocs-style checks for any public docs site, then adds `@farming-labs/docs`
-framework probes when the site exposes `/.well-known/agent.json`. Those framework probes cover the
-discovery spec, full-context files, sitemap routes, `robots.txt`, `skill.md`, MCP, search,
-feedback, JSON-LD structured data on sampled pages, canonical `Link` headers on markdown
-responses, and the `<link rel="alternate" type="text/markdown">` head links that point agents to
-each page's `.md` route. Existing leaderboard entries hydrate from the saved report, so a shared
-score URL can be reviewed without triggering a new calculation unless no saved result exists.
+framework probes when the site exposes `/.well-known/agent.json`. The public score also adds a
+strict adjacent markdown probe that samples docs page routes and verifies that appending `.md`
+returns markdown, so `llms.txt` markdown mirrors do not hide missing `/docs/foo.md` routes. The
+framework probes cover the discovery spec, full-context files, sitemap routes, `robots.txt`,
+`skill.md`, MCP, search, feedback, JSON-LD structured data on sampled pages, canonical `Link`
+headers on markdown responses, and the `<link rel="alternate" type="text/markdown">` head links
+that point agents to each page's `.md` route. Existing leaderboard entries hydrate from the saved
+report, so a shared score URL can be reviewed without triggering a new calculation unless no saved
+result exists.
 
 Use the web score for demos, public comparisons, and quick regression checks. Use
 `docs doctor --agent --url` when you need CI-friendly JSON, local project context, or a command an

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -430,8 +430,8 @@ https://docs.farming-labs.dev/score?url=docs.example.com
 
 The score page runs AFDocs-style checks for any public docs site, then adds `@farming-labs/docs`
 framework probes when the site exposes `/.well-known/agent.json`. The public score also adds a
-strict adjacent markdown probe that samples docs page routes and verifies that appending `.md`
-returns markdown, so `llms.txt` markdown mirrors do not hide missing `/docs/foo.md` routes. The
+strict `.md` route probe that samples docs page routes and verifies that appending `.md` returns
+markdown, so `llms.txt` markdown mirrors do not hide missing `/docs/foo.md` routes. The
 framework probes cover the discovery spec, full-context files, sitemap routes, `robots.txt`,
 `skill.md`, MCP, search, feedback, JSON-LD structured data on sampled pages, canonical `Link`
 headers on markdown responses, and the `<link rel="alternate" type="text/markdown">` head links

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -1321,10 +1321,7 @@ function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function adjacentMarkdownPageUrlsFromAfDocsReport(
-  baseUrl: string,
-  report: ReportResult,
-): string[] {
+function adjacentMarkdownPageUrlsFromAfDocsReport(baseUrl: string, report: ReportResult): string[] {
   const urls: string[] = [];
   const base = new URL(baseUrl);
   if (base.pathname !== "/") {

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -33,6 +33,7 @@ const PROBE_TIMEOUT_MS = 9000;
 const AF_DOCS_MAX_LINKS_TO_TEST = 10;
 const AF_DOCS_REQUEST_DELAY_MS = 50;
 const AF_DOCS_MAX_CONCURRENCY = 6;
+const ADJACENT_MARKDOWN_MAX_SCORE = 3;
 const MAX_SAFE_REDIRECTS = 5;
 const FARMING_LABS_DOCS_UPGRADE_RECOMMENDATION =
   "Because this site uses @farming-labs/docs, upgrade to the latest version with `npx @farming-labs/docs upgrade --latest`, redeploy, then rescore before working through the remaining checks.";
@@ -908,7 +909,7 @@ const AF_DOCS_CHECK_TITLES: Record<string, string> = {
   "llms-txt-links-markdown": "llms.txt markdown links",
   "llms-txt-directive-html": "HTML llms.txt directive",
   "llms-txt-directive-md": "Markdown llms.txt directive",
-  "markdown-url-support": ".md URL support",
+  "markdown-url-support": "Markdown URL availability",
   "content-negotiation": "Markdown negotiation",
   "rendering-strategy": "Server-rendered content",
   "page-size-markdown": "Markdown page size",
@@ -1062,6 +1063,14 @@ interface MarkdownCanonicalProbe {
   hasCanonicalLink: boolean;
 }
 
+interface AdjacentMarkdownRouteProbe {
+  pageUrl: string;
+  markdownUrl: string;
+  ok: boolean;
+  status?: number;
+  detail: string;
+}
+
 function decodeHtmlEntity(value: string): string {
   const named: Record<string, string> = {
     amp: "&",
@@ -1139,6 +1148,42 @@ function markdownUrlForHtmlPage(pageUrl: string, alternateHref?: string): string
   url.search = "";
   url.hash = "";
   return url.toString();
+}
+
+function adjacentMarkdownUrlForHtmlPage(pageUrl: string): string {
+  const url = new URL(pageUrl);
+  const pathname = url.pathname.replace(/\/+$/, "") || url.pathname;
+  url.pathname = `${pathname.replace(/\.html?$/i, "")}.md`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function looksLikeHtmlContent(body: string): boolean {
+  const sample = body
+    .replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*$/gm, "")
+    .replace(/`[^`\n]+`/g, "``")
+    .slice(0, 2000);
+  return /<!doctype\s/i.test(sample) || /<html[\s>]/i.test(sample) || /<body[\s>]/i.test(sample);
+}
+
+function looksLikeMarkdownContent(body: string): boolean {
+  if (!body.trim() || looksLikeHtmlContent(body)) return false;
+  const sample = body.slice(0, 5000);
+  let signals = 0;
+  if (/^#{1,6}\s+\S/m.test(sample)) signals++;
+  if (/\[[^\]]+\]\([^)]+\)/.test(sample)) signals++;
+  if (/^```/m.test(sample)) signals++;
+  return signals > 0;
+}
+
+function isMarkdownResponse(response: Response, body: string): boolean {
+  const contentType = response.headers.get("content-type") ?? "";
+  return (
+    response.ok &&
+    body.trim().length > 0 &&
+    (contentType.includes("text/markdown") || looksLikeMarkdownContent(body))
+  );
 }
 
 function canonicalLinkFromHeader(header: string | null): string | undefined {
@@ -1234,6 +1279,117 @@ function samplePageUrls(urls: string[], limit: number): string[] {
   return Array.from({ length: limit }, (_, index) => unique[Math.floor(index * stride)]!).filter(
     Boolean,
   );
+}
+
+function isNonHtmlPagePath(pathname: string): boolean {
+  const lastSegment = pathname.split("/").pop() ?? "";
+  return /\.[a-z0-9]+$/i.test(lastSegment) && !/\.html?$/i.test(lastSegment);
+}
+
+function normalizeAdjacentMarkdownPageUrl(rawUrl: string, baseUrl: string): string | undefined {
+  try {
+    const base = new URL(baseUrl);
+    const url = new URL(rawUrl, baseUrl);
+    if (url.origin !== base.origin) return undefined;
+
+    url.hash = "";
+    url.search = "";
+
+    let pathname = url.pathname;
+    if (pathname.startsWith("/llms.txt/")) {
+      pathname = pathname.slice("/llms.txt".length) || "/";
+    }
+    if (pathname.endsWith("/index.md") || pathname.endsWith("/index.mdx")) {
+      pathname = pathname.replace(/\/index\.mdx?$/i, "");
+    } else {
+      pathname = pathname.replace(/\.mdx?$/i, "");
+    }
+    pathname = pathname.replace(/\/+$/, "") || "/";
+
+    if (pathname === "/" || pathname === "/llms.txt") return undefined;
+    if (pathname.startsWith("/.well-known/")) return undefined;
+    if (isNonHtmlPagePath(pathname)) return undefined;
+
+    url.pathname = pathname;
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function adjacentMarkdownPageUrlsFromAfDocsReport(
+  baseUrl: string,
+  report: ReportResult,
+): string[] {
+  const urls: string[] = [];
+  const base = new URL(baseUrl);
+  if (base.pathname !== "/") {
+    const normalized = normalizeAdjacentMarkdownPageUrl(baseUrl, baseUrl);
+    if (normalized) urls.push(normalized);
+  }
+
+  const markdownUrlResult = report.results.find((result) => result.id === "markdown-url-support");
+  const pageResults = Array.isArray(markdownUrlResult?.details?.pageResults)
+    ? markdownUrlResult.details.pageResults
+    : [];
+
+  for (const pageResult of pageResults) {
+    const record = asRecord(pageResult);
+    const pageUrl = readString(record?.url);
+    const markdownUrl = readString(record?.mdUrl);
+    for (const candidate of [pageUrl, markdownUrl]) {
+      if (!candidate) continue;
+      const normalized = normalizeAdjacentMarkdownPageUrl(candidate, baseUrl);
+      if (normalized) urls.push(normalized);
+    }
+  }
+
+  return samplePageUrls(urls, AF_DOCS_MAX_LINKS_TO_TEST);
+}
+
+async function probeAdjacentMarkdownRoute(pageUrl: string): Promise<AdjacentMarkdownRouteProbe> {
+  const markdownUrl = adjacentMarkdownUrlForHtmlPage(pageUrl);
+
+  try {
+    const response = await fetchWithTimeout(markdownUrl, {
+      headers: { Accept: "text/markdown, */*" },
+    });
+    const body = await response.text().catch(() => "");
+    const ok = isMarkdownResponse(response, body);
+    const pathname = new URL(markdownUrl).pathname;
+    const contentType = response.headers.get("content-type")?.split(";")[0]?.trim();
+
+    return {
+      pageUrl,
+      markdownUrl,
+      ok,
+      status: response.status,
+      detail: ok
+        ? `${pathname} returned markdown${contentType ? ` (${contentType})` : ""}.`
+        : response.ok
+          ? `${pathname} returned HTTP ${response.status} but did not look like markdown.`
+          : `${pathname} returned HTTP ${response.status}.`,
+    };
+  } catch (error) {
+    return {
+      pageUrl,
+      markdownUrl,
+      ok: false,
+      detail: `${markdownUrl} failed: ${error instanceof Error ? error.message : String(error)}.`,
+    };
+  }
+}
+
+async function probeAdjacentMarkdownRoutes(
+  baseUrl: string,
+  report: ReportResult,
+): Promise<AdjacentMarkdownRouteProbe[]> {
+  const urls = adjacentMarkdownPageUrlsFromAfDocsReport(baseUrl, report);
+  return Promise.all(urls.map((url) => probeAdjacentMarkdownRoute(url)));
 }
 
 function discoverHtmlSurfacePageUrls(
@@ -1378,6 +1534,43 @@ function scoreMarkdownCanonicalCoverage(
     return { status: "warn", score: roundScore((passed / total) * maxScore), passed, total };
   }
   return { status: "fail", score: 0, passed, total };
+}
+
+function scoreAdjacentMarkdownRoutes(
+  probes: AdjacentMarkdownRouteProbe[],
+  maxScore: number,
+): { status: ScoreStatus; score: number; passed: number; total: number } {
+  const total = probes.length;
+  const passed = probes.filter((probe) => probe.ok).length;
+  if (total === 0) return { status: "fail", score: 0, passed: 0, total };
+  if (passed === total) return { status: "pass", score: maxScore, passed, total };
+  if (passed > 0) {
+    return { status: "warn", score: roundScore((passed / total) * maxScore), passed, total };
+  }
+  return { status: "fail", score: 0, passed, total };
+}
+
+function buildAdjacentMarkdownRouteCheck(probes: AdjacentMarkdownRouteProbe[]): AgentScoreCheck {
+  const score = scoreAdjacentMarkdownRoutes(probes, ADJACENT_MARKDOWN_MAX_SCORE);
+  const failures = probes
+    .filter((probe) => !probe.ok)
+    .slice(0, 3)
+    .map((probe) => probe.detail)
+    .join(" ");
+
+  return makeCheck(
+    "agent:adjacent-markdown-routes",
+    "Adjacent .md routes",
+    score.status,
+    score.score,
+    ADJACENT_MARKDOWN_MAX_SCORE,
+    score.total > 0
+      ? `${score.passed}/${score.total} sampled docs page routes returned markdown when .md was appended.${failures ? ` ${failures}` : ""}`
+      : "No docs page routes were available to verify adjacent .md support.",
+    score.status === "pass"
+      ? undefined
+      : "Serve each docs page at the same route with .md appended, for example /docs/installation -> /docs/installation.md.",
+  );
 }
 
 function buildMcpReadinessCheck(result: McpProbeResult): AgentScoreCheck {
@@ -1752,26 +1945,39 @@ export async function inspectHostedAgentReadiness(rawUrl: string): Promise<Agent
   const baseUrl = normalizeAgentScoreBaseUrl(rawUrl);
   await assertPublicAgentScoreUrl(baseUrl);
 
-  const { afdocsReport, framework } = await withPublicAgentScoreFetch(async () => {
-    const report = await runChecks(baseUrl, {
-      samplingStrategy: "deterministic",
-      maxLinksToTest: AF_DOCS_MAX_LINKS_TO_TEST,
-      maxConcurrency: AF_DOCS_MAX_CONCURRENCY,
-      requestDelay: AF_DOCS_REQUEST_DELAY_MS,
-      requestTimeout: PROBE_TIMEOUT_MS,
-    });
-    return {
-      afdocsReport: report,
-      framework: await buildFrameworkChecks(baseUrl),
-    };
-  });
+  const { afdocsReport, adjacentMarkdownChecks, framework } = await withPublicAgentScoreFetch(
+    async () => {
+      const report = await runChecks(baseUrl, {
+        samplingStrategy: "deterministic",
+        maxLinksToTest: AF_DOCS_MAX_LINKS_TO_TEST,
+        maxConcurrency: AF_DOCS_MAX_CONCURRENCY,
+        requestDelay: AF_DOCS_REQUEST_DELAY_MS,
+        requestTimeout: PROBE_TIMEOUT_MS,
+      });
+      const adjacentMarkdownProbes = await probeAdjacentMarkdownRoutes(baseUrl, report);
+      return {
+        afdocsReport: report,
+        adjacentMarkdownChecks: [buildAdjacentMarkdownRouteCheck(adjacentMarkdownProbes)],
+        framework: await buildFrameworkChecks(baseUrl),
+      };
+    },
+  );
   const afdocsScore = computeScore(afdocsReport);
 
-  const checks = [...buildAfDocsChecks(afdocsReport, afdocsScore), ...framework.checks];
+  const checks = [
+    ...buildAfDocsChecks(afdocsReport, afdocsScore),
+    ...adjacentMarkdownChecks,
+    ...framework.checks,
+  ];
+  const genericRawScore = adjacentMarkdownChecks.reduce((total, check) => total + check.score, 0);
+  const genericRawMaxScore = adjacentMarkdownChecks.reduce(
+    (total, check) => total + check.maxScore,
+    0,
+  );
   const frameworkRawScore = framework.checks.reduce((total, check) => total + check.score, 0);
   const frameworkRawMaxScore = framework.checks.reduce((total, check) => total + check.maxScore, 0);
-  const rawScore = roundScore(afdocsScore.overall + frameworkRawScore);
-  const rawMaxScore = roundScore(100 + frameworkRawMaxScore);
+  const rawScore = roundScore(afdocsScore.overall + genericRawScore + frameworkRawScore);
+  const rawMaxScore = roundScore(100 + genericRawMaxScore + frameworkRawMaxScore);
   const score = rawMaxScore <= 0 ? 0 : Math.round((rawScore / rawMaxScore) * 100);
   const name = deriveAgentScoreSiteName(baseUrl);
   const recoveryRecommendations = scoreRecoveryRecommendations(score, {

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -1560,13 +1560,13 @@ function buildAdjacentMarkdownRouteCheck(probes: AdjacentMarkdownRouteProbe[]): 
 
   return makeCheck(
     "agent:adjacent-markdown-routes",
-    "Adjacent .md routes",
+    ".md routes",
     score.status,
     score.score,
     ADJACENT_MARKDOWN_MAX_SCORE,
     score.total > 0
       ? `${score.passed}/${score.total} sampled docs page routes returned markdown when .md was appended.${failures ? ` ${failures}` : ""}`
-      : "No docs page routes were available to verify adjacent .md support.",
+      : "No docs page routes were available to verify .md route support.",
     score.status === "pass"
       ? undefined
       : "Serve each docs page at the same route with .md appended, for example /docs/installation -> /docs/installation.md.",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a strict adjacent .md route probe and merges it with AFDocs markdown URL support into a single ".md routes" score, so sites need real same‑path .md pages instead of only markdown mirrors. Updates scoring, UI, and docs to reflect the stricter requirement.

- **Bug Fixes**
  - Added `agent:adjacent-markdown-routes` (up to 3 pts): samples docs routes, appends `.md`, validates markdown via content-type and body heuristics.
  - Combined with `afdocs:markdown-url-support` as `.md routes` (`agent:md-routes`), averaged in the “Markdown” group; the “Markdown availability” category now averages in these hosted probes and shows “plus hosted route probes.”
  - Hardened URL normalization and sampling: same-origin only, strips `.md/.mdx` and `/index.md`, ignores non-HTML asset paths, derives candidates from AFDocs page results and the base URL.
  - Updated UI copy and docs; renamed to “Markdown URL availability” and clarified that `llms.txt` mirrors don’t replace real adjacent routes.

<sup>Written for commit d93cdebf5a41c043663073a1f48bb86733571b1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

