### PR TITLE
feat: add multiple edgecase for mcp spec

### DIFF
--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDocsAgentDiscoverySpec,
+  buildDocsMcpEndpointCandidates,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
@@ -266,6 +267,50 @@ describe("agent route helpers", () => {
         new Request("https://example.com/api/docs?format=llms"),
       ),
     ).toBe(false);
+  });
+
+  it("builds MCP endpoint probes for default routes, origin fallback, and MCP subdomains", () => {
+    expect(
+      buildDocsMcpEndpointCandidates("https://docs.example.com/docs").map(
+        (candidate) => candidate.url,
+      ),
+    ).toEqual([
+      "https://docs.example.com/docs/mcp",
+      "https://docs.example.com/docs/.well-known/mcp",
+      "https://docs.example.com/mcp",
+      "https://docs.example.com/.well-known/mcp",
+      "https://example.com/mcp",
+      "https://example.com/.well-known/mcp",
+      "https://mcp.example.com/mcp",
+      "https://mcp.example.com/",
+    ]);
+
+    expect(
+      buildDocsMcpEndpointCandidates("https://example.com/docs").map((candidate) => candidate.url),
+    ).toEqual([
+      "https://example.com/docs/mcp",
+      "https://example.com/docs/.well-known/mcp",
+      "https://example.com/mcp",
+      "https://example.com/.well-known/mcp",
+      "https://mcp.example.com/mcp",
+      "https://mcp.example.com/",
+    ]);
+
+    expect(
+      buildDocsMcpEndpointCandidates("https://mcp.example.com").map((candidate) => candidate.url),
+    ).toEqual([
+      "https://mcp.example.com/mcp",
+      "https://mcp.example.com/.well-known/mcp",
+      "https://example.com/mcp",
+      "https://example.com/.well-known/mcp",
+      "https://mcp.example.com/",
+    ]);
+
+    expect(
+      buildDocsMcpEndpointCandidates("https://docs.example.co.uk").map(
+        (candidate) => candidate.url,
+      ),
+    ).toContain("https://mcp.example.co.uk/mcp");
   });
 
   it("resolves markdown route and Accept-header requests", () => {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -311,6 +311,12 @@ describe("agent route helpers", () => {
         (candidate) => candidate.url,
       ),
     ).toContain("https://mcp.example.co.uk/mcp");
+
+    const koreaCandidates = buildDocsMcpEndpointCandidates("https://docs.example.co.kr").map(
+      (candidate) => candidate.url,
+    );
+    expect(koreaCandidates).toContain("https://mcp.example.co.kr/mcp");
+    expect(koreaCandidates).not.toContain("https://mcp.co.kr/mcp");
   });
 
   it("resolves markdown route and Accept-header requests", () => {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -86,6 +86,44 @@ export const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
 const DOCS_LLMS_TXT_DIRECTIVE_LINE = "LLM index: /llms.txt";
 
+const COMMON_MULTI_PART_PUBLIC_SUFFIXES = new Set([
+  "ac.uk",
+  "co.in",
+  "co.jp",
+  "co.nz",
+  "co.uk",
+  "com.au",
+  "com.br",
+  "com.cn",
+  "com.mx",
+  "com.sg",
+  "com.tr",
+  "com.tw",
+  "gov.uk",
+  "net.au",
+  "net.br",
+  "net.cn",
+  "net.nz",
+  "org.au",
+  "org.br",
+  "org.cn",
+  "org.nz",
+  "org.uk",
+]);
+
+export interface DocsMcpEndpointCandidate {
+  baseUrl: string;
+  route: string;
+  url: string;
+  label: string;
+}
+
+export interface DocsMcpEndpointCandidateOptions {
+  includeOriginFallback?: boolean;
+  includeRootDomainFallback?: boolean;
+  includeMcpSubdomainFallback?: boolean;
+}
+
 export interface DocsAgentFeedbackResolvedConfig {
   enabled: boolean;
   route: string;
@@ -843,6 +881,121 @@ export function isDocsMcpRequest(url: URL): boolean {
     pathname === DEFAULT_MCP_PUBLIC_ROUTE ||
     pathname === DEFAULT_MCP_WELL_KNOWN_ROUTE
   );
+}
+
+export function buildDocsMcpEndpointCandidates(
+  baseUrl: string,
+  routes: readonly string[] = [DEFAULT_MCP_PUBLIC_ROUTE, DEFAULT_MCP_WELL_KNOWN_ROUTE],
+  options: DocsMcpEndpointCandidateOptions = {},
+): DocsMcpEndpointCandidate[] {
+  const includeOriginFallback = options.includeOriginFallback !== false;
+  const includeRootDomainFallback = options.includeRootDomainFallback !== false;
+  const includeMcpSubdomainFallback = options.includeMcpSubdomainFallback !== false;
+  const base = new URL(baseUrl);
+  const primaryOrigin = base.origin;
+  const seen = new Set<string>();
+  const candidates: DocsMcpEndpointCandidate[] = [];
+
+  const addCandidate = (candidateBaseUrl: string, route: string) => {
+    const resolved = resolveDocsMcpCandidateUrl(candidateBaseUrl, route);
+    if (seen.has(resolved.url)) return;
+    seen.add(resolved.url);
+    candidates.push({
+      ...resolved,
+      label: formatDocsMcpCandidateLabel(resolved.url, primaryOrigin),
+    });
+  };
+
+  for (const route of routes) {
+    addCandidate(baseUrl, route);
+  }
+
+  const originBaseUrl = primaryOrigin;
+  if (includeOriginFallback && originBaseUrl !== baseUrl.replace(/\/+$/, "")) {
+    for (const route of routes) {
+      addCandidate(originBaseUrl, route);
+    }
+  }
+
+  const rootDomainBaseUrl = toDocsRootDomainBaseUrl(base);
+  if (includeRootDomainFallback && rootDomainBaseUrl) {
+    for (const route of routes) {
+      addCandidate(rootDomainBaseUrl, route);
+    }
+  }
+
+  if (includeMcpSubdomainFallback) {
+    const mcpBaseUrl = toDocsMcpSubdomainBaseUrl(base);
+    if (mcpBaseUrl) {
+      addCandidate(mcpBaseUrl, DEFAULT_MCP_PUBLIC_ROUTE);
+      addCandidate(mcpBaseUrl, "/");
+    }
+  }
+
+  return candidates;
+}
+
+function resolveDocsMcpCandidateUrl(
+  baseUrl: string,
+  route: string,
+): { baseUrl: string; route: string; url: string } {
+  if (/^https?:\/\//i.test(route)) {
+    const parsed = new URL(route);
+    const path = `${parsed.pathname || "/"}${parsed.search}`;
+    return {
+      baseUrl: parsed.origin,
+      route: path,
+      url: parsed.toString(),
+    };
+  }
+
+  const base = new URL(baseUrl);
+  const basePath = base.pathname.replace(/\/+$/, "");
+  const routePath = route.startsWith("/") ? route : `/${route}`;
+  const parsed = new URL(`${basePath}${routePath}`, base.origin);
+
+  return {
+    baseUrl: parsed.origin,
+    route: `${parsed.pathname}${parsed.search}`,
+    url: parsed.toString(),
+  };
+}
+
+function formatDocsMcpCandidateLabel(url: string, primaryOrigin: string): string {
+  const parsed = new URL(url);
+  const path = `${parsed.pathname}${parsed.search}`;
+  return parsed.origin === primaryOrigin ? path : `${parsed.origin}${path}`;
+}
+
+function toDocsMcpSubdomainBaseUrl(base: URL): string | undefined {
+  const rootDomain = getDocsMcpRegistrableDomain(base.hostname);
+  if (!rootDomain) return undefined;
+  return `${base.protocol}//mcp.${rootDomain}${base.port ? `:${base.port}` : ""}`;
+}
+
+function toDocsRootDomainBaseUrl(base: URL): string | undefined {
+  const rootDomain = getDocsMcpRegistrableDomain(base.hostname);
+  if (!rootDomain) return undefined;
+  return `${base.protocol}//${rootDomain}${base.port ? `:${base.port}` : ""}`;
+}
+
+function getDocsMcpRegistrableDomain(hostname: string): string | undefined {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+  if (!normalized || !normalized.includes(".") || isDocsIpHostname(normalized)) return undefined;
+
+  const labels = normalized.split(".").filter(Boolean);
+  if (labels.length < 2) return undefined;
+
+  const publicSuffix = labels.slice(-2).join(".");
+  if (COMMON_MULTI_PART_PUBLIC_SUFFIXES.has(publicSuffix) && labels.length >= 3) {
+    return labels.slice(-3).join(".");
+  }
+
+  return labels.slice(-2).join(".");
+}
+
+function isDocsIpHostname(hostname: string): boolean {
+  return /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname) || hostname.includes(":");
 }
 
 export function isDocsSkillRequest(url: URL): boolean {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -86,29 +86,28 @@ export const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
 const DOCS_LLMS_TXT_DIRECTIVE_LINE = "LLM index: /llms.txt";
 
-const COMMON_MULTI_PART_PUBLIC_SUFFIXES = new Set([
-  "ac.uk",
-  "co.in",
-  "co.jp",
-  "co.nz",
-  "co.uk",
-  "com.au",
-  "com.br",
-  "com.cn",
-  "com.mx",
-  "com.sg",
-  "com.tr",
-  "com.tw",
-  "gov.uk",
-  "net.au",
-  "net.br",
-  "net.cn",
-  "net.nz",
-  "org.au",
-  "org.br",
-  "org.cn",
-  "org.nz",
-  "org.uk",
+const DOCS_MCP_SERVICE_SUBDOMAIN_LABELS = new Set([
+  "api",
+  "developer",
+  "developers",
+  "dev",
+  "docs",
+  "help",
+  "mcp",
+  "reference",
+]);
+const COMMON_SECOND_LEVEL_PUBLIC_SUFFIX_LABELS = new Set([
+  "ac",
+  "co",
+  "com",
+  "edu",
+  "go",
+  "gov",
+  "mil",
+  "ne",
+  "net",
+  "or",
+  "org",
 ]);
 
 export interface DocsMcpEndpointCandidate {
@@ -917,16 +916,16 @@ export function buildDocsMcpEndpointCandidates(
     }
   }
 
-  const rootDomainBaseUrl = toDocsRootDomainBaseUrl(base);
-  if (includeRootDomainFallback && rootDomainBaseUrl) {
-    for (const route of routes) {
-      addCandidate(rootDomainBaseUrl, route);
+  if (includeRootDomainFallback) {
+    for (const rootDomainBaseUrl of toDocsRootDomainBaseUrls(base)) {
+      for (const route of routes) {
+        addCandidate(rootDomainBaseUrl, route);
+      }
     }
   }
 
   if (includeMcpSubdomainFallback) {
-    const mcpBaseUrl = toDocsMcpSubdomainBaseUrl(base);
-    if (mcpBaseUrl) {
+    for (const mcpBaseUrl of toDocsMcpSubdomainBaseUrls(base)) {
       addCandidate(mcpBaseUrl, DEFAULT_MCP_PUBLIC_ROUTE);
       addCandidate(mcpBaseUrl, "/");
     }
@@ -967,34 +966,52 @@ function formatDocsMcpCandidateLabel(url: string, primaryOrigin: string): string
   return parsed.origin === primaryOrigin ? path : `${parsed.origin}${path}`;
 }
 
-function toDocsMcpSubdomainBaseUrl(base: URL): string | undefined {
-  const rootDomain = getDocsMcpRegistrableDomain(base.hostname);
-  if (!rootDomain) return undefined;
-  return `${base.protocol}//mcp.${rootDomain}${base.port ? `:${base.port}` : ""}`;
+function toDocsMcpSubdomainBaseUrls(base: URL): string[] {
+  return getDocsMcpRootDomainCandidates(base.hostname).map(
+    (rootDomain) => `${base.protocol}//mcp.${rootDomain}${base.port ? `:${base.port}` : ""}`,
+  );
 }
 
-function toDocsRootDomainBaseUrl(base: URL): string | undefined {
-  const rootDomain = getDocsMcpRegistrableDomain(base.hostname);
-  if (!rootDomain) return undefined;
-  return `${base.protocol}//${rootDomain}${base.port ? `:${base.port}` : ""}`;
+function toDocsRootDomainBaseUrls(base: URL): string[] {
+  return getDocsMcpRootDomainCandidates(base.hostname).map(
+    (rootDomain) => `${base.protocol}//${rootDomain}${base.port ? `:${base.port}` : ""}`,
+  );
 }
 
-function getDocsMcpRegistrableDomain(hostname: string): string | undefined {
+function getDocsMcpRootDomainCandidates(hostname: string): string[] {
   const normalized = hostname
     .toLowerCase()
     .replace(/^\[|\]$/g, "")
     .replace(/\.$/, "");
-  if (!normalized || !normalized.includes(".") || isDocsIpHostname(normalized)) return undefined;
+  if (!normalized || !normalized.includes(".") || isDocsIpHostname(normalized)) return [];
 
   const labels = normalized.split(".").filter(Boolean);
-  if (labels.length < 2) return undefined;
+  if (labels.length < 2) return [];
 
-  const publicSuffix = labels.slice(-2).join(".");
-  if (COMMON_MULTI_PART_PUBLIC_SUFFIXES.has(publicSuffix) && labels.length >= 3) {
-    return labels.slice(-3).join(".");
+  const candidates: string[] = [];
+  const addCandidate = (candidateLabels: string[]) => {
+    if (candidateLabels.length < 2) return;
+    const candidate = candidateLabels.join(".");
+    if (!candidates.includes(candidate)) candidates.push(candidate);
+  };
+
+  if (labels.length >= 3 && DOCS_MCP_SERVICE_SUBDOMAIN_LABELS.has(labels[0] ?? "")) {
+    addCandidate(labels.slice(1));
   }
 
-  return labels.slice(-2).join(".");
+  const tld = labels.at(-1) ?? "";
+  const secondLevel = labels.at(-2) ?? "";
+  const shouldPreserveSecondLevelSuffix =
+    labels.length >= 3 &&
+    tld.length === 2 &&
+    COMMON_SECOND_LEVEL_PUBLIC_SUFFIX_LABELS.has(secondLevel);
+
+  if (shouldPreserveSecondLevelSuffix) {
+    addCandidate(labels.slice(-3));
+  } else {
+    addCandidate(labels.slice(-2));
+  }
+  return candidates;
 }
 
 function isDocsIpHostname(hostname: string): boolean {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -980,7 +980,10 @@ function toDocsRootDomainBaseUrl(base: URL): string | undefined {
 }
 
 function getDocsMcpRegistrableDomain(hostname: string): string | undefined {
-  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
   if (!normalized || !normalized.includes(".") || isDocsIpHostname(normalized)) return undefined;
 
   const labels = normalized.split(".").filter(Boolean);

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_MCP_WELL_KNOWN_ROUTE,
   DEFAULT_SKILL_MD_ROUTE,
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
+  buildDocsMcpEndpointCandidates,
 } from "../agent.js";
 import { createFilesystemDocsMcpSource, resolveDocsMcpConfig } from "../server.js";
 import {
@@ -1519,6 +1520,27 @@ async function probeMcpRoute(
   }
 }
 
+async function probeMcpRouteCandidates(
+  baseUrl: string,
+  routes: string[],
+): Promise<{ labels: string[]; probes: Array<{ ok: boolean; detail: string }> }> {
+  const candidates = buildDocsMcpEndpointCandidates(baseUrl, routes);
+  const probes = await Promise.all(
+    candidates.map(async (candidate) => {
+      const probe = await probeMcpRoute(candidate.baseUrl, candidate.route);
+      return {
+        ...probe,
+        detail: `${candidate.label}: ${probe.detail}`,
+      };
+    }),
+  );
+
+  return {
+    labels: candidates.map((candidate) => candidate.label),
+    probes,
+  };
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
@@ -1560,6 +1582,25 @@ function hostedRobotsRoute(discoveryBody: unknown): { enabled: boolean; route: s
     enabled: robots?.enabled === false ? false : true,
     route: readDiscoveryRoute(robots?.route) ?? DEFAULT_ROBOTS_TXT_ROUTE,
   };
+}
+
+function hostedMcpRoutes(discoveryBody: unknown): string[] {
+  const mcp = asRecord(asRecord(discoveryBody)?.mcp);
+  const publicEndpoints = (mcp?.publicEndpoints ?? mcp?.endpoints) as unknown;
+  const declaredRoutes = Array.isArray(publicEndpoints)
+    ? publicEndpoints.filter(
+        (value): value is string => typeof value === "string" && value.startsWith("/"),
+      )
+    : [];
+
+  if (declaredRoutes.length > 0) return Array.from(new Set(declaredRoutes));
+
+  return Array.from(
+    new Set([
+      readDiscoveryRoute(mcp?.publicEndpoint) ?? DEFAULT_MCP_PUBLIC_ROUTE,
+      readDiscoveryRoute(mcp?.wellKnownEndpoint) ?? DEFAULT_MCP_WELL_KNOWN_ROUTE,
+    ]),
+  );
 }
 
 function hostedCapability(discoveryBody: unknown, key: string): boolean | undefined {
@@ -1954,22 +1995,20 @@ async function buildHostedAgentChecks(
     ),
   );
 
-  const mcp = await Promise.all([
-    probeMcpRoute(baseUrl, DEFAULT_MCP_PUBLIC_ROUTE),
-    probeMcpRoute(baseUrl, DEFAULT_MCP_WELL_KNOWN_ROUTE),
-  ]);
-  const mcpPassed = mcp.filter((result) => result.ok).length;
+  const mcp = await probeMcpRouteCandidates(baseUrl, hostedMcpRoutes(discovery.body));
+  const mcpPassed = mcp.probes.filter((result) => result.ok).length;
+  const mcpDetailProbes = mcpPassed > 0 ? mcp.probes.filter((result) => result.ok) : mcp.probes;
   checks.push(
     makeCheck(
       "hosted-mcp",
       "Hosted MCP handshake",
-      mcpPassed === mcp.length ? "pass" : mcpPassed > 0 ? "warn" : "fail",
-      mcpPassed === mcp.length ? 10 : mcpPassed > 0 ? 5 : 0,
+      mcpPassed > 0 ? "pass" : "fail",
+      mcpPassed > 0 ? 10 : 0,
       10,
-      mcp.map((result) => result.detail).join(" "),
-      mcpPassed === mcp.length
+      mcpDetailProbes.map((result) => result.detail).join(" "),
+      mcpPassed > 0
         ? undefined
-        : `Verify deployed ${DEFAULT_MCP_PUBLIC_ROUTE} and ${DEFAULT_MCP_WELL_KNOWN_ROUTE} support Streamable HTTP initialize and tools/list.`,
+        : `Verify one of ${mcp.labels.join(" or ")} supports Streamable HTTP initialize and tools/list.`,
     ),
   );
 

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -78,6 +78,7 @@ export {
   DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER,
   buildDocsAgentDiscoverySpec,
   buildDocsAgentFeedbackSchema,
+  buildDocsMcpEndpointCandidates,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
@@ -121,6 +122,8 @@ export type {
   DocsLlmsTxtResolvedMaxChars,
   DocsLlmsTxtResolvedSection,
   DocsLlmsTxtSelectedContent,
+  DocsMcpEndpointCandidate,
+  DocsMcpEndpointCandidateOptions,
   DocsOpenApiDiscoveryConfig,
   DocsOpenApiResolvedDiscoveryConfig,
 } from "./agent.js";

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -449,6 +449,8 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 - one representative `.md` page route, such as `/docs.md`
 - `/mcp`
 - `/.well-known/mcp`
+- `mcp.<your-domain>/mcp`
+- `mcp.<your-domain>/`
 
 For hosted MCP, the command performs a Streamable HTTP initialize handshake, checks for
 `mcp-session-id`, calls `tools/list`, and expects `list_pages`, `get_navigation`, `search_docs`,

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -449,8 +449,8 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 - one representative `.md` page route, such as `/docs.md`
 - `/mcp`
 - `/.well-known/mcp`
-- `mcp.<your-domain>/mcp`
-- `mcp.<your-domain>/`
+- `https://mcp.<your-domain>/mcp`
+- `https://mcp.<your-domain>/`
 
 For hosted MCP, the command performs a Streamable HTTP initialize handshake, checks for
 `mcp-session-id`, calls `tools/list`, and expects `list_pages`, `get_navigation`, `search_docs`,

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -566,6 +566,8 @@ The hosted pass probes:
 - sampled docs page HTML for `<link rel="alternate" type="text/markdown">`
 - `/mcp`
 - `/.well-known/mcp`
+- `mcp.<your-domain>/mcp`
+- `mcp.<your-domain>/`
 
 For MCP, the doctor performs a Streamable HTTP `initialize` request, reuses `mcp-session-id` when
 the server returns one, sends `tools/list`, and expects the built-in docs tools:

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -566,8 +566,8 @@ The hosted pass probes:
 - sampled docs page HTML for `<link rel="alternate" type="text/markdown">`
 - `/mcp`
 - `/.well-known/mcp`
-- `mcp.<your-domain>/mcp`
-- `mcp.<your-domain>/`
+- `https://mcp.<your-domain>/mcp`
+- `https://mcp.<your-domain>/`
 
 For MCP, the doctor performs a Streamable HTTP `initialize` request, reuses `mcp-session-id` when
 the server returns one, sends `tools/list`, and expects the built-in docs tools:

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -431,8 +431,8 @@ pnpm exec docs doctor --agent --url https://docs.example.com
 
 That hosted pass checks discovery, `llms.txt`, sitemap routes, `skill.md`, representative `.md`
 pages, canonical markdown response headers, `robots.txt`, JSON-LD structured data, markdown
-alternate head links, and MCP at `/mcp`, `/.well-known/mcp`, `mcp.<your-domain>/mcp`, or
-`mcp.<your-domain>/`.
+alternate head links, and MCP at `/mcp`, `/.well-known/mcp`,
+`https://mcp.<your-domain>/mcp`, or `https://mcp.<your-domain>/`.
 
 If you want the same public check without leaving the browser, use the hosted
 [Agent readiness score](/score) page:

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -431,7 +431,8 @@ pnpm exec docs doctor --agent --url https://docs.example.com
 
 That hosted pass checks discovery, `llms.txt`, sitemap routes, `skill.md`, representative `.md`
 pages, canonical markdown response headers, `robots.txt`, JSON-LD structured data, markdown
-alternate head links, and MCP at both `/mcp` and `/.well-known/mcp`.
+alternate head links, and MCP at `/mcp`, `/.well-known/mcp`, `mcp.<your-domain>/mcp`, or
+`mcp.<your-domain>/`.
 
 If you want the same public check without leaving the browser, use the hosted
 [Agent readiness score](/score) page:
@@ -445,7 +446,7 @@ framework probes when the site exposes `/.well-known/agent.json`. The public sco
 strict `.md` route probe that samples docs page routes and verifies that appending `.md` returns
 markdown, so `llms.txt` markdown mirrors do not hide missing `/docs/foo.md` routes. The
 framework probes cover the discovery spec, full-context files, sitemap routes, `robots.txt`,
-`skill.md`, MCP, search, feedback, JSON-LD structured data on sampled pages, canonical `Link`
+`skill.md`, same-domain or MCP-subdomain MCP, search, feedback, JSON-LD structured data on sampled pages, canonical `Link`
 headers on markdown responses, and the `<link rel="alternate" type="text/markdown">` head links
 that point agents to each page's `.md` route. Existing leaderboard entries hydrate from the saved
 report, so a shared score URL can be reviewed without triggering a new calculation unless no saved

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -829,6 +829,11 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
   const feedbackRoot = asRecord(root.feedback);
   const openapiRoot = asRecord(root.openapi);
   const apiRoot = asRecord(root.api);
+  const openapiRouteFromSpec = readDiscoveryRoute(openapiRoot?.url);
+  const openapiEnabled =
+    openapiRoot?.enabled === false
+      ? false
+      : cap.openapi === true || cap.apiReference === true || Boolean(openapiRouteFromSpec);
 
   return {
     available: true,
@@ -844,7 +849,12 @@ function buildDiscoveryView(body: unknown): DiscoveryView {
     markdownRoute,
     searchEndpoint: readDiscoveryRoute(searchRoot?.endpoint),
     feedbackSchemaRoute: readDiscoveryRoute(feedbackRoot?.schema),
-    openapiRoute: readDiscoveryRoute(openapiRoot?.url) ?? readDiscoveryRoute(apiRoot?.openapi),
+    openapiRoute: openapiEnabled
+      ? (openapiRouteFromSpec ??
+        (cap.openapi === true || cap.apiReference === true
+          ? readDiscoveryRoute(apiRoot?.openapi)
+          : undefined))
+      : undefined,
   };
 }
 

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_SKILL_MD_ROUTE,
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
   analyzeDocsRobotsTxt,
+  buildDocsMcpEndpointCandidates,
 } from "@farming-labs/docs";
 
 // Kept in sync with @modelcontextprotocol/sdk; the deployed MCP server
@@ -569,29 +570,9 @@ async function probeMcpRouteCandidates(
   routes: string[],
   options: { includeOriginFallback?: boolean } = {},
 ): Promise<McpProbeResult> {
-  const bases = [baseUrl];
-  const origin = originBaseUrl(baseUrl);
-  if (options.includeOriginFallback !== false && origin !== baseUrl) {
-    bases.push(origin);
-  }
-
-  const seen = new Set<string>();
-  const candidates: Array<{ baseUrl: string; route: string; url: string; label: string }> = [];
-
-  for (const candidateBaseUrl of bases) {
-    for (const route of routes) {
-      const url = joinUrl(candidateBaseUrl, route);
-      if (seen.has(url)) continue;
-      seen.add(url);
-      const parsed = new URL(url);
-      candidates.push({
-        baseUrl: candidateBaseUrl,
-        route,
-        url,
-        label: parsed.origin === origin ? parsed.pathname : `${parsed.origin}${parsed.pathname}`,
-      });
-    }
-  }
+  const candidates = buildDocsMcpEndpointCandidates(baseUrl, routes, {
+    includeOriginFallback: options.includeOriginFallback,
+  });
 
   const probes = await Promise.all(
     candidates.map(async (candidate) => {
@@ -1590,13 +1571,14 @@ function buildMcpReadinessCheck(result: McpProbeResult): AgentScoreCheck {
   }
 
   const passed = result.probes.filter((probe) => probe.ok).length;
+  const detailProbes = passed > 0 ? result.probes.filter((probe) => probe.ok) : result.probes;
   return makeCheck(
     "framework:mcp",
     "MCP handshake",
     passed > 0 ? "pass" : "fail",
     passed > 0 ? 6 : 0,
     6,
-    result.probes.map((probe) => probe.detail).join(" "),
+    detailProbes.map((probe) => probe.detail).join(" "),
     passed > 0
       ? undefined
       : `Verify ${result.labels.join(" and ")} support MCP initialize and tools/list.`,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds robust MCP endpoint discovery with origin, root-domain, and `mcp.` subdomain fallbacks (handles multi-part public suffixes). Updates `docs doctor` and the score page to pass when any MCP endpoint works and show clearer, targeted probe details.

- **New Features**
  - Added `buildDocsMcpEndpointCandidates()` with origin, root-domain, and `mcp.` subdomain fallbacks; supports domains like `example.co.uk` and `example.co.kr`.
  - Exported `buildDocsMcpEndpointCandidates`, `DocsMcpEndpointCandidate`, and `DocsMcpEndpointCandidateOptions`.
  - `docs doctor --agent` now probes declared `mcp.publicEndpoints` (or `mcp.endpoints`) from discovery or defaults, plus `mcp.<domain>/mcp` and `mcp.<domain>/`.
  - Docs updated to list the new MCP probe targets; tests added for candidate generation.

- **Refactors**
  - Hosted MCP check now passes if any candidate succeeds and shows only successful probe details; otherwise shows all with a targeted action listing candidate labels.
  - Agent score page uses `buildDocsMcpEndpointCandidates()` and the same pass-if-any logic for MCP readiness.
  - OpenAPI route display on the score page respects `discovery.openapi.enabled` and capabilities; only shows a route when enabled or required.

<sup>Written for commit 68adb93af8edf2b6f6b32d3df1aa734ddc312636. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

