### PR TITLE
feat: default agent surfaces

### DIFF
--- a/benchmark/codex/farming-labs/app/api/docs/route.ts
+++ b/benchmark/codex/farming-labs/app/api/docs/route.ts
@@ -1,13 +1,6 @@
 import docsConfig from "@/docs.config";
 import { createDocsAPI } from "@farming-labs/next/api";
 
-export const { GET, POST } = createDocsAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  feedback: docsConfig.feedback,
-  mcp: docsConfig.mcp,
-  search: docsConfig.search,
-  ai: docsConfig.ai,
-});
+export const { GET, POST } = createDocsAPI(docsConfig);
 
 export const revalidate = false;

--- a/examples/next/app/api/docs/mcp/route.ts
+++ b/examples/next/app/api/docs/mcp/route.ts
@@ -3,15 +3,6 @@
 import docsConfig from "@/docs.config";
 import { createDocsMCPAPI } from "@farming-labs/next/api";
 
-export const { GET, POST, DELETE } = createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  mcp: docsConfig.mcp,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-});
+export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 
 export const revalidate = false;

--- a/examples/next/app/api/docs/route.ts
+++ b/examples/next/app/api/docs/route.ts
@@ -1,18 +1,6 @@
 import docsConfig from "@/docs.config";
 import { createDocsAPI } from "@farming-labs/next/api";
 
-export const { GET, POST } = createDocsAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  i18n: docsConfig.i18n,
-  changelog: docsConfig.changelog,
-  feedback: docsConfig.feedback,
-  mcp: docsConfig.mcp,
-  llmsTxt: docsConfig.llmsTxt,
-  search: docsConfig.search,
-  ai: docsConfig.ai,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-});
+export const { GET, POST } = createDocsAPI(docsConfig);
 
 export const revalidate = false;

--- a/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
@@ -49,7 +49,7 @@ For this page:
 ## Markdown Route Shape
 
 ```ts
-const handlers = createDocsAPI({ ... });
+const handlers = createDocsAPI(docsConfig);
 
 export async function GET(request, { params }) {
   const { slug = [] } = await params;
@@ -96,14 +96,7 @@ Implementation contract:
 The Next example exposes MCP through:
 
 ```ts
-createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  mcp: docsConfig.mcp,
-});
+createDocsMCPAPI(docsConfig);
 ```
 
 Use MCP for tool-based reads and parity checks, but keep the `.md` route as the simple public HTTP

--- a/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
@@ -147,14 +147,7 @@ The example app also exposes the standard MCP surface:
 import docsConfig from "@/docs.config";
 import { createDocsMCPAPI } from "@farming-labs/next/api";
 
-export const { GET, POST, DELETE } = createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  mcp: docsConfig.mcp,
-});
+export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 ```
 
 When `agent.md` exists, the `.md` route returns that file. MCP remains available for tool-based

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -400,10 +400,10 @@ Notes:
 
 - `search: false` disables search entirely
 - Search requires the docs API route; static export hides the UI because there is no server route
-- On Next.js, generated routes from `withDocs()` already forward `docsConfig.search`
+- On Next.js, generated routes from `withDocs()` pass `docsConfig` directly into `createDocsAPI`
 - MCP-backed search works with relative endpoints like `/api/docs/mcp` and absolute remote endpoints like `https://docs.example.com/api/docs/mcp`
 - If MCP-backed search points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally to avoid recursive loops
-- On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search`
+- On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass the whole config: `createDocsAPI(docsConfig)`
 
 <Callout type="warning" title="@farming-labs/theme/api still works for now">
   `@farming-labs/theme/api` remains supported as a compatibility import path today, but prefer

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -35,6 +35,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsRobotsResponse,
   createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
@@ -48,6 +49,7 @@ import {
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
   normalizeDocsRelated,
+  parseDocsAgentFeedbackData,
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsMarkdownNotFound,
@@ -56,6 +58,8 @@ import {
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
@@ -71,6 +75,7 @@ import {
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
+  validateDocsAgentFeedbackPayload,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -807,6 +812,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       defaultName: llmsTitle,
     },
   );
+  const agentFeedbackConfig = resolveDocsAgentFeedbackConfig(
+    (config as Record<string, unknown>).feedback as Record<string, unknown> | boolean | undefined,
+  );
+  const agentFeedbackDiscovery = {
+    enabled: agentFeedbackConfig.enabled,
+    route: "/api/docs?feedback=agent",
+    schemaRoute: "/api/docs?feedback=agent&schema=1",
+  };
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
@@ -854,6 +867,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             i18n,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -881,6 +895,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "submit") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "POST",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
+        headers: {
+          "Content-Type": "application/schema+json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
+    }
+
     if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
@@ -889,6 +924,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             entry,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -923,6 +959,15 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       manifest: preloadedSitemapManifest ?? readDocsSitemapManifest(rootDir, config.sitemap),
     });
     if (sitemapResponse) return sitemapResponse;
+
+    const robotsResponse = createDocsRobotsResponse({
+      request: context.request,
+      entry,
+      sitemap: config.sitemap,
+      baseUrl: llmsBaseUrl || url.origin,
+      robots: config.robots,
+    });
+    if (robotsResponse) return robotsResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
@@ -1091,6 +1136,35 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   async function POST(context: { request: Request }): Promise<Response> {
     const requestUrl = new URL(context.request.url);
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "schema") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "GET",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      const parsed = await parseDocsAgentFeedbackData(context.request);
+      if (!parsed.ok) return parsed.response;
+
+      const payloadError = validateDocsAgentFeedbackPayload(
+        parsed.data.payload,
+        agentFeedbackConfig.payloadSchema,
+      );
+      if (payloadError) return Response.json({ error: payloadError }, { status: 400 });
+
+      if (!agentFeedbackConfig.onFeedback) {
+        return Response.json({ ok: true, handled: false }, { status: 202 });
+      }
+
+      await agentFeedbackConfig.onFeedback(parsed.data);
+      return Response.json({ ok: true, handled: true }, { status: 201 });
+    }
+
     const requestStartedAt = Date.now();
     const trace = createDocsAgentTraceContext("ask-ai");
     const runSpanId = createDocsAgentTraceId("span");

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -15,6 +15,8 @@ import {
   renderDocsMarkdownNotFound,
   renderDocsLlmsTxt,
   renderDocsSkillDocument,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolveDocsAgentMdxContent,
   resolveDocsLlmsTxtFormat,
   resolveDocsLlmsTxtRequest,
@@ -202,9 +204,23 @@ describe("agent route helpers", () => {
         "docs",
         new URL("https://example.com/sitemap.xml"),
         new Request("https://example.com/sitemap.xml"),
-        { sitemap: true },
       ),
     ).toBe(true);
+    expect(
+      isDocsPublicGetRequest(
+        "docs",
+        new URL("https://example.com/robots.txt"),
+        new Request("https://example.com/robots.txt"),
+      ),
+    ).toBe(true);
+    expect(
+      isDocsPublicGetRequest(
+        "docs",
+        new URL("https://example.com/robots.txt"),
+        new Request("https://example.com/robots.txt"),
+        { robots: false },
+      ),
+    ).toBe(false);
     expect(
       isDocsPublicGetRequest(
         "docs",
@@ -477,5 +493,28 @@ describe("agent route helpers", () => {
       canonicalUrlField: "url",
       breadcrumbType: "BreadcrumbList",
     });
+  });
+
+  it("resolves agent feedback endpoints as default-on with explicit opt-out", () => {
+    const enabled = resolveDocsAgentFeedbackConfig();
+
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.route).toBe("/api/docs/agent/feedback");
+    expect(enabled.schemaRoute).toBe("/api/docs/agent/feedback/schema");
+    expect(
+      resolveDocsAgentFeedbackRequest(
+        new URL("https://example.com/api/docs/agent/feedback/schema"),
+        enabled,
+      ),
+    ).toEqual({ kind: "schema" });
+    expect(
+      resolveDocsAgentFeedbackRequest(
+        new URL("https://example.com/api/docs?feedback=agent"),
+        enabled,
+      ),
+    ).toEqual({ kind: "submit" });
+
+    expect(resolveDocsAgentFeedbackConfig(false).enabled).toBe(false);
+    expect(resolveDocsAgentFeedbackConfig({ agent: false }).enabled).toBe(false);
   });
 });

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1,7 +1,10 @@
 import type {
   DocsRobotsConfig,
+  DocsAgentFeedbackContext,
+  DocsAgentFeedbackData,
   DocsSearchConfig,
   DocsSearchSourcePage,
+  FeedbackConfig,
   LlmsTxtConfig,
   LlmsTxtMaxCharsConfig,
   LlmsTxtMaxCharsMode,
@@ -36,8 +39,64 @@ export const DEFAULT_SKILL_MD_ROUTE = "/skill.md";
 export const DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE = "/.well-known/skill.md";
 const DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE = "/robots.txt";
 export const DEFAULT_AGENT_FEEDBACK_ROUTE = "/api/docs/agent/feedback";
+export const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    task: {
+      type: "string",
+      description: "Short description of what the agent was trying to do.",
+    },
+    understanding: {
+      type: "string",
+      description: 'How well the docs supported the task, e.g. "partial" or "clear".',
+    },
+    outcome: {
+      type: "string",
+      description: 'What happened after reading the docs, e.g. "implemented" or "blocked".',
+    },
+    confidence: {
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+      description: "Confidence score from 0 to 1.",
+    },
+    neededCodeReading: {
+      type: "boolean",
+      description: "Whether the agent still needed to inspect repository code.",
+    },
+    missingContext: {
+      type: "array",
+      items: { type: "string" },
+      description: "Important details the docs did not provide clearly enough.",
+    },
+    docIssues: {
+      type: "array",
+      items: { type: "string" },
+      description: "Specific documentation problems encountered during the task.",
+    },
+    suggestedImprovement: {
+      type: "string",
+      description: "Concrete suggestion for improving the docs page or examples.",
+    },
+  },
+  required: ["task", "outcome"],
+};
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
 const DOCS_LLMS_TXT_DIRECTIVE_LINE = "LLM index: /llms.txt";
+
+export interface DocsAgentFeedbackResolvedConfig {
+  enabled: boolean;
+  route: string;
+  schemaRoute: string;
+  payloadSchema: Record<string, unknown>;
+  schema: Record<string, unknown>;
+  onFeedback?: (data: DocsAgentFeedbackData) => void | Promise<void>;
+}
+
+export interface DocsAgentFeedbackRequest {
+  kind: "schema" | "submit";
+}
 
 export interface DocsAgentFeedbackDiscoveryConfig {
   enabled?: boolean;
@@ -176,6 +235,256 @@ export function normalizeDocsUrlPath(value: string): string {
   const normalized = value.replace(/\/+/g, "/");
   if (normalized === "/") return normalized;
   return normalized.replace(/\/+$/, "");
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeDocsAgentFeedbackRoute(
+  route?: string,
+  fallback = DEFAULT_AGENT_FEEDBACK_ROUTE,
+): string {
+  if (!route || route.trim().length === 0) return fallback;
+
+  const normalized = `/${route}`.replace(/\/+/g, "/");
+  return normalized !== "/" ? normalized.replace(/\/+$/, "") : fallback;
+}
+
+export function buildDocsAgentFeedbackSchema(
+  payloadSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      context: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          page: { type: "string" },
+          url: { type: "string" },
+          slug: { type: "string" },
+          locale: { type: "string" },
+          source: { type: "string" },
+        },
+      },
+      payload: payloadSchema,
+    },
+    required: ["payload"],
+  };
+}
+
+export function resolveDocsAgentFeedbackConfig(
+  feedback?: boolean | FeedbackConfig,
+): DocsAgentFeedbackResolvedConfig {
+  const route = normalizeDocsAgentFeedbackRoute();
+  const enabled = {
+    enabled: true,
+    route,
+    schemaRoute: `${route}/schema`,
+    payloadSchema: DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
+    schema: buildDocsAgentFeedbackSchema(DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA),
+  } satisfies DocsAgentFeedbackResolvedConfig;
+  const disabled = {
+    enabled: false,
+    route,
+    schemaRoute: `${route}/schema`,
+    payloadSchema: DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
+    schema: buildDocsAgentFeedbackSchema(DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA),
+  } satisfies DocsAgentFeedbackResolvedConfig;
+
+  if (feedback === false) return disabled;
+  if (!feedback || feedback === true || typeof feedback !== "object") return enabled;
+
+  const agent = feedback.agent;
+  if (agent === false) return disabled;
+  if (!agent) return enabled;
+  if (agent === true) return enabled;
+
+  const resolvedRoute = normalizeDocsAgentFeedbackRoute(agent.route, route);
+  const resolvedSchemaRoute = normalizeDocsAgentFeedbackRoute(
+    agent.schemaRoute,
+    `${resolvedRoute}/schema`,
+  );
+  const payloadSchema = agent.schema ?? DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA;
+
+  return {
+    enabled: agent.enabled !== false,
+    route: resolvedRoute,
+    schemaRoute: resolvedSchemaRoute,
+    payloadSchema,
+    schema: buildDocsAgentFeedbackSchema(payloadSchema),
+    onFeedback: agent.onFeedback,
+  };
+}
+
+export function resolveDocsAgentFeedbackRequest(
+  url: URL,
+  feedback: DocsAgentFeedbackResolvedConfig,
+): DocsAgentFeedbackRequest | null {
+  if (!feedback.enabled) return null;
+
+  const feedbackMode = url.searchParams.get("feedback")?.trim();
+  const schemaMode = url.searchParams.get("schema")?.trim();
+  if (feedbackMode === "agent") {
+    return {
+      kind: schemaMode === "1" || schemaMode === "true" ? "schema" : "submit",
+    };
+  }
+
+  const pathname = normalizeDocsUrlPath(url.pathname);
+  if (pathname === feedback.schemaRoute) return { kind: "schema" };
+  if (pathname === feedback.route) return { kind: "submit" };
+
+  return null;
+}
+
+function normalizeDocsAgentFeedbackContext(value: unknown): DocsAgentFeedbackContext | undefined {
+  if (!isPlainObject(value)) return undefined;
+
+  const context: DocsAgentFeedbackContext = {};
+  if (typeof value.page === "string") context.page = value.page;
+  if (typeof value.url === "string") context.url = value.url;
+  if (typeof value.slug === "string") context.slug = value.slug;
+  if (typeof value.locale === "string") context.locale = value.locale;
+  if (typeof value.source === "string") context.source = value.source;
+
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+export async function parseDocsAgentFeedbackData(
+  request: Request,
+): Promise<{ ok: true; data: DocsAgentFeedbackData } | { ok: false; response: Response }> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: Response.json({ error: "Agent feedback body must be valid JSON" }, { status: 400 }),
+    };
+  }
+
+  if (!isPlainObject(body)) {
+    return {
+      ok: false,
+      response: Response.json({ error: "Agent feedback body must be an object" }, { status: 400 }),
+    };
+  }
+
+  if (!isPlainObject(body.payload)) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: "Agent feedback body must include a payload object" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      context: normalizeDocsAgentFeedbackContext(body.context),
+      payload: body.payload,
+    },
+  };
+}
+
+export function validateDocsAgentFeedbackPayload(
+  value: unknown,
+  schema: Record<string, unknown>,
+  valuePath = "payload",
+): string | undefined {
+  const schemaType = typeof schema.type === "string" ? schema.type : undefined;
+
+  if (Array.isArray(schema.enum) && !schema.enum.some((entry) => Object.is(entry, value))) {
+    return `${valuePath} must be one of the configured enum values`;
+  }
+
+  if (schemaType === "object" || (!schemaType && (schema.properties || schema.required))) {
+    if (!isPlainObject(value)) return `${valuePath} must be an object`;
+
+    const properties = isPlainObject(schema.properties) ? schema.properties : {};
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((entry): entry is string => typeof entry === "string")
+      : [];
+
+    for (const key of required) {
+      if (!(key in value)) return `${valuePath}.${key} is required`;
+    }
+
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!(key in properties)) return `${valuePath}.${key} is not allowed`;
+      }
+    }
+
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      if (!(key in value)) continue;
+      if (!isPlainObject(propertySchema)) continue;
+
+      const error = validateDocsAgentFeedbackPayload(
+        value[key],
+        propertySchema,
+        `${valuePath}.${key}`,
+      );
+      if (error) return error;
+    }
+
+    return undefined;
+  }
+
+  if (schemaType === "array") {
+    if (!Array.isArray(value)) return `${valuePath} must be an array`;
+    if (!isPlainObject(schema.items)) return undefined;
+
+    for (const [index, item] of value.entries()) {
+      const error = validateDocsAgentFeedbackPayload(item, schema.items, `${valuePath}[${index}]`);
+      if (error) return error;
+    }
+
+    return undefined;
+  }
+
+  if (schemaType === "string") {
+    if (typeof value !== "string") return `${valuePath} must be a string`;
+
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      return `${valuePath} must be at least ${schema.minLength} characters`;
+    }
+
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      return `${valuePath} must be at most ${schema.maxLength} characters`;
+    }
+
+    return undefined;
+  }
+
+  if (schemaType === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return `${valuePath} must be a number`;
+    }
+
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      return `${valuePath} must be >= ${schema.minimum}`;
+    }
+
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      return `${valuePath} must be <= ${schema.maximum}`;
+    }
+
+    return undefined;
+  }
+
+  if (schemaType === "boolean") {
+    if (typeof value !== "boolean") return `${valuePath} must be a boolean`;
+    return undefined;
+  }
+
+  return undefined;
 }
 
 export function toDocsMarkdownUrl(url: string, options: { locale?: string } = {}): string {
@@ -515,6 +824,7 @@ export function isDocsPublicGetRequest(
   options: {
     sitemap?: boolean | DocsSitemapConfig;
     llms?: boolean | DocsLlmsDiscoveryConfig | LlmsTxtConfig;
+    robots?: boolean | DocsRobotsConfig;
   } = {},
 ): boolean {
   const pathname = normalizeDocsUrlPath(url.pathname);
@@ -523,6 +833,8 @@ export function isDocsPublicGetRequest(
   return (
     isDocsAgentDiscoveryRequest(url) ||
     isDocsSkillRequest(url) ||
+    (pathname === DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE &&
+      isRobotsDiscoveryEnabled(options.robots)) ||
     resolveDocsLlmsTxtRequest(url, options.llms) !== null ||
     resolveDocsSitemapRequest(url, options.sitemap) !== null ||
     resolveDocsMarkdownRequest(entry, url, request) !== null

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -325,6 +325,8 @@ Allow: /
     expect(report.checks.find((check) => check.id === "robots")?.detail).toContain(
       "public/robots.txt",
     );
+    expect(report.checks.find((check) => check.id === "feedback")?.status).toBe("pass");
+    expect(report.checks.find((check) => check.id === "skill")?.status).toBe("pass");
   });
 
   it("detects agent.compact in static config parsing when feedback.agent appears first", async () => {

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -448,21 +448,27 @@ function resolveStaticExport(config: DocsConfig | undefined, content: string): b
 
 function resolveAgentFeedbackEnabled(config: DocsConfig | undefined, content: string): boolean {
   const feedback = config?.feedback;
+  if (feedback === false) return false;
+  if (feedback === true) return true;
   if (feedback && typeof feedback === "object") {
     const agent = feedback.agent;
     if (typeof agent === "boolean") return agent;
     if (agent && typeof agent === "object") return agent.enabled ?? true;
+    return true;
   }
 
+  const topLevelBoolean = readTopLevelBooleanProperty(content, "feedback");
+  if (typeof topLevelBoolean === "boolean") return topLevelBoolean;
+
   const feedbackBlock = extractNestedObjectLiteral(content, ["feedback"]);
-  if (!feedbackBlock) return false;
+  if (!feedbackBlock) return true;
 
   const nestedAgentBlock = extractNestedObjectLiteral(content, ["feedback", "agent"]);
   if (nestedAgentBlock) {
     return readBooleanProperty(nestedAgentBlock, "enabled") ?? true;
   }
 
-  return readBooleanProperty(feedbackBlock, "agent") ?? false;
+  return readBooleanProperty(feedbackBlock, "agent") ?? true;
 }
 
 function resolveHumanFeedbackEnabled(config: DocsConfig | undefined, content: string): boolean {
@@ -2108,7 +2114,7 @@ export async function inspectAgentReadiness(
     },
   );
   const sitemapConfig = resolveDocsSitemapConfig(
-    config?.sitemap ?? readSitemapConfigFromStatic(configContent) ?? false,
+    config?.sitemap ?? readSitemapConfigFromStatic(configContent) ?? true,
   );
   const robotsInput = config?.robots ?? readRobotsConfigFromStatic(configContent) ?? true;
   const robotsConfig =
@@ -2264,17 +2270,30 @@ export async function inspectAgentReadiness(
       ),
     );
   } else if (!existsSync(robotsPath)) {
-    checks.push(
-      makeCheck(
-        "robots",
-        "Robots agent policy",
-        "warn",
-        0,
-        5,
-        `No robots.txt found at ${relativeRobotsPath}.`,
-        `Run docs robots generate --path ${relativeRobotsPath} to publish an agent-friendly crawl policy.`,
-      ),
-    );
+    if (routeSurface.apiMounted && routeSurface.publicMounted && !staticExport) {
+      checks.push(
+        makeCheck(
+          "robots",
+          "Robots agent policy",
+          "pass",
+          5,
+          5,
+          "Runtime /robots.txt is served by the shared docs handler.",
+        ),
+      );
+    } else {
+      checks.push(
+        makeCheck(
+          "robots",
+          "Robots agent policy",
+          "warn",
+          0,
+          5,
+          `No robots.txt found at ${relativeRobotsPath}.`,
+          `Run docs robots generate --path ${relativeRobotsPath} to publish an agent-friendly crawl policy.`,
+        ),
+      );
+    }
   } else {
     const robots = readFileSync(robotsPath, "utf-8");
     const analysis = analyzeDocsRobotsTxt(robots, {
@@ -2318,11 +2337,10 @@ export async function inspectAgentReadiness(
       : makeCheck(
           "skill",
           "Skill document",
-          "warn",
-          3,
+          "pass",
+          5,
           5,
           `No root skill.md found; the framework will serve the generated fallback at ${DEFAULT_SKILL_MD_ROUTE}.`,
-          "Add a root skill.md if you want a custom site-specific bootstrap document instead of the generated fallback.",
         ),
   );
 

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -405,6 +405,7 @@ describe("api reference route templates", () => {
     const out = svelteDocsPublicHookTemplate("src/hooks.server.ts", false);
     expect(out).toContain("export const handle");
     expect(out).toContain("isDocsPublicGetRequest");
+    expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE"');
   });
@@ -425,6 +426,8 @@ export const handle: Handle = async ({ event, resolve }) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingHandle: Handle =");
     expect(out).toContain("const docsPublicHandle: Handle =");
+    expect(out).toContain("sitemap: docsConfig.sitemap");
+    expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain("export const handle = sequence(docsPublicHandle, existingHandle);");
   });
 
@@ -438,6 +441,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     const out = astroDocsMiddlewareTemplate("src/middleware.ts", false);
     expect(out).toContain("export const onRequest");
     expect(out).toContain("isDocsPublicGetRequest");
+    expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE"');
   });
@@ -458,6 +462,8 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingOnRequest: MiddlewareHandler =");
     expect(out).toContain("const docsPublicMiddleware: MiddlewareHandler =");
+    expect(out).toContain("sitemap: docsConfig.sitemap");
+    expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain(
       "export const onRequest = sequence(docsPublicMiddleware, existingOnRequest);",
     );

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1765,7 +1765,7 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
     return docsGET({ url: event.url, request: event.request });
   }
 
@@ -2310,7 +2310,7 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
     return docsGET({ request: context.request });
   }
 

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1131,7 +1131,7 @@ export const Route = createFileRoute("${entryUrl}/$")({
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url);
-        if (isDocsPublicGetRequest(${JSON.stringify(opts.entry)}, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt })) {
+        if (isDocsPublicGetRequest(${JSON.stringify(opts.entry)}, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
           return docsServer.GET({ request });
         }
         return undefined;
@@ -1224,7 +1224,7 @@ async function handlePublicDocsRequest(request: Request) {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
     return docsServer.GET({ request });
   }
 
@@ -1700,7 +1700,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
     return GET({ url: event.url, request: event.request });
   }
 
@@ -1765,7 +1765,7 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
     return docsGET({ url: event.url, request: event.request });
   }
 
@@ -2243,7 +2243,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
     return GET({ request: context.request });
   }
 
@@ -2310,7 +2310,7 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt })) {
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
     return docsGET({ request: context.request });
   }
 

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -59,6 +59,7 @@ export {
 } from "./agent-provenance.js";
 export {
   DEFAULT_AGENT_FEEDBACK_ROUTE,
+  DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
   DEFAULT_AGENT_SPEC_ROUTE,
   DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
   DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
@@ -75,6 +76,7 @@ export {
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
   DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER,
   buildDocsAgentDiscoverySpec,
+  buildDocsAgentFeedbackSchema,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
@@ -91,6 +93,9 @@ export {
   renderDocsMarkdownNotFound,
   renderDocsLlmsTxt,
   renderDocsSkillDocument,
+  parseDocsAgentFeedbackData,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolveDocsMarkdownCanonicalUrl,
   resolveDocsAgentMdxContent,
   resolveDocsLlmsTxtRequest,
@@ -100,8 +105,11 @@ export {
   resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
   toDocsMarkdownUrl,
+  validateDocsAgentFeedbackPayload,
 } from "./agent.js";
 export type {
+  DocsAgentFeedbackRequest,
+  DocsAgentFeedbackResolvedConfig,
   DocsLlmsTxtGeneratedContent,
   DocsLlmsTxtGeneratedSection,
   DocsLlmsTxtMaxCharsIssue,
@@ -132,10 +140,12 @@ export {
   DOCS_ROBOTS_GENERATED_BLOCK_END,
   DOCS_ROBOTS_GENERATED_BLOCK_START,
   analyzeDocsRobotsTxt,
+  createDocsRobotsResponse,
   getDocsRobotsAllowRoutes,
   renderDocsRobotsGeneratedBlock,
   renderDocsRobotsTxt,
   resolveDocsRobotsConfig,
+  resolveDocsRobotsRequest,
   upsertDocsRobotsGeneratedBlock,
 } from "./robots.js";
 export type {

--- a/packages/docs/src/robots.test.ts
+++ b/packages/docs/src/robots.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDocsRobotsResponse,
+  renderDocsRobotsTxt,
+  resolveDocsRobotsRequest,
+} from "./robots.js";
+
+describe("docs robots helpers", () => {
+  it("serves a default robots.txt response with agent routes and sitemap hints", async () => {
+    const response = createDocsRobotsResponse({
+      request: new Request("https://docs.example.com/robots.txt"),
+      entry: "docs",
+      baseUrl: "https://docs.example.com",
+    });
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("content-type")).toContain("text/plain");
+
+    const content = await response?.text();
+    expect(content).toContain("Allow: /llms.txt");
+    expect(content).toContain("Allow: /sitemap.xml");
+    expect(content).toContain("Allow: /.well-known/agent.json");
+    expect(content).toContain("User-agent: GPTBot");
+    expect(content).toContain("Sitemap: https://docs.example.com/sitemap.xml");
+  });
+
+  it("honors robots opt-out for public and API robots requests", () => {
+    expect(resolveDocsRobotsRequest(new URL("https://example.com/robots.txt"), false)).toBeNull();
+    expect(
+      createDocsRobotsResponse({
+        request: new Request("https://example.com/api/docs?format=robots"),
+        robots: false,
+      }),
+    ).toBeNull();
+    expect(renderDocsRobotsTxt({ robots: false })).toBe("");
+  });
+});

--- a/packages/docs/src/robots.ts
+++ b/packages/docs/src/robots.ts
@@ -53,6 +53,10 @@ export interface DocsRobotsAnalysis {
   missingRoutes: string[];
 }
 
+export interface CreateDocsRobotsResponseOptions extends DocsRobotsRenderOptions {
+  request: Request;
+}
+
 function normalizeRoute(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return "/";
@@ -210,6 +214,41 @@ export function renderDocsRobotsTxt(options: DocsRobotsRenderOptions = {}): stri
   }
 
   return `${lines.join("\n")}\n`;
+}
+
+export function resolveDocsRobotsRequest(
+  url: URL,
+  robots?: boolean | DocsRobotsConfig,
+): "robots" | null {
+  const pathname = normalizeRoute(url.pathname);
+  const format = url.searchParams.get("format")?.trim();
+  if (pathname === "/api/docs" && format === "robots") return "robots";
+
+  const resolved = resolveDocsRobotsConfig(robots);
+  if (!resolved.enabled) return null;
+
+  return pathname === DEFAULT_ROBOTS_TXT_ROUTE ? "robots" : null;
+}
+
+export function createDocsRobotsResponse({
+  request,
+  ...options
+}: CreateDocsRobotsResponseOptions): Response | null {
+  const url = new URL(request.url);
+  if (!resolveDocsRobotsRequest(url, options.robots)) return null;
+
+  const content = renderDocsRobotsTxt({
+    ...options,
+    baseUrl: options.baseUrl ?? url.origin,
+  });
+  if (!content) return null;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=3600",
+    },
+  });
 }
 
 export function renderDocsRobotsGeneratedBlock(options: DocsRobotsRenderOptions = {}): string {

--- a/packages/docs/src/sitemap.test.ts
+++ b/packages/docs/src/sitemap.test.ts
@@ -11,6 +11,8 @@ import {
 
 describe("docs sitemap helpers", () => {
   it("resolves default and prefixed sitemap routes", () => {
+    expect(resolveDocsSitemapConfig().enabled).toBe(true);
+    expect(resolveDocsSitemapConfig().xml.route).toBe("/sitemap.xml");
     expect(resolveDocsSitemapConfig(true).xml.route).toBe("/sitemap.xml");
     expect(resolveDocsSitemapConfig(true).markdown.wellKnownRoute).toBe("/.well-known/sitemap.md");
 
@@ -21,6 +23,7 @@ describe("docs sitemap helpers", () => {
   });
 
   it("detects public and API sitemap requests", () => {
+    expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"))).toBe("xml");
     expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.xml"), true)).toBe("xml");
     expect(resolveDocsSitemapRequest(new URL("https://example.com/sitemap.md"), true)).toBe(
       "markdown",

--- a/packages/docs/src/sitemap.ts
+++ b/packages/docs/src/sitemap.ts
@@ -105,7 +105,8 @@ function normalizeBaseUrl(value?: string): string | undefined {
 }
 
 function isEnabledObject(config: boolean | DocsSitemapConfig | undefined): boolean {
-  if (config === false || config === undefined) return false;
+  if (config === false) return false;
+  if (config === undefined) return true;
   if (config === true) return true;
   return config.enabled !== false;
 }

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -974,7 +974,7 @@ export interface SitemapMarkdownConfig {
 export interface DocsSitemapConfig {
   /**
    * Whether to enable sitemap routes.
-   * @default true when `sitemap` is an object
+   * @default true
    */
   enabled?: boolean;
   /**
@@ -1919,7 +1919,7 @@ export interface DocsAgentFeedbackData {
  * route wrapper.
  */
 export interface AgentFeedbackConfig {
-  /** Enable the agent feedback endpoints. Defaults to `true` when provided. */
+  /** Enable the agent feedback endpoints. Defaults to `true`; set to `false` to opt out. */
   enabled?: boolean;
   /**
    * Public HTTP route for posting agent feedback.
@@ -1978,7 +1978,8 @@ export interface FeedbackConfig {
   onFeedback?: (data: DocsFeedbackData) => void | Promise<void>;
   /**
    * Machine-oriented feedback endpoints exposed through the shared `/api/docs`
-   * route when configured.
+   * route. The shared docs API exposes the default no-op schema/submit routes
+   * unless this is set to `false`.
    *
    * This does not enable the human page feedback UI by itself. To show the
    * built-in footer prompt, keep using `feedback: true` or `feedback.enabled`.
@@ -2524,6 +2525,8 @@ export interface DocsConfig {
   /**
    * Generated XML and Markdown sitemaps for crawlers, agents, and static export.
    *
+   * Enabled by default. Set `sitemap: false` to opt out.
+   *
    * @example
    * ```ts
    * sitemap: true
@@ -2537,6 +2540,10 @@ export interface DocsConfig {
   sitemap?: boolean | DocsSitemapConfig;
   /**
    * Generated robots.txt policy for docs and agent-readable routes.
+   *
+   * Served by the runtime by default when no static `robots.txt` exists. Use
+   * `docs robots generate` for static export or when you want to append to an
+   * existing file.
    *
    * @example
    * ```ts

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -642,6 +642,30 @@ Start here.
     expect(text).toContain("- [Getting Started](/docs/getting-started.md): First steps");
   });
 
+  it("serves robots.txt by default through the shared docs api handler", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-robots-default-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    for (const path of ["/robots.txt", "/api/docs?format=robots"]) {
+      const response = await GET(new Request(`http://localhost${path}`));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/plain");
+      const content = await response.text();
+      expect(content).toContain("Allow: /llms.txt");
+      expect(content).toContain("Allow: /sitemap.xml");
+      expect(content).toContain("User-agent: GPTBot");
+    }
+  });
+
   it("honors llmsTxt opt-out in the shared docs api handler", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-disabled-route-"));
     tempDirs.push(rootDir);
@@ -1640,7 +1664,7 @@ title: "Home"
       skills: true,
       mcp: true,
       search: true,
-      sitemap: false,
+      sitemap: true,
       robots: true,
       structuredData: true,
       agentFeedback: true,
@@ -1825,7 +1849,7 @@ title: "Home"
       skills: true,
       mcp: false,
       search: false,
-      sitemap: false,
+      sitemap: true,
       robots: true,
       structuredData: true,
       agentFeedback: false,
@@ -1900,11 +1924,6 @@ title: "Home"
     const { GET } = createDocsAPI({
       rootDir,
       entry: "docs",
-      feedback: {
-        agent: {
-          enabled: true,
-        },
-      },
     });
 
     const response = await GET(new Request("http://localhost/api/docs/agent/feedback/schema"));
@@ -2026,11 +2045,6 @@ title: "Home"
     const { POST } = createDocsAPI({
       rootDir,
       entry: "docs",
-      feedback: {
-        agent: {
-          enabled: true,
-        },
-      },
     });
 
     const response = await POST(

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -29,6 +29,7 @@ import {
   resolveChangelogConfig,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
+  createDocsRobotsResponse,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
   getDocsMarkdownCanonicalLinkHeader,
@@ -286,6 +287,13 @@ function resolveAgentFeedbackConfig(
   feedback?: boolean | FeedbackConfig,
 ): ResolvedAgentFeedbackConfig {
   const route = normalizeAgentFeedbackRoute();
+  const enabled = {
+    enabled: true,
+    route,
+    schemaRoute: `${route}/schema`,
+    payloadSchema: DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
+    schema: buildAgentFeedbackSchema(DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA),
+  } satisfies ResolvedAgentFeedbackConfig;
   const disabled = {
     enabled: false,
     route,
@@ -294,19 +302,15 @@ function resolveAgentFeedbackConfig(
     schema: buildAgentFeedbackSchema(DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA),
   } satisfies ResolvedAgentFeedbackConfig;
 
-  if (!feedback || typeof feedback !== "object") return disabled;
+  if (feedback === false) return disabled;
+  if (!feedback || feedback === true || typeof feedback !== "object") return enabled;
 
   const agent = feedback.agent;
-  if (!agent) return disabled;
+  if (agent === false) return disabled;
+  if (!agent) return enabled;
 
   if (agent === true) {
-    return {
-      enabled: true,
-      route,
-      schemaRoute: `${route}/schema`,
-      payloadSchema: DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
-      schema: buildAgentFeedbackSchema(DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA),
-    };
+    return enabled;
   }
 
   const resolvedRoute = normalizeAgentFeedbackRoute(agent.route, route);
@@ -2775,6 +2779,15 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           },
         );
       }
+
+      const robotsResponse = createDocsRobotsResponse({
+        request,
+        entry,
+        sitemap: sitemapConfig,
+        baseUrl: llmsConfig.baseUrl ?? url.origin,
+        robots: robotsConfig,
+      });
+      if (robotsResponse) return robotsResponse;
 
       const sitemapResponse = createDocsSitemapResponse({
         request,

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -517,7 +517,11 @@ describe("withDocs (app dir: src/app vs app)", () => {
   });
 
   it("skips agent feedback rewrites when explicitly disabled", async () => {
-    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_AGENT_FEEDBACK_DISABLED, "utf-8");
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      DOCS_CONFIG_WITH_AGENT_FEEDBACK_DISABLED,
+      "utf-8",
+    );
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
 

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -8,7 +8,7 @@ import {
   readFileSync,
   realpathSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { withDocs } from "./config.js";
 
@@ -439,6 +439,34 @@ describe("withDocs (app dir: src/app vs app)", () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     mkdirSync(join(tmpDir, "public"), { recursive: true });
     writeFileSync(join(tmpDir, "public", "robots.txt"), "User-agent: *\nAllow: /\n", "utf-8");
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/robots.txt",
+          destination: "/api/docs?format=robots",
+        }),
+      ]),
+    );
+  });
+
+  it.each([
+    [
+      "app/robots.ts",
+      "export default function robots() { return { rules: [{ userAgent: '*', allow: '/' }] }; }\n",
+    ],
+    ["app/robots.txt", "User-agent: *\nAllow: /\n"],
+    [
+      "src/app/robots.ts",
+      "export default function robots() { return { rules: [{ userAgent: '*', allow: '/' }] }; }\n",
+    ],
+  ])("keeps an existing %s file in control", async (robotsPath, source) => {
+    mkdirSync(dirname(join(tmpDir, robotsPath)), { recursive: true });
+    writeFileSync(join(tmpDir, robotsPath), source, "utf-8");
     process.chdir(tmpDir);
 
     const nextConfig = withDocs({});

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -137,14 +137,24 @@ const DOCS_CONFIG_WITH_SITEMAP = `export default {
 };
 `;
 
-const DOCS_CONFIG_WITH_AGENT_FEEDBACK = `export default {
+const DOCS_CONFIG_WITH_AGENT_FEEDBACK_DISABLED = `export default {
   entry: "docs",
   feedback: {
-    agent: {
-      enabled: true,
-      route: "/api/docs/agent/feedback",
-      schemaRoute: "/api/docs/agent/feedback/schema",
-    },
+    agent: false,
+  },
+};
+`;
+
+const DOCS_CONFIG_WITH_TOP_LEVEL_FEEDBACK_DISABLED = `export default {
+  entry: "docs",
+  feedback: false,
+};
+`;
+
+const DOCS_CONFIG_WITH_AI_FEEDBACK_DISABLED = `export default {
+  entry: "docs",
+  ai: {
+    feedback: false,
   },
 };
 `;
@@ -189,10 +199,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(existsSync(join(tmpDir, "src/app/docs/layout.tsx"))).toBe(true);
     expect(existsSync(join(tmpDir, "src/app/api/docs/route.ts"))).toBe(true);
     expect(readFileSync(join(tmpDir, "src/app/api/docs/route.ts"), "utf-8")).toContain(
-      "feedback: docsConfig.feedback",
-    );
-    expect(readFileSync(join(tmpDir, "src/app/api/docs/route.ts"), "utf-8")).toContain(
-      "mcp: docsConfig.mcp",
+      "createDocsAPI(docsConfig)",
     );
     expect(existsSync(join(tmpDir, "app/docs/layout.tsx"))).toBe(false);
     expect(existsSync(join(tmpDir, "app/api/docs/route.ts"))).toBe(false);
@@ -260,7 +267,8 @@ describe("withDocs (app dir: src/app vs app)", () => {
     const route = readFileSync(join(tmpDir, "app/api/docs/mcp/route.ts"), "utf-8");
     expect(route).toContain('import { createDocsMCPAPI } from "@farming-labs/next/api";');
     expect(route).not.toContain("resolveNextProjectRoot");
-    expect(route).toContain("search: docsConfig.search");
+    expect(route).toContain("createDocsMCPAPI(docsConfig)");
+    expect(route).not.toContain("search: docsConfig.search");
   });
 
   it("generates the default MCP route when mcp config is omitted", () => {
@@ -338,6 +346,30 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?format=skill",
         }),
         expect.objectContaining({
+          source: "/sitemap.xml",
+          destination: "/api/docs?format=sitemap-xml",
+        }),
+        expect.objectContaining({
+          source: "/sitemap.md",
+          destination: "/api/docs?format=sitemap-md",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/sitemap.md",
+          destination: "/api/docs?format=sitemap-md",
+        }),
+        expect.objectContaining({
+          source: "/robots.txt",
+          destination: "/api/docs?format=robots",
+        }),
+        expect.objectContaining({
+          source: "/api/docs/agent/feedback",
+          destination: "/api/docs?feedback=agent",
+        }),
+        expect.objectContaining({
+          source: "/api/docs/agent/feedback/schema",
+          destination: "/api/docs?feedback=agent&schema=1",
+        }),
+        expect.objectContaining({
           source: "/docs.md",
           destination: "/api/docs?format=markdown",
         }),
@@ -403,6 +435,25 @@ describe("withDocs (app dir: src/app vs app)", () => {
     );
   });
 
+  it("keeps an existing public robots.txt file in control", async () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    mkdirSync(join(tmpDir, "public"), { recursive: true });
+    writeFileSync(join(tmpDir, "public", "robots.txt"), "User-agent: *\nAllow: /\n", "utf-8");
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/robots.txt",
+          destination: "/api/docs?format=robots",
+        }),
+      ]),
+    );
+  });
+
   it("redirects hidden folder parents to their first visible child", async () => {
     mkdirSync(join(tmpDir, "app", "docs", "overview", "what-is-surge"), { recursive: true });
     mkdirSync(join(tmpDir, "app", "docs", "sending", "send-one"), { recursive: true });
@@ -444,8 +495,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
     );
   });
 
-  it("adds agent feedback rewrites through the shared docs api handler when configured", async () => {
-    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_AGENT_FEEDBACK, "utf-8");
+  it("adds agent feedback rewrites through the shared docs api handler by default", async () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
 
@@ -461,6 +511,64 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/api/docs/agent/feedback/schema",
           destination: "/api/docs?feedback=agent&schema=1",
+        }),
+      ]),
+    );
+  });
+
+  it("skips agent feedback rewrites when explicitly disabled", async () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_AGENT_FEEDBACK_DISABLED, "utf-8");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/api/docs/agent/feedback",
+          destination: "/api/docs?feedback=agent",
+        }),
+      ]),
+    );
+  });
+
+  it("skips agent feedback rewrites when top-level feedback is false", async () => {
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      DOCS_CONFIG_WITH_TOP_LEVEL_FEEDBACK_DISABLED,
+      "utf-8",
+    );
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/api/docs/agent/feedback",
+          destination: "/api/docs?feedback=agent",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps agent feedback rewrites when only Ask AI feedback is disabled", async () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_AI_FEEDBACK_DISABLED, "utf-8");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+
+    expect(rewrites).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/api/docs/agent/feedback",
+          destination: "/api/docs?feedback=agent",
         }),
       ]),
     );
@@ -625,10 +733,13 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(route).toContain('import { createDocsAPI } from "@farming-labs/next/api";');
     expect(route).not.toContain("resolveNextProjectRoot");
     expect(route).not.toContain("rootDir,");
-    expect(route).toContain("changelog: docsConfig.changelog");
-    expect(route).toContain("llmsTxt: docsConfig.llmsTxt");
-    expect(route).toContain("search: docsConfig.search");
-    expect(route).toContain("ai: docsConfig.ai");
+    expect(route).toContain("createDocsAPI(docsConfig)");
+    expect(route).not.toContain("changelog: docsConfig.changelog");
+    expect(route).not.toContain("llmsTxt: docsConfig.llmsTxt");
+    expect(route).not.toContain("sitemap: docsConfig.sitemap");
+    expect(route).not.toContain("robots: docsConfig.robots");
+    expect(route).not.toContain("search: docsConfig.search");
+    expect(route).not.toContain("ai: docsConfig.ai");
   });
 
   it("adds docs content to output file tracing for docs api routes", () => {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1117,8 +1117,12 @@ function readRobotsConfig(root: string): {
   enabled: boolean;
   hasStaticFile: boolean;
 } {
-  const staticPath = join(root, "public", "robots.txt");
-  const hasStaticFile = existsSync(staticPath);
+  const publicStaticPath = join(root, "public", "robots.txt");
+  const appDir = getNextAppDir(root);
+  const appStaticPath = join(root, appDir, "robots.txt");
+  const appRouteExists = FILE_EXTS.some((ext) => existsSync(join(root, appDir, `robots.${ext}`)));
+  const hasStaticFile =
+    existsSync(publicStaticPath) || existsSync(appStaticPath) || appRouteExists;
 
   for (const ext of FILE_EXTS) {
     const configPath = join(root, `docs.config.${ext}`);

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -97,20 +97,7 @@ ${GENERATED_BANNER}
 import docsConfig from "@/docs.config";
 import { createDocsAPI } from "@farming-labs/next/api";
 
-export const { GET, POST } = createDocsAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  i18n: docsConfig.i18n,
-  changelog: docsConfig.changelog,
-  feedback: docsConfig.feedback,
-  mcp: docsConfig.mcp,
-  llmsTxt: docsConfig.llmsTxt,
-  sitemap: docsConfig.sitemap,
-  search: docsConfig.search,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-  ai: docsConfig.ai,
-});
+export const { GET, POST } = createDocsAPI(docsConfig);
 
 export const revalidate = false;
 `;
@@ -120,16 +107,7 @@ ${GENERATED_BANNER}
 import docsConfig from "@/docs.config";
 import { createDocsMCPAPI } from "@farming-labs/next/api";
 
-export const { GET, POST, DELETE } = createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-  mcp: docsConfig.mcp,
-});
+export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 
 export const revalidate = false;
 `;
@@ -195,6 +173,7 @@ const DEFAULT_LLMS_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms.txt";
 const DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE = "/.well-known/llms-full.txt";
 const DEFAULT_SKILL_MD_ROUTE = "/skill.md";
 const DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE = "/.well-known/skill.md";
+const DEFAULT_ROBOTS_TXT_ROUTE = "/robots.txt";
 const DEFAULT_SITEMAP_XML_ROUTE = "/sitemap.xml";
 const DEFAULT_SITEMAP_MD_ROUTE = "/sitemap.md";
 const DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE = "/.well-known/sitemap.md";
@@ -593,10 +572,7 @@ function extractRootObjectLiteral(content: string): string | undefined {
   return undefined;
 }
 
-function readTopLevelStringProperty(content: string, key: string): string | undefined {
-  const block = extractRootObjectLiteral(content);
-  if (!block) return undefined;
-
+function findTopLevelPropertyValueIndex(block: string, key: string): number | undefined {
   let objectDepth = 0;
   let arrayDepth = 0;
   let parenDepth = 0;
@@ -701,31 +677,133 @@ function readTopLevelStringProperty(content: string, key: string): string | unde
     cursor += 1;
     while (/\s/.test(block[cursor] ?? "")) cursor += 1;
 
-    const quote = block[cursor];
-    if (quote !== '"' && quote !== "'") continue;
-
-    cursor += 1;
-    let value = "";
-
-    for (; cursor < block.length; cursor += 1) {
-      const valueChar = block[cursor];
-      if (valueChar === "\\") {
-        const escapedChar = block[cursor + 1];
-        if (escapedChar) {
-          value += escapedChar;
-          cursor += 1;
-        }
-        continue;
-      }
-
-      if (valueChar === quote) return value;
-      value += valueChar;
-    }
-
-    return undefined;
+    return cursor;
   }
 
   return undefined;
+}
+
+function findMatchingObjectEnd(block: string, start: number): number | undefined {
+  let depth = 0;
+  let inString: '"' | "'" | "`" | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let escaped = false;
+
+  for (let index = start; index < block.length; index += 1) {
+    const char = block[index];
+    const next = block[index + 1];
+
+    if (inLineComment) {
+      if (char === "\n") inLineComment = false;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (char === inString) inString = null;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      inString = char;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char !== "}") continue;
+
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+
+  return undefined;
+}
+
+function readTopLevelStringProperty(content: string, key: string): string | undefined {
+  const block = extractRootObjectLiteral(content);
+  if (!block) return undefined;
+
+  const cursor = findTopLevelPropertyValueIndex(block, key);
+  if (cursor === undefined) return undefined;
+
+  const quote = block[cursor];
+  if (quote !== '"' && quote !== "'") return undefined;
+
+  let value = "";
+
+  for (let index = cursor + 1; index < block.length; index += 1) {
+    const valueChar = block[index];
+    if (valueChar === "\\") {
+      const escapedChar = block[index + 1];
+      if (escapedChar) {
+        value += escapedChar;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (valueChar === quote) return value;
+    value += valueChar;
+  }
+
+  return undefined;
+}
+
+function readTopLevelBooleanProperty(content: string, key: string): boolean | undefined {
+  const block = extractRootObjectLiteral(content);
+  if (!block) return undefined;
+
+  const cursor = findTopLevelPropertyValueIndex(block, key);
+  if (cursor === undefined) return undefined;
+
+  if (block.startsWith("true", cursor)) return true;
+  if (block.startsWith("false", cursor)) return false;
+  return undefined;
+}
+
+function extractTopLevelObjectLiteral(content: string, key: string): string | undefined {
+  const block = extractRootObjectLiteral(content);
+  if (!block) return undefined;
+
+  const cursor = findTopLevelPropertyValueIndex(block, key);
+  if (cursor === undefined || block[cursor] !== "{") return undefined;
+
+  const end = findMatchingObjectEnd(block, cursor);
+  return end === undefined ? undefined : block.slice(cursor + 1, end);
 }
 
 function extractObjectLiteral(content: string, key: string): string | undefined {
@@ -1028,11 +1106,50 @@ function readSitemapConfig(root: string): {
         routePrefix: normalizeRoutePrefix(routePrefixMatch?.[1]),
       };
     } catch {
-      return { enabled: false, routePrefix: "" };
+      return { enabled: true, routePrefix: "" };
     }
   }
 
-  return { enabled: false, routePrefix: "" };
+  return { enabled: true, routePrefix: "" };
+}
+
+function readRobotsConfig(root: string): {
+  enabled: boolean;
+  hasStaticFile: boolean;
+} {
+  const staticPath = join(root, "public", "robots.txt");
+  const hasStaticFile = existsSync(staticPath);
+
+  for (const ext of FILE_EXTS) {
+    const configPath = join(root, `docs.config.${ext}`);
+    if (!existsSync(configPath)) continue;
+
+    try {
+      const content = readFileSync(configPath, "utf-8");
+
+      if (content.match(/robots\s*:\s*false/)) {
+        return { enabled: false, hasStaticFile };
+      }
+
+      if (content.match(/robots\s*:\s*true/)) {
+        return { enabled: true, hasStaticFile };
+      }
+
+      const block = extractObjectLiteral(content, "robots");
+      if (!block) continue;
+
+      const enabledMatch = block.match(/enabled\s*:\s*(true|false)/);
+
+      return {
+        enabled: enabledMatch ? enabledMatch[1] !== "false" : true,
+        hasStaticFile,
+      };
+    } catch {
+      return { enabled: true, hasStaticFile };
+    }
+  }
+
+  return { enabled: true, hasStaticFile };
 }
 
 function normalizeAgentFeedbackRoute(
@@ -1051,6 +1168,11 @@ function readAgentFeedbackConfig(root: string): {
   schemaRoute: string;
 } {
   const defaultRoute = normalizeAgentFeedbackRoute();
+  const enabled = {
+    enabled: true,
+    route: defaultRoute,
+    schemaRoute: `${defaultRoute}/schema`,
+  };
   const disabled = {
     enabled: false,
     route: defaultRoute,
@@ -1063,20 +1185,18 @@ function readAgentFeedbackConfig(root: string): {
 
     try {
       const content = readFileSync(configPath, "utf-8");
-      const feedbackBlock = extractObjectLiteral(content, "feedback");
-      if (!feedbackBlock) continue;
+      const feedbackBoolean = readTopLevelBooleanProperty(content, "feedback");
+      if (feedbackBoolean === false) return disabled;
+      if (feedbackBoolean === true) return enabled;
+
+      const feedbackBlock = extractTopLevelObjectLiteral(content, "feedback");
+      if (!feedbackBlock) return enabled;
 
       if (feedbackBlock.match(/agent\s*:\s*false/)) return disabled;
-      if (feedbackBlock.match(/agent\s*:\s*true/)) {
-        return {
-          enabled: true,
-          route: defaultRoute,
-          schemaRoute: `${defaultRoute}/schema`,
-        };
-      }
+      if (feedbackBlock.match(/agent\s*:\s*true/)) return enabled;
 
       const agentBlock = extractObjectLiteral(feedbackBlock, "agent");
-      if (!agentBlock) continue;
+      if (!agentBlock) return enabled;
 
       const enabledMatch = agentBlock.match(/enabled\s*:\s*(true|false)/);
       const routeMatch = agentBlock.match(/route\s*:\s*["']([^"']+)["']/);
@@ -1093,7 +1213,7 @@ function readAgentFeedbackConfig(root: string): {
     }
   }
 
-  return disabled;
+  return enabled;
 }
 
 type NextRewrite = {
@@ -1240,6 +1360,17 @@ function buildSitemapRewrites(config: { enabled: boolean; routePrefix: string })
     {
       source: joinPublicRoute(prefix, DEFAULT_SITEMAP_MD_WELL_KNOWN_ROUTE),
       destination: "/api/docs?format=sitemap-md",
+    },
+  ];
+}
+
+function buildRobotsRewrites(config: { enabled: boolean; hasStaticFile: boolean }): NextRewrite[] {
+  if (!config.enabled || config.hasStaticFile) return [];
+
+  return [
+    {
+      source: DEFAULT_ROBOTS_TXT_ROUTE,
+      destination: "/api/docs?format=robots",
     },
   ];
 }
@@ -1438,6 +1569,10 @@ function mergeDocsMarkdownRewrites(
     route: string;
     schemaRoute: string;
   },
+  robots: {
+    enabled: boolean;
+    hasStaticFile: boolean;
+  },
   result?: NextRewriteResult,
 ): NextRewriteResult {
   const autoRewrites = [
@@ -1446,6 +1581,7 @@ function mergeDocsMarkdownRewrites(
     ...buildLlmsTxtRewrites(entry),
     ...buildSkillMdRewrites(),
     ...buildSitemapRewrites(sitemap),
+    ...buildRobotsRewrites(robots),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
@@ -1521,6 +1657,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
 
   const mcp = readMcpConfig(root);
   const sitemap = readSitemapConfig(root);
+  const robots = readRobotsConfig(root);
   const docsMcpRouteDir = join(root, appDir, "api", "docs", "mcp");
   if (
     mcp.enabled &&
@@ -1808,7 +1945,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     nextConfig.rewrites = async () => {
       const rewrites =
         typeof existingRewrites === "function" ? await existingRewrites() : existingRewrites;
-      return mergeDocsMarkdownRewrites(entry, mcp, sitemap, agentFeedback, rewrites);
+      return mergeDocsMarkdownRewrites(entry, mcp, sitemap, agentFeedback, robots, rewrites);
     };
 
     const autoRedirects = buildHiddenFolderRedirects(docsContentRoot, entry);

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1121,8 +1121,7 @@ function readRobotsConfig(root: string): {
   const appDir = getNextAppDir(root);
   const appStaticPath = join(root, appDir, "robots.txt");
   const appRouteExists = FILE_EXTS.some((ext) => existsSync(join(root, appDir, `robots.${ext}`)));
-  const hasStaticFile =
-    existsSync(publicStaticPath) || existsSync(appStaticPath) || appRouteExists;
+  const hasStaticFile = existsSync(publicStaticPath) || existsSync(appStaticPath) || appRouteExists;
 
   for (const ext of FILE_EXTS) {
     const configPath = join(root, `docs.config.${ext}`);

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -22,6 +22,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsRobotsResponse,
   createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
@@ -37,6 +38,7 @@ import {
   isDocsPublicGetRequest,
   isDocsSkillRequest,
   normalizeDocsRelated,
+  parseDocsAgentFeedbackData,
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsMarkdownNotFound,
@@ -45,6 +47,8 @@ import {
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
@@ -60,6 +64,7 @@ import {
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
+  validateDocsAgentFeedbackPayload,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -796,6 +801,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       defaultName: llmsTitle,
     },
   );
+  const agentFeedbackConfig = resolveDocsAgentFeedbackConfig(
+    (config as Record<string, unknown>).feedback as Record<string, unknown> | boolean | undefined,
+  );
+  const agentFeedbackDiscovery = {
+    enabled: agentFeedbackConfig.enabled,
+    route: "/api/docs?feedback=agent",
+    schemaRoute: "/api/docs?feedback=agent&schema=1",
+  };
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
@@ -843,6 +856,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             i18n,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -870,6 +884,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "submit") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "POST",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
+        headers: {
+          "Content-Type": "application/schema+json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
+    }
+
     if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
@@ -878,6 +913,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             entry,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -912,6 +948,15 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       manifest: preloadedSitemapManifest ?? readDocsSitemapManifest(rootDir, config.sitemap),
     });
     if (sitemapResponse) return sitemapResponse;
+
+    const robotsResponse = createDocsRobotsResponse({
+      request: context.request,
+      entry,
+      sitemap: config.sitemap,
+      baseUrl: llmsBaseUrl || url.origin,
+      robots: config.robots,
+    });
+    if (robotsResponse) return robotsResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
@@ -1080,6 +1125,35 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   async function POST(context: { request: Request }): Promise<Response> {
     const requestUrl = new URL(context.request.url);
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "schema") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "GET",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      const parsed = await parseDocsAgentFeedbackData(context.request);
+      if (!parsed.ok) return parsed.response;
+
+      const payloadError = validateDocsAgentFeedbackPayload(
+        parsed.data.payload,
+        agentFeedbackConfig.payloadSchema,
+      );
+      if (payloadError) return Response.json({ error: payloadError }, { status: 400 });
+
+      if (!agentFeedbackConfig.onFeedback) {
+        return Response.json({ ok: true, handled: false }, { status: 202 });
+      }
+
+      await agentFeedbackConfig.onFeedback(parsed.data);
+      return Response.json({ ok: true, handled: true }, { status: 201 });
+    }
+
     const requestStartedAt = Date.now();
     const trace = createDocsAgentTraceContext("ask-ai");
     const runSpanId = createDocsAgentTraceId("span");
@@ -1787,6 +1861,7 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
         !isDocsPublicGetRequest(entry, url, request, {
           sitemap: config.sitemap,
           llms: config.llmsTxt,
+          robots: config.robots,
         })
       ) {
         return undefined;

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -35,6 +35,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsRobotsResponse,
   createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
@@ -48,6 +49,7 @@ import {
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
   normalizeDocsRelated,
+  parseDocsAgentFeedbackData,
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsMarkdownNotFound,
@@ -56,6 +58,8 @@ import {
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
@@ -71,6 +75,7 @@ import {
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
+  validateDocsAgentFeedbackPayload,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -816,6 +821,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       defaultName: llmsTitle,
     },
   );
+  const agentFeedbackConfig = resolveDocsAgentFeedbackConfig(
+    (config as Record<string, unknown>).feedback as Record<string, unknown> | boolean | undefined,
+  );
+  const agentFeedbackDiscovery = {
+    enabled: agentFeedbackConfig.enabled,
+    route: "/api/docs?feedback=agent",
+    schemaRoute: "/api/docs?feedback=agent&schema=1",
+  };
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
@@ -862,6 +875,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             i18n,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -889,6 +903,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       );
     }
 
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(event.url, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "submit") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "POST",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
+        headers: {
+          "Content-Type": "application/schema+json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
+    }
+
     if (isDocsSkillRequest(event.url) || resolveDocsSkillFormat(event.url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
@@ -897,6 +932,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             entry,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -931,6 +967,15 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       manifest: preloadedSitemapManifest ?? readDocsSitemapManifest(rootDir, config.sitemap),
     });
     if (sitemapResponse) return sitemapResponse;
+
+    const robotsResponse = createDocsRobotsResponse({
+      request: event.request,
+      entry,
+      sitemap: config.sitemap,
+      baseUrl: llmsBaseUrl || event.url.origin,
+      robots: config.robots,
+    });
+    if (robotsResponse) return robotsResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, event.url, event.request);
     if (markdownRequest) {
@@ -1099,6 +1144,35 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   async function POST(event: RequestEvent): Promise<Response> {
     const requestUrl = new URL(event.request.url);
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "schema") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "GET",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      const parsed = await parseDocsAgentFeedbackData(event.request);
+      if (!parsed.ok) return parsed.response;
+
+      const payloadError = validateDocsAgentFeedbackPayload(
+        parsed.data.payload,
+        agentFeedbackConfig.payloadSchema,
+      );
+      if (payloadError) return Response.json({ error: payloadError }, { status: 400 });
+
+      if (!agentFeedbackConfig.onFeedback) {
+        return Response.json({ ok: true, handled: false }, { status: 202 });
+      }
+
+      await agentFeedbackConfig.onFeedback(parsed.data);
+      return Response.json({ ok: true, handled: true }, { status: 201 });
+    }
+
     const requestStartedAt = Date.now();
     const trace = createDocsAgentTraceContext("ask-ai");
     const runSpanId = createDocsAgentTraceId("span");

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -5,6 +5,7 @@ import {
   applySidebarFolderIndexBehavior,
   buildDocsAskAIContext,
   buildDocsAgentDiscoverySpec,
+  createDocsRobotsResponse,
   createDocsSitemapResponse,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
@@ -18,6 +19,7 @@ import {
   isDocsAgentDiscoveryRequest,
   isDocsSkillRequest,
   normalizeDocsRelated,
+  parseDocsAgentFeedbackData,
   performDocsSearch,
   renderDocsMarkdownDocument,
   renderDocsMarkdownNotFound,
@@ -26,6 +28,8 @@ import {
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
   resolveDocsAgentMdxContent,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
@@ -41,6 +45,7 @@ import {
   resolveDocsSkillFormat,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
+  validateDocsAgentFeedbackPayload,
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
@@ -781,6 +786,12 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   const mcpConfig = resolveDocsMcpConfig(config.mcp, {
     defaultName: llmsTitle,
   });
+  const agentFeedbackConfig = resolveDocsAgentFeedbackConfig(config.feedback);
+  const agentFeedbackDiscovery = {
+    enabled: agentFeedbackConfig.enabled,
+    route: "/api/docs?feedback=agent",
+    schemaRoute: "/api/docs?feedback=agent&schema=1",
+  };
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
@@ -827,6 +838,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             i18n,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -854,6 +866,27 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       );
     }
 
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "submit") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "POST",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
+        headers: {
+          "Content-Type": "application/schema+json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
+    }
+
     if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
       return new Response(
         readRootSkillDocument(preloaded, rootDir) ??
@@ -862,6 +895,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             entry,
             search: config.search,
             mcp: mcpConfig,
+            feedback: agentFeedbackDiscovery,
             llms: {
               enabled: llmsEnabled,
               baseUrl: llmsBaseUrl || undefined,
@@ -896,6 +930,15 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       manifest: preloadedSitemapManifest ?? readDocsSitemapManifest(rootDir, config.sitemap),
     });
     if (sitemapResponse) return sitemapResponse;
+
+    const robotsResponse = createDocsRobotsResponse({
+      request: event.request,
+      entry,
+      sitemap: config.sitemap,
+      baseUrl: llmsBaseUrl || url.origin,
+      robots: config.robots,
+    });
+    if (robotsResponse) return robotsResponse;
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, event.request);
     if (markdownRequest) {
@@ -1059,6 +1102,35 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
   async function POST(event: { request: Request }): Promise<Response> {
     const requestUrl = new URL(event.request.url);
+    const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
+    if (agentFeedbackRequest) {
+      if (agentFeedbackRequest.kind === "schema") {
+        return new Response(JSON.stringify({ error: "Method Not Allowed" }), {
+          status: 405,
+          headers: {
+            Allow: "GET",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        });
+      }
+
+      const parsed = await parseDocsAgentFeedbackData(event.request);
+      if (!parsed.ok) return parsed.response;
+
+      const payloadError = validateDocsAgentFeedbackPayload(
+        parsed.data.payload,
+        agentFeedbackConfig.payloadSchema,
+      );
+      if (payloadError) return Response.json({ error: payloadError }, { status: 400 });
+
+      if (!agentFeedbackConfig.onFeedback) {
+        return Response.json({ ok: true, handled: false }, { status: 202 });
+      }
+
+      await agentFeedbackConfig.onFeedback(parsed.data);
+      return Response.json({ ok: true, handled: true }, { status: 201 });
+    }
+
     const requestStartedAt = Date.now();
     const trace = createDocsAgentTraceContext("ask-ai");
     const runSpanId = createDocsAgentTraceId("span");

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -432,7 +432,7 @@ What it checks:
 - `skill.md`
 - MCP
 - search
-- agent feedback
+- agent feedback, which is enabled by default and can be explicitly opted out
 - page metadata
 - explicit agent-friendly pages
 - generated `agent.md` freshness and `agent.compact` defaults

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -41,7 +41,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `icons` | `Record<string, Component>` | — | Shared icon registry for frontmatter `icon` fields and built-ins like `Prompt` |
 | `components` | `Record<string, Component>` | — | Custom MDX components and built-in overrides like `HoverLink` and `Prompt` |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | — | Callback when user copies a code block (title, content, url, language) |
-| `feedback` | `boolean \| FeedbackConfig` | `false` | Human page feedback UI plus optional agent feedback endpoints |
+| `feedback` | `boolean \| FeedbackConfig` | `false` for UI | Human page feedback UI; agent feedback endpoints are default-on unless opted out |
 | `readingTime` | `boolean \| ReadingTimeConfig` | `false` | Opt-in estimated read-time label with per-page overrides |
 | `agent` | `DocsAgentConfig` | — | Defaults for `docs agent compact` |
 | `pageActions` | `PageActionsConfig` | — | Copy Markdown, Open in LLM (see `page-actions` skill) |
@@ -51,8 +51,8 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `changelog` | `boolean \| ChangelogConfig` | `false` | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp` | `boolean \| DocsMcpConfig` | enabled | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false` | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON document |
-| `sitemap` | `boolean \| DocsSitemapConfig` | `false` | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
-| `robots` | `boolean \| DocsRobotsConfig` | enabled for generation when configured | Generated `robots.txt` policy for docs routes, agent-readable files, and common AI crawler user agents |
+| `sitemap` | `boolean \| DocsSitemapConfig` | `true` | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
+| `robots` | `boolean \| DocsRobotsConfig` | `true` | Runtime/generated `robots.txt` policy for docs routes, agent-readable files, and common AI crawler user agents |
 | `metadata` | `DocsMetadata` | — | SEO and JSON-LD inputs: titleTemplate, description, etc. |
 | `og` | `OGConfig` | — | Dynamic Open Graph images |
 
@@ -199,8 +199,8 @@ Use `/docs/customization/llms-txt` for output examples.
 
 ## Sitemaps
 
-Use `sitemap` when the project should expose crawler-friendly XML and agent-friendly Markdown maps
-of the docs tree.
+Sitemaps are exposed by default. Use `sitemap` when the project should customize crawler-friendly
+XML and agent-friendly Markdown maps of the docs tree.
 
 ```ts
 sitemap: {
@@ -259,8 +259,9 @@ Use the `cli` skill when they ask about command syntax.
 
 ## Robots.txt
 
-Use `robots` when the project should generate a static `robots.txt` policy for docs and
-agent-readable routes.
+`robots` is served by the runtime by default when no static `robots.txt` exists. Use it when the
+project should customize or generate a static `robots.txt` policy for docs and agent-readable
+routes.
 
 ```ts
 robots: {
@@ -273,7 +274,8 @@ robots: {
 
 Behavior:
 
-- `docs robots generate` writes the generated policy
+- runtime adapters serve `/robots.txt` by default when no static file already owns that route
+- `docs robots generate` writes the generated policy for static export or committed files
 - default output is `public/robots.txt`, or `static/robots.txt` for SvelteKit
 - `path` changes where the CLI reads and writes the file
 - existing files are preserved unless the user passes `--append` or `--force`
@@ -491,7 +493,7 @@ Important notes:
 - Typesense and Algolia can sync the index on first request when `adminApiKey` is present
 - `provider: "mcp"` supports relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints
 - if `provider: "mcp"` points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally so the route does not recurse forever
-- On custom/manual Next routes, forward `search: docsConfig.search` into `createDocsAPI(...)`
+- On custom/manual Next routes, pass the full config into `createDocsAPI(docsConfig)`
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want to push external indexes from the CLI instead of waiting for the first request
 - Search is hidden when `staticExport: true` because there is no docs API route
 
@@ -556,13 +558,13 @@ feedback: {
 
 ## Agent feedback endpoints
 
-Use `feedback.agent` when agents or automation should be able to report docs understanding or
-implementation outcomes back through the shared docs API.
+Agent feedback endpoints are enabled by default so agents or automation can report docs
+understanding or implementation outcomes back through the shared docs API. Use `feedback.agent` to
+customize the callback, route, or payload schema.
 
 ```ts
 feedback: {
   agent: {
-    enabled: true,
     async onFeedback(data) {
       console.log(data.context?.page, data.payload);
     },
@@ -576,14 +578,16 @@ Default behavior:
 - the discovery document includes site identity, locale config, capability flags, search, markdown routes, root and section `llms.txt` routes, sitemap routes, `robots.route`, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
 - `GET /skill.md` serves the root `skill.md` file when present, `GET /.well-known/skill.md` is the fallback alias, and `GET /api/docs?format=skill` is the shared API format
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
-- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
+- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`; without `onFeedback` it returns `{ ok: true, handled: false }`
 - the shared `/api/docs` handler remains the source of truth
 - **Next.js:** `withDocs()` adds the public rewrites automatically
+- **TanStack Start / SvelteKit / Astro / Nuxt:** the shared `/api/docs?feedback=agent` query route is advertised and handled by the existing server wrapper
 - **TanStack Start:** current `init` scaffolds one `src/routes/$.ts` public forwarder for well-known routes and `/skill.md`
 - **SvelteKit:** current `init` scaffolds one `src/hooks.server.ts` public forwarder for well-known routes and `/skill.md`
 - **Astro:** current `init` scaffolds one `src/middleware.ts` public forwarder for well-known routes and `/skill.md`
 - **Nuxt:** current `init` scaffolds one `server/middleware/docs-public.ts` public forwarder for well-known routes and `/skill.md`
 - `feedback.agent` alone does not enable the human footer UI
+- set `feedback: false` or `feedback: { agent: false }` to opt out of the agent feedback routes
 
 Default payload shape:
 

--- a/website/app/api/docs/mcp/route.ts
+++ b/website/app/api/docs/mcp/route.ts
@@ -3,15 +3,6 @@
 import docsConfig from "@/docs.config";
 import { createDocsMCPAPI } from "@farming-labs/next/api";
 
-export const { GET, POST, DELETE } = createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-  mcp: docsConfig.mcp,
-});
+export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 
 export const revalidate = false;

--- a/website/app/api/docs/route.ts
+++ b/website/app/api/docs/route.ts
@@ -1,18 +1,6 @@
 import docsConfig from "@/docs.config";
 import { createDocsAPI } from "@farming-labs/next/api";
 
-export const { GET, POST } = createDocsAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  i18n: docsConfig.i18n,
-  changelog: docsConfig.changelog,
-  feedback: docsConfig.feedback,
-  mcp: docsConfig.mcp,
-  llmsTxt: docsConfig.llmsTxt,
-  search: docsConfig.search,
-  analytics: docsConfig.analytics,
-  observability: docsConfig.observability,
-  ai: docsConfig.ai,
-});
+export const { GET, POST } = createDocsAPI(docsConfig);
 
 export const revalidate = false;

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -440,7 +440,7 @@ What it checks:
 - `skill.md`
 - MCP
 - search
-- agent feedback
+- agent feedback, which is enabled by default and can be explicitly opted out
 - page metadata that feeds markdown output and JSON-LD structured data
 - explicit agent-friendly pages
 - generated `agent.md` freshness and `agent.compact` defaults
@@ -530,7 +530,7 @@ Sample shape:
     }
   ],
   "recommendations": [
-    "Enable feedback.agent if you want agents to discover and post feedback through the shared docs API."
+    "Add page-level Agent blocks or agent.md files for workflows where the rendered docs need machine-only hints."
   ]
 }
 ```

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -132,7 +132,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `icons`       | `Record<string, Component>`    | —               | Shared icon registry for frontmatter `icon` fields and built-ins like `Prompt` |
 | `components`  | `Record<string, Component>`    | —               | Custom MDX components and built-in overrides like `HoverLink` and `Prompt` |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | —         | Callback when the user clicks the copy button on a code block |
-| `feedback`    | `boolean \| FeedbackConfig`    | `false`         | Human page feedback UI plus optional agent feedback endpoints |
+| `feedback`    | `boolean \| FeedbackConfig`    | `false` for UI  | Human page feedback UI; agent feedback endpoints are default-on unless opted out |
 | `agent`       | `DocsAgentConfig`              | —               | Defaults for `docs agent compact`                  |
 | `readingTime` | `boolean \| ReadingTimeConfig` | `false`         | Opt-in estimated read-time label with optional per-page overrides |
 | `pageActions` | `PageActionsConfig`            | —               | Copy Markdown, Open in LLM buttons                 |
@@ -142,8 +142,8 @@ All configuration lives in a single `docs.config.ts` file.
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |
 | `apiReference` | `boolean \| ApiReferenceConfig` | `false`       | Generated API reference from framework route conventions or a hosted OpenAPI JSON |
-| `sitemap`     | `boolean \| DocsSitemapConfig` | `false`         | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
-| `robots`     | `boolean \| DocsRobotsConfig`  | enabled when configured | Generated `robots.txt` policy for docs and agent-readable routes |
+| `sitemap`     | `boolean \| DocsSitemapConfig` | `true`          | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md` |
+| `robots`     | `boolean \| DocsRobotsConfig`  | `true`          | Runtime/generated `robots.txt` policy for docs and agent-readable routes |
 | `i18n`        | `DocsI18nConfig`               | —               | Query-param locale support and locale switcher     |
 | `metadata`    | `DocsMetadata`                 | —               | SEO metadata template and JSON-LD page inputs      |
 | `og`          | `OGConfig`                     | —               | Dynamic Open Graph images (see [API Reference](/docs/reference#ogconfig)) |
@@ -246,7 +246,8 @@ available, the runtime omits `dateModified` instead of using the current request
 
 ## Sitemaps
 
-Use `sitemap` when you want both crawler-friendly XML and agent-friendly Markdown maps of your docs:
+Sitemaps are enabled by default. Add `sitemap` only when you want to customize the base URL, route
+prefix, manifest path, or output format details:
 
 ```ts title="docs.config.ts"
 export default defineDocs({
@@ -314,6 +315,10 @@ Generate the file with:
 pnpm exec docs robots generate
 ```
 
+Server-rendered apps also serve `/robots.txt` through the shared docs handler by default when no
+static file already owns that route. The generator is still the right tool for static export or when
+you want to commit a policy file.
+
 If a project already owns `public/robots.txt`, the command leaves it alone. Use `--append` to add or
 update the generated block inside the existing file, or `--force` when you intentionally want to
 replace the file:
@@ -335,8 +340,8 @@ export default defineDocs({
 });
 ```
 
-`docs doctor --agent` checks the resolved `robots.txt` path, warns when it is missing, and flags
-policies that block agent-readable docs routes or common AI crawlers.
+`docs doctor --agent` checks the resolved `robots.txt` path or runtime route and flags policies that
+block agent-readable docs routes or common AI crawlers.
 
 ## Static export
 
@@ -496,7 +501,7 @@ Notes:
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want manual indexing as a CLI step
 - `provider: "mcp"` can target a relative route like `/mcp` or `/.well-known/mcp` or an absolute remote MCP endpoint
 - when MCP search points at the same site's relative MCP route, the MCP `search_docs` tool falls back to built-in simple search to avoid recursive loops
-- If you use a custom Next.js docs API route, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search` so your adapter config reaches the route handler
+- If you use a custom Next.js docs API route, import `createDocsAPI` from `@farming-labs/next/api` and pass the whole config: `createDocsAPI(docsConfig)`
 - Search requires the docs API route; with `staticExport: true` the UI is hidden because there is no server route
 
 <Callout type="warning" title="@farming-labs/theme/api compatibility">
@@ -1273,8 +1278,12 @@ when to use compaction instead of writing `agent.md` by hand.
 
 ## Agent Feedback Endpoints
 
-Use `feedback.agent` when you want machine-readable feedback routes for coding agents or docs-aware
-automation. This is separate from the built-in page footer UI.
+Machine-readable feedback routes are enabled by default for coding agents and docs-aware automation.
+The default submit route is a no-op `202` response until you add a callback. This is separate from
+the built-in page footer UI, which remains opt-in.
+
+Use `feedback.agent` only when you want to customize the callback, routes, schema, or explicitly opt
+out.
 
 Agents should discover the configured routes first with `GET /.well-known/agent.json`.
 `GET /.well-known/agent` is the fallback public alias, and `GET /api/docs/agent/spec` is the
@@ -1283,15 +1292,14 @@ site identity, locale config, capability flags, the search endpoint, markdown ro
 `Accept: text/markdown` contract, `Signature-Agent` support, API, public, and section-level
 `llms.txt` routes, sitemap routes, the `robots.txt` route, root `skill.md` metadata, Skills CLI
 install metadata, MCP public/well-known endpoints and enabled tools, and the active agent feedback
-schema and submit endpoints. Publish `/robots.txt` with `docs robots generate` when crawlers and AI
-agents need an explicit access policy at the advertised route.
+schema and submit endpoints. Use `docs robots generate` when a static export or committed policy
+file should own the advertised route.
 
 ```ts title="docs.config.ts"
 export default defineDocs({
   entry: "docs",
   feedback: {
     agent: {
-      enabled: true,
       async onFeedback(data) {
         console.log(data.context?.source, data.payload);
       },
@@ -1309,10 +1317,12 @@ Default behavior:
 - `GET /.well-known/skill.md` and `GET /api/docs?format=skill` return the same skill document
 - the discovery JSON advertises `agentSpecDefault`, `agentSpecFallback`, `skills.file`, `skills.route`, the root and section `llms.txt` routes, `robots.route`, and sitemap routes when enabled
 - `GET /api/docs/agent/feedback/schema` returns the feedback schema
-- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`
+- `POST /api/docs/agent/feedback` accepts `{ context?, payload }`; without `onFeedback` it returns `{ ok: true, handled: false }`
+- non-Next server adapters also expose the same contract through `GET /api/docs?feedback=agent&schema=1` and `POST /api/docs?feedback=agent`
 - the shared `/api/docs` handler is still the source of truth
 - in Next.js, `withDocs()` adds the public rewrites automatically
 - `feedback.agent` alone does not enable the human footer UI
+- set `feedback: false` or `feedback: { agent: false }` to opt out of the agent feedback routes
 
 <Callout type="info" title="Safe by default">
   Agent feedback submissions are validated data passed to `feedback.agent.onFeedback`; they are not

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -99,7 +99,7 @@ Recommended bootstrap flow:
 5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
 6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy.
 7. Use `spec.mcp.wellKnownEndpoint`, `spec.mcp.publicEndpoint`, or `spec.mcp.endpoint` when MCP is enabled and your environment supports MCP.
-8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+8. If `spec.feedback.enabled` is true, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
 available in the spec.
@@ -108,7 +108,7 @@ available in the spec.
 
 ## Feedback Contract
 
-If agent feedback is enabled for the site, use these default endpoints:
+Agent feedback is enabled by default unless the site opts out. Use these default endpoints:
 
 - schema: `/api/docs/agent/feedback/schema`
 - submit: `/api/docs/agent/feedback`

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -109,7 +109,7 @@ Recommended bootstrap flow:
 5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
 6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy.
 7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
-8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+8. If `spec.feedback.enabled` is true, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
 available in the spec.
@@ -185,8 +185,8 @@ coverage instead of only looking correct in the UI.
 Page primitives are also a good place to tell agents how to report whether the docs were enough to
 complete a task.
 
-If `feedback.agent` is enabled in `docs.config`, agents can read the schema first and then post
-structured feedback back into the shared docs API:
+Agent feedback is enabled by default unless the site opts out. Agents can read the schema first and
+then post structured feedback back into the shared docs API:
 
 - schema: `/api/docs/agent/feedback/schema`
 - submit: `/api/docs/agent/feedback`

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -210,14 +210,7 @@ Example custom Next.js route:
 import docsConfig from "@/docs.config";
 import { createDocsMCPAPI } from "@farming-labs/next/api";
 
-export const { GET, POST, DELETE } = createDocsMCPAPI({
-  entry: docsConfig.entry,
-  contentDir: docsConfig.contentDir,
-  nav: docsConfig.nav,
-  ordering: docsConfig.ordering,
-  search: docsConfig.search,
-  mcp: docsConfig.mcp,
-});
+export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 
 export const revalidate = false;
 ```

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -29,7 +29,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[Observability](/docs/customization/observability)** — Trace Ask AI and MCP runs with span IDs, timing, status, previews, and errors
 - **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio, `/mcp`, and `/.well-known/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation
-- **[Sitemaps](/docs/customization/sitemaps)** — Generate `sitemap.xml` and `sitemap.md` for crawlers, agents, and static exports
-- **Robots.txt** — Generate an agent-friendly crawl policy with `docs robots generate`; configure defaults in [Configuration](/docs/configuration)
+- **[Sitemaps](/docs/customization/sitemaps)** — Runtime `sitemap.xml` and `sitemap.md` for crawlers and agents, plus static export generation
+- **Robots.txt** — Runtime agent-friendly crawl policy at `/robots.txt`; use `docs robots generate` for static export or committed policies
 
 All customization happens through the `theme` and top-level config options in `docs.config.ts`.

--- a/website/app/docs/customization/sitemaps/page.mdx
+++ b/website/app/docs/customization/sitemaps/page.mdx
@@ -19,7 +19,8 @@ agents, contributors, and automation a readable map of the docs tree with titles
 markdown URLs, last-updated dates, and related pages.
 
 <Agent>
-Use this page when the task is to enable or troubleshoot generated sitemaps.
+Use this page when the task is to customize or troubleshoot generated sitemaps. Runtime sitemap
+routes are enabled by default; use `sitemap: false` only when a project must opt out.
 
 Default public routes:
 - `/sitemap.xml`
@@ -40,7 +41,8 @@ for JSON-LD `dateModified`.
 
 ## Quick Start
 
-Enable sitemaps in `docs.config.ts`:
+No config is required for the default runtime routes. Add `sitemap` only when you want to customize
+the public base URL or route prefix:
 
 ```ts title="docs.config.ts"
 import { defineDocs } from "@farming-labs/docs";
@@ -260,8 +262,8 @@ export default defineDocs({
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
-| `sitemap` | `boolean \| DocsSitemapConfig` | `false` | Enable or configure sitemap routes. |
-| `sitemap.enabled` | `boolean` | `true` when `sitemap` is an object | Disable without removing the object. |
+| `sitemap` | `boolean \| DocsSitemapConfig` | `true` | Enable or configure sitemap routes. Set `false` to opt out. |
+| `sitemap.enabled` | `boolean` | `true` | Disable without removing the object. |
 | `sitemap.routePrefix` | `string` | `""` | Prefix all public sitemap routes. |
 | `sitemap.baseUrl` | `string` | request origin at runtime, `llmsTxt.baseUrl` in the CLI | Absolute base URL for XML `<loc>` values. |
 | `sitemap.manifestPath` | `string` | `.farming-labs/sitemap-manifest.json` | Internal generated manifest path. |
@@ -342,7 +344,7 @@ Generated: 2026-05-08
 
 ## Verification
 
-After enabling the feature, check the public routes:
+Check the public routes:
 
 ```bash title="terminal"
 curl "http://127.0.0.1:3000/sitemap.xml"

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -205,6 +205,8 @@ So use it when that stronger machine contract is genuinely worth owning.
 
 Great page writing helps, but agents still need the routes that tell them how to use your site.
 With `@farming-labs/docs`, the goal is to expose a compact discovery layer around the docs tree.
+Most agent surfaces are enabled by default; the config below only adds site-specific details such as
+the public base URL and section-level `llms.txt`.
 
 ```ts title="docs.config.ts"
 import { defineDocs } from "@farming-labs/docs";
@@ -226,16 +228,7 @@ export default defineDocs({
     ],
   },
   sitemap: {
-    enabled: true,
     baseUrl: "https://docs.example.com",
-  },
-  mcp: {
-    enabled: true,
-  },
-  feedback: {
-    agent: {
-      enabled: true,
-    },
   },
 });
 ```
@@ -252,6 +245,7 @@ That gives agents a much better workflow:
 - `{page}.md` gives them clean page markdown
 - canonical `{page}` URLs with `Signature-Agent` give agents the same markdown without appending `.md`
 - MCP lets tool-enabled agents search and read docs semantically
+- `/api/docs/agent/feedback/schema` and `/api/docs/agent/feedback` let agents report missing context without enabling the human feedback UI
 
 The big win is that the discovery layer comes from the same docs runtime instead of a parallel
 system you have to keep in sync by hand.
@@ -292,9 +286,9 @@ end.
 
 ## Keep The Sitemap In The Build
 
-If the site is server-rendered, the shared docs handler can serve sitemap routes at runtime. The
-generator is still useful because it writes `.farming-labs/sitemap-manifest.json`, which gives the
-runtime stable `lastmod` values based on each page source file's last git commit date.
+If the site is server-rendered, the shared docs handler serves sitemap routes at runtime by default.
+The generator is still useful because it writes `.farming-labs/sitemap-manifest.json`, which gives
+the runtime stable `lastmod` values based on each page source file's last git commit date.
 
 For static export, the generator is required because there is no server handler to answer
 `/sitemap.xml` or `/sitemap.md`:

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -35,7 +35,7 @@ Recommended bootstrap flow:
 5. Use `spec.sitemap.markdown.route` for the semantic page map and `spec.sitemap.xml.route` for canonical URL freshness when sitemap is enabled.
 6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy for the public docs surface.
 7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
-8. If feedback is enabled, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+8. If `spec.feedback.enabled` is true, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
 Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
 available in the spec.
@@ -92,8 +92,8 @@ Modern docs features are built in; you turn them on in [configuration](/docs/con
 - **[Sidebar](/docs/customization/sidebar)** — Collapsible, flat or nested, banner, footer. [Customize](/docs/customization/sidebar) structure, style, and content (banner, footer, nav title).
 - **[Components](/docs/customization/components)** — Built-in MDX components like `Callout`, `Tabs`, and `HoverLink`, plus your own custom React components.
 - **[llms.txt](/docs/customization/llms-txt)** — LLM-friendly index whose page links point directly to markdown routes. Options described in the [llms.txt docs](/docs/customization/llms-txt).
-- **[Sitemaps](/docs/customization/sitemaps)** — XML and Markdown maps of canonical docs URLs, descriptions, related pages, and freshness metadata.
-- **Robots.txt** — Generate an agent-friendly crawl policy with `docs robots generate`. Configure defaults from [Configuration](/docs/configuration) and see the command in [CLI](/docs/cli).
+- **[Sitemaps](/docs/customization/sitemaps)** — XML and Markdown maps of canonical docs URLs, descriptions, related pages, and freshness metadata. Runtime routes are enabled by default.
+- **Robots.txt** — Runtime agent-friendly crawl policy at `/robots.txt` when no static file already exists; use `docs robots generate` for static export or committed policies.
 
 Theme-level customization (colors, typography, components) is covered in [Configuration](/docs/configuration) and [Customization](/docs/customization) (including [Colors](/docs/customization/colors) and [Typography](/docs/customization/typography)). No custom components or routes required — enable and tweak what you need in `docs.config`.
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -52,7 +52,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `analytics`    | `boolean \| DocsAnalyticsConfig`              | `false`          | Product/usage event stream for docs UI, search, AI, feedback, agent reads, and MCP usage |
 | `observability` | `boolean \| DocsObservabilityConfig`          | `false`          | Trace event stream for Ask AI and MCP runs, including spans, timing, status, and errors |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void`              | —                | Callback when the user clicks the copy button on a code block (runs in addition to copy) |
-| `feedback`    | `boolean \| FeedbackConfig`                     | `false`          | Human page feedback UI plus optional agent feedback endpoints                        |
+| `feedback`    | `boolean \| FeedbackConfig`                     | `false` for UI   | Human page feedback UI; agent feedback endpoints are default-on unless opted out     |
 | `agent`       | `DocsAgentConfig`                               | —                | Defaults for `docs agent compact` and related machine-docs workflows                 |
 | `readingTime` | `boolean \| ReadingTimeConfig`                  | `false`          | Opt-in estimated reading-time label with per-page overrides                          |
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
@@ -60,8 +60,8 @@ Top-level configuration object passed to `defineDocs()`.
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
 | `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp`                       |
 | `apiReference` | `boolean \| ApiReferenceConfig`               | `false`          | Generated API reference pages from supported framework route conventions or a hosted OpenAPI JSON |
-| `sitemap`    | `boolean \| DocsSitemapConfig`                  | `false`          | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md`                 |
-| `robots`     | `boolean \| DocsRobotsConfig`                   | enabled when configured | Generated `robots.txt` policy for docs and agent-readable routes                     |
+| `sitemap`    | `boolean \| DocsSitemapConfig`                  | `true`           | Generated `sitemap.xml`, `sitemap.md`, and `/.well-known/sitemap.md`                 |
+| `robots`     | `boolean \| DocsRobotsConfig`                   | `true`           | Runtime/generated `robots.txt` policy for docs and agent-readable routes             |
 | `changelog`   | `boolean \| ChangelogConfig`                    | `false`          | Generated changelog feed and entry pages from dated MDX entries                      |
 | `ordering`    | `"alphabetical" \| "numeric" \| OrderingItem[]` | `"alphabetical"` | Sidebar page ordering strategy                                                       |
 | `metadata`    | `DocsMetadata`                                  | —                | SEO metadata                                                                         |
@@ -344,12 +344,13 @@ See [MCP Server](/docs/customization/mcp) for the route snippets and examples.
 
 ## `DocsRobotsConfig`
 
-Generated `robots.txt` policy for docs and agent-readable routes. The CLI writes a static file; it
-does not add a runtime route or another server wrapper.
+Runtime and generated `robots.txt` policy for docs and agent-readable routes. Server-rendered apps
+serve `/robots.txt` through the shared docs handler when no static file already owns that path; the
+CLI writes or appends a static file for static export and committed policies.
 
 | Property       | Type                              | Default                          | Description |
 | -------------- | --------------------------------- | -------------------------------- | ----------- |
-| `enabled`      | `boolean`                         | `true` when object is passed     | Enable or disable robots generation |
+| `enabled`      | `boolean`                         | `true`                           | Enable or disable the robots policy |
 | `path`         | `string`                          | `public/robots.txt`, or `static/robots.txt` for SvelteKit | File path used by `docs robots generate` |
 | `baseUrl`      | `string`                          | `sitemap.baseUrl` or `llmsTxt.baseUrl` in the CLI | Public site URL used for the `Sitemap:` line |
 | `ai`           | `boolean \| "allow" \| "disallow"` | `"allow"`                        | Explicitly allow or disallow common AI crawler user agents |
@@ -373,8 +374,7 @@ default; use `docs robots generate --append` to add or update the managed block,
 replace the file.
 
 The agent discovery JSON advertises this surface as `robots.enabled`, `robots.route`, and
-`robots.defaultRoute`, so agents can find the policy without guessing. The JSON points to the route;
-the actual policy contents still live in the generated static `robots.txt` file.
+`robots.defaultRoute`, so agents can find the policy without guessing.
 
 ### `DocsRobotsRule`
 
@@ -588,10 +588,10 @@ Notes:
 
 - `search: false` disables search entirely
 - Search requires the docs API route; static export hides the UI because there is no server route
-- On Next.js, generated routes from `withDocs()` already forward `docsConfig.search`
+- On Next.js, generated routes from `withDocs()` pass `docsConfig` directly into `createDocsAPI`
 - MCP-backed search works with relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints like `https://docs.example.com/mcp`
 - If MCP-backed search points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally to avoid recursive loops
-- On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass `search: docsConfig.search`
+- On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass the whole config: `createDocsAPI(docsConfig)`
 
 <Callout type="warning" title="@farming-labs/theme/api still works for now">
   `@farming-labs/theme/api` remains supported as a compatibility import path today, but prefer
@@ -851,7 +851,7 @@ Optional docs page feedback UI. When enabled, a built-in "Good / Bad" prompt is 
 | `positiveLabel` | `string`                                 | `"Good"`          | Label for the positive button                |
 | `negativeLabel` | `string`                                 | `"Bad"`           | Label for the negative button                |
 | `onFeedback`    | `(data: DocsFeedbackData) => void`       | —                 | Callback fired when the user clicks a button |
-| `agent`         | `boolean \| AgentFeedbackConfig`         | —                 | Agent feedback routes served through `/api/docs` |
+| `agent`         | `boolean \| AgentFeedbackConfig`         | `true`            | Agent feedback routes served through `/api/docs` |
 
 ### `DocsFeedbackData`
 
@@ -895,7 +895,7 @@ Optional machine-facing feedback routes for agents, scripts, or evaluation flows
 
 | Property      | Type                                                | Default                            | Description |
 | ------------- | --------------------------------------------------- | ---------------------------------- | ----------- |
-| `enabled`     | `boolean`                                           | `true` when `agent` is provided    | Enable or disable the agent feedback endpoints |
+| `enabled`     | `boolean`                                           | `true`                             | Enable or disable the agent feedback endpoints |
 | `route`       | `string`                                            | `"/api/docs/agent/feedback"`       | Public HTTP route for feedback submission |
 | `schemaRoute` | `string`                                            | `${route}/schema`                  | Public HTTP route for the machine-readable schema |
 | `schema`      | `Record<string, unknown>`                           | built-in payload schema            | Schema used to validate the `payload` object |
@@ -903,10 +903,13 @@ Optional machine-facing feedback routes for agents, scripts, or evaluation flows
 
 Notes:
 
+- agent feedback routes are enabled by default; set `feedback: false` or `feedback: { agent: false }` to opt out
 - `feedback.agent` does not enable the human footer UI by itself
 - the request body always uses `{ context?, payload }`
+- without `feedback.agent.onFeedback`, valid submissions return `{ ok: true, handled: false }`
 - submitted feedback is not added to Ask AI prompts or docs search context by the framework
 - in Next.js, `withDocs()` adds the public route rewrites automatically
+- Astro, SvelteKit, TanStack Start, and Nuxt expose the same feedback contract through the shared `/api/docs?feedback=agent` query route
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
 - agents should discover site identity, locale config, capability flags, search, active markdown routes, `Accept: text/markdown`, `Signature-Agent` support, JSON-LD structured data, `llms.txt`, sitemap routes, `robots.txt`, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
 


### PR DESCRIPTION
- **feat: enable agent-ready surfaces by default**
- **chore: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable agent-ready surfaces by default and simplify docs API wiring. Sites now get `robots.txt`, sitemaps, and agent feedback endpoints out of the box; framework servers route them automatically, and handlers just pass `docsConfig`.

- New Features
  - Default-on surfaces: `robots.txt`, `sitemap.xml`, and `sitemap.md` at public routes and `/api/docs?format=...`; added `resolveDocsRobotsRequest`, `createDocsRobotsResponse`, and updated `isDocsPublicGetRequest`.
  - Agent feedback enabled by default at `/api/docs/agent/feedback` with `/schema`, a default payload schema, and parse/validate helpers; exports include `DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA` and schema builder.
  - Sitemaps default to enabled when unset.
  - Framework servers (Astro, Nuxt, SvelteKit, TanStack Start) handle robots and feedback; Next `withDocs`, examples, and website now call `createDocsAPI(docsConfig)` / `createDocsMCPAPI(docsConfig)`.
  - CLI doctor checks include robots/feedback/skill and detect explicit opt-outs.

- Migration
  - Use `createDocsAPI(docsConfig)` and `createDocsMCPAPI(docsConfig)` from `@farming-labs/next/api`.
  - Opt out when needed: `sitemap: false`, `robots: false`, or `feedback: false` (or `feedback: { agent: false }`).

<sup>Written for commit ca105501bda50dce57afeb135fd2f10d84c9ac47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

