### PR TITLE
feat: add OpenAPI schema discovery for agents

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -79,8 +79,10 @@ import {
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
+  buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,
@@ -90,6 +92,23 @@ import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createAstroApiReference } from "./api-reference.js";
+
+function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
+}
+
+function resolveApiReferenceOpenApiDiscovery(value: unknown) {
+  const apiReference = resolveApiReferenceConfig(value as any);
+  if (!apiReference.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: "/api/docs?format=openapi",
+    source: apiReference.specUrl ? ("configured" as const) : ("generated" as const),
+    specUrl: apiReference.specUrl,
+    apiReferencePath: `/${apiReference.path}`,
+  };
+}
 
 interface GithubConfigObj {
   url: string;
@@ -806,6 +825,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const llmsEnabled =
     llmsTxtConfig !== false &&
     !(llmsTxtConfig && typeof llmsTxtConfig === "object" && llmsTxtConfig.enabled === false);
+  const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
+    (config as Record<string, unknown>).apiReference as any,
+  );
   const mcpConfig = resolveDocsMcpConfig(
     (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     {
@@ -834,7 +856,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       baseUrl: llmsBaseUrl,
       maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
       sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-    });
+      openapi: openapiDiscovery,
+    } as any);
     llmsCache.set(key, next);
     return next;
   }
@@ -878,10 +901,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
           null,
           2,
         ),
@@ -893,6 +917,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isApiReferenceOpenApiRequest(url)) {
+      if (!openapiDiscovery.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      const document = await buildApiReferenceOpenApiDocumentAsync(config as any, {
+        framework: "astro",
+        rootDir,
+        baseUrl: url.origin,
+      });
+
+      return new Response(JSON.stringify(document, null, 2), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
     }
 
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
@@ -935,10 +985,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -157,6 +157,12 @@ describe("agent route helpers", () => {
         siteTitle: "Example Docs",
         baseUrl: "https://docs.example.com",
         maxChars: { mode: "warn", chars: 80 },
+        openapi: {
+          enabled: true,
+          url: "/api/docs?format=openapi",
+          apiReferencePath: "/api-reference",
+          source: "generated",
+        },
         sections: [
           {
             title: "API",
@@ -172,6 +178,10 @@ describe("agent route helpers", () => {
       "- [API](https://docs.example.com/docs/api/llms.txt): Endpoint reference",
     );
     expect(content.llmsTxt).toContain("- [Overview](https://docs.example.com/docs.md): Start here");
+    expect(content.llmsTxt).toContain("## API Schemas");
+    expect(content.llmsTxt).toContain(
+      "- [OpenAPI schema](https://docs.example.com/api/docs?format=openapi): Machine-readable API schema for tool use and API clients; rendered API reference at https://docs.example.com/api-reference",
+    );
     expect(content.llmsTxt).not.toContain("Users API");
 
     const request = resolveDocsLlmsTxtRequest(
@@ -444,6 +454,12 @@ describe("agent route helpers", () => {
         siteTitle: "Guides",
         siteDescription: "Machine-readable guides",
       },
+      openapi: {
+        enabled: true,
+        url: "/api/docs?format=openapi",
+        apiReferencePath: "/api-reference",
+        source: "generated",
+      },
     });
 
     expect(document).toContain("name: docs");
@@ -453,6 +469,8 @@ describe("agent route helpers", () => {
     expect(document).toContain("/.well-known/agent.json");
     expect(document).toContain("/robots.txt");
     expect(document).toContain("/api/docs?format=skill");
+    expect(document).toContain("OpenAPI schema: /api/docs?format=openapi");
+    expect(document).toContain("API reference: /api-reference");
     expect(document).toContain("npx skills add farming-labs/docs");
   });
 
@@ -475,9 +493,16 @@ describe("agent route helpers", () => {
       llms: { enabled: true, siteTitle: "Docs" },
       sitemap: true,
       robots: true,
+      openapi: {
+        enabled: true,
+        url: "/api/docs?format=openapi",
+        apiReferencePath: "/api-reference",
+        source: "generated",
+      },
     });
 
     expect(spec.api.agentSpecDefault).toBe("/.well-known/agent.json");
+    expect(spec.api.openapi).toBe("/api/docs?format=openapi");
     expect(spec.markdown.rootPage).toBe("/docs.md");
     expect(spec.markdown.signatureAgentHeader).toBe("Signature-Agent");
     expect(spec.llms.publicTxt).toBe("/llms.txt");
@@ -491,6 +516,16 @@ describe("agent route helpers", () => {
     expect(spec.sitemap.markdown.wellKnownRoute).toBe("/.well-known/sitemap.md");
     expect(spec.capabilities.robots).toBe(true);
     expect(spec.capabilities.structuredData).toBe(true);
+    expect(spec.capabilities.apiReference).toBe(true);
+    expect(spec.capabilities.openapi).toBe(true);
+    expect(spec.openapi).toEqual({
+      enabled: true,
+      url: "/api/docs?format=openapi",
+      source: "generated",
+      specUrl: null,
+      apiReferencePath: "/api-reference",
+      format: "OpenAPI 3.1",
+    });
     expect(spec.robots).toEqual({
       enabled: true,
       route: "/robots.txt",

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -24,6 +24,7 @@ import {
 import type { DocsSitemapConfig } from "./types.js";
 
 export const DEFAULT_DOCS_API_ROUTE = "/api/docs";
+export const DEFAULT_OPENAPI_SCHEMA_ROUTE = `${DEFAULT_DOCS_API_ROUTE}?format=openapi`;
 export const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 export const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 export const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
@@ -111,6 +112,23 @@ export interface DocsLlmsDiscoveryConfig {
   siteDescription?: string;
   maxChars?: LlmsTxtMaxCharsConfig;
   sections?: LlmsTxtSectionConfig[];
+  openapi?: boolean | DocsOpenApiDiscoveryConfig;
+}
+
+export interface DocsOpenApiDiscoveryConfig {
+  enabled?: boolean;
+  url?: string;
+  source?: "generated" | "configured";
+  specUrl?: string;
+  apiReferencePath?: string;
+}
+
+export interface DocsOpenApiResolvedDiscoveryConfig {
+  enabled: boolean;
+  url?: string;
+  source?: "generated" | "configured";
+  specUrl?: string;
+  apiReferencePath?: string;
 }
 
 export interface DocsLlmsTxtResolvedMaxChars {
@@ -175,6 +193,7 @@ export interface DocsAgentDiscoverySpecOptions {
   llms?: DocsLlmsDiscoveryConfig;
   sitemap?: boolean | DocsSitemapConfig;
   robots?: boolean | DocsRobotsConfig;
+  openapi?: boolean | DocsOpenApiDiscoveryConfig;
   markdown?: {
     acceptHeader?: boolean;
     signatureAgentHeader?: boolean;
@@ -190,6 +209,7 @@ export interface DocsSkillDocumentOptions {
   llms?: DocsLlmsDiscoveryConfig;
   sitemap?: boolean | DocsSitemapConfig;
   robots?: boolean | DocsRobotsConfig;
+  openapi?: boolean | DocsOpenApiDiscoveryConfig;
   markdown?: {
     acceptHeader?: boolean;
     signatureAgentHeader?: boolean;
@@ -665,6 +685,12 @@ function renderLlmsTxtPageList(pages: DocsLlmsTxtPageInput[], baseUrl: string): 
   return content;
 }
 
+function resolveDocsResourceUrl(baseUrl: string, url: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return url;
+  const normalized = url.startsWith("/") ? url : `/${url}`;
+  return `${baseUrl}${normalized}`;
+}
+
 function renderLlmsFullTxtPages(pages: DocsLlmsTxtPageInput[], baseUrl: string): string {
   let content = "";
   for (const page of pages) {
@@ -685,6 +711,7 @@ export function renderDocsLlmsTxt(
   const baseUrl = options.baseUrl ?? "";
   const maxChars = normalizeLlmsTxtMaxChars(options.maxChars);
   const sections = resolveDocsLlmsTxtSections(options);
+  const openapi = resolveDocsOpenApiDiscoveryConfig(options.openapi);
   const matchedPageUrls = new Set<string>();
 
   const generatedSections = sections.map((section) => {
@@ -724,6 +751,20 @@ export function renderDocsLlmsTxt(
       llmsTxt += "\n";
     }
     llmsTxt += "\n";
+  }
+  if (openapi.enabled && openapi.url) {
+    llmsTxt += "## API Schemas\n\n";
+    llmsTxt += `- [OpenAPI schema](${resolveDocsResourceUrl(
+      baseUrl,
+      openapi.url,
+    )}): Machine-readable API schema for tool use and API clients`;
+    if (openapi.apiReferencePath) {
+      llmsTxt += `; rendered API reference at ${resolveDocsResourceUrl(
+        baseUrl,
+        openapi.apiReferencePath,
+      )}`;
+    }
+    llmsTxt += "\n\n";
   }
   if (rootPages.length > 0 || generatedSections.length === 0) {
     llmsTxt += "## Pages\n\n";
@@ -1025,6 +1066,7 @@ export function renderDocsSkillDocument({
   llms,
   sitemap,
   robots,
+  openapi,
   markdown,
 }: DocsSkillDocumentOptions): string {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -1037,6 +1079,7 @@ export function renderDocsSkillDocument({
   const feedbackEnabled = feedback?.enabled ?? false;
   const sitemapConfig = resolveDocsSitemapConfig(sitemap);
   const robotsEnabled = isRobotsDiscoveryEnabled(robots);
+  const openapiConfig = resolveDocsOpenApiDiscoveryConfig(openapi);
   const feedbackRoute = feedback?.route ?? DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const llmsSections = resolveDocsLlmsTxtSections(llms);
@@ -1086,6 +1129,10 @@ export function renderDocsSkillDocument({
     lines.push(
       `- Search with ${DEFAULT_DOCS_API_ROUTE}?query={query} when you do not know the page.`,
     );
+  }
+
+  if (openapiConfig.enabled && openapiConfig.url) {
+    lines.push(`- Fetch ${openapiConfig.url} for the machine-readable OpenAPI schema before scraping API reference pages.`);
   }
 
   if (llmsEnabled) {
@@ -1148,6 +1195,13 @@ export function renderDocsSkillDocument({
     for (const section of llmsSections) {
       lines.push(`- ${section.title} llms.txt: ${section.route}`);
       lines.push(`- ${section.title} llms-full.txt: ${section.fullRoute}`);
+    }
+  }
+
+  if (openapiConfig.enabled && openapiConfig.url) {
+    lines.push(`- OpenAPI schema: ${openapiConfig.url}`);
+    if (openapiConfig.apiReferencePath) {
+      lines.push(`- API reference: ${openapiConfig.apiReferencePath}`);
     }
   }
 
@@ -1267,6 +1321,7 @@ export function buildDocsAgentDiscoverySpec({
   llms,
   sitemap,
   robots,
+  openapi,
   markdown,
 }: DocsAgentDiscoverySpecOptions) {
   const normalizedEntry = normalizeDocsPathSegment(entry) || "docs";
@@ -1278,6 +1333,7 @@ export function buildDocsAgentDiscoverySpec({
   const llmsSections = resolveDocsLlmsTxtSections(llms);
   const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms?.baseUrl });
   const robotsEnabled = isRobotsDiscoveryEnabled(robots);
+  const openapiConfig = resolveDocsOpenApiDiscoveryConfig(openapi);
 
   return {
     version: "1",
@@ -1307,6 +1363,8 @@ export function buildDocsAgentDiscoverySpec({
       sitemap: sitemapConfig.enabled,
       robots: robotsEnabled,
       structuredData: true,
+      apiReference: openapiConfig.enabled,
+      openapi: openapiConfig.enabled,
       agentFeedback: feedback?.enabled ?? false,
       locales: localesEnabled,
     },
@@ -1318,6 +1376,7 @@ export function buildDocsAgentDiscoverySpec({
       agentSpecWellKnown: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
       agentSpecWellKnownJson: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
       agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
+      openapi: DEFAULT_OPENAPI_SCHEMA_ROUTE,
     },
     markdown: {
       enabled: true,
@@ -1381,6 +1440,14 @@ export function buildDocsAgentDiscoverySpec({
       canonicalUrlField: "url",
       breadcrumbType: "BreadcrumbList",
     },
+    openapi: {
+      enabled: openapiConfig.enabled,
+      url: openapiConfig.url ?? null,
+      source: openapiConfig.source ?? null,
+      specUrl: openapiConfig.specUrl ?? null,
+      apiReferencePath: openapiConfig.apiReferencePath ?? null,
+      format: "OpenAPI 3.1",
+    },
     search: {
       enabled: searchEnabled,
       endpoint: `${DEFAULT_DOCS_API_ROUTE}?query={query}`,
@@ -1427,6 +1494,7 @@ export function buildDocsAgentDiscoverySpec({
     instructions: {
       preferMarkdownRoutes: true,
       useMcpWhenAvailable: true,
+      useOpenApiWhenAvailable: true,
       readFeedbackSchemaBeforeSubmitting: true,
       doNotAssumeFeedbackPayloadShape: true,
     },
@@ -1476,6 +1544,29 @@ function isRobotsDiscoveryEnabled(robots?: boolean | DocsRobotsConfig): boolean 
   if (robots === false) return false;
   if (robots && typeof robots === "object" && robots.enabled === false) return false;
   return true;
+}
+
+export function resolveDocsOpenApiDiscoveryConfig(
+  openapi?: boolean | DocsOpenApiDiscoveryConfig,
+): DocsOpenApiResolvedDiscoveryConfig {
+  if (openapi === false || openapi === undefined) return { enabled: false };
+  if (openapi === true) {
+    return {
+      enabled: true,
+      url: DEFAULT_OPENAPI_SCHEMA_ROUTE,
+      source: "generated",
+    };
+  }
+
+  if (openapi.enabled === false) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: openapi.url ?? DEFAULT_OPENAPI_SCHEMA_ROUTE,
+    source: openapi.source ?? "generated",
+    specUrl: openapi.specUrl,
+    apiReferencePath: openapi.apiReferencePath,
+  };
 }
 
 function compactSkillText(value: string): string {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1132,7 +1132,9 @@ export function renderDocsSkillDocument({
   }
 
   if (openapiConfig.enabled && openapiConfig.url) {
-    lines.push(`- Fetch ${openapiConfig.url} for the machine-readable OpenAPI schema before scraping API reference pages.`);
+    lines.push(
+      `- Fetch ${openapiConfig.url} for the machine-readable OpenAPI schema before scraping API reference pages.`,
+    );
   }
 
   if (llmsEnabled) {

--- a/packages/docs/src/api-reference.ts
+++ b/packages/docs/src/api-reference.ts
@@ -29,6 +29,14 @@ export interface ResolvedApiReferenceConfig {
   exclude: string[];
 }
 
+export interface ApiReferenceOpenApiDiscovery {
+  enabled: boolean;
+  url?: string;
+  source?: "generated" | "configured";
+  specUrl?: string;
+  apiReferencePath?: string;
+}
+
 interface BuildApiReferenceOptions {
   framework: ApiReferenceFramework;
   rootDir?: string;
@@ -47,6 +55,7 @@ const TANSTACK_ROUTE_FILE_RE = /\.(ts|tsx|js|jsx)$/;
 const METHOD_RE =
   /export\s+(?:async\s+function|function|const)\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|ALL)\b/g;
 const METHOD_NAMES: HttpMethod[] = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"];
+export const DEFAULT_API_REFERENCE_OPENAPI_ROUTE = "/api/docs?format=openapi";
 
 function normalizePathSegment(value: string): string {
   return value.replace(/^\/+|\/+$/g, "");
@@ -99,6 +108,26 @@ export function resolveApiReferenceRenderer(
   const config = resolveApiReferenceConfig(value);
   if (config.renderer) return config.renderer;
   return framework === "next" ? "fumadocs" : "scalar";
+}
+
+export function resolveApiReferenceOpenApiDiscovery(
+  value: DocsConfig["apiReference"],
+  options: { route?: string } = {},
+): ApiReferenceOpenApiDiscovery {
+  const config = resolveApiReferenceConfig(value);
+  if (!config.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: options.route ?? DEFAULT_API_REFERENCE_OPENAPI_ROUTE,
+    source: config.specUrl ? "configured" : "generated",
+    specUrl: config.specUrl,
+    apiReferencePath: `/${config.path}`,
+  };
+}
+
+export function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
 }
 
 function normalizeRemoteSpecUrl(value?: string): string | undefined {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -64,6 +64,7 @@ export {
   DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
   DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
   DEFAULT_DOCS_API_ROUTE,
+  DEFAULT_OPENAPI_SCHEMA_ROUTE,
   DEFAULT_LLMS_FULL_TXT_ROUTE,
   DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
   DEFAULT_LLMS_TXT_MAX_CHARS,
@@ -102,6 +103,7 @@ export {
   resolveDocsLlmsTxtRequest,
   resolveDocsLlmsTxtSections,
   resolveDocsLlmsTxtFormat,
+  resolveDocsOpenApiDiscoveryConfig,
   selectDocsLlmsTxtContent,
   resolveDocsSkillFormat,
   resolveDocsMarkdownRequest,
@@ -119,6 +121,8 @@ export type {
   DocsLlmsTxtResolvedMaxChars,
   DocsLlmsTxtResolvedSection,
   DocsLlmsTxtSelectedContent,
+  DocsOpenApiDiscoveryConfig,
+  DocsOpenApiResolvedDiscoveryConfig,
 } from "./agent.js";
 export {
   DEFAULT_SITEMAP_MANIFEST_PATH,

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -10,8 +10,11 @@ export {
   resolveDocsObservabilityConfig,
 } from "./analytics.js";
 export {
+  DEFAULT_API_REFERENCE_OPENAPI_ROUTE,
   resolveApiReferenceConfig,
   resolveApiReferenceRenderer,
+  resolveApiReferenceOpenApiDiscovery,
+  isApiReferenceOpenApiRequest,
   buildApiReferenceOpenApiDocument,
   buildApiReferenceOpenApiDocumentAsync,
   buildApiReferenceHtmlDocument,
@@ -21,6 +24,7 @@ export {
 } from "./api-reference.js";
 export type {
   ApiReferenceFramework,
+  ApiReferenceOpenApiDiscovery,
   ApiReferenceRenderer,
   ApiReferenceRoute,
   ResolvedApiReferenceConfig,

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -642,6 +642,52 @@ Start here.
     expect(text).toContain("- [Getting Started](/docs/getting-started.md): First steps");
   });
 
+  it("serves an OpenAPI schema through the shared docs api handler", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-openapi-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+    mkdirSync(join(rootDir, "app", "api", "hello"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "api", "hello", "route.ts"),
+      `/** Hello endpoint */
+export async function GET() {
+  return Response.json({ ok: true });
+}
+`,
+      "utf-8",
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      apiReference: {
+        enabled: true,
+        path: "api-reference",
+      },
+    });
+
+    const response = await GET(new Request("http://localhost/api/docs?format=openapi"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+
+    const document = (await response.json()) as {
+      openapi: string;
+      paths: Record<string, Record<string, unknown>>;
+    };
+    expect(document.openapi).toBe("3.1.0");
+    expect(document.paths).toMatchObject({
+      "/api/hello": {
+        get: {
+          summary: "Hello endpoint",
+        },
+      },
+    });
+  });
+
   it("serves robots.txt by default through the shared docs api handler", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-robots-default-route-"));
     tempDirs.push(rootDir);
@@ -1586,6 +1632,10 @@ title: "Home"
           getNavigation: true,
         },
       },
+      apiReference: {
+        enabled: true,
+        path: "api-reference",
+      },
     });
 
     const response = await GET(new Request("http://localhost/api/docs/agent/spec"));
@@ -1604,6 +1654,7 @@ title: "Home"
       };
       capabilities: Record<string, boolean>;
       api: Record<string, string>;
+      openapi: Record<string, unknown>;
       markdown: Record<string, unknown>;
       llms: Record<string, string | boolean>;
       search: {
@@ -1667,6 +1718,8 @@ title: "Home"
       sitemap: true,
       robots: true,
       structuredData: true,
+      apiReference: true,
+      openapi: true,
       agentFeedback: true,
       locales: true,
     });
@@ -1678,6 +1731,15 @@ title: "Home"
       agentSpecWellKnown: "/.well-known/agent",
       agentSpecWellKnownJson: "/.well-known/agent.json",
       agentSpecQuery: "/api/docs?agent=spec",
+      openapi: "/api/docs?format=openapi",
+    });
+    expect(spec.openapi).toEqual({
+      enabled: true,
+      url: "/api/docs?format=openapi",
+      source: "generated",
+      specUrl: null,
+      apiReferencePath: "/api-reference",
+      format: "OpenAPI 3.1",
     });
     expect(spec.markdown).toMatchObject({
       enabled: true,
@@ -1804,6 +1866,7 @@ title: "Home"
       capabilities: Record<string, boolean>;
       markdown: { acceptHeader: string; pagePattern: string; rootPage: string };
       llms: Record<string, string | boolean>;
+      openapi: Record<string, unknown>;
       search: { enabled: boolean; endpoint: string; method: string };
       robots: { enabled: boolean; route: string; defaultRoute: string };
       structuredData: Record<string, unknown>;
@@ -1852,8 +1915,15 @@ title: "Home"
       sitemap: true,
       robots: true,
       structuredData: true,
+      apiReference: false,
+      openapi: false,
       agentFeedback: false,
       locales: false,
+    });
+    expect(spec.openapi).toMatchObject({
+      enabled: false,
+      url: null,
+      apiReferencePath: null,
     });
     expect(spec.markdown).toMatchObject({
       acceptHeader: "text/markdown",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -53,15 +53,18 @@ import type {
   DocsAnalyticsConfig,
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
+  DocsConfig,
   DocsI18nConfig,
   LlmsTxtConfig,
   DocsObservabilityConfig,
   FeedbackConfig,
 } from "@farming-labs/docs";
 import {
+  buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   createFilesystemDocsMcpSource,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveDocsMcpConfig,
   type DocsMcpPage,
 } from "@farming-labs/docs/server";
@@ -148,6 +151,10 @@ interface DocsAPIOptions {
   sitemap?: boolean | DocsSitemapConfig;
   /** Robots.txt generation policy used for the agent discovery spec. */
   robots?: boolean | DocsRobotsConfig;
+  /** API reference / OpenAPI schema configuration used for agent discovery. */
+  apiReference?: DocsConfig["apiReference"];
+  /** Metadata used in generated OpenAPI documents. */
+  metadata?: DocsConfig["metadata"];
 }
 
 interface DocsMCPAPIOptions {
@@ -247,6 +254,7 @@ interface AgentSpecOptions {
   llms: LlmsTxtOptions & { enabled: boolean };
   sitemap?: boolean | DocsSitemapConfig;
   robots?: boolean | DocsRobotsConfig;
+  openapi: ReturnType<typeof resolveApiReferenceOpenApiDiscovery>;
 }
 
 interface SkillDocumentOptions extends AgentSpecOptions {}
@@ -383,6 +391,31 @@ function isRobotsDiscoveryEnabled(robots?: boolean | DocsRobotsConfig): boolean 
   return true;
 }
 
+function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
+}
+
+function resolveApiReferenceOpenApiDiscovery(
+  value: DocsConfig["apiReference"],
+): {
+  enabled: boolean;
+  url?: string;
+  source?: "generated" | "configured";
+  specUrl?: string;
+  apiReferencePath?: string;
+} {
+  const apiReference = resolveApiReferenceConfig(value);
+  if (!apiReference.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: `${DEFAULT_DOCS_API_ROUTE}?format=openapi`,
+    source: apiReference.specUrl ? "configured" : "generated",
+    specUrl: apiReference.specUrl,
+    apiReferencePath: `/${apiReference.path}`,
+  };
+}
+
 function buildAgentSpec({
   origin,
   entry,
@@ -393,6 +426,7 @@ function buildAgentSpec({
   llms,
   sitemap,
   robots,
+  openapi,
 }: AgentSpecOptions) {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const localesEnabled = i18n !== null;
@@ -429,6 +463,8 @@ function buildAgentSpec({
       sitemap: sitemapConfig.enabled,
       robots: robotsEnabled,
       structuredData: true,
+      apiReference: openapi.enabled,
+      openapi: openapi.enabled,
       agentFeedback: feedback.enabled,
       locales: localesEnabled,
     },
@@ -440,6 +476,7 @@ function buildAgentSpec({
       agentSpecWellKnown: DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE,
       agentSpecWellKnownJson: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
       agentSpecQuery: `${DEFAULT_DOCS_API_ROUTE}?agent=spec`,
+      openapi: `${DEFAULT_DOCS_API_ROUTE}?format=openapi`,
     },
     // Always-on agent content surfaces. If these ever become configurable,
     // this spec must be wired to the same docs.config toggles instead of
@@ -501,6 +538,14 @@ function buildAgentSpec({
       canonicalUrlField: "url",
       breadcrumbType: "BreadcrumbList",
     },
+    openapi: {
+      enabled: openapi.enabled,
+      url: openapi.url ?? null,
+      source: openapi.source ?? null,
+      specUrl: openapi.specUrl ?? null,
+      apiReferencePath: openapi.apiReferencePath ?? null,
+      format: "OpenAPI 3.1",
+    },
     search: {
       enabled: searchEnabled,
       endpoint: `${DEFAULT_DOCS_API_ROUTE}?query={query}`,
@@ -549,6 +594,7 @@ function buildAgentSpec({
     instructions: {
       preferMarkdownRoutes: true,
       useMcpWhenAvailable: true,
+      useOpenApiWhenAvailable: true,
       readFeedbackSchemaBeforeSubmitting: true,
       doNotAssumeFeedbackPayloadShape: true,
     },
@@ -1521,6 +1567,7 @@ function renderSkillDocument({
   llms,
   sitemap,
   robots,
+  openapi,
 }: SkillDocumentOptions): string {
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const siteTitle = compactSkillText(llms.siteTitle ?? "Documentation");
@@ -1562,6 +1609,12 @@ function renderSkillDocument({
   if (searchEnabled) {
     lines.push(
       `- Search with ${DEFAULT_DOCS_API_ROUTE}?query={query} when you do not know the page.`,
+    );
+  }
+
+  if (openapi.enabled && openapi.url) {
+    lines.push(
+      `- Fetch ${openapi.url} for the machine-readable OpenAPI schema before scraping API reference pages.`,
     );
   }
 
@@ -1625,6 +1678,13 @@ function renderSkillDocument({
     for (const section of llmsSections) {
       lines.push(`- ${section.title} llms.txt: ${section.route}`);
       lines.push(`- ${section.title} llms-full.txt: ${section.fullRoute}`);
+    }
+  }
+
+  if (openapi.enabled && openapi.url) {
+    lines.push(`- OpenAPI schema: ${openapi.url}`);
+    if (openapi.apiReferencePath) {
+      lines.push(`- API reference: ${openapi.apiReferencePath}`);
     }
   }
 
@@ -2420,6 +2480,51 @@ function readRobotsConfig(root: string): boolean | DocsRobotsConfig | undefined 
   return undefined;
 }
 
+function readApiReferenceConfig(root: string): DocsConfig["apiReference"] | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = path.join(root, `docs.config.${ext}`);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      if (!content.includes("apiReference")) return undefined;
+      if (/apiReference\s*:\s*false/.test(content)) return false;
+      if (/apiReference\s*:\s*true/.test(content)) return true;
+
+      const block = content.match(/apiReference\s*:\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? "";
+      const enabledMatch = block.match(/enabled\s*:\s*(true|false)/);
+      const pathMatch = block.match(/path\s*:\s*["']([^"']+)["']/);
+      const routeRootMatch = block.match(/routeRoot\s*:\s*["']([^"']+)["']/);
+      const specUrlMatch = block.match(/specUrl\s*:\s*["']([^"']+)["']/);
+      const rendererMatch = block.match(/renderer\s*:\s*["'](fumadocs|scalar)["']/);
+      const excludeMatch = block.match(/exclude\s*:\s*\[([\s\S]*?)\]/);
+      const exclude =
+        excludeMatch?.[1] === undefined
+          ? undefined
+          : Array.from(excludeMatch[1].matchAll(/["']([^"']+)["']/g))
+              .map((match) => match[1])
+              .filter(Boolean);
+      const renderer =
+        rendererMatch?.[1] === "fumadocs" || rendererMatch?.[1] === "scalar"
+          ? rendererMatch[1]
+          : undefined;
+
+      return {
+        enabled: enabledMatch ? enabledMatch[1] === "true" : true,
+        path: pathMatch?.[1],
+        routeRoot: routeRootMatch?.[1],
+        specUrl: specUrlMatch?.[1],
+        renderer,
+        exclude,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
 function generateLlmsTxt(
   indexes: DocsSearchSourcePage[],
   options: LlmsTxtOptions,
@@ -2474,6 +2579,13 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const llmsConfig = resolveLlmsTxtConfig(options?.llmsTxt, readLlmsTxtConfig(root));
   const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
   const robotsConfig = options?.robots ?? readRobotsConfig(root);
+  const apiReferenceConfig = options?.apiReference ?? readApiReferenceConfig(root);
+  const apiReferenceDocsConfig = {
+    ...options,
+    entry,
+    apiReference: apiReferenceConfig,
+  } as DocsConfig;
+  const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(apiReferenceConfig);
   const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
     defaultName: llmsConfig.siteTitle ?? "Documentation",
   });
@@ -2668,7 +2780,8 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       baseUrl: llmsConfig.baseUrl ?? "",
       maxChars: llmsConfig.maxChars,
       sections: llmsConfig.sections,
-    });
+      openapi: openapiDiscovery,
+    } as any);
     llmsCacheByLocale.set(key, next);
     return next;
   }
@@ -2702,6 +2815,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             llms: llmsConfig,
             sitemap: sitemapConfig,
             robots: robotsConfig,
+            openapi: openapiDiscovery,
           }),
           {
             headers: {
@@ -2710,6 +2824,32 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             },
           },
         );
+      }
+
+      if (isApiReferenceOpenApiRequest(url)) {
+        if (!openapiDiscovery.enabled) {
+          return new Response("Not Found", {
+            status: 404,
+            headers: {
+              "Content-Type": "text/plain; charset=utf-8",
+              "X-Robots-Tag": "noindex",
+            },
+          });
+        }
+
+        const document = await buildApiReferenceOpenApiDocumentAsync(apiReferenceDocsConfig, {
+          framework: "next",
+          rootDir: root,
+          baseUrl: url.origin,
+        });
+
+        return new Response(JSON.stringify(document, null, 2), {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
+        });
       }
 
       const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
@@ -2769,6 +2909,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
               llms: llmsConfig,
               sitemap: sitemapConfig,
               robots: robotsConfig,
+              openapi: openapiDiscovery,
             }),
           {
             headers: {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -395,9 +395,7 @@ function isApiReferenceOpenApiRequest(url: URL): boolean {
   return url.searchParams.get("format")?.trim() === "openapi";
 }
 
-function resolveApiReferenceOpenApiDiscovery(
-  value: DocsConfig["apiReference"],
-): {
+function resolveApiReferenceOpenApiDiscovery(value: DocsConfig["apiReference"]): {
   enabled: boolean;
   url?: string;
   source?: "generated" | "configured";

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -69,8 +69,10 @@ import {
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
+  buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,
@@ -80,6 +82,23 @@ import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { defineApiReferenceHandler } from "./api-reference.js";
+
+function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
+}
+
+function resolveApiReferenceOpenApiDiscovery(value: unknown) {
+  const apiReference = resolveApiReferenceConfig(value as any);
+  if (!apiReference.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: "/api/docs?format=openapi",
+    source: apiReference.specUrl ? ("configured" as const) : ("generated" as const),
+    specUrl: apiReference.specUrl,
+    apiReferencePath: `/${apiReference.path}`,
+  };
+}
 
 interface GithubConfigObj {
   url: string;
@@ -796,6 +815,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const llmsEnabled =
     llmsTxtConfig !== false &&
     !(llmsTxtConfig && typeof llmsTxtConfig === "object" && llmsTxtConfig.enabled === false);
+  const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
+    (config as Record<string, unknown>).apiReference as any,
+  );
   const mcpConfig = resolveDocsMcpConfig(
     (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     {
@@ -824,7 +846,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       baseUrl: llmsBaseUrl,
       maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
       sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-    });
+      openapi: openapiDiscovery,
+    } as any);
     llmsCache.set(key, next);
     return next;
   }
@@ -868,10 +891,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
           null,
           2,
         ),
@@ -883,6 +907,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isApiReferenceOpenApiRequest(url)) {
+      if (!openapiDiscovery.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      const document = await buildApiReferenceOpenApiDocumentAsync(config as any, {
+        framework: "nuxt",
+        rootDir,
+        baseUrl: url.origin,
+      });
+
+      return new Response(JSON.stringify(document, null, 2), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
     }
 
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
@@ -925,10 +975,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -79,8 +79,10 @@ import {
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
+  buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveDocsMcpConfig,
   serializeDocsIconRegistry,
   serializeOpenDocsProviders,
@@ -90,6 +92,23 @@ import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createSvelteApiReference } from "./api-reference.js";
+
+function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
+}
+
+function resolveApiReferenceOpenApiDiscovery(value: unknown) {
+  const apiReference = resolveApiReferenceConfig(value as any);
+  if (!apiReference.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: "/api/docs?format=openapi",
+    source: apiReference.specUrl ? ("configured" as const) : ("generated" as const),
+    specUrl: apiReference.specUrl,
+    apiReferencePath: `/${apiReference.path}`,
+  };
+}
 
 interface GithubConfigObj {
   url: string;
@@ -815,6 +834,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const llmsEnabled =
     llmsTxtConfig !== false &&
     !(llmsTxtConfig && typeof llmsTxtConfig === "object" && llmsTxtConfig.enabled === false);
+  const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
+    (config as Record<string, unknown>).apiReference as any,
+  );
   const mcpConfig = resolveDocsMcpConfig(
     (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     {
@@ -843,7 +865,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       baseUrl: llmsBaseUrl,
       maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
       sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-    });
+      openapi: openapiDiscovery,
+    } as any);
     llmsCache.set(key, next);
     return next;
   }
@@ -886,10 +909,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
           null,
           2,
         ),
@@ -901,6 +925,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isApiReferenceOpenApiRequest(event.url)) {
+      if (!openapiDiscovery.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      const document = await buildApiReferenceOpenApiDocumentAsync(config as any, {
+        framework: "sveltekit",
+        rootDir,
+        baseUrl: event.url.origin,
+      });
+
+      return new Response(JSON.stringify(document, null, 2), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
     }
 
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(event.url, agentFeedbackConfig);
@@ -943,10 +993,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -49,14 +49,33 @@ import {
 } from "@farming-labs/docs";
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
+  buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveDocsMcpConfig,
 } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
 import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createTanstackApiReference } from "./api-reference.js";
+
+function isApiReferenceOpenApiRequest(url: URL): boolean {
+  return url.searchParams.get("format")?.trim() === "openapi";
+}
+
+function resolveApiReferenceOpenApiDiscovery(value: unknown) {
+  const apiReference = resolveApiReferenceConfig(value as any);
+  if (!apiReference.enabled) return { enabled: false };
+
+  return {
+    enabled: true,
+    url: "/api/docs?format=openapi",
+    source: apiReference.specUrl ? ("configured" as const) : ("generated" as const),
+    specUrl: apiReference.specUrl,
+    apiReferencePath: `/${apiReference.path}`,
+  };
+}
 
 interface GithubConfigObj {
   url: string;
@@ -783,6 +802,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   const llmsEnabled =
     llmsTxtConfig !== false &&
     !(llmsTxtConfig && typeof llmsTxtConfig === "object" && llmsTxtConfig.enabled === false);
+  const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(config.apiReference);
   const mcpConfig = resolveDocsMcpConfig(config.mcp, {
     defaultName: llmsTitle,
   });
@@ -806,7 +826,8 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       baseUrl: llmsBaseUrl,
       maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
       sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-    });
+      openapi: openapiDiscovery,
+    } as any);
     llmsCache.set(key, next);
     return next;
   }
@@ -849,10 +870,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
           null,
           2,
         ),
@@ -864,6 +886,32 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
           },
         },
       );
+    }
+
+    if (isApiReferenceOpenApiRequest(url)) {
+      if (!openapiDiscovery.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      const document = await buildApiReferenceOpenApiDocumentAsync(config as any, {
+        framework: "tanstack-start",
+        rootDir,
+        baseUrl: url.origin,
+      });
+
+      return new Response(JSON.stringify(document, null, 2), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+        },
+      });
     }
 
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(url, agentFeedbackConfig);
@@ -906,10 +954,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             },
             sitemap: config.sitemap,
             robots: config.robots,
+            openapi: openapiDiscovery,
             markdown: {
               acceptHeader: false,
             },
-          }),
+          } as any),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -39,9 +39,10 @@ pnpm --dir examples/next exec docs robots generate --config docs.config.tsx
 pnpm --dir examples/next exec docs agent compact installation --config docs.config.tsx
 ```
 
-The agent discovery spec also advertises structured data support, the sitemap routes, `robots.route`, the root `skill.md`
-route, this Skills pack through `npx skills add farming-labs/docs`, and recommends the
-`getting-started` skill for first-run setup.
+The agent discovery spec also advertises structured data support, OpenAPI schema discovery when
+`apiReference` is enabled, the sitemap routes, `robots.route`, the root `skill.md` route, this Skills
+pack through `npx skills add farming-labs/docs`, and recommends the `getting-started` skill for
+first-run setup.
 
 ---
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -577,7 +577,7 @@ feedback: {
 Default behavior:
 
 - `GET /.well-known/agent.json` is the preferred public agent discovery document, with `/.well-known/agent` as fallback and `/api/docs/agent/spec` as the canonical framework route
-- the discovery document includes site identity, locale config, capability flags, search, markdown routes, root and section `llms.txt` routes, sitemap routes, `robots.route`, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
+- the discovery document includes site identity, locale config, capability flags, search, markdown routes, root and section `llms.txt` routes, OpenAPI schema discovery when `apiReference` is enabled, sitemap routes, `robots.route`, root `skill.md` metadata, Skills CLI install metadata, MCP, and feedback routes
 - `GET /skill.md` serves the root `skill.md` file when present, `GET /.well-known/skill.md` is the fallback alias, and `GET /api/docs?format=skill` is the shared API format
 - `GET /api/docs/agent/feedback/schema` returns the machine-readable schema
 - `POST /api/docs/agent/feedback` accepts `{ context?, payload }`; without `onFeedback` it returns `{ ok: true, handled: false }`
@@ -728,6 +728,8 @@ Notes:
 - **TanStack Start / SvelteKit / Astro / Nuxt:** `docs.config` controls scanning, remote spec rendering, and styling, but the app must still add the framework route handler for `/{path}`
 - **CLI:** `init --api-reference` writes the `apiReference` block and scaffolds the non-Next route handler files automatically
 - `path` controls the public URL for the generated reference
+- `GET /api/docs?format=openapi` returns the machine-readable OpenAPI schema when `apiReference` is enabled
+- agent discovery, generated `llms.txt`, and generated `skill.md` advertise the OpenAPI schema route so agents can fetch schemas before scraping API pages
 - `specUrl` points to a hosted OpenAPI JSON document; when set, local route scanning is skipped
 - `routeRoot` controls the filesystem route root to scan
 - `exclude` accepts either URL-style paths (`"/api/hello"`) or route-root-relative entries (`"hello"` / `"hello/route.ts"`)

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -41,7 +41,7 @@ Eleven built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-bor
 
 - **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
-- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, JSON-LD structured data support, `llms.txt` routes, sitemap routes, `robots.route`, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
+- **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, JSON-LD structured data support, `llms.txt` routes, OpenAPI schema discovery when `apiReference` is enabled, sitemap routes, `robots.route`, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Generated robots.txt** — use `docs robots generate` to write a static policy that allows docs routes, `.md` routes, `llms.txt`, sitemaps, `skill.md`, MCP aliases, agent discovery routes, and common AI crawler user agents. Existing files are preserved by default; use `--append` to add the managed block or `--force` to replace the file.
 - **Structured data** — every docs page emits Schema.org `TechArticle` JSON-LD with title, description, canonical URL, freshness, and breadcrumbs. It reuses `sitemap.baseUrl`, `llmsTxt.baseUrl`, `robots.baseUrl`, or `ai.docsUrl`; no separate config flag is required.
 - **Agent feedback endpoints** — add `feedback.agent` when agents should report structured `{ context?, payload }` feedback through `/api/docs/agent/feedback` and `/api/docs/agent/feedback/schema`.
@@ -127,6 +127,7 @@ Important framework behavior:
 - **Next.js**: `withDocs()` auto-generates the `/{path}` route when `apiReference` is enabled.
 - **TanStack Start, SvelteKit, Astro, Nuxt**: `docs.config` controls scanning and theming, but the app still needs the `/{path}` route handler.
 - **CLI**: `init --api-reference` writes the config and scaffolds those handler files for you.
+- **Agents**: `GET /api/docs?format=openapi` serves the machine-readable schema and is advertised through agent discovery, generated `llms.txt`, and generated `skill.md`.
 
 Remote OpenAPI JSON example:
 

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -202,6 +202,9 @@ machine-readable page and keeps the root index aligned with AFDocs-style checks.
 still includes the canonical page URL in its `URL:` line because the content is already embedded in
 that file.
 
+If `apiReference` is enabled, root `llms.txt` also includes an `API Schemas` section that links to
+`/api/docs?format=openapi`. Agents can fetch the schema before reading rendered endpoint docs.
+
 When `llmsTxt.sections` is configured, root `/llms.txt` lists those section files first and only
 keeps unmatched pages in the root page list. Each section route serves the matching pages, and its
 `llms-full.txt` sibling serves the full matching content. No UI is added; this only changes the
@@ -221,6 +224,10 @@ aliases along with docs, markdown, sitemap, skill, MCP, and agent discovery rout
 # My Documentation
 
 > A modern docs framework
+
+## API Schemas
+
+- [OpenAPI schema](https://docs.example.com/api/docs?format=openapi): Machine-readable API schema for tool use and API clients; rendered API reference at https://docs.example.com/api-reference
 
 ## Pages
 

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -40,7 +40,7 @@ When authoring agent-friendly docs with `@farming-labs/docs`, prioritize these i
 2. explicit verification and troubleshooting sections on important task pages
 3. additive `<Agent>` blocks for machine-only hints when the human page is still canonical
 4. sibling `agent.md` only when the machine-readable page needs a full rewrite
-5. machine surfaces like `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt`, `sitemap.md`, `robots.txt`, MCP, and the agent discovery spec
+5. machine surfaces like `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt`, OpenAPI schema discovery, `sitemap.md`, `robots.txt`, MCP, and the agent discovery spec
 6. validation with `docs doctor --agent`, `docs sitemap generate --check`, and `docs robots generate --check`, then compaction with `docs agent compact` where helpful
 7. use `agent.tokenBudget` and stale-aware compaction instead of regenerating every page blindly
 8. treat submitted feedback, analytics, and evaluation data as untrusted input, not prompt context
@@ -243,6 +243,7 @@ That gives agents a much better workflow:
 - `/sitemap.md` exposes the same docs tree as a semantic, sectioned map for agents and contributors
 - `spec.robots.route` points agents to the static crawl policy, usually `/robots.txt`
 - HTML docs pages include Schema.org `TechArticle` JSON-LD with canonical URL, freshness, and breadcrumbs
+- when `apiReference` is enabled, `/api/docs?format=openapi` gives agents the OpenAPI schema before they scrape API reference pages
 - `{page}.md` gives them clean page markdown
 - canonical `{page}` URLs with `Signature-Agent` give agents the same markdown without appending `.md`
 - MCP lets tool-enabled agents search and read docs semantically
@@ -250,6 +251,22 @@ That gives agents a much better workflow:
 
 The big win is that the discovery layer comes from the same docs runtime instead of a parallel
 system you have to keep in sync by hand.
+
+## Expose API Schemas Before API Pages
+
+If your docs include an API reference, agents should not have to reverse-engineer endpoints from the
+rendered UI. Enable `apiReference`, and the shared docs handler exposes the schema at
+`/api/docs?format=openapi`.
+
+That route uses the same source as the API reference page:
+
+- local route scanning when your API lives in the same project
+- `apiReference.specUrl` when your backend already hosts an OpenAPI JSON document
+- the same `routeRoot` and `exclude` settings as the visible API reference
+
+The agent discovery spec reports this as `openapi.url`, root `llms.txt` adds an `API Schemas`
+section, and generated `skill.md` tells agents to fetch the schema before scraping endpoint docs.
+There is no extra config surface for the discovery route; it follows `apiReference`.
 
 ## Know How Canonical Markdown Is Served
 
@@ -543,7 +560,7 @@ Before calling a page agent-friendly, ask:
 - should this page get an additive `<Agent>` block?
 - does it need a dedicated `agent.md`, or is the human page still canonical?
 - does this page need `agent.tokenBudget` before compaction?
-- can an agent find it through `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt` markdown links, sitemaps, `robots.txt`, MCP, and the discovery spec?
+- can an agent find it through `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt` markdown links, OpenAPI schema discovery, sitemaps, `robots.txt`, MCP, and the discovery spec?
 - do canonical `Signature-Agent` reads use the existing `/api/docs` handler instead of a custom wrapper route?
 - if the adapter preloads content, is the sitemap manifest bundled so JSON-LD freshness stays stable?
 - if the site is static, does the build generate `sitemap.xml`, `sitemap.md`, `/.well-known/sitemap.md`, and `robots.txt`?

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -23,8 +23,9 @@ You are reading the machine-readable entry page for `@farming-labs/docs`.
 Before implementing from this docs site, fetch `/.well-known/agent.json` from the same origin. If
 that is unavailable, fall back to `/.well-known/agent`. Treat that JSON as the source of truth for
 the docs entry path, markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes,
-`sitemap.xml` / `sitemap.md` routes, `robots.txt` route, `skill.md` route, skills install command,
-JSON-LD structured data, locale handling, `Signature-Agent` support, and feedback endpoints.
+OpenAPI schema route, `sitemap.xml` / `sitemap.md` routes, `robots.txt` route, `skill.md` route,
+skills install command, JSON-LD structured data, locale handling, `Signature-Agent` support, and
+feedback endpoints.
 
 Recommended bootstrap flow:
 
@@ -32,13 +33,14 @@ Recommended bootstrap flow:
 2. Read `spec.skills.route` or `spec.skills.wellKnown` when a concise site skill is useful.
 3. Use `spec.markdown.pagePattern`, `spec.markdown.acceptHeader`, or `spec.markdown.signatureAgentHeader` to read the exact docs pages you need as markdown.
 4. Use `spec.search.endpoint` when you need to find the right page before reading it.
-5. Use `spec.sitemap.markdown.route` for the semantic page map and `spec.sitemap.xml.route` for canonical URL freshness when sitemap is enabled.
-6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy for the public docs surface.
-7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
-8. If `spec.feedback.enabled` is true, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
+5. Use `spec.openapi.url` before scraping API reference pages when `spec.openapi.enabled` is true.
+6. Use `spec.sitemap.markdown.route` for the semantic page map and `spec.sitemap.xml.route` for canonical URL freshness when sitemap is enabled.
+7. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy for the public docs surface.
+8. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and the environment supports MCP.
+9. If `spec.feedback.enabled` is true, fetch `spec.feedback.schema` before submitting to `spec.feedback.submit`.
 
-Do not scrape the HTML page when markdown, search, sitemap, robots, MCP, or `llms.txt` routes are
-available in the spec.
+Do not scrape the HTML page when markdown, search, OpenAPI, sitemap, robots, MCP, or `llms.txt`
+routes are available in the spec.
 </Agent>
 
 ## Why @farming-labs/docs?

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -629,6 +629,12 @@ deployed elsewhere and already exposes an `openapi.json`.
   Point it at a hosted `openapi.json` and keep the same themed API reference UI.
 </Callout>
 
+<Callout type="info" title="Agent schema discovery">
+  When `apiReference` is enabled, the shared docs API also serves
+  `GET /api/docs?format=openapi`. The agent discovery spec advertises that OpenAPI schema URL, and
+  generated `llms.txt` / `skill.md` output points agents there before they scrape API reference pages.
+</Callout>
+
 | Property    | Type       | Default           | Description |
 | ----------- | ---------- | ----------------- | ----------- |
 | `enabled`   | `boolean`  | `true` inside the object | Enable generated API reference pages |
@@ -914,7 +920,7 @@ Notes:
 - in Next.js, `withDocs()` adds the public route rewrites automatically
 - Astro, SvelteKit, TanStack Start, and Nuxt expose the same feedback contract through the shared `/api/docs?feedback=agent` query route
 - the shared `/api/docs` handler is still the source of truth, so `?feedback=agent` also works
-- agents should discover site identity, locale config, capability flags, search, active markdown routes, `Accept: text/markdown`, `Signature-Agent` support, JSON-LD structured data, `llms.txt`, sitemap routes, `robots.txt`, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
+- agents should discover site identity, locale config, capability flags, search, active markdown routes, `Accept: text/markdown`, `Signature-Agent` support, JSON-LD structured data, `llms.txt`, OpenAPI schema routes, sitemap routes, `robots.txt`, `skill.md`, skills, MCP, and feedback routes with `GET /.well-known/agent.json`; `GET /.well-known/agent` is the public fallback and `GET /api/docs/agent/spec` is the canonical framework route
 
 ### `DocsAgentFeedbackContext`
 
@@ -1680,7 +1686,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | Property | Type                                                       | Description |
 | -------- | ---------------------------------------------------------- | ----------- |
 | `load`   | `({ pathname, locale? }) => Promise<DocsServerLoadResult>` | Loads docs page data and the sidebar tree for a pathname |
-| `GET`    | `({ request }) => Response`                                | Search / markdown / `llms.txt` / sitemap / `skill.md` endpoint handler |
+| `GET`    | `({ request }) => Response`                                | Search / markdown / `llms.txt` / OpenAPI / sitemap / `skill.md` endpoint handler |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
 
 ```ts title="src/lib/docs.server.ts"

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -174,8 +174,9 @@ function AgentScoreCalloutSection() {
               How agent-ready are your docs?
             </h2>
             <p className="mt-3 max-w-xl text-sm leading-relaxed text-black/45 dark:text-white/40 sm:text-base">
-              Run a public readiness check for llms.txt, markdown routes, MCP, sitemap, robots,
-              structure, access, and cache hygiene, then compare your docs on the leaderboard.
+              Run a public readiness check for llms.txt, markdown routes, OpenAPI discovery, MCP,
+              sitemap, robots, structure, access, and cache hygiene, then compare your docs on the
+              leaderboard.
             </p>
           </div>
 

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -863,8 +863,7 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
     markdownRoute,
     searchEndpoint: readDiscoveryRoute(searchRoot?.endpoint),
     feedbackSchemaRoute: readDiscoveryRoute(feedbackRoot?.schema),
-    openapiRoute:
-      readDiscoveryRoute(openapiRoot?.url) ?? readDiscoveryRoute(apiRoot?.openapi),
+    openapiRoute: readDiscoveryRoute(openapiRoot?.url) ?? readDiscoveryRoute(apiRoot?.openapi),
   };
 }
 
@@ -1662,7 +1661,9 @@ async function buildFrameworkChecks(
     view.capabilities.agentFeedback === false || !view.feedbackSchemaRoute
       ? Promise.resolve(undefined)
       : probeJsonRoute(frameworkBaseUrl, view.feedbackSchemaRoute),
-    view.openapiRoute ? probeJsonRoute(frameworkBaseUrl, view.openapiRoute) : Promise.resolve(undefined),
+    view.openapiRoute
+      ? probeJsonRoute(frameworkBaseUrl, view.openapiRoute)
+      : Promise.resolve(undefined),
   ]);
   const htmlSurfaceProbes = await probeHtmlPageSurfaces(frameworkBaseUrl, view, sitemapProbes);
   const markdownCanonicalProbes =
@@ -1847,7 +1848,11 @@ async function buildFrameworkChecks(
     ),
   );
 
-  if (view.capabilities.openapi === true || view.capabilities.apiReference === true || view.openapiRoute) {
+  if (
+    view.capabilities.openapi === true ||
+    view.capabilities.apiReference === true ||
+    view.openapiRoute
+  ) {
     const openapiBody = asRecord(openapiProbe?.body);
     const openapiLooksValid =
       openapiProbe?.ok &&

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -725,6 +725,7 @@ interface DiscoveryView {
   markdownRoute?: string;
   searchEndpoint?: string;
   feedbackSchemaRoute?: string;
+  openapiRoute?: string;
 }
 
 function readDiscoveryFramework(body: unknown): string | undefined {
@@ -778,6 +779,8 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
     mcp: readCapability(root, capabilities, "mcp"),
     search: readCapability(root, capabilities, "search"),
     agentFeedback: readCapability(root, capabilities, "agentFeedback"),
+    apiReference: readCapability(root, capabilities, "apiReference"),
+    openapi: readCapability(root, capabilities, "openapi"),
     structuredData: readBool(capabilities.structuredData),
     agentBlocks: readBool(capabilities.agentBlocks),
     agentMdOverrides: readBool(capabilities.agentMdOverrides),
@@ -843,6 +846,8 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
   const markdownRoute = readDiscoveryRoute(markdownRoot?.rootPage);
   const searchRoot = asRecord(root.search);
   const feedbackRoot = asRecord(root.feedback);
+  const openapiRoot = asRecord(root.openapi);
+  const apiRoot = asRecord(root.api);
 
   return {
     available: true,
@@ -858,6 +863,8 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
     markdownRoute,
     searchEndpoint: readDiscoveryRoute(searchRoot?.endpoint),
     feedbackSchemaRoute: readDiscoveryRoute(feedbackRoot?.schema),
+    openapiRoute:
+      readDiscoveryRoute(openapiRoot?.url) ?? readDiscoveryRoute(apiRoot?.openapi),
   };
 }
 
@@ -1630,6 +1637,7 @@ async function buildFrameworkChecks(
     mcpProbes,
     searchProbe,
     feedbackSchemaProbe,
+    openapiProbe,
   ] = await Promise.all([
     Promise.all(view.llmsFullRoutes.map((route) => probeTextRoute(frameworkBaseUrl, route))),
     view.sitemapEnabled
@@ -1654,6 +1662,7 @@ async function buildFrameworkChecks(
     view.capabilities.agentFeedback === false || !view.feedbackSchemaRoute
       ? Promise.resolve(undefined)
       : probeJsonRoute(frameworkBaseUrl, view.feedbackSchemaRoute),
+    view.openapiRoute ? probeJsonRoute(frameworkBaseUrl, view.openapiRoute) : Promise.resolve(undefined),
   ]);
   const htmlSurfaceProbes = await probeHtmlPageSurfaces(frameworkBaseUrl, view, sitemapProbes);
   const markdownCanonicalProbes =
@@ -1837,6 +1846,30 @@ async function buildFrameworkChecks(
         : "Expose the search endpoint through agent discovery so agents can narrow retrieval.",
     ),
   );
+
+  if (view.capabilities.openapi === true || view.capabilities.apiReference === true || view.openapiRoute) {
+    const openapiBody = asRecord(openapiProbe?.body);
+    const openapiLooksValid =
+      openapiProbe?.ok &&
+      (typeof openapiBody?.openapi === "string" || typeof openapiBody?.swagger === "string");
+    checks.push(
+      makeCheck(
+        "framework:openapi",
+        "OpenAPI schema",
+        openapiLooksValid ? "pass" : "warn",
+        openapiLooksValid ? 2 : 0,
+        2,
+        openapiLooksValid
+          ? "OpenAPI schema route returned a machine-readable OpenAPI document."
+          : openapiProbe
+            ? openapiProbe.detail
+            : "Discovery spec did not advertise an OpenAPI schema route.",
+        openapiLooksValid
+          ? undefined
+          : "When apiReference is enabled, expose /api/docs?format=openapi through agent discovery so agents can use schemas before scraping API docs.",
+      ),
+    );
+  }
 
   checks.push(
     makeCheck(

--- a/website/skill.md
+++ b/website/skill.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Use the Farming Labs docs website through agent discovery, markdown routes, search, llms.txt, and MCP.
+description: Use the Farming Labs docs website through agent discovery, markdown routes, search, llms.txt, OpenAPI schema discovery, and MCP.
 ---
 
 # Farming Labs Docs Website Skill
@@ -15,4 +15,5 @@ Use this skill when reading or implementing from the hosted Farming Labs docs we
 - On Next.js docs routes, you can also read `/docs/{slug}` with `Signature-Agent` for the same markdown.
 - Search with `/api/docs?query={query}` when the right page is unknown.
 - Use `/llms.txt` for a compact index and `/llms-full.txt` for full markdown context.
+- Use `/api/docs?format=openapi` for the machine-readable API schema when API routes matter.
 - Use `/mcp` or `/.well-known/mcp` when MCP is available.


### PR DESCRIPTION
- **feat: add OpenAPI schema discovery for agents**
- **chore: format**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAPI schema discovery for agents. When `apiReference` is enabled, docs serve an OpenAPI 3.1 document at `/api/docs?format=openapi` and advertise it in agent discovery, `llms.txt`, and the site skill.

- **New Features**
  - Serve OpenAPI JSON at `/api/docs?format=openapi` (generated from local routes or via `apiReference.specUrl`).
  - Supported in the shared docs API (Next) and `astro`, `svelte`, `nuxt`, and `tanstack-start` servers.
  - Agent discovery spec now includes `api.openapi`, `openapi.url/source/specUrl/apiReferencePath`, and sets `capabilities.apiReference`/`capabilities.openapi`.
  - `llms.txt` adds an “API Schemas” section linking to the OpenAPI route; generated `skill.md` instructs agents to fetch it before scraping API pages.
  - New utilities and exports in `@farming-labs/docs`: `DEFAULT_OPENAPI_SCHEMA_ROUTE`, `resolveApiReferenceOpenApiDiscovery`, and `isApiReferenceOpenApiRequest`.
  - Tests cover OpenAPI routing and spec wiring; docs and the agent score now check for OpenAPI discovery.

- **Migration**
  - Enable by configuring `apiReference` in `docs.config` (optionally set `specUrl` for a hosted schema). No other changes; the route and discovery updates are automatic when enabled.

<sup>Written for commit 0fc994aaaeb9c922d254a8bd0f059eaadb54dfaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

