### PR TITLE
feat: custom version upgrade cli

### DIFF
--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -80,6 +80,11 @@ describe("parseFlags", () => {
     expect(parseFlags(["--framework=sveltekit"]).framework).toBe("sveltekit");
   });
 
+  it("parses upgrade option: version", () => {
+    expect(parseFlags(["upgrade", "--version", "0.1.104"]).version).toBe("0.1.104");
+    expect(parseFlags(["upgrade", "--version=0.1.104-beta.1"]).version).toBe("0.1.104-beta.1");
+  });
+
   it("returns empty object for empty argv", () => {
     expect(parseFlags([])).toEqual({});
   });

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -183,12 +183,19 @@ async function main() {
     const framework =
       (typeof flags.framework === "string" ? flags.framework : undefined) ??
       (args[1] && !args[1].startsWith("--") ? args[1] : undefined);
-    const tag = args.includes("--beta")
-      ? "beta"
-      : args.includes("--latest")
-        ? "latest"
-        : (parsedCommand.tag ?? "latest");
-    await upgrade({ framework, tag });
+    const hasVersionFlag =
+      args.includes("--version") || args.some((arg) => arg.startsWith("--version="));
+    const version =
+      typeof flags.version === "string" ? flags.version : hasVersionFlag ? "" : undefined;
+    const tag =
+      version !== undefined
+        ? undefined
+        : args.includes("--beta")
+          ? "beta"
+          : args.includes("--latest")
+            ? "latest"
+            : (parsedCommand.tag ?? "latest");
+    await upgrade({ framework, tag, version });
   } else if (parsedCommand.command === "--help" || parsedCommand.command === "-h") {
     printHelp();
   } else if (parsedCommand.command === "--version" || parsedCommand.command === "-v") {
@@ -218,7 +225,7 @@ ${pc.dim("Commands:")}
   ${pc.cyan("robots")}   Robots.txt utilities (${pc.dim("generate")} for agent access policy)
   ${pc.cyan("search")}   Search utilities (${pc.dim("sync")} for external indexes)
   ${pc.cyan("sitemap")}  Sitemap utilities (${pc.dim("generate")} for sitemap XML/Markdown data)
-  ${pc.cyan("upgrade")}  Upgrade @farming-labs/* packages to latest (auto-detect or use --framework)
+  ${pc.cyan("upgrade")}  Upgrade @farming-labs/* packages (auto-detect or use --framework)
 
 ${pc.dim("Supported frameworks:")}
   Next.js, TanStack Start, SvelteKit, Astro, Nuxt
@@ -300,6 +307,7 @@ ${pc.dim("Options for robots generate:")}
 
 ${pc.dim("Options for upgrade:")}
   ${pc.cyan("--framework <name>")}  Explicit framework (${pc.dim("next")}, ${pc.dim("tanstack-start")}, ${pc.dim("nuxt")}, ${pc.dim("sveltekit")}, ${pc.dim("astro")}); omit to auto-detect
+  ${pc.cyan("--version <version>")} Install an exact version (e.g. ${pc.dim("0.1.104")})
   ${pc.cyan("--latest")}            Install latest stable (default)
   ${pc.cyan("--beta")}             Install beta versions
   ${pc.cyan("upgrade@beta")}       Shortcut for ${pc.cyan("upgrade --beta")}

--- a/packages/docs/src/cli/upgrade.flow.test.ts
+++ b/packages/docs/src/cli/upgrade.flow.test.ts
@@ -119,6 +119,29 @@ describe("upgrade package manager selection", () => {
     );
   });
 
+  it("upgrades to an exact version when requested", async () => {
+    const utils = await import("./utils.js");
+
+    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+
+    await upgrade({ version: "0.1.104" });
+
+    expect(utils.exec).toHaveBeenCalledWith(
+      "pnpm add @farming-labs/docs@0.1.104 @farming-labs/theme@0.1.104 @farming-labs/next@0.1.104",
+      process.cwd(),
+    );
+  });
+
+  it("rejects invalid exact versions", async () => {
+    const utils = await import("./utils.js");
+
+    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+
+    await expect(upgrade({ version: "latest" })).rejects.toThrow("process.exit");
+
+    expect(utils.exec).not.toHaveBeenCalled();
+  });
+
   it("does not scaffold or rewrite docs files during upgrade", async () => {
     const utils = await import("./utils.js");
 

--- a/packages/docs/src/cli/upgrade.test.ts
+++ b/packages/docs/src/cli/upgrade.test.ts
@@ -7,6 +7,8 @@ import {
   frameworkFromPreset,
   getPackagesForFramework,
   buildUpgradeCommand,
+  resolveUpgradeTarget,
+  validateUpgradeVersion,
 } from "./upgrade.js";
 
 describe("upgrade", () => {
@@ -130,6 +132,13 @@ describe("upgrade", () => {
       expect(cmd).toContain("@farming-labs/next@beta");
     });
 
+    it("builds command with an exact version", () => {
+      const cmd = buildUpgradeCommand("nextjs", "0.1.104", "pnpm");
+      expect(cmd).toContain("@farming-labs/docs@0.1.104");
+      expect(cmd).toContain("@farming-labs/theme@0.1.104");
+      expect(cmd).toContain("@farming-labs/next@0.1.104");
+    });
+
     it("uses yarn add for yarn package manager", () => {
       const cmd = buildUpgradeCommand("nextjs", "latest", "yarn");
       expect(cmd).toContain("yarn add");
@@ -139,6 +148,21 @@ describe("upgrade", () => {
       const cmd = buildUpgradeCommand("nuxt", "latest", "npm");
       expect(cmd).toContain("npm add");
       expect(cmd).toContain("@farming-labs/nuxt@latest");
+    });
+  });
+
+  describe("resolveUpgradeTarget", () => {
+    it("uses exact version before dist-tag", () => {
+      expect(resolveUpgradeTarget({ tag: "beta", version: "0.1.104" })).toBe("0.1.104");
+    });
+
+    it("accepts prerelease exact versions", () => {
+      expect(validateUpgradeVersion("0.1.104-beta.1")).toBe("0.1.104-beta.1");
+    });
+
+    it("rejects non-version values", () => {
+      expect(() => validateUpgradeVersion("latest")).toThrow("Invalid version");
+      expect(() => validateUpgradeVersion("0.1")).toThrow("Invalid version");
     });
   });
 });

--- a/packages/docs/src/cli/upgrade.ts
+++ b/packages/docs/src/cli/upgrade.ts
@@ -1,5 +1,5 @@
 /**
- * Upgrade @farming-labs/* packages to latest.
+ * Upgrade @farming-labs/* packages to a dist-tag or exact version.
  * Detects framework from package.json by default, or use --framework (next, tanstack-start, nuxt, sveltekit, astro).
  */
 import path from "node:path";
@@ -40,31 +40,60 @@ export function getPackagesForFramework(framework: UpgradeFramework): string[] {
   return PACKAGES_BY_FRAMEWORK[framework];
 }
 
+const exactSemverPattern =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+export type UpgradeTag = "latest" | "beta";
+export type UpgradeTarget = UpgradeTag | (string & {});
+
+export function validateUpgradeVersion(version: string): string {
+  const normalized = version.trim();
+  if (!exactSemverPattern.test(normalized)) {
+    throw new Error(`Invalid version "${version}". Use an exact semver version like 0.1.104.`);
+  }
+  return normalized;
+}
+
+export function resolveUpgradeTarget(options: Pick<UpgradeOptions, "tag" | "version">): string {
+  if (options.version !== undefined) {
+    return validateUpgradeVersion(options.version);
+  }
+
+  return options.tag ?? "latest";
+}
+
 /** Build the install command for upgrade (for testing). */
 export function buildUpgradeCommand(
   framework: UpgradeFramework,
-  tag: UpgradeTag,
+  target: UpgradeTarget,
   pm: PackageManager,
 ): string {
   const packages = PACKAGES_BY_FRAMEWORK[framework];
-  const packagesWithTag = packages.map((name) => `${name}@${tag}`);
-  return `${installCommand(pm)} ${packagesWithTag.join(" ")}`;
+  const packagesWithTarget = packages.map((name) => `${name}@${target}`);
+  return `${installCommand(pm)} ${packagesWithTarget.join(" ")}`;
 }
-
-export type UpgradeTag = "latest" | "beta";
 
 export interface UpgradeOptions {
   /** Explicit framework: next, tanstack-start, nuxt, sveltekit, astro. If not set, framework is auto-detected. */
   framework?: string;
   /** npm dist-tag to install: "latest" (default) or "beta". */
   tag?: UpgradeTag;
+  /** Exact package version to install, e.g. 0.1.104. Overrides tag when provided. */
+  version?: string;
 }
 
 export async function upgrade(options: UpgradeOptions = {}) {
   const cwd = process.cwd();
-  const tag = options.tag ?? "latest";
 
   p.intro(pc.bgCyan(pc.black(" @farming-labs/docs upgrade ")));
+
+  let target: string;
+  try {
+    target = resolveUpgradeTarget(options);
+  } catch (error) {
+    p.log.error(error instanceof Error ? error.message : "Invalid upgrade version.");
+    process.exit(1);
+  }
 
   const packageJsonPath = path.join(cwd, "package.json");
   if (!fileExists(packageJsonPath)) {
@@ -123,15 +152,15 @@ export async function upgrade(options: UpgradeOptions = {}) {
     p.log.info(`Using ${pc.cyan(pm)} as package manager`);
   }
 
-  const cmd = buildUpgradeCommand(framework, tag, pm);
+  const cmd = buildUpgradeCommand(framework, target, pm);
   const packages = getPackagesForFramework(framework);
 
-  p.log.step(`Upgrading ${preset} docs packages to ${tag}...`);
+  p.log.step(`Upgrading ${preset} docs packages to ${target}...`);
   p.log.message(pc.dim(packages.join(", ")));
 
   try {
     exec(cmd, cwd);
-    p.log.success(`Packages upgraded to ${tag}.`);
+    p.log.success(`Packages upgraded to ${target}.`);
     p.outro(pc.green("Done. Run your dev server to confirm everything works."));
   } catch {
     p.log.error("Upgrade failed. Try running manually:\n  " + pc.cyan(cmd));

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, compact agent docs, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, upgrade, doctor, agent compact, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, compact agent docs, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, upgrade, doctor, agent compact, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
@@ -118,17 +118,18 @@ npx @farming-labs/docs@latest upgrade tanstack-start
 
 Valid values: `next`, `tanstack-start`, `nuxt`, `sveltekit`, `astro`.
 
-**Version channel:**
+**Version target:**
 
 ```bash
 npx @farming-labs/docs@latest upgrade              # latest stable (default)
 npx @farming-labs/docs@latest upgrade --latest     # same
 npx @farming-labs/docs@latest upgrade --beta       # beta versions
+npx @farming-labs/docs@latest upgrade --version 0.1.104
 npx @farming-labs/docs@latest upgrade@beta         # shorthand for --beta
 npx @farming-labs/docs@latest upgrade@latest       # shorthand for --latest
 ```
 
-If someone uses `pnpx @farming-labs/docs upgrade@beta`, treat it as the supported shorthand for upgrading to the latest beta dist-tag.
+Use `--version <version>` when the user needs an exact release instead of an npm dist-tag. If someone uses `pnpx @farming-labs/docs upgrade@beta`, treat it as the supported shorthand for upgrading to the latest beta dist-tag.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -762,7 +762,7 @@ The generated project gets:
 
 ## Upgrade
 
-Upgrade all `@farming-labs/*` docs packages to the latest version. Run from your project root; the CLI **auto-detects** your framework from `package.json` and upgrades the right packages for Next.js, TanStack Start, Nuxt, SvelteKit, and Astro.
+Upgrade all `@farming-labs/*` docs packages to the latest version, beta channel, or an exact version. Run from your project root; the CLI **auto-detects** your framework from `package.json` and upgrades the right packages for Next.js, TanStack Start, Nuxt, SvelteKit, and Astro.
 
 The CLI also detects your package manager from the lockfile in the current directory (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, or `package-lock.json`). If no lockfile is found, it asks which package manager you want to use instead of defaulting to npm.
 
@@ -789,7 +789,7 @@ The CLI also detects your package manager from the lockfile in the current direc
   </Tab>
 </Tabs>
 
-| Framework | Packages upgraded to `@latest` |
+| Framework | Packages upgraded |
 | --------- | ------------------------------ |
 | Next.js   | `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/next` |
 | TanStack Start | `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/tanstack-start` |
@@ -832,7 +832,7 @@ To specify the framework explicitly (e.g. in a monorepo or when auto-detect fail
 
 Valid values: `next`, `tanstack-start`, `nuxt`, `sveltekit`, `astro`.
 
-Use **`--latest`** (default) to install the latest stable release, or **`--beta`** to install beta versions:
+Use **`--latest`** (default) to install the latest stable release, **`--beta`** to install beta versions, or **`--version <version>`** to install a specific release:
 
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tab value="npm">
@@ -840,6 +840,7 @@ Use **`--latest`** (default) to install the latest stable release, or **`--beta`
     npx @farming-labs/docs upgrade              # latest stable (default)
     npx @farming-labs/docs upgrade --latest     # same
     npx @farming-labs/docs upgrade --beta       # beta versions
+    npx @farming-labs/docs upgrade --version 0.1.104
     ```
   </Tab>
   <Tab value="pnpm">
@@ -847,6 +848,7 @@ Use **`--latest`** (default) to install the latest stable release, or **`--beta`
     pnpm dlx @farming-labs/docs upgrade              # latest stable (default)
     pnpm dlx @farming-labs/docs upgrade --latest     # same
     pnpm dlx @farming-labs/docs upgrade --beta       # beta versions
+    pnpm dlx @farming-labs/docs upgrade --version 0.1.104
     ```
   </Tab>
   <Tab value="yarn">
@@ -854,6 +856,7 @@ Use **`--latest`** (default) to install the latest stable release, or **`--beta`
     yarn dlx @farming-labs/docs upgrade              # latest stable (default)
     yarn dlx @farming-labs/docs upgrade --latest     # same
     yarn dlx @farming-labs/docs upgrade --beta       # beta versions
+    yarn dlx @farming-labs/docs upgrade --version 0.1.104
     ```
   </Tab>
   <Tab value="bun">
@@ -861,6 +864,7 @@ Use **`--latest`** (default) to install the latest stable release, or **`--beta`
     bunx @farming-labs/docs upgrade              # latest stable (default)
     bunx @farming-labs/docs upgrade --latest     # same
     bunx @farming-labs/docs upgrade --beta       # beta versions
+    bunx @farming-labs/docs upgrade --version 0.1.104
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add exact version upgrades to the `@farming-labs/docs` CLI. You can now run `upgrade --version <x.y.z>` to install a specific release of `@farming-labs/*`, with version taking priority over `--latest`/`--beta`.

- New Features
  - Support `upgrade --version <version>` for exact semver (including prereleases); overrides dist-tags.
  - Validate version input with clear errors; updated CLI help, `SKILL.md`, and website docs; added tests for parsing, flow, and command building.

<sup>Written for commit 98e5e4f533f79f79ee741166e1fcb58e0409f9bd. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

