### PR TITLE
feat: brand backed prompt bootstraping

### DIFF
--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -546,7 +546,7 @@ figure.shiki:has(figcaption) figcaption {
 }
 
 .fd-prompt-description {
-  margin: 0.25rem 0 0;
+  margin: -0.05rem 0 0;
   color: var(--color-fd-muted-foreground);
   font-size: 0.875rem;
   line-height: 1.55;

--- a/packages/nuxt-theme/styles/docs.css
+++ b/packages/nuxt-theme/styles/docs.css
@@ -1059,7 +1059,7 @@ samp {
 }
 
 .fd-prompt-description {
-  margin: 0.25rem 0 0;
+  margin: -0.05rem 0 0;
   color: var(--color-fd-muted-foreground);
   font-size: 0.875rem;
   line-height: 1.55;

--- a/skills/farming-labs/creating-themes/SKILL.md
+++ b/skills/farming-labs/creating-themes/SKILL.md
@@ -56,8 +56,9 @@ Create or update an @farming-labs/docs theme so the documentation feels visually
 
 Inputs:
 - Website URL: [WEBSITE_URL]
-- Docs route or app folder: [DOCS_LOCATION]
+- Docs entry folder: [DOCS_ENTRY]
 - Framework: [FRAMEWORK, defaults to Next.js]
+- Brandfetch brand context: [BRAND_CONTEXT]
 
 Use the @farming-labs/docs website as implementation context before coding:
 - Framework docs: https://docs.farming-labs.dev
@@ -65,13 +66,7 @@ Use the @farming-labs/docs website as implementation context before coding:
 - Components guide: https://docs.farming-labs.dev/docs/customization/components
 - CLI guide: https://docs.farming-labs.dev/docs/cli
 
-When a website URL is available, derive the brand domain from the hostname and gather brand details from Context.dev first. Example endpoint shape for `better-auth.studio`: https://www.context.dev/api/trpc/demo.brandData?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22domain%22%3A%22better-auth.studio%22%7D%7D%7D
-
-Decoded input payload: {"0":{"json":{"domain":"better-auth.studio"}}}
-
-Use Context.dev `brandData.brand` fields such as title, description, slogan, logos, backdrops, colors, socials, industries, and language as brand hints. If the response has no colors, infer colors from the logo, backdrop, and website inspection.
-
-Then inspect the existing website and extract its design system: brand colors, typography, spacing, border radius, shadows, navigation style, cards, buttons, callouts, code blocks, tables, and light/dark mode behavior.
+Use the Brandfetch brand context as brand hints, then inspect the existing website and extract its design system: brand colors, typography, spacing, border radius, shadows, navigation style, cards, buttons, callouts, code blocks, tables, and light/dark mode behavior.
 
 Then implement the docs theme:
 - choose the closest built-in theme as the base, or create a custom theme with createTheme() / extendTheme()

--- a/skills/farming-labs/creating-themes/SKILL.md
+++ b/skills/farming-labs/creating-themes/SKILL.md
@@ -57,9 +57,21 @@ Create or update an @farming-labs/docs theme so the documentation feels visually
 Inputs:
 - Website URL: [WEBSITE_URL]
 - Docs route or app folder: [DOCS_LOCATION]
-- Framework: [Next.js, TanStack Start, SvelteKit, Astro, or Nuxt]
+- Framework: [FRAMEWORK, defaults to Next.js]
 
-First inspect the existing website and extract its design system: brand colors, typography, spacing, border radius, shadows, navigation style, cards, buttons, callouts, code blocks, tables, and light/dark mode behavior.
+Use the @farming-labs/docs website as implementation context before coding:
+- Framework docs: https://docs.farming-labs.dev
+- Theme guide: https://docs.farming-labs.dev/docs/themes/creating-themes
+- Components guide: https://docs.farming-labs.dev/docs/customization/components
+- CLI guide: https://docs.farming-labs.dev/docs/cli
+
+When a website URL is available, derive the brand domain from the hostname and gather brand details from Context.dev first. Example endpoint shape for `better-auth.studio`: https://www.context.dev/api/trpc/demo.brandData?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22domain%22%3A%22better-auth.studio%22%7D%7D%7D
+
+Decoded input payload: {"0":{"json":{"domain":"better-auth.studio"}}}
+
+Use Context.dev `brandData.brand` fields such as title, description, slogan, logos, backdrops, colors, socials, industries, and language as brand hints. If the response has no colors, infer colors from the logo, backdrop, and website inspection.
+
+Then inspect the existing website and extract its design system: brand colors, typography, spacing, border radius, shadows, navigation style, cards, buttons, callouts, code blocks, tables, and light/dark mode behavior.
 
 Then implement the docs theme:
 - choose the closest built-in theme as the base, or create a custom theme with createTheme() / extendTheme()

--- a/website/.env.example
+++ b/website/.env.example
@@ -8,6 +8,9 @@
 # PostgreSQL connection for Showcase (submit & list docs built with @farming-labs/docs)
 # DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?schema=public"
 
+# Brandfetch key used by the website-matching theme prompt modal.
+# BRANDFETCH_API_KEY=...
+
 # Optional: switch docs search to Algolia for the website.
 # DOCS_SEARCH_PROVIDER=algolia
 # ALGOLIA_APP_ID=your-app-id

--- a/website/app/api/brandfetch/route.ts
+++ b/website/app/api/brandfetch/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+type BrandfetchBody = {
+  url?: string;
+};
+
+function readBodyRecord(value: unknown): BrandfetchBody {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function readDomain(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const url = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
+    return url.hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function readBrandfetchPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function readBrandfetchError(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const record = payload as Record<string, unknown>;
+
+  for (const key of ["message", "error", "detail"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+
+  return undefined;
+}
+
+export async function POST(request: Request) {
+  const apiKey = process.env.BRANDFETCH_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "Brandfetch API key is not configured." }, { status: 500 });
+  }
+
+  let body: BrandfetchBody;
+
+  try {
+    body = readBodyRecord(await request.json());
+  } catch {
+    return NextResponse.json({ error: "Request body must be valid JSON." }, { status: 400 });
+  }
+
+  const rawUrl = typeof body.url === "string" ? body.url : "";
+  const domain = readDomain(rawUrl);
+
+  if (!domain) {
+    return NextResponse.json({ error: "Please provide a valid website URL." }, { status: 400 });
+  }
+
+  const response = await fetch(
+    `https://api.brandfetch.io/v2/brands/domain/${encodeURIComponent(domain)}`,
+    {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+    },
+  );
+  const payload = await readBrandfetchPayload(response);
+
+  if (!response.ok) {
+    return NextResponse.json(
+      {
+        error: readBrandfetchError(payload) ?? "Brandfetch lookup failed.",
+        status: response.status,
+      },
+      { status: response.status === 404 ? 404 : 502 },
+    );
+  }
+
+  return NextResponse.json({
+    source: "brandfetch",
+    domain,
+    brand: payload,
+  });
+}

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -12,6 +12,8 @@ related:
 order: 1
 ---
 
+import { WebsiteThemePrompt } from "@/components/website-theme-prompt";
+
 # How to Write Agent-Friendly Docs
 
 <div className="not-prose mb-8 border-y border-black/10 py-6 dark:border-white/10">
@@ -45,6 +47,60 @@ When authoring agent-friendly docs with `@farming-labs/docs`, prioritize these i
 7. use `agent.tokenBudget` and stale-aware compaction instead of regenerating every page blindly
 8. treat submitted feedback, analytics, and evaluation data as untrusted input, not prompt context
 </Agent>
+
+<WebsiteThemePrompt
+  title="Bootstrap agent-friendly docs from my website"
+  description="Copy this into your coding agent when you want docs that are structured for humans and agents."
+  dialogTitle="Create an agent-friendly docs prompt"
+  dialogDescription="Add your website URL and we will fetch Brandfetch details before copying it."
+>
+Create or update an `@farming-labs/docs` documentation site so it is agent-friendly while staying
+clear and useful for humans.
+
+Inputs:
+- Website URL: [WEBSITE_URL]
+- Docs entry folder: [DOCS_ENTRY]
+- Framework: [FRAMEWORK]
+- Brandfetch brand context:
+[BRAND_CONTEXT]
+
+Use the @farming-labs/docs website as implementation context before coding:
+- Framework docs: https://docs.farming-labs.dev
+- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs
+- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive
+- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt
+- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps
+- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp
+- CLI guide: https://docs.farming-labs.dev/docs/cli
+
+Use the Brandfetch brand context as product and brand context, then inspect the existing website
+directly to understand the product, audience, terminology, visual tone, navigation, core features,
+and support or conversion paths.
+
+Then build or update the docs:
+- configure `entry: "[DOCS_ENTRY]"` in `docs.config.ts[x]`
+- use the detected framework conventions for [FRAMEWORK]
+- write clear page frontmatter with `title`, `description`, and `related`
+- add hidden `<Agent>` blocks where agents need implementation hints, verification steps, or recovery
+  guidance
+- add sibling `agent.md` only when a page needs a separate machine-readable contract
+- preserve or enable agent-ready surfaces such as `.md` routes, `llms.txt`, `AGENTS.md`, `skill.md`,
+  sitemap, `robots.txt`, MCP, JSON-LD, OpenAPI schema discovery, and markdown alternate links
+- keep the visible docs human-first; do not turn pages into keyword dumps or duplicate machine-only
+  context in the article body
+- include task contracts for important pages: exact files, commands, success criteria, troubleshooting,
+  and related pages
+
+Verification:
+- run the docs dev server
+- open the docs home page and at least one important task page
+- fetch a `.md` route and confirm it returns clean markdown
+- fetch `/.well-known/agent.json` or the fallback agent route when enabled
+- check `llms.txt`, sitemap, robots, MCP, and page metadata routes according to the project config
+- run `docs doctor --agent`, `docs sitemap generate --check`, and `docs robots generate --check`
+  where available
+- list the files changed and explain which agent-ready surfaces were added or improved
+</WebsiteThemePrompt>
 
 ## Start With The Human Page
 

--- a/website/app/docs/themes/creating-themes/page.mdx
+++ b/website/app/docs/themes/creating-themes/page.mdx
@@ -5,6 +5,8 @@ icon: "lightbulb"
 order: 4.95
 ---
 
+import { WebsiteThemePrompt } from "@/components/website-theme-prompt";
+
 # Creating Your Own Theme
 
 <Agent>
@@ -58,20 +60,134 @@ theme: myTheme({
 Use this prompt when you already have a product or marketing website and want the docs to feel like
 the same brand.
 
-<Prompt
-  title="Create a docs theme from my website"
-  description="Copy this into your coding agent when you want docs that match an existing site."
-  showPrompt
->
+<WebsiteThemePrompt>
 Create or update an `@farming-labs/docs` theme so the documentation feels visually consistent with
 my existing website.
 
 Inputs:
 - Website URL: [WEBSITE_URL]
 - Docs route or app folder: [DOCS_LOCATION]
-- Framework: [Next.js, TanStack Start, SvelteKit, Astro, or Nuxt]
+- Framework: [FRAMEWORK]
 
-First inspect the existing website and extract its design system:
+Use the @farming-labs/docs website as implementation context before coding:
+- Framework docs: https://docs.farming-labs.dev
+- Theme guide: https://docs.farming-labs.dev/docs/themes/creating-themes
+- Components guide: https://docs.farming-labs.dev/docs/customization/components
+- CLI guide: https://docs.farming-labs.dev/docs/cli
+
+First gather brand details from Context.dev when a website URL is available. Derive the brand domain
+from the Website URL hostname. For example, `https://better-auth.studio` uses `better-auth.studio`.
+Use this tRPC endpoint shape and replace the domain:
+
+```text
+https://www.context.dev/api/trpc/demo.brandData?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22domain%22%3A%22better-auth.studio%22%7D%7D%7D
+```
+
+Decoded input payload:
+
+```json
+{
+  "0": {
+    "json": {
+      "domain": "better-auth.studio"
+    }
+  }
+}
+```
+
+Example Context.dev response shape:
+
+```json
+[
+  {
+    "result": {
+      "data": {
+        "json": {
+          "brandData": {
+            "status": "ok",
+            "brand": {
+              "domain": "better-auth.studio",
+              "title": "Better Auth",
+              "description": "Better Auth Studio is a developer-focused platform created by kinfish.dev that provides an admin dashboard for the Better Auth authentication system. It lets administrators manage users, sessions, organizations, teams, and the underlying database through an intuitive web interface. The solution includes testing tools, utilities, and self-hosting options, with simple installation via npm (e.g., `pnpx better-auth-studio@latest start`). Better Auth Studio aims to simplify authentication management for SaaS applications, offering versioned releases and a public beta for early adopters.",
+              "slogan": "An admin dashboard for Better Auth - manage users, sessions, and more.",
+              "colors": [],
+              "logos": [
+                {
+                  "url": "https://media.brand.dev/9bb5b30e-69a4-47e3-abb0-2242bf59a8d1.svg",
+                  "mode": "light",
+                  "colors": [],
+                  "resolution": {
+                    "width": 61,
+                    "height": 20,
+                    "aspect_ratio": 3.05
+                  },
+                  "type": "logo"
+                }
+              ],
+              "backdrops": [
+                {
+                  "url": "https://media.brand.dev/49d79321-1a21-49d5-a87f-ef621e643105.jpg",
+                  "colors": [
+                    {
+                      "hex": "#535353",
+                      "name": "Black Space"
+                    },
+                    {
+                      "hex": "#444444",
+                      "name": "Goshawk Grey"
+                    }
+                  ],
+                  "resolution": {
+                    "width": 1000,
+                    "height": 507,
+                    "aspect_ratio": 1.97
+                  }
+                }
+              ],
+              "socials": [
+                {
+                  "type": "x",
+                  "url": "https://x.com/kinfisht"
+                }
+              ],
+              "is_nsfw": false,
+              "industries": {
+                "eic": [
+                  {
+                    "industry": "Technology",
+                    "subindustry": "Software (B2B)"
+                  },
+                  {
+                    "industry": "Technology",
+                    "subindustry": "Cybersecurity"
+                  },
+                  {
+                    "industry": "Technology",
+                    "subindustry": "Developer Tools & APIs"
+                  }
+                ]
+              },
+              "links": {
+                "careers": null,
+                "terms": null,
+                "contact": null,
+                "privacy": null,
+                "blog": null,
+                "pricing": null
+              },
+              "primary_language": "english"
+            },
+            "code": 200
+          }
+        }
+      }
+    }
+  }
+]
+```
+
+Use Context.dev results as brand hints, then inspect the existing website directly and extract its
+design system:
 - brand colors, accent colors, background colors, border colors, and focus states
 - typography, font families, heading scale, body size, line height, and code font
 - border radius, shadows, dividers, spacing rhythm, and card/button treatment
@@ -95,12 +211,12 @@ Verification:
 - confirm text does not overflow buttons, cards, sidebars, or code blocks
 - confirm search, sidebar navigation, code blocks, callouts, tabs, and page actions still work
 - list the files changed and explain which website design tokens were mapped into the docs theme
-</Prompt>
+</WebsiteThemePrompt>
 
-When asking an agent to use this prompt, replace the placeholders before sending it. If the website
-uses a very expressive landing page, ask for a docs interpretation of the brand instead of a literal
-copy. Documentation should feel connected to the product while staying calmer, denser, and easier to
-scan.
+The copy button asks for the website URL, defaults the docs location to `app/docs`, defaults the
+framework to `Next.js`, and fills those placeholders before copying. If the website uses a very
+expressive landing page, ask for a docs interpretation of the brand instead of a literal copy.
+Documentation should feel connected to the product while staying calmer, denser, and easier to scan.
 
 ---
 

--- a/website/app/docs/themes/creating-themes/page.mdx
+++ b/website/app/docs/themes/creating-themes/page.mdx
@@ -66,8 +66,10 @@ my existing website.
 
 Inputs:
 - Website URL: [WEBSITE_URL]
-- Docs route or app folder: [DOCS_LOCATION]
+- Docs entry folder: [DOCS_ENTRY]
 - Framework: [FRAMEWORK]
+- Brandfetch brand context:
+[BRAND_CONTEXT]
 
 Use the @farming-labs/docs website as implementation context before coding:
 - Framework docs: https://docs.farming-labs.dev
@@ -75,119 +77,8 @@ Use the @farming-labs/docs website as implementation context before coding:
 - Components guide: https://docs.farming-labs.dev/docs/customization/components
 - CLI guide: https://docs.farming-labs.dev/docs/cli
 
-First gather brand details from Context.dev when a website URL is available. Derive the brand domain
-from the Website URL hostname. For example, `https://better-auth.studio` uses `better-auth.studio`.
-Use this tRPC endpoint shape and replace the domain:
-
-```text
-https://www.context.dev/api/trpc/demo.brandData?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22domain%22%3A%22better-auth.studio%22%7D%7D%7D
-```
-
-Decoded input payload:
-
-```json
-{
-  "0": {
-    "json": {
-      "domain": "better-auth.studio"
-    }
-  }
-}
-```
-
-Example Context.dev response shape:
-
-```json
-[
-  {
-    "result": {
-      "data": {
-        "json": {
-          "brandData": {
-            "status": "ok",
-            "brand": {
-              "domain": "better-auth.studio",
-              "title": "Better Auth",
-              "description": "Better Auth Studio is a developer-focused platform created by kinfish.dev that provides an admin dashboard for the Better Auth authentication system. It lets administrators manage users, sessions, organizations, teams, and the underlying database through an intuitive web interface. The solution includes testing tools, utilities, and self-hosting options, with simple installation via npm (e.g., `pnpx better-auth-studio@latest start`). Better Auth Studio aims to simplify authentication management for SaaS applications, offering versioned releases and a public beta for early adopters.",
-              "slogan": "An admin dashboard for Better Auth - manage users, sessions, and more.",
-              "colors": [],
-              "logos": [
-                {
-                  "url": "https://media.brand.dev/9bb5b30e-69a4-47e3-abb0-2242bf59a8d1.svg",
-                  "mode": "light",
-                  "colors": [],
-                  "resolution": {
-                    "width": 61,
-                    "height": 20,
-                    "aspect_ratio": 3.05
-                  },
-                  "type": "logo"
-                }
-              ],
-              "backdrops": [
-                {
-                  "url": "https://media.brand.dev/49d79321-1a21-49d5-a87f-ef621e643105.jpg",
-                  "colors": [
-                    {
-                      "hex": "#535353",
-                      "name": "Black Space"
-                    },
-                    {
-                      "hex": "#444444",
-                      "name": "Goshawk Grey"
-                    }
-                  ],
-                  "resolution": {
-                    "width": 1000,
-                    "height": 507,
-                    "aspect_ratio": 1.97
-                  }
-                }
-              ],
-              "socials": [
-                {
-                  "type": "x",
-                  "url": "https://x.com/kinfisht"
-                }
-              ],
-              "is_nsfw": false,
-              "industries": {
-                "eic": [
-                  {
-                    "industry": "Technology",
-                    "subindustry": "Software (B2B)"
-                  },
-                  {
-                    "industry": "Technology",
-                    "subindustry": "Cybersecurity"
-                  },
-                  {
-                    "industry": "Technology",
-                    "subindustry": "Developer Tools & APIs"
-                  }
-                ]
-              },
-              "links": {
-                "careers": null,
-                "terms": null,
-                "contact": null,
-                "privacy": null,
-                "blog": null,
-                "pricing": null
-              },
-              "primary_language": "english"
-            },
-            "code": 200
-          }
-        }
-      }
-    }
-  }
-]
-```
-
-Use Context.dev results as brand hints, then inspect the existing website directly and extract its
-design system:
+Use the Brandfetch brand context as brand hints, then inspect the existing website directly and
+extract its design system:
 - brand colors, accent colors, background colors, border colors, and focus states
 - typography, font families, heading scale, body size, line height, and code font
 - border radius, shadows, dividers, spacing rhythm, and card/button treatment
@@ -213,10 +104,11 @@ Verification:
 - list the files changed and explain which website design tokens were mapped into the docs theme
 </WebsiteThemePrompt>
 
-The copy button asks for the website URL, defaults the docs location to `app/docs`, defaults the
-framework to `Next.js`, and fills those placeholders before copying. If the website uses a very
-expressive landing page, ask for a docs interpretation of the brand instead of a literal copy.
-Documentation should feel connected to the product while staying calmer, denser, and easier to scan.
+The copy button asks for the website URL, fetches Brandfetch brand details, defaults the docs entry
+folder to `docs`, defaults the framework to `Next.js`, and fills those placeholders before copying.
+If the website uses a very expressive landing page, ask for a docs interpretation of the brand
+instead of a literal copy. Documentation should feel connected to the product while staying calmer,
+denser, and easier to scan.
 
 ---
 

--- a/website/components/website-theme-prompt.tsx
+++ b/website/components/website-theme-prompt.tsx
@@ -14,8 +14,19 @@ import {
 interface WebsiteThemePromptProps {
   title?: string;
   description?: string;
+  dialogTitle?: string;
+  dialogDescription?: string;
   children?: React.ReactNode;
 }
+
+type BrandfetchRouteResponse = {
+  source?: string;
+  domain?: string;
+  brand?: unknown;
+  error?: string;
+};
+
+type SubmitState = "idle" | "bootstrapping" | "done";
 
 const FRAMEWORK_OPTIONS = ["Next.js", "TanStack Start", "SvelteKit", "Astro", "Nuxt"] as const;
 
@@ -117,39 +128,89 @@ async function copyText(text: string): Promise<boolean> {
   return fallbackCopyText(text);
 }
 
+async function fetchBrandContext(websiteUrl: string): Promise<string> {
+  const response = await fetch("/api/brandfetch", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url: websiteUrl }),
+  });
+  const result = (await response.json().catch(() => ({}))) as BrandfetchRouteResponse;
+
+  if (!response.ok) {
+    throw new Error(result.error ?? "Brandfetch lookup failed.");
+  }
+
+  return JSON.stringify(
+    {
+      source: result.source ?? "brandfetch",
+      domain: result.domain,
+      brand: result.brand,
+    },
+    null,
+    2,
+  );
+}
+
 export function WebsiteThemePrompt({
   title = "Create a docs theme from my website",
   description = "Copy this into your coding agent when you want docs that match an existing site.",
+  dialogTitle = "Create a website-matching docs prompt",
+  dialogDescription = "Add your website URL and we will fetch Brandfetch details before copying it.",
   children,
 }: WebsiteThemePromptProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [websiteUrl, setWebsiteUrl] = useState("");
-  const [docsLocation, setDocsLocation] = useState("app/docs");
+  const [docsEntry, setDocsEntry] = useState("docs");
   const [framework, setFramework] = useState<(typeof FRAMEWORK_OPTIONS)[number]>("Next.js");
+  const [submitState, setSubmitState] = useState<SubmitState>("idle");
+  const [brandError, setBrandError] = useState<string | null>(null);
   const promptSourceRef = useRef<HTMLDivElement>(null);
+  const isSubmitting = submitState !== "idle";
+  const submitLabel =
+    submitState === "bootstrapping"
+      ? "Bootstrapping..."
+      : submitState === "done"
+        ? "Done"
+        : "Copy filled prompt";
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      setBrandError(null);
+      setSubmitState("bootstrapping");
 
-      const promptText = extractPromptTextFromElement(promptSourceRef.current);
-      if (!promptText) return;
+      try {
+        const promptText = extractPromptTextFromElement(promptSourceRef.current);
+        if (!promptText) {
+          setSubmitState("idle");
+          return;
+        }
 
-      const filledPrompt = fillPromptTemplate(promptText, {
-        WEBSITE_URL: websiteUrl,
-        DOCS_LOCATION: docsLocation,
-        FRAMEWORK: framework,
-      });
-      const didCopy = await copyText(filledPrompt);
+        const brandContext = await fetchBrandContext(websiteUrl);
+        const filledPrompt = fillPromptTemplate(promptText, {
+          WEBSITE_URL: websiteUrl,
+          DOCS_ENTRY: docsEntry,
+          FRAMEWORK: framework,
+          BRAND_CONTEXT: brandContext,
+        });
+        const didCopy = await copyText(filledPrompt);
 
-      if (!didCopy) return;
+        if (!didCopy) return;
 
-      setCopied(true);
-      setOpen(false);
-      window.setTimeout(() => setCopied(false), 2000);
+        setCopied(true);
+        setSubmitState("done");
+        window.setTimeout(() => {
+          setCopied(false);
+          setSubmitState("idle");
+          setOpen(false);
+        }, 900);
+      } catch (error) {
+        setBrandError(error instanceof Error ? error.message : "Brandfetch lookup failed.");
+        setSubmitState("idle");
+      }
     },
-    [docsLocation, framework, websiteUrl],
+    [docsEntry, framework, websiteUrl],
   );
 
   return (
@@ -187,11 +248,9 @@ export function WebsiteThemePrompt({
         <DialogContent className="max-w-[30rem] rounded-none border-[var(--color-fd-border)] bg-[var(--color-fd-popover)] text-[var(--color-fd-popover-foreground)] shadow-[3px_3px_0_color-mix(in_srgb,var(--color-fd-border)_65%,transparent)] sm:rounded-none">
           <form onSubmit={handleSubmit}>
             <DialogHeader>
-              <DialogTitle className="text-[var(--color-fd-foreground)]">
-                Create a website-matching docs prompt
-              </DialogTitle>
+              <DialogTitle className="text-[var(--color-fd-foreground)]">{dialogTitle}</DialogTitle>
               <DialogDescription className="text-[var(--color-fd-muted-foreground)]">
-                Add your website URL and we will fill the prompt before copying it.
+                {dialogDescription}
               </DialogDescription>
             </DialogHeader>
 
@@ -207,17 +266,17 @@ export function WebsiteThemePrompt({
                   className={fieldControlClassName}
                 />
                 <span className="text-xs font-normal leading-5 text-[var(--color-fd-muted-foreground)]">
-                  Used to inspect the site with Context.dev and direct website review.
+                  Used to fetch logos, colors, fonts, and brand metadata from Brandfetch.
                 </span>
               </label>
 
               <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
-                Docs route or app folder
+                Docs entry folder
                 <input
                   type="text"
                   required
-                  value={docsLocation}
-                  onChange={(event) => setDocsLocation(event.target.value)}
+                  value={docsEntry}
+                  onChange={(event) => setDocsEntry(event.target.value)}
                   className={fieldControlClassName}
                 />
               </label>
@@ -245,6 +304,12 @@ export function WebsiteThemePrompt({
                   />
                 </span>
               </label>
+
+              {brandError ? (
+                <p className="border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 py-2 text-xs leading-5 text-[var(--color-fd-muted-foreground)]">
+                  {brandError}
+                </p>
+              ) : null}
             </div>
 
             <DialogFooter className="mt-5 gap-2 sm:space-x-0">
@@ -257,9 +322,11 @@ export function WebsiteThemePrompt({
               </button>
               <button
                 type="submit"
-                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-primary)] bg-[var(--color-fd-primary)] px-3 text-sm font-medium text-[var(--color-fd-primary-foreground)] transition-opacity hover:opacity-90"
+                disabled={isSubmitting}
+                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-primary)] bg-[var(--color-fd-primary)] px-3 text-sm font-medium text-[var(--color-fd-primary-foreground)] transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
               >
-                Copy filled prompt
+                {submitState === "done" ? <Check className="mr-1.5 size-3.5" /> : null}
+                {submitLabel}
               </button>
             </DialogFooter>
           </form>

--- a/website/components/website-theme-prompt.tsx
+++ b/website/components/website-theme-prompt.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import React, { useCallback, useRef, useState } from "react";
+import { Check, ChevronDown, Copy, Sparkles } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface WebsiteThemePromptProps {
+  title?: string;
+  description?: string;
+  children?: React.ReactNode;
+}
+
+const FRAMEWORK_OPTIONS = ["Next.js", "TanStack Start", "SvelteKit", "Astro", "Nuxt"] as const;
+
+const fieldControlClassName =
+  "h-10 rounded-none border border-[var(--color-fd-border)] bg-[var(--color-fd-background)] px-3 text-sm font-normal text-[var(--color-fd-foreground)] outline-none transition-colors placeholder:text-[var(--color-fd-muted-foreground)] focus:border-[var(--color-fd-primary)]";
+
+function normalizePromptText(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
+function extractPromptTextFromElement(element: HTMLElement | null): string {
+  if (!element) return "";
+
+  function inner(node: Node): string {
+    if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+    if (!(node instanceof HTMLElement)) return "";
+
+    const tagName = node.tagName.toLowerCase();
+    if (tagName === "button" || node.getAttribute("aria-hidden") === "true") return "";
+    if (tagName === "br") return "\n";
+    if (tagName === "pre") return `${node.textContent?.trim() ?? ""}\n\n`;
+
+    const childText = Array.from(node.childNodes)
+      .map((child) => inner(child))
+      .join("");
+
+    if (tagName === "li") return `- ${childText.trim()}\n`;
+    if (tagName === "p") return `${childText.trim()}\n\n`;
+    if (tagName === "ul" || tagName === "ol") return `${childText.trim()}\n`;
+    if (/^h[1-6]$/.test(tagName)) return `${childText.trim()}\n\n`;
+
+    return childText;
+  }
+
+  return normalizePromptText(inner(element));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function fillPromptTemplate(text: string, values: Record<string, string>): string {
+  let next = text;
+
+  for (const [name, rawValue] of Object.entries(values)) {
+    const value = rawValue.trim();
+    if (!value) continue;
+
+    const escaped = escapeRegExp(name);
+    next = next
+      .replace(new RegExp(`\\[${escaped}\\]`, "g"), value)
+      .replace(new RegExp(`\\{${escaped}\\}`, "g"), value);
+  }
+
+  return next;
+}
+
+async function fallbackCopyText(text: string): Promise<boolean> {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let copied = false;
+
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+
+  return copied;
+}
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    return fallbackCopyText(text);
+  }
+
+  return fallbackCopyText(text);
+}
+
+export function WebsiteThemePrompt({
+  title = "Create a docs theme from my website",
+  description = "Copy this into your coding agent when you want docs that match an existing site.",
+  children,
+}: WebsiteThemePromptProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [websiteUrl, setWebsiteUrl] = useState("");
+  const [docsLocation, setDocsLocation] = useState("app/docs");
+  const [framework, setFramework] = useState<(typeof FRAMEWORK_OPTIONS)[number]>("Next.js");
+  const promptSourceRef = useRef<HTMLDivElement>(null);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const promptText = extractPromptTextFromElement(promptSourceRef.current);
+      if (!promptText) return;
+
+      const filledPrompt = fillPromptTemplate(promptText, {
+        WEBSITE_URL: websiteUrl,
+        DOCS_LOCATION: docsLocation,
+        FRAMEWORK: framework,
+      });
+      const didCopy = await copyText(filledPrompt);
+
+      if (!didCopy) return;
+
+      setCopied(true);
+      setOpen(false);
+      window.setTimeout(() => setCopied(false), 2000);
+    },
+    [docsLocation, framework, websiteUrl],
+  );
+
+  return (
+    <>
+      <div className="fd-prompt" data-prompt-card style={{ borderRadius: 0 }}>
+        <div className="fd-prompt-header">
+          <span className="fd-prompt-icon">
+            <Sparkles size={16} />
+          </span>
+          <div className="fd-prompt-copy">
+            <p className="fd-prompt-title">{title}</p>
+            <p className="fd-prompt-description">{description}</p>
+          </div>
+        </div>
+
+        <div className="fd-prompt-actions">
+          <button
+            type="button"
+            className="fd-prompt-action-btn"
+            data-copied={copied}
+            onClick={() => setOpen(true)}
+            style={{ borderRadius: 0 }}
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            <span>{copied ? "Copied" : "Copy prompt"}</span>
+          </button>
+        </div>
+      </div>
+
+      <div ref={promptSourceRef} hidden>
+        {children}
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-[30rem] rounded-none border-[var(--color-fd-border)] bg-[var(--color-fd-popover)] text-[var(--color-fd-popover-foreground)] shadow-[3px_3px_0_color-mix(in_srgb,var(--color-fd-border)_65%,transparent)] sm:rounded-none">
+          <form onSubmit={handleSubmit}>
+            <DialogHeader>
+              <DialogTitle className="text-[var(--color-fd-foreground)]">
+                Create a website-matching docs prompt
+              </DialogTitle>
+              <DialogDescription className="text-[var(--color-fd-muted-foreground)]">
+                Add your website URL and we will fill the prompt before copying it.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="mt-5 grid gap-4">
+              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                Website URL
+                <input
+                  type="url"
+                  required
+                  placeholder="https://example.com"
+                  value={websiteUrl}
+                  onChange={(event) => setWebsiteUrl(event.target.value)}
+                  className={fieldControlClassName}
+                />
+                <span className="text-xs font-normal leading-5 text-[var(--color-fd-muted-foreground)]">
+                  Used to inspect the site with Context.dev and direct website review.
+                </span>
+              </label>
+
+              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                Docs route or app folder
+                <input
+                  type="text"
+                  required
+                  value={docsLocation}
+                  onChange={(event) => setDocsLocation(event.target.value)}
+                  className={fieldControlClassName}
+                />
+              </label>
+
+              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                Framework
+                <span className="relative">
+                  <select
+                    required
+                    value={framework}
+                    onChange={(event) =>
+                      setFramework(event.target.value as (typeof FRAMEWORK_OPTIONS)[number])
+                    }
+                    className={`${fieldControlClassName} w-full appearance-none pr-9`}
+                  >
+                    {FRAMEWORK_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown
+                    aria-hidden="true"
+                    className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-fd-muted-foreground)]"
+                  />
+                </span>
+              </label>
+            </div>
+
+            <DialogFooter className="mt-5 gap-2 sm:space-x-0">
+              <button
+                type="button"
+                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 text-sm font-medium text-[var(--color-fd-muted-foreground)] transition-colors hover:bg-[var(--color-fd-accent)] hover:text-[var(--color-fd-accent-foreground)]"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-primary)] bg-[var(--color-fd-primary)] px-3 text-sm font-medium text-[var(--color-fd-primary-foreground)] transition-opacity hover:opacity-90"
+              >
+                Copy filled prompt
+              </button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/website/components/website-theme-prompt.tsx
+++ b/website/components/website-theme-prompt.tsx
@@ -171,7 +171,7 @@ export function WebsiteThemePrompt({
     submitState === "bootstrapping"
       ? "Bootstrapping..."
       : submitState === "done"
-        ? "Done"
+        ? "Done & copied"
         : "Copy filled prompt";
 
   const handleSubmit = useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a website-backed prompt to bootstrap `@farming-labs/docs` themes and agent-friendly docs from an existing site using Brandfetch data. Also tightens prompt card spacing and fixes dialog labels.

- New Features
  - New `WebsiteThemePrompt` component: opens a dialog, collects Website URL, Docs entry folder (defaults `docs`), and Framework (defaults `Next.js`); fetches Brandfetch details; fills `[WEBSITE_URL]`, `[DOCS_ENTRY]`, `[FRAMEWORK]`, `[BRAND_CONTEXT]`; copies with clipboard fallback.
  - New `POST /api/brandfetch` route: validates URL, normalizes domain, calls Brandfetch v2, returns brand JSON; requires `BRANDFETCH_API_KEY` (added to `.env.example`).
  - Docs: Creating Themes and Agent-Friendly Docs pages embed the prompt; skill guide updated with Brandfetch context and core guide links.

- Bug Fixes
  - Clarified labels and descriptions in the `WebsiteThemePrompt` dialog.

<sup>Written for commit 7c40eac4c1ad39cbea31d3fc42062e41d6de6fd1. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

