### PR TITLE
fix: flag compacted on with base cmd

### DIFF
--- a/packages/fumadocs/src/code-block-spacing.tsx
+++ b/packages/fumadocs/src/code-block-spacing.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+type PreProps = React.ComponentPropsWithoutRef<"pre">;
+
+const leadingWhitespacePattern = /^[\t ]+/;
+
+function whitespaceColumnCount(value: string): number {
+  let columns = 0;
+  for (const char of value) {
+    columns += char === "\t" ? 4 : 1;
+  }
+  return columns;
+}
+
+function splitLeadingWhitespace(value: string, key: string): React.ReactNode {
+  const match = value.match(leadingWhitespacePattern);
+  if (!match) return value;
+
+  const leadingWhitespace = match[0] ?? "";
+  const rest = value.slice(leadingWhitespace.length);
+  if (!rest.startsWith("--")) return value;
+
+  const isSingleWordGap = leadingWhitespace === " ";
+
+  return [
+    <span
+      key={`${key}-space`}
+      data-fd-code-space={isSingleWordGap ? "gap" : "indent"}
+      style={
+        {
+          "--fd-code-space-count": whitespaceColumnCount(leadingWhitespace),
+        } as React.CSSProperties
+      }
+    >
+      {leadingWhitespace}
+    </span>,
+    rest,
+  ];
+}
+
+function normalizeNode(node: React.ReactNode, key: string): React.ReactNode {
+  if (typeof node === "string") {
+    return splitLeadingWhitespace(node, key);
+  }
+
+  if (!React.isValidElement(node)) {
+    return node;
+  }
+
+  const props = node.props as { children?: React.ReactNode };
+  if (props.children === undefined) {
+    return node;
+  }
+
+  return React.cloneElement(
+    node as React.ReactElement<{ children?: React.ReactNode }>,
+    undefined,
+    React.Children.map(props.children, (child, index) => normalizeNode(child, `${key}-${index}`)),
+  );
+}
+
+function normalizeCodeSpacing(children: React.ReactNode): React.ReactNode {
+  return React.Children.map(children, (child, index) => normalizeNode(child, `${index}`));
+}
+
+export function createPreWithCodeSpacing(
+  DefaultPre: React.ComponentType<PreProps> | "pre",
+): React.ComponentType<PreProps> {
+  return function PreWithCodeSpacing(props: PreProps) {
+    const normalizedChildren = normalizeCodeSpacing(props.children);
+
+    if (typeof DefaultPre === "string") {
+      return <pre {...props}>{normalizedChildren}</pre>;
+    }
+
+    const Pre = DefaultPre;
+    return <Pre {...props}>{normalizedChildren}</Pre>;
+  };
+}

--- a/packages/fumadocs/src/mdx.test.ts
+++ b/packages/fumadocs/src/mdx.test.ts
@@ -121,4 +121,34 @@ describe("getMDXComponents", () => {
 
     expect(html).toContain("Open in Internal");
   });
+
+  it("renders leading Shiki flag spaces as explicit code spacers", () => {
+    const components = getMDXComponents({
+      pre: (props: React.ComponentPropsWithoutRef<"pre">) => React.createElement("pre", props),
+    });
+    const Pre = components.pre as React.ComponentType<React.ComponentPropsWithoutRef<"pre">>;
+
+    const html = renderToStaticMarkup(
+      React.createElement(
+        Pre,
+        null,
+        React.createElement(
+          "code",
+          null,
+          React.createElement(
+            "span",
+            { className: "line" },
+            React.createElement("span", null, "lim"),
+            React.createElement("span", null, " xcode"),
+            React.createElement("span", null, " --upload"),
+          ),
+        ),
+      ),
+    );
+
+    expect(html).toContain('data-fd-code-space="gap"');
+    expect(html).toContain("--upload");
+    expect(html).not.toContain("> --upload</span>");
+    expect(html).toContain("> xcode</span>");
+  });
 });

--- a/packages/fumadocs/src/mdx.ts
+++ b/packages/fumadocs/src/mdx.ts
@@ -21,6 +21,7 @@ import React from "react";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { MDXImg } from "./mdx-img.js";
+import { createPreWithCodeSpacing } from "./code-block-spacing.js";
 import { createPreWithCopyCallback } from "./code-block-copy-wrapper.js";
 import { HoverLink, type HoverLinkProps } from "./hover-link.js";
 import {
@@ -134,6 +135,14 @@ export function getMDXComponents<T extends Record<string, unknown> = Record<stri
   const builtIns = applyBuiltInComponentDefaults<T>(options);
   const base = { ...builtIns, ...overrides } as typeof extendedMdxComponents & T;
 
+  const DefaultPre = (base as Record<string, unknown>).pre as
+    | React.ComponentType<React.ComponentPropsWithoutRef<"pre">>
+    | "pre"
+    | undefined;
+  if (DefaultPre) {
+    (base as Record<string, unknown>).pre = createPreWithCodeSpacing(DefaultPre);
+  }
+
   if ((base as Record<string, unknown>).Prompt) {
     const DefaultPrompt = (base as Record<string, unknown>).Prompt as React.ComponentType<
       React.PropsWithChildren<PromptProps>
@@ -154,13 +163,13 @@ export function getMDXComponents<T extends Record<string, unknown> = Record<stri
   }
 
   if (options?.onCopyClick) {
-    const DefaultPre = (base as Record<string, unknown>).pre as
+    const CopyPre = (base as Record<string, unknown>).pre as
       | React.ComponentType<React.ComponentPropsWithoutRef<"pre">>
       | "pre"
       | undefined;
-    if (DefaultPre) {
+    if (CopyPre) {
       (base as Record<string, unknown>).pre = createPreWithCopyCallback(
-        DefaultPre,
+        CopyPre,
         options.onCopyClick,
       );
     }

--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -139,10 +139,36 @@ article small,
 
 figure.shiki pre {
   padding: 0.15rem 0.5rem;
+  white-space: pre;
 }
 
 figure.shiki pre > code {
+  display: block;
+  white-space: inherit;
+}
+
+/* Wrapped Shiki lines can use grid rows; unwrapped token spans need inline flow for spaces. */
+figure.shiki pre > code:has(> .line),
+figure.shiki pre > code:has(> [data-line]) {
   display: grid;
+}
+
+figure.shiki pre > code > .line,
+figure.shiki pre > code > [data-line] {
+  white-space: inherit;
+}
+
+figure.shiki [data-fd-code-space] {
+  display: inline-block;
+  white-space: pre;
+}
+
+figure.shiki [data-fd-code-space="gap"] {
+  width: var(--fd-code-token-gap, 1.75ch);
+}
+
+figure.shiki [data-fd-code-space="indent"] {
+  width: calc(var(--fd-code-space-count, 1) * 1ch);
 }
 
 figure.shiki pre > code > [data-line] {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CLI flags being glued to the base command in Shiki code blocks by converting leading spaces before `--flags` into explicit spacer elements. This keeps commands and flags visually separate and preserves wrapping.

- **Bug Fixes**
  - Added `createPreWithCodeSpacing` and applied it to the `pre` component in `getMDXComponents`.
  - Converted leading indentation or single-space gaps before `--...` tokens into spans with `data-fd-code-space` and accurate widths.
  - Updated CSS in `packages/fumadocs/styles/base.css` to support spacer rendering and correct `pre > code` white-space/layout for Shiki.
  - Added a unit test in `mdx.test.ts` to verify spacer injection and output.

<sup>Written for commit 475a7828a9dcec6e3adff99398299efefd352512. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

