### PR TITLE
feat: respect native static llms.txt files

### DIFF
--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -1,4 +1,8 @@
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsLlmsTxtPublicRequest,
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+} from "@farming-labs/docs";
 import type { MiddlewareHandler } from "astro";
 import config from "./lib/docs.config";
 import { GET, MCP } from "./lib/docs.server";
@@ -16,6 +20,14 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt)
+  ) {
+    const nativeResponse = await next();
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if (

--- a/examples/sveltekit/src/hooks.server.js
+++ b/examples/sveltekit/src/hooks.server.js
@@ -1,4 +1,8 @@
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsLlmsTxtPublicRequest,
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+} from "@farming-labs/docs";
 import config from "$lib/docs.config";
 import { GET, MCP } from "$lib/docs.server.js";
 
@@ -15,6 +19,14 @@ export async function handle({ event, resolve }) {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt)
+  ) {
+    const nativeResponse = await resolve(event);
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if (

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -51,9 +51,9 @@ describe("agent route helpers", () => {
     expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/.well-known/llms.txt"))).toBe(
       true,
     );
-    expect(
-      isDocsLlmsTxtPublicRequest(new URL("https://example.com/api/docs?format=llms")),
-    ).toBe(false);
+    expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/api/docs?format=llms"))).toBe(
+      false,
+    );
 
     expect(isDocsSkillRequest(new URL("https://example.com/skill.md"))).toBe(true);
     expect(isDocsSkillRequest(new URL("https://example.com/.well-known/skill.md"))).toBe(true);

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -6,6 +6,7 @@ import {
   getDocsMarkdownVaryHeader,
   hasDocsMarkdownSignatureAgent,
   isDocsAgentDiscoveryRequest,
+  isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
   isDocsPublicGetRequest,
   isDocsSkillRequest,
@@ -46,6 +47,13 @@ describe("agent route helpers", () => {
     expect(resolveDocsLlmsTxtFormat(new URL("https://example.com/.well-known/llms-full.txt"))).toBe(
       "llms-full",
     );
+    expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/llms.txt"))).toBe(true);
+    expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/.well-known/llms.txt"))).toBe(
+      true,
+    );
+    expect(
+      isDocsLlmsTxtPublicRequest(new URL("https://example.com/api/docs?format=llms")),
+    ).toBe(false);
 
     expect(isDocsSkillRequest(new URL("https://example.com/skill.md"))).toBe(true);
     expect(isDocsSkillRequest(new URL("https://example.com/.well-known/skill.md"))).toBe(true);
@@ -97,6 +105,9 @@ describe("agent route helpers", () => {
       format: "llms-full",
       section: { title: "API", route: "/docs/api/llms.txt" },
     });
+    expect(
+      isDocsLlmsTxtPublicRequest(new URL("https://example.com/docs/api/llms.txt"), config),
+    ).toBe(true);
     expect(
       isDocsPublicGetRequest(
         "docs",

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -841,6 +841,14 @@ export function isDocsPublicGetRequest(
   );
 }
 
+export function isDocsLlmsTxtPublicRequest(
+  url: URL,
+  llms?: boolean | DocsLlmsDiscoveryConfig | LlmsTxtConfig,
+): boolean {
+  const pathname = normalizeDocsUrlPath(url.pathname);
+  return pathname !== DEFAULT_DOCS_API_ROUTE && resolveDocsLlmsTxtRequest(url, llms) !== null;
+}
+
 export function resolveDocsLlmsTxtFormat(url: URL): "llms" | "llms-full" | null {
   return resolveDocsLlmsTxtRequest(url)?.format ?? null;
 }

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -404,6 +404,8 @@ describe("api reference route templates", () => {
   it("creates a SvelteKit public docs hook", () => {
     const out = svelteDocsPublicHookTemplate("src/hooks.server.ts", false);
     expect(out).toContain("export const handle");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest");
+    expect(out).toContain("const nativeResponse = await resolve(event)");
     expect(out).toContain("isDocsPublicGetRequest");
     expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
@@ -426,6 +428,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingHandle: Handle =");
     expect(out).toContain("const docsPublicHandle: Handle =");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt)");
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain("export const handle = sequence(docsPublicHandle, existingHandle);");
@@ -440,6 +443,8 @@ export const handle: Handle = async ({ event, resolve }) => {
   it("creates an Astro public docs middleware", () => {
     const out = astroDocsMiddlewareTemplate("src/middleware.ts", false);
     expect(out).toContain("export const onRequest");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest");
+    expect(out).toContain("const nativeResponse = await next()");
     expect(out).toContain("isDocsPublicGetRequest");
     expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
@@ -462,6 +467,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingOnRequest: MiddlewareHandler =");
     expect(out).toContain("const docsPublicMiddleware: MiddlewareHandler =");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt)");
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain(

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1680,7 +1680,7 @@ export function svelteDocsPublicHookTemplate(filePath: string, useAlias: boolean
   const configImport = svelteRouteConfigImport(filePath, useAlias);
 
   return `\
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
 import type { Handle } from "@sveltejs/kit";
 import config from "${configImport}";
 import { GET, MCP } from "${serverImport}";
@@ -1698,6 +1698,11 @@ export const handle: Handle = async ({ event, resolve }) => {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt)) {
+    const nativeResponse = await resolve(event);
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
@@ -1740,7 +1745,7 @@ export function injectSvelteDocsPublicHook(
   }
 
   const imports = [
-    'import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
+    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
     ...(next.includes("Handle") ? [] : ['import type { Handle } from "@sveltejs/kit";']),
     ...(hasExistingHandle && !next.includes("sequence")
       ? ['import { sequence } from "@sveltejs/kit/hooks";']
@@ -1763,6 +1768,11 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt)) {
+    const nativeResponse = await resolve(event);
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
@@ -2223,7 +2233,7 @@ export function astroDocsMiddlewareTemplate(filePath: string, useAlias: boolean)
   const configImport = astroRouteConfigImport(filePath, useAlias);
 
   return `\
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
 import type { MiddlewareHandler } from "astro";
 import config from "${configImport}";
 import { GET, MCP } from "${serverImport}";
@@ -2241,6 +2251,11 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt)) {
+    const nativeResponse = await next();
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
@@ -2283,7 +2298,7 @@ export function injectAstroDocsMiddleware(
   }
 
   const imports = [
-    'import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
+    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
     ...(next.includes("MiddlewareHandler")
       ? []
       : ['import type { MiddlewareHandler } from "astro";']),
@@ -2308,6 +2323,11 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
       status: 405,
       headers: { Allow: "GET, HEAD, POST, DELETE" },
     });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt)) {
+    const nativeResponse = await next();
+    if (nativeResponse.status !== 404) return nativeResponse;
   }
 
   if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -82,6 +82,7 @@ export {
   getDocsMarkdownVaryHeader,
   hasDocsMarkdownSignatureAgent,
   isDocsAgentDiscoveryRequest,
+  isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
   isDocsPublicGetRequest,
   isDocsSkillRequest,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -848,6 +848,7 @@ export interface DocsObservabilityConfig {
  */
 /**
  * Configuration for auto-generated `/llms.txt` and `/llms-full.txt` routes.
+ * Native static files at the same public routes take precedence.
  *
  * @see https://llmstxt.org
  */
@@ -2510,7 +2511,9 @@ export interface DocsConfig {
   ordering?: "alphabetical" | "numeric" | OrderingItem[];
   /**
    * Auto-generate `/llms.txt` and `/llms-full.txt` routes for LLM-friendly
-   * documentation. These files let AI tools quickly understand your docs.
+   * documentation. Native static files at those routes take precedence, so
+   * `public/llms.txt` or SvelteKit `static/llms.txt` can override the
+   * generated output without extra config.
    *
    * @example
    * ```ts

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -289,9 +289,11 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     expect(existsSync(join(tmpDir, "app/api/docs/markdown/[[...slug]]/route.ts"))).toBe(false);
 
-    const rewrites = getBeforeFilesRewrites(await readRewrites(nextConfig));
+    const rewritesResult = await readRewrites(nextConfig);
+    const beforeFiles = getBeforeFilesRewrites(rewritesResult);
+    const afterFiles = getAfterFilesRewrites(rewritesResult);
 
-    expect(rewrites).toEqual(
+    expect(beforeFiles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           source: "/api/docs/agent/spec",
@@ -312,30 +314,6 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/.well-known/mcp",
           destination: "/api/docs/mcp",
-        }),
-        expect.objectContaining({
-          source: "/llms.txt",
-          destination: "/api/docs?format=llms",
-        }),
-        expect.objectContaining({
-          source: "/llms-full.txt",
-          destination: "/api/docs?format=llms-full",
-        }),
-        expect.objectContaining({
-          source: "/.well-known/llms.txt",
-          destination: "/api/docs?format=llms",
-        }),
-        expect.objectContaining({
-          source: "/.well-known/llms-full.txt",
-          destination: "/api/docs?format=llms-full",
-        }),
-        expect.objectContaining({
-          source: "/docs/:section*/llms.txt",
-          destination: "/api/docs?format=llms&section=/docs/:section*/llms.txt",
-        }),
-        expect.objectContaining({
-          source: "/docs/:section*/llms-full.txt",
-          destination: "/api/docs?format=llms-full&section=/docs/:section*/llms-full.txt",
         }),
         expect.objectContaining({
           source: "/skill.md",
@@ -399,6 +377,34 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
       ]),
     );
+    expect(afterFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/docs/:section*/llms.txt",
+          destination: "/api/docs?format=llms&section=/docs/:section*/llms.txt",
+        }),
+        expect.objectContaining({
+          source: "/docs/:section*/llms-full.txt",
+          destination: "/api/docs?format=llms-full&section=/docs/:section*/llms-full.txt",
+        }),
+      ]),
+    );
 
     const acceptPattern = new RegExp(MARKDOWN_ACCEPT_HEADER.value);
     expect(acceptPattern.test("text/markdown")).toBe(true);
@@ -449,6 +455,44 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/robots.txt",
           destination: "/api/docs?format=robots",
+        }),
+      ]),
+    );
+  });
+
+  it("lets native static llms.txt files win before generated llms rewrites", async () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    mkdirSync(join(tmpDir, "public"), { recursive: true });
+    writeFileSync(join(tmpDir, "public", "llms.txt"), "# Custom llms\n", "utf-8");
+    writeFileSync(join(tmpDir, "public", "llms-full.txt"), "# Custom full llms\n", "utf-8");
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const rewritesResult = await readRewrites(nextConfig);
+    const beforeFiles = getBeforeFilesRewrites(rewritesResult);
+    const afterFiles = getAfterFilesRewrites(rewritesResult);
+
+    expect(beforeFiles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+      ]),
+    );
+    expect(afterFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
         }),
       ]),
     );
@@ -839,30 +883,6 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs/mcp",
         }),
         expect.objectContaining({
-          source: "/llms.txt",
-          destination: "/api/docs?format=llms",
-        }),
-        expect.objectContaining({
-          source: "/llms-full.txt",
-          destination: "/api/docs?format=llms-full",
-        }),
-        expect.objectContaining({
-          source: "/.well-known/llms.txt",
-          destination: "/api/docs?format=llms",
-        }),
-        expect.objectContaining({
-          source: "/.well-known/llms-full.txt",
-          destination: "/api/docs?format=llms-full",
-        }),
-        expect.objectContaining({
-          source: "/docs/:section*/llms.txt",
-          destination: "/api/docs?format=llms&section=/docs/:section*/llms.txt",
-        }),
-        expect.objectContaining({
-          source: "/docs/:section*/llms-full.txt",
-          destination: "/api/docs?format=llms-full&section=/docs/:section*/llms-full.txt",
-        }),
-        expect.objectContaining({
           source: "/skill.md",
           destination: "/api/docs?format=skill",
         }),
@@ -895,6 +915,30 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/legacy",
           destination: "/docs/getting-started/quickstart",
+        }),
+        expect.objectContaining({
+          source: "/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/.well-known/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/docs/:section*/llms.txt",
+          destination: "/api/docs?format=llms&section=/docs/:section*/llms.txt",
+        }),
+        expect.objectContaining({
+          source: "/docs/:section*/llms-full.txt",
+          destination: "/api/docs?format=llms-full&section=/docs/:section*/llms-full.txt",
         }),
       ]),
     );

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1578,32 +1578,34 @@ function mergeDocsMarkdownRewrites(
   },
   result?: NextRewriteResult,
 ): NextRewriteResult {
-  const autoRewrites = [
+  const autoBeforeFilesRewrites = [
     ...buildAgentSpecRewrites(),
     ...buildMcpRewrites(mcp),
-    ...buildLlmsTxtRewrites(entry),
     ...buildSkillMdRewrites(),
     ...buildSitemapRewrites(sitemap),
     ...buildRobotsRewrites(robots),
     ...buildDocsMarkdownRewrites(entry),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
+  const autoAfterFilesRewrites = buildLlmsTxtRewrites(entry);
+
   if (!result) {
     return {
-      beforeFiles: dedupeRewrites(autoRewrites),
+      beforeFiles: dedupeRewrites(autoBeforeFilesRewrites),
+      afterFiles: dedupeRewrites(autoAfterFilesRewrites),
     };
   }
 
   if (Array.isArray(result)) {
     return {
-      beforeFiles: dedupeRewrites(autoRewrites),
-      afterFiles: result,
+      beforeFiles: dedupeRewrites(autoBeforeFilesRewrites),
+      afterFiles: dedupeRewrites([...result, ...autoAfterFilesRewrites]),
     };
   }
 
   return {
-    beforeFiles: dedupeRewrites([...autoRewrites, ...(result.beforeFiles ?? [])]),
-    afterFiles: result.afterFiles ?? [],
+    beforeFiles: dedupeRewrites([...autoBeforeFilesRewrites, ...(result.beforeFiles ?? [])]),
+    afterFiles: dedupeRewrites([...(result.afterFiles ?? []), ...autoAfterFilesRewrites]),
     fallback: result.fallback ?? [],
   };
 }

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -34,6 +34,7 @@ import {
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
   isDocsAgentDiscoveryRequest,
+  isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
   isDocsPublicGetRequest,
   isDocsSkillRequest,
@@ -1858,6 +1859,13 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
     if (method === "GET" || method === "HEAD") {
       const request = new Request(url.href, { method, headers });
       if (
+        isDocsLlmsTxtPublicRequest(url, config.llmsTxt) &&
+        hasNativeNuxtPublicFile(url.pathname)
+      ) {
+        return undefined;
+      }
+
+      if (
         !isDocsPublicGetRequest(entry, url, request, {
           sitemap: config.sitemap,
           llms: config.llmsTxt,
@@ -1871,6 +1879,27 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
       return server.GET({
         request,
       });
+    }
+  });
+}
+
+function hasNativeNuxtPublicFile(pathname: string): boolean {
+  const relativePath = pathname.replace(/^\/+/, "");
+  if (!relativePath || relativePath.split("/").some((part) => part === ".." || part === "")) {
+    return false;
+  }
+
+  const candidates = [
+    path.join(process.cwd(), "public", relativePath),
+    path.join(process.cwd(), ".output", "public", relativePath),
+    path.join(process.cwd(), "..", "public", relativePath),
+  ];
+
+  return candidates.some((candidate) => {
+    try {
+      return fs.statSync(candidate).isFile();
+    } catch {
+      return false;
     }
   });
 }

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -184,6 +184,8 @@ Behavior:
 
 - default routes are `/llms.txt`, `/llms-full.txt`, `/.well-known/llms.txt`, and
   `/.well-known/llms-full.txt`
+- native static files at those same routes win automatically (`public/llms.txt` for most
+  frameworks, `static/llms.txt` for SvelteKit)
 - compact `llms.txt` links point to page markdown routes such as `/docs/install.md`
 - `maxChars` defaults to `{ mode: "warn", chars: 50000 }`; `mode: "error"` returns an error for
   an over-budget compact file, and `mode: "off"` disables the check

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -46,6 +46,21 @@ That's it. The existing API handler serves the content automatically. Next.js ad
 `withDocs()`; TanStack Start, SvelteKit, Astro, and Nuxt add one public forwarder each so the public
 aliases do not need one route file per URL.
 
+## Custom Static Files
+
+You do not need a config flag to replace the generated files. If your app already ships a native
+static file at the same public route, that file wins and the generated route is only used as the
+fallback.
+
+| Framework | Static file location |
+| --------- | -------------------- |
+| Next.js, Astro, Nuxt, TanStack Start | `public/llms.txt`, `public/llms-full.txt` |
+| SvelteKit | `static/llms.txt`, `static/llms-full.txt` |
+
+The same convention applies to `/.well-known/llms.txt` and `/.well-known/llms-full.txt` when you
+publish those files in the framework's static directory. Keep `llmsTxt` configured only when you
+want generated fallback metadata such as `baseUrl`, `siteTitle`, sections, or a size budget.
+
 ---
 
 ## Configuration Reference

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -238,6 +238,7 @@ That gives agents a much better workflow:
 - `/.well-known/agent.json` tells them which routes exist
 - `/llms.txt` links directly to page markdown routes, while `/llms-full.txt` exposes full machine-readable context
 - section-level files like [`/docs/guides/llms.txt`](/docs/guides/llms.txt) give larger docs progressive disclosure without adding UI
+- custom static `llms.txt` files still win when present, so `public/llms.txt` or SvelteKit `static/llms.txt` can replace the generated index without extra config
 - `/sitemap.xml` exposes canonical URLs and `lastmod` freshness for crawlers and monitors
 - `/sitemap.md` exposes the same docs tree as a semantic, sectioned map for agents and contributors
 - `spec.robots.route` points agents to the static crawl policy, usually `/robots.txt`

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -225,6 +225,9 @@ nav: {
 
 Generated `llms.txt` files for agent-readable docs indexes. The root files are enabled by default;
 section files are opt-in and only add route handling plus discovery metadata.
+If a native static file already exists at the same public route, such as `public/llms.txt` or
+SvelteKit `static/llms.txt`, that file takes precedence and the generated output remains the
+fallback.
 
 | Property          | Type                     | Default                          | Description |
 | ----------------- | ------------------------ | -------------------------------- | ----------- |


### PR DESCRIPTION
- **feat: respect native static llms.txt files**
- **chore: fmt**
- **chore: docs**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated `llms.txt` routes now defer to native static files across frameworks, so your own `llms.txt`/`llms-full.txt` are served first. Added a small helper to detect public `llms.txt` requests and updated Next.js rewrites to make this precedence reliable.

- **New Features**
  - Static `llms.txt`/`llms-full.txt` win by default (Next.js, SvelteKit, Astro, Nuxt).
  - Exported `isDocsLlmsTxtPublicRequest` from `@farming-labs/docs`; used in example middleware and CLI templates to return native responses when present.
  - Next.js: moved `llms` rewrites to `afterFiles` so `public/llms.txt` and `public/llms-full.txt` take precedence; tests added for ordering.
  - Nuxt: server handler detects native public files and skips generated handler.
  - Docs updated to clarify override behavior and static file locations.

<sup>Written for commit b2e0e7a1915a67342b1466ad25462c7e96cd2936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

