### PR TITLE
feat: downgrade cli with custom version

### DIFF
--- a/packages/docs/src/cli/downgrade.flow.test.ts
+++ b/packages/docs/src/cli/downgrade.flow.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cancelSymbol = Symbol("clack:cancel");
+
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  log: {
+    step: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+  select: vi.fn(),
+  isCancel: vi.fn((value: unknown) => value === cancelSymbol),
+}));
+
+vi.mock("./utils.js", async () => {
+  const actual = await vi.importActual<typeof import("./utils.js")>("./utils.js");
+  return {
+    ...actual,
+    detectFramework: vi.fn(),
+    detectPackageManagerFromLockfile: vi.fn(),
+    exec: vi.fn(),
+    execOutput: vi.fn(),
+    fileExists: vi.fn(),
+  };
+});
+
+import { downgrade } from "./downgrade.js";
+
+function writePackageJson(project: string, version: string) {
+  writeFileSync(
+    join(project, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        dependencies: {
+          "@farming-labs/docs": version,
+          next: "16.1.6",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
+function writeInstalledDocsPackage(project: string, version: string) {
+  const packageDir = join(project, "node_modules", "@farming-labs", "docs");
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name: "@farming-labs/docs", version }, null, 2),
+    "utf-8",
+  );
+}
+
+describe("downgrade", () => {
+  let exitMock: { mockRestore: () => void };
+  let originalCwd: string;
+  let tempProject: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempProject = mkdtempSync(join(tmpdir(), "docs-downgrade-"));
+    writePackageJson(tempProject, "0.1.105");
+    writeInstalledDocsPackage(tempProject, "0.1.105");
+    process.chdir(tempProject);
+
+    const prompts = await import("@clack/prompts");
+    const utils = await import("./utils.js");
+
+    vi.mocked(prompts.select).mockReset();
+    vi.mocked(prompts.isCancel).mockImplementation((value: unknown) => value === cancelSymbol);
+
+    vi.mocked(utils.fileExists).mockReset();
+    vi.mocked(utils.detectFramework).mockReset();
+    vi.mocked(utils.detectPackageManagerFromLockfile).mockReset();
+    vi.mocked(utils.exec).mockReset();
+    vi.mocked(utils.execOutput).mockReset();
+
+    vi.mocked(utils.fileExists).mockImplementation((filePath: string) => existsSync(filePath));
+    vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
+    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.execOutput).mockReturnValue('["0.1.103","0.1.104","0.1.105"]');
+
+    exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as () => never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempProject, { recursive: true, force: true });
+    exitMock.mockRestore();
+  });
+
+  it("downgrades to the previous published version by default", async () => {
+    const utils = await import("./utils.js");
+
+    await downgrade();
+
+    expect(utils.execOutput).toHaveBeenCalledWith(
+      "npm view @farming-labs/docs versions --json",
+      process.cwd(),
+    );
+    expect(utils.exec).toHaveBeenCalledWith(
+      "pnpm add @farming-labs/docs@0.1.104 @farming-labs/theme@0.1.104 @farming-labs/next@0.1.104",
+      process.cwd(),
+    );
+  });
+
+  it("downgrades to an exact lower version when requested", async () => {
+    const utils = await import("./utils.js");
+
+    await downgrade({ version: "0.1.103" });
+
+    expect(utils.execOutput).not.toHaveBeenCalled();
+    expect(utils.exec).toHaveBeenCalledWith(
+      "pnpm add @farming-labs/docs@0.1.103 @farming-labs/theme@0.1.103 @farming-labs/next@0.1.103",
+      process.cwd(),
+    );
+  });
+
+  it("rejects a version newer than the current version", async () => {
+    const utils = await import("./utils.js");
+
+    await expect(downgrade({ version: "0.1.106" })).rejects.toThrow("process.exit");
+
+    expect(utils.exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects the current version", async () => {
+    const utils = await import("./utils.js");
+
+    await expect(downgrade({ version: "0.1.105" })).rejects.toThrow("process.exit");
+
+    expect(utils.exec).not.toHaveBeenCalled();
+  });
+
+  it("prompts for package manager when no lockfile is found", async () => {
+    const prompts = await import("@clack/prompts");
+    const utils = await import("./utils.js");
+
+    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue(null);
+    vi.mocked(prompts.select).mockResolvedValueOnce("bun" as never);
+
+    await downgrade({ version: "0.1.104" });
+
+    expect(prompts.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("package manager"),
+      }),
+    );
+    expect(utils.exec).toHaveBeenCalledWith(
+      "bun add @farming-labs/docs@0.1.104 @farming-labs/theme@0.1.104 @farming-labs/next@0.1.104",
+      process.cwd(),
+    );
+  });
+});

--- a/packages/docs/src/cli/downgrade.test.ts
+++ b/packages/docs/src/cli/downgrade.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDowngradeCommand,
+  compareSemver,
+  getPreviousVersion,
+  parsePublishedVersions,
+} from "./downgrade.js";
+
+describe("downgrade", () => {
+  describe("compareSemver", () => {
+    it("orders patch versions", () => {
+      expect(compareSemver("0.1.103", "0.1.104")).toBeLessThan(0);
+      expect(compareSemver("0.1.105", "0.1.104")).toBeGreaterThan(0);
+      expect(compareSemver("0.1.104", "0.1.104")).toBe(0);
+    });
+
+    it("orders prerelease versions below stable versions", () => {
+      expect(compareSemver("0.1.104-beta.1", "0.1.104")).toBeLessThan(0);
+      expect(compareSemver("0.1.104-beta.2", "0.1.104-beta.1")).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getPreviousVersion", () => {
+    it("returns the highest published version below the current version", () => {
+      expect(getPreviousVersion(["0.1.102", "0.1.103", "0.1.104"], "0.1.104")).toBe(
+        "0.1.103",
+      );
+    });
+
+    it("returns null when there is no lower published version", () => {
+      expect(getPreviousVersion(["0.1.104", "0.1.105"], "0.1.104")).toBeNull();
+    });
+  });
+
+  describe("parsePublishedVersions", () => {
+    it("parses npm view JSON output", () => {
+      expect(parsePublishedVersions('["0.1.103","0.1.104"]')).toEqual(["0.1.103", "0.1.104"]);
+    });
+
+    it("drops non-version values", () => {
+      expect(parsePublishedVersions('["latest","0.1.104"]')).toEqual(["0.1.104"]);
+    });
+  });
+
+  describe("buildDowngradeCommand", () => {
+    it("builds install command with the exact downgrade version", () => {
+      const cmd = buildDowngradeCommand("nextjs", "0.1.103", "pnpm");
+
+      expect(cmd).toContain("pnpm add");
+      expect(cmd).toContain("@farming-labs/docs@0.1.103");
+      expect(cmd).toContain("@farming-labs/theme@0.1.103");
+      expect(cmd).toContain("@farming-labs/next@0.1.103");
+    });
+  });
+});

--- a/packages/docs/src/cli/downgrade.test.ts
+++ b/packages/docs/src/cli/downgrade.test.ts
@@ -22,9 +22,7 @@ describe("downgrade", () => {
 
   describe("getPreviousVersion", () => {
     it("returns the highest published version below the current version", () => {
-      expect(getPreviousVersion(["0.1.102", "0.1.103", "0.1.104"], "0.1.104")).toBe(
-        "0.1.103",
-      );
+      expect(getPreviousVersion(["0.1.102", "0.1.103", "0.1.104"], "0.1.104")).toBe("0.1.103");
     });
 
     it("returns null when there is no lower published version", () => {

--- a/packages/docs/src/cli/downgrade.ts
+++ b/packages/docs/src/cli/downgrade.ts
@@ -1,0 +1,334 @@
+/**
+ * Downgrade @farming-labs/* packages to a lower exact version.
+ * Detects framework from package.json by default, or use --framework (next, tanstack-start, nuxt, sveltekit, astro).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  type PackageManager,
+  detectFramework,
+  detectPackageManagerFromLockfile,
+  exec,
+  execOutput,
+  fileExists,
+} from "./utils.js";
+import {
+  PRESETS,
+  buildUpgradeCommand,
+  frameworkFromPreset,
+  getPackagesForFramework,
+  presetFromFramework,
+  validateUpgradeVersion,
+  type PresetName,
+  type UpgradeFramework,
+} from "./upgrade.js";
+
+export interface DowngradeOptions {
+  /** Explicit framework: next, tanstack-start, nuxt, sveltekit, astro. If not set, framework is auto-detected. */
+  framework?: string;
+  /** Exact package version to install, e.g. 0.1.104. Must be lower than the current installed version. */
+  version?: string;
+}
+
+interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+function parseSemver(version: string): ParsedSemver {
+  const normalized = validateUpgradeVersion(version).split("+", 1)[0] ?? version;
+  const prereleaseIndex = normalized.indexOf("-");
+  const core = prereleaseIndex === -1 ? normalized : normalized.slice(0, prereleaseIndex);
+  const prerelease = prereleaseIndex === -1 ? "" : normalized.slice(prereleaseIndex + 1);
+  const [major = "0", minor = "0", patch = "0"] = core.split(".");
+
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
+    prerelease: prerelease ? prerelease.split(".") : [],
+  };
+}
+
+function comparePrereleaseIdentifier(a: string, b: string): number {
+  const aNumber = /^\d+$/.test(a) ? Number.parseInt(a, 10) : null;
+  const bNumber = /^\d+$/.test(b) ? Number.parseInt(b, 10) : null;
+
+  if (aNumber !== null && bNumber !== null) return Math.sign(aNumber - bNumber);
+  if (aNumber !== null) return -1;
+  if (bNumber !== null) return 1;
+  return a.localeCompare(b);
+}
+
+export function compareSemver(a: string, b: string): number {
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (left[key] !== right[key]) return Math.sign(left[key] - right[key]);
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) return 0;
+  if (left.prerelease.length === 0) return 1;
+  if (right.prerelease.length === 0) return -1;
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index++) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+
+    const compared = comparePrereleaseIdentifier(leftPart, rightPart);
+    if (compared !== 0) return compared;
+  }
+
+  return 0;
+}
+
+function normalizeMaybeVersion(value: string): string | null {
+  try {
+    return validateUpgradeVersion(value);
+  } catch {
+    return null;
+  }
+}
+
+function extractVersionFromSpec(spec: string): string | null {
+  const exact = normalizeMaybeVersion(spec);
+  if (exact) return exact;
+
+  const rangeMatch = spec.match(/^[~^]([^~^<>=|\s]+)/);
+  if (!rangeMatch) return null;
+
+  return normalizeMaybeVersion(rangeMatch[1] ?? "");
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function packageJsonPath(cwd: string, packageName: string): string {
+  return path.join(cwd, "node_modules", ...packageName.split("/"), "package.json");
+}
+
+export function readCurrentPackageVersion(cwd: string, packageNames: string[]): string | null {
+  for (const packageName of packageNames) {
+    const installedPackageJson = readJsonFile(packageJsonPath(cwd, packageName));
+    const installedVersion =
+      typeof installedPackageJson?.version === "string"
+        ? normalizeMaybeVersion(installedPackageJson.version)
+        : null;
+    if (installedVersion) return installedVersion;
+  }
+
+  const projectPackageJson = readJsonFile(path.join(cwd, "package.json"));
+  const dependencyGroups = [
+    projectPackageJson?.dependencies,
+    projectPackageJson?.devDependencies,
+    projectPackageJson?.peerDependencies,
+  ];
+
+  for (const group of dependencyGroups) {
+    if (!group || typeof group !== "object") continue;
+
+    for (const packageName of packageNames) {
+      const spec = (group as Record<string, unknown>)[packageName];
+      if (typeof spec !== "string") continue;
+
+      const version = extractVersionFromSpec(spec);
+      if (version) return version;
+    }
+  }
+
+  return null;
+}
+
+export function parsePublishedVersions(raw: string): string[] {
+  const parsed = JSON.parse(raw) as unknown;
+  const versions = Array.isArray(parsed) ? parsed : [parsed];
+
+  return versions
+    .filter((version): version is string => typeof version === "string")
+    .map((version) => normalizeMaybeVersion(version))
+    .filter((version): version is string => version !== null);
+}
+
+export function getPreviousVersion(versions: string[], currentVersion: string): string | null {
+  const current = validateUpgradeVersion(currentVersion);
+
+  return versions
+    .filter((version) => compareSemver(version, current) < 0)
+    .sort(compareSemver)
+    .at(-1) ?? null;
+}
+
+export function fetchPublishedVersions(cwd: string): string[] {
+  return parsePublishedVersions(execOutput("npm view @farming-labs/docs versions --json", cwd));
+}
+
+export function buildDowngradeCommand(
+  framework: UpgradeFramework,
+  version: string,
+  pm: PackageManager,
+): string {
+  return buildUpgradeCommand(framework, validateUpgradeVersion(version), pm);
+}
+
+function resolveFramework(cwd: string, rawFramework?: string): {
+  framework: UpgradeFramework;
+  preset: PresetName;
+} {
+  if (rawFramework) {
+    const raw = rawFramework.toLowerCase().trim();
+    const normalized = raw === "nextjs" ? "next" : raw;
+    if (!PRESETS.includes(normalized as PresetName)) {
+      p.log.error(
+        `Invalid framework ${pc.cyan(rawFramework)}. Use one of: ${PRESETS.map((t) => pc.cyan(t)).join(", ")}`,
+      );
+      process.exit(1);
+    }
+
+    const preset = normalized as PresetName;
+    return {
+      framework: frameworkFromPreset(preset),
+      preset,
+    };
+  }
+
+  const detected = detectFramework(cwd);
+  if (!detected) {
+    p.log.error(
+      "Could not detect a supported framework (Next.js, TanStack Start, Nuxt, SvelteKit, Astro). Use " +
+        pc.cyan("--framework <next|tanstack-start|nuxt|sveltekit|astro>") +
+        " to specify.",
+    );
+    process.exit(1);
+  }
+
+  return {
+    framework: detected,
+    preset: presetFromFramework(detected),
+  };
+}
+
+async function resolvePackageManager(cwd: string): Promise<PackageManager> {
+  const detected = detectPackageManagerFromLockfile(cwd);
+  if (detected) {
+    p.log.info(`Detected ${pc.cyan(detected)} from lockfile`);
+    return detected;
+  }
+
+  const pmAnswer = await p.select({
+    message: "Which package manager do you want to use for this downgrade?",
+    options: [
+      { value: "pnpm", label: "pnpm", hint: "Use pnpm add" },
+      { value: "npm", label: "npm", hint: "Use npm add" },
+      { value: "yarn", label: "yarn", hint: "Use yarn add" },
+      { value: "bun", label: "bun", hint: "Use bun add" },
+    ] as const,
+  });
+
+  if (p.isCancel(pmAnswer)) {
+    p.outro(pc.red("Downgrade cancelled."));
+    process.exit(0);
+  }
+
+  const pm = pmAnswer as PackageManager;
+  p.log.info(`Using ${pc.cyan(pm)} as package manager`);
+  return pm;
+}
+
+export async function downgrade(options: DowngradeOptions = {}) {
+  const cwd = process.cwd();
+
+  p.intro(pc.bgCyan(pc.black(" @farming-labs/docs downgrade ")));
+
+  const projectPackageJsonPath = path.join(cwd, "package.json");
+  if (!fileExists(projectPackageJsonPath)) {
+    p.log.error("No package.json found in the current directory. Run this from your project root.");
+    process.exit(1);
+  }
+
+  const { framework, preset } = resolveFramework(cwd, options.framework);
+  const packages = getPackagesForFramework(framework);
+  const currentVersion = readCurrentPackageVersion(cwd, packages);
+
+  if (!currentVersion) {
+    p.log.error(
+      "Could not determine the current @farming-labs docs package version. Install dependencies first or use an exact package version in package.json.",
+    );
+    process.exit(1);
+  }
+
+  let targetVersion: string;
+  if (options.version !== undefined) {
+    try {
+      targetVersion = validateUpgradeVersion(options.version);
+    } catch (error) {
+      p.log.error(error instanceof Error ? error.message : "Invalid downgrade version.");
+      process.exit(1);
+    }
+
+    const comparison = compareSemver(targetVersion, currentVersion);
+    if (comparison > 0) {
+      p.log.error(
+        `Version ${pc.cyan(targetVersion)} is newer than current ${pc.cyan(currentVersion)}.`,
+      );
+      p.log.info(`Use ${pc.cyan(`docs upgrade --version ${targetVersion}`)} instead.`);
+      process.exit(1);
+    }
+
+    if (comparison === 0) {
+      p.log.error(
+        `Version ${pc.cyan(targetVersion)} is already installed. Choose a lower version to downgrade.`,
+      );
+      process.exit(1);
+    }
+  } else {
+    let publishedVersions: string[];
+    try {
+      publishedVersions = fetchPublishedVersions(cwd);
+    } catch {
+      p.log.error(
+        "Could not fetch published @farming-labs/docs versions. Pass an exact version with " +
+          pc.cyan("--version <version>") +
+          ".",
+      );
+      process.exit(1);
+    }
+
+    const previousVersion = getPreviousVersion(publishedVersions, currentVersion);
+    if (!previousVersion) {
+      p.log.error(`No published version found below current ${pc.cyan(currentVersion)}.`);
+      process.exit(1);
+    }
+
+    targetVersion = previousVersion;
+  }
+
+  const pm = await resolvePackageManager(cwd);
+  const cmd = buildDowngradeCommand(framework, targetVersion, pm);
+
+  p.log.step(
+    `Downgrading ${preset} docs packages from ${currentVersion} to ${targetVersion}...`,
+  );
+  p.log.message(pc.dim(packages.join(", ")));
+
+  try {
+    exec(cmd, cwd);
+    p.log.success(`Packages downgraded to ${targetVersion}.`);
+    p.outro(pc.green("Done. Run your dev server to confirm everything works."));
+  } catch {
+    p.log.error("Downgrade failed. Try running manually:\n  " + pc.cyan(cmd));
+    process.exit(1);
+  }
+}

--- a/packages/docs/src/cli/downgrade.ts
+++ b/packages/docs/src/cli/downgrade.ts
@@ -165,10 +165,12 @@ export function parsePublishedVersions(raw: string): string[] {
 export function getPreviousVersion(versions: string[], currentVersion: string): string | null {
   const current = validateUpgradeVersion(currentVersion);
 
-  return versions
-    .filter((version) => compareSemver(version, current) < 0)
-    .sort(compareSemver)
-    .at(-1) ?? null;
+  return (
+    versions
+      .filter((version) => compareSemver(version, current) < 0)
+      .sort(compareSemver)
+      .at(-1) ?? null
+  );
 }
 
 export function fetchPublishedVersions(cwd: string): string[] {
@@ -183,7 +185,10 @@ export function buildDowngradeCommand(
   return buildUpgradeCommand(framework, validateUpgradeVersion(version), pm);
 }
 
-function resolveFramework(cwd: string, rawFramework?: string): {
+function resolveFramework(
+  cwd: string,
+  rawFramework?: string,
+): {
   framework: UpgradeFramework;
   preset: PresetName;
 } {
@@ -318,9 +323,7 @@ export async function downgrade(options: DowngradeOptions = {}) {
   const pm = await resolvePackageManager(cwd);
   const cmd = buildDowngradeCommand(framework, targetVersion, pm);
 
-  p.log.step(
-    `Downgrading ${preset} docs packages from ${currentVersion} to ${targetVersion}...`,
-  );
+  p.log.step(`Downgrading ${preset} docs packages from ${currentVersion} to ${targetVersion}...`);
   p.log.message(pc.dim(packages.join(", ")));
 
   try {

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -178,6 +178,16 @@ async function main() {
     const { printRobotsGenerateHelp } = await import("./robots.js");
     printRobotsGenerateHelp();
     process.exit(1);
+  } else if (parsedCommand.command === "downgrade") {
+    const { downgrade } = await import("./downgrade.js");
+    const framework =
+      (typeof flags.framework === "string" ? flags.framework : undefined) ??
+      (args[1] && !args[1].startsWith("--") ? args[1] : undefined);
+    const hasVersionFlag =
+      args.includes("--version") || args.some((arg) => arg.startsWith("--version="));
+    const version =
+      typeof flags.version === "string" ? flags.version : hasVersionFlag ? "" : undefined;
+    await downgrade({ framework, version });
   } else if (parsedCommand.command === "upgrade") {
     const { upgrade } = await import("./upgrade.js");
     const framework =
@@ -226,6 +236,7 @@ ${pc.dim("Commands:")}
   ${pc.cyan("search")}   Search utilities (${pc.dim("sync")} for external indexes)
   ${pc.cyan("sitemap")}  Sitemap utilities (${pc.dim("generate")} for sitemap XML/Markdown data)
   ${pc.cyan("upgrade")}  Upgrade @farming-labs/* packages (auto-detect or use --framework)
+  ${pc.cyan("downgrade")} Downgrade @farming-labs/* packages (auto-detect or use --framework)
 
 ${pc.dim("Supported frameworks:")}
   Next.js, TanStack Start, SvelteKit, Astro, Nuxt
@@ -312,6 +323,11 @@ ${pc.dim("Options for upgrade:")}
   ${pc.cyan("--beta")}             Install beta versions
   ${pc.cyan("upgrade@beta")}       Shortcut for ${pc.cyan("upgrade --beta")}
   ${pc.cyan("upgrade@latest")}     Shortcut for ${pc.cyan("upgrade --latest")}
+
+${pc.dim("Options for downgrade:")}
+  ${pc.cyan("downgrade")}           Install the published version immediately below the current installed version
+  ${pc.cyan("--framework <name>")}  Explicit framework (${pc.dim("next")}, ${pc.dim("tanstack-start")}, ${pc.dim("nuxt")}, ${pc.dim("sveltekit")}, ${pc.dim("astro")}); omit to auto-detect
+  ${pc.cyan("--version <version>")} Install an exact lower version (e.g. ${pc.dim("0.1.103")})
 
   ${pc.cyan("-h, --help")}         Show this help message
   ${pc.cyan("-v, --version")}     Show version

--- a/packages/docs/src/cli/utils.ts
+++ b/packages/docs/src/cli/utils.ts
@@ -151,6 +151,17 @@ export function exec(command: string, cwd: string): void {
 }
 
 /**
+ * Run a shell command synchronously and return stdout.
+ */
+export function execOutput(command: string, cwd: string): string {
+  return execSync(command, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/**
  * Spawn a process and wait for a specific string in stdout,
  * then resolve with the child process (still running).
  */

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, run doctor audits, compact agent docs, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, upgrade, doctor, agent compact, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, run doctor audits, compact agent docs, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, upgrade, downgrade, doctor, agent compact, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
 
-The `@farming-labs/docs` CLI scaffolds, upgrades, audits agent and reader readiness, compacts
+The `@farming-labs/docs` CLI scaffolds, upgrades, downgrades, audits agent and reader readiness, compacts
 page-level agent docs, generates `AGENTS.md`, syncs external search indexes, generates robots.txt policy files, and can
 run the built-in MCP server for documentation projects. Use this skill when the user asks about CLI
-commands, init, upgrade, `doctor`, `agent compact`, `agents generate`, `sitemap generate`, `robots generate`, search
+commands, init, upgrade, downgrade, `doctor`, `agent compact`, `agents generate`, `sitemap generate`, `robots generate`, search
 sync, mcp, or scaffolding.
 
 ---
@@ -130,6 +130,25 @@ npx @farming-labs/docs@latest upgrade@latest       # shorthand for --latest
 ```
 
 Use `--version <version>` when the user needs an exact release instead of an npm dist-tag. If someone uses `pnpx @farming-labs/docs upgrade@beta`, treat it as the supported shorthand for upgrading to the latest beta dist-tag.
+
+## Downgrade
+
+Downgrade all `@farming-labs/*` docs packages to a lower version. Run from the **project root**. The CLI auto-detects the framework and package manager like `upgrade`.
+
+Without `--version`, `downgrade` fetches published `@farming-labs/docs` versions and installs the highest version lower than the current installed version.
+
+```bash
+npx @farming-labs/docs@latest downgrade
+pnpm dlx @farming-labs/docs@latest downgrade
+```
+
+Use `--version <version>` to choose an exact lower version:
+
+```bash
+npx @farming-labs/docs@latest downgrade --version 0.1.103
+```
+
+If the requested version is equal to or newer than the current installed version, `downgrade` stops and tells the user to use `upgrade --version <version>` for newer versions.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -871,6 +871,43 @@ Use **`--latest`** (default) to install the latest stable release, **`--beta`** 
 
 If you prefer the shorter command form, the CLI also accepts `upgrade@beta` and `upgrade@latest`. For example, `pnpx @farming-labs/docs upgrade@beta` behaves like `pnpx @farming-labs/docs upgrade --beta`.
 
+## Downgrade
+
+Use `downgrade` when you need to move the docs packages back to a lower published version. The CLI auto-detects your framework and package manager the same way `upgrade` does.
+
+Without `--version`, it installs the published version immediately below your current installed `@farming-labs/docs` version:
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tab value="npm">
+    ```bash title="terminal"
+    npx @farming-labs/docs downgrade
+    ```
+  </Tab>
+  <Tab value="pnpm">
+    ```bash title="terminal"
+    pnpm dlx @farming-labs/docs downgrade
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash title="terminal"
+    yarn dlx @farming-labs/docs downgrade
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash title="terminal"
+    bunx @farming-labs/docs downgrade
+    ```
+  </Tab>
+</Tabs>
+
+Pass `--version` to choose an exact lower version:
+
+```bash title="terminal"
+npx @farming-labs/docs downgrade --version 0.1.103
+```
+
+If the requested version is newer than the current installed version, the command stops and points you to `upgrade --version <version>` instead.
+
 ## MCP
 
 Run the built-in docs MCP server over stdio from the current project.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `downgrade` CLI command to install a lower exact version of `@farming-labs/*` packages, defaulting to the previously published version. It auto-detects framework and package manager, and blocks attempts to install the same or newer version.

- **New Features**
  - `downgrade` command for Next.js, TanStack Start, Nuxt, SvelteKit, and Astro; downgrades the framework-specific set (e.g., `@farming-labs/docs`, `@farming-labs/theme`, `@farming-labs/next`) to one exact version.
  - `--version <x.y.z>` to choose an exact lower version; otherwise picks the highest published version below the current.
  - Auto-detects package manager from lockfile; prompts when none is found.
  - Clear errors and guidance when the requested version is equal/newer than the current version.
  - Added `execOutput` utility, CLI wiring/help text, unit/flow tests, and docs updates (`SKILL.md`, website CLI page).

<sup>Written for commit 4e0dce7f06b32c92ad05df077ca500d8e11fce4a. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

