### PR TITLE
feat: add docsPath config for root-mounted docs

### DIFF
--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -6,6 +6,7 @@ import type { DocsConfig } from "./types.js";
 export function defineDocs(config: DocsConfig): DocsConfig {
   return {
     entry: config.entry ?? "docs",
+    docsPath: config.docsPath,
     contentDir: config.contentDir,
     i18n: config.i18n,
     theme: config.theme,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2177,6 +2177,12 @@ export interface DocsAgentConfig {
 export interface DocsConfig {
   /** Entry folder for docs (e.g. "docs" → /docs) */
   entry: string;
+  /**
+   * Public route prefix for docs pages. Defaults to the `entry` path.
+   * Set to "" or "/" to serve docs from the site root while keeping the
+   * source files and generated app route under `entry`.
+   */
+  docsPath?: string;
   /** Path to the content directory. Defaults to `entry` value. */
   contentDir?: string;
   /**

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -2448,6 +2448,72 @@ The changelog now has its own dedicated route.
     expect(payload.some((result) => result.url.startsWith("/docs/changelog/"))).toBe(false);
   });
 
+  it("serves changelog markdown with the public docsPath in lookups and canonical links", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-changelog-docspath-markdown-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "changelog", "2026-04-15"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+description: "Start here"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "app", "docs", "changelog", "2026-04-15", "page.mdx"),
+      `---
+title: "OpenAPI mode is now default"
+description: "A changelog entry"
+---
+
+# OpenAPI mode is now default
+
+The changelog now has its own dedicated route.
+`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      docsPath: "learn",
+      changelog: {
+        enabled: true,
+        path: "changelogs",
+        contentDir: "changelog",
+      },
+    });
+
+    const mdRouteResponse = await GET(
+      new Request("http://localhost/learn/changelogs/2026-04-15.md"),
+    );
+    expect(mdRouteResponse.status).toBe(200);
+    expect(mdRouteResponse.headers.get("content-type")).toContain("text/markdown");
+    expect(mdRouteResponse.headers.get("link")).toBe(
+      '<http://localhost/learn/changelogs/2026-04-15>; rel="canonical"',
+    );
+    expect(await mdRouteResponse.text()).toContain(
+      "# OpenAPI mode is now default\nURL: /learn/changelogs/2026-04-15",
+    );
+
+    const acceptResponse = await GET(
+      new Request("http://localhost/learn/changelogs/2026-04-15", {
+        headers: { accept: "text/markdown" },
+      }),
+    );
+    expect(acceptResponse.status).toBe(200);
+    expect(acceptResponse.headers.get("link")).toBe(
+      '<http://localhost/learn/changelogs/2026-04-15>; rel="canonical"',
+    );
+  });
+
   it("skips changelog indexing when reading the changelog directory fails", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-changelog-search-read-failure-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -33,7 +33,6 @@ import {
   createDocsRobotsResponse,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
-  getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
   hasDocsMarkdownSignatureAgent,
   getDocsLlmsTxtMaxCharsIssue,
@@ -126,6 +125,8 @@ interface DocsAPIOptions {
   rootDir?: string;
   /** Docs entry folder (default: read from docs.config) */
   entry?: string;
+  /** Public docs route prefix. Defaults to the docs entry path. */
+  docsPath?: string;
   /** Override the docs content directory when it does not live in app/<entry>. */
   contentDir?: string;
   /** Changelog configuration. */
@@ -1300,6 +1301,7 @@ function scanDocsDir(
   entry: string,
   locale?: string,
   excludedDirs: string[] = [],
+  publicPath = `/${normalizePathSegment(entry) || "docs"}`,
 ): DocsSearchSourcePage[] {
   const indexes: Array<DocsSearchSourcePage & { relatedInput?: unknown }> = [];
 
@@ -1336,7 +1338,7 @@ function scanDocsDir(
           const rawContent = resolveAgentMdxContent(fileContent, "human");
           const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
           const content = stripMdx(rawContent);
-          const baseUrl = slugParts.length === 0 ? `/${entry}` : `/${entry}/${slugParts.join("/")}`;
+          const baseUrl = publicDocsRoute(publicPath, slugParts);
           const url = withLangInUrl(baseUrl, locale);
 
           indexes.push({
@@ -1385,6 +1387,7 @@ function scanChangelogDir(
   entryPath: string,
   changelogPath: string,
   locale?: string,
+  publicPath = `/${normalizePathSegment(entryPath) || "docs"}`,
 ): DocsSearchSourcePage[] {
   if (!fs.existsSync(changelogDir)) return [];
 
@@ -1423,7 +1426,7 @@ function scanChangelogDir(
       const rawContent = resolveAgentMdxContent(fileContent, "human");
       const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
       const content = stripMdx(rawContent);
-      const url = withLangInUrl(`/${entryPath}/${changelogPath}/${name}`, locale);
+      const url = withLangInUrl(publicDocsRoute(publicPath, [changelogPath, name]), locale);
       const tags = Array.isArray(data.tags)
         ? data.tags.filter((value): value is string => typeof value === "string")
         : undefined;
@@ -1482,6 +1485,66 @@ function normalizeRequestedMarkdownPath(entry: string, requestedPath: string): s
   return slug ? normalizeUrlPath(`${normalizedEntry}/${slug}`) : normalizedEntry;
 }
 
+function normalizePublicRequestedMarkdownPath(ctx: DocsContext, requestedPath: string): string {
+  const trimmed = requestedPath.trim().replace(/\.md$/i, "");
+  if (!trimmed) return ctx.publicPath || "/";
+
+  const normalized = normalizeUrlPath(trimmed.startsWith("/") ? trimmed : `/${trimmed}`);
+  const normalizedEntry = `/${normalizePathSegment(ctx.entryPath)}`;
+  if (normalized === normalizedEntry) return ctx.publicPath || "/";
+
+  if (normalized.startsWith(`${normalizedEntry}/`)) {
+    const suffix = normalized.slice(normalizedEntry.length + 1);
+    return publicDocsRoute(ctx.publicPath, suffix.split("/").filter(Boolean));
+  }
+
+  if (ctx.publicPath) {
+    if (normalized === ctx.publicPath || normalized.startsWith(`${ctx.publicPath}/`)) {
+      return normalized;
+    }
+  } else if (normalized === "/") {
+    return "/";
+  }
+
+  const slug = normalizePathSegment(trimmed);
+  return publicDocsRoute(ctx.publicPath, slug ? slug.split("/").filter(Boolean) : []);
+}
+
+function normalizePublicDocsSlug(ctx: DocsContext, value: string): string {
+  const pathname = normalizeUrlPath(value);
+  const normalizedEntry = `/${normalizePathSegment(ctx.entryPath)}`;
+
+  if (ctx.publicPath) {
+    if (pathname === ctx.publicPath) return "";
+    if (pathname.startsWith(`${ctx.publicPath}/`)) {
+      return normalizePathSegment(pathname.slice(ctx.publicPath.length + 1));
+    }
+  } else if (pathname === "/") {
+    return "";
+  }
+
+  if (pathname === normalizedEntry) return "";
+  if (pathname.startsWith(`${normalizedEntry}/`)) {
+    return normalizePathSegment(pathname.slice(normalizedEntry.length + 1));
+  }
+
+  return normalizePathSegment(pathname);
+}
+
+function getPublicMarkdownCanonicalLinkHeader({
+  origin,
+  ctx,
+  requestedPath,
+}: {
+  origin: string;
+  ctx: DocsContext;
+  requestedPath: string;
+}): string {
+  const canonicalUrl = new URL(normalizePublicRequestedMarkdownPath(ctx, requestedPath), origin);
+  if (ctx.locale) canonicalUrl.searchParams.set("lang", ctx.locale);
+  return `<${canonicalUrl.toString()}>; rel="canonical"`;
+}
+
 function findDocsMcpPage(
   entry: string,
   pages: DocsMcpPage[],
@@ -1527,6 +1590,14 @@ type MarkdownRequest = {
   delivery: "api_format" | "md_route" | "accept_header" | "signature_agent";
 };
 
+type DocsContext = {
+  entryPath: string;
+  publicPath: string;
+  docsDirs: string[];
+  changelogDirs: string[];
+  locale?: string;
+};
+
 function resolveMarkdownRequest(entry: string, url: URL, request: Request): MarkdownRequest | null {
   const format = url.searchParams.get("format")?.trim();
   if (format === "markdown") {
@@ -1556,6 +1627,130 @@ function resolveMarkdownRequest(entry: string, url: URL, request: Request): Mark
     const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
 
     if (pathname === normalizedEntry) {
+      return { requestedPath: "", delivery };
+    }
+
+    if (pathname.startsWith(slugPrefix)) {
+      return {
+        requestedPath: pathname.slice(slugPrefix.length),
+        delivery,
+      };
+    }
+  }
+
+  return null;
+}
+
+function normalizeDocsPublicPath(value: string | undefined, entry: string): string {
+  if (typeof value !== "string") return `/${normalizePathSegment(entry)}`;
+
+  const cleaned = value.trim();
+  if (cleaned === "" || cleaned === "/") return "";
+
+  return `/${cleaned.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function publicDocsRoute(publicPath: string, slugParts: string[] = []): string {
+  const slug = slugParts.join("/");
+  if (!slug) return publicPath || "/";
+  return publicPath ? `${publicPath}/${slug}` : `/${slug}`;
+}
+
+function toPublicDocsUrl(value: string, entry: string, publicPath: string): string {
+  const normalizedEntry = `/${normalizePathSegment(entry)}`;
+  const hashIndex = value.indexOf("#");
+  const hash = hashIndex >= 0 ? value.slice(hashIndex) : "";
+  const withoutHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+  const queryIndex = withoutHash.indexOf("?");
+  const query = queryIndex >= 0 ? withoutHash.slice(queryIndex) : "";
+  const pathname = normalizeUrlPath(
+    queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash,
+  );
+
+  if (publicPath === normalizedEntry) return value;
+  if (pathname === normalizedEntry) return `${publicPath || "/"}${query}${hash}`;
+  if (pathname.startsWith(`${normalizedEntry}/`)) {
+    const suffix = pathname.slice(normalizedEntry.length + 1);
+    const publicPathname = publicPath ? `${publicPath}/${suffix}` : `/${suffix}`;
+    return `${publicPathname}${query}${hash}`;
+  }
+
+  return value;
+}
+
+function withPublicDocsUrl<T extends { url: string }>(page: T, ctx: DocsContext): T {
+  const url = toPublicDocsUrl(page.url, ctx.entryPath, ctx.publicPath);
+  return url === page.url ? page : { ...page, url };
+}
+
+function readDocsPath(root: string): string | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = path.join(root, `docs.config.${ext}`);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      const match = content.match(/docsPath\s*:\s*["']([^"']*)["']/);
+      if (match) return match[1];
+    } catch {
+      // fall through
+    }
+  }
+
+  return undefined;
+}
+
+function resolvePublicMarkdownRequest(
+  entry: string,
+  docsPath: string,
+  url: URL,
+  request: Request,
+): MarkdownRequest | null {
+  if (docsPath === `/${normalizePathSegment(entry)}`) return null;
+
+  const pathname = normalizeUrlPath(url.pathname);
+
+  if (docsPath === "") {
+    if (pathname === `/${normalizePathSegment(entry)}.md`) {
+      return { requestedPath: "", delivery: "md_route" };
+    }
+
+    if (pathname !== "/docs.md" && pathname.endsWith(".md")) {
+      return {
+        requestedPath: pathname.slice(1, -3),
+        delivery: "md_route",
+      };
+    }
+
+    const hasSignatureAgent = hasDocsMarkdownSignatureAgent(request);
+    if (acceptsMarkdown(request) || hasSignatureAgent) {
+      const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
+      return {
+        requestedPath: pathname === "/" ? "" : pathname.slice(1),
+        delivery,
+      };
+    }
+
+    return null;
+  }
+
+  if (pathname === `${docsPath}.md`) {
+    return { requestedPath: "", delivery: "md_route" };
+  }
+
+  const slugPrefix = `${docsPath}/`;
+  if (pathname.startsWith(slugPrefix) && pathname.endsWith(".md")) {
+    return {
+      requestedPath: pathname.slice(slugPrefix.length, -3),
+      delivery: "md_route",
+    };
+  }
+
+  const hasSignatureAgent = hasDocsMarkdownSignatureAgent(request);
+  if (acceptsMarkdown(request) || hasSignatureAgent) {
+    const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
+
+    if (pathname === docsPath) {
       return { requestedPath: "", delivery };
     }
 
@@ -2759,6 +2954,7 @@ function generateLlmsTxt(
 export function createDocsAPI(options?: DocsAPIOptions) {
   const root = options?.rootDir ?? process.cwd();
   const entry = options?.entry ?? readEntry(root);
+  const docsPath = normalizeDocsPublicPath(options?.docsPath ?? readDocsPath(root), entry);
   const analytics = options?.analytics;
   const observability = options?.observability;
   const appDir = getNextAppDir(root);
@@ -2787,13 +2983,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
     defaultName: llmsConfig.siteTitle ?? "Documentation",
   });
-
-  type DocsContext = {
-    entryPath: string;
-    docsDirs: string[];
-    changelogDirs: string[];
-    locale?: string;
-  };
 
   function resolveDocsDirCandidates(locale?: string): string[] {
     const relativeCandidates = new Set<string>();
@@ -2866,6 +3055,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       const docsDirs = resolveDocsDirCandidates();
       return {
         entryPath: entry,
+        publicPath: docsPath,
         docsDirs,
         changelogDirs: resolveChangelogDirCandidates(docsDirs),
       };
@@ -2875,6 +3065,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     const docsDirs = resolveDocsDirCandidates(locale);
     return {
       entryPath: entry,
+      publicPath: docsPath,
       locale,
       docsDirs,
       changelogDirs: resolveChangelogDirCandidates(docsDirs),
@@ -2896,7 +3087,13 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     let next: DocsSearchSourcePage[] = [];
     for (const docsDir of ctx.docsDirs) {
       const excludedDirs = ctx.changelogDirs.filter((dir) => isWithinDir(dir, docsDir));
-      const docsPages = scanDocsDir(docsDir, ctx.entryPath, ctx.locale, excludedDirs);
+      const docsPages = scanDocsDir(
+        docsDir,
+        ctx.entryPath,
+        ctx.locale,
+        excludedDirs,
+        ctx.publicPath,
+      );
       if (docsPages.length === 0) continue;
 
       next = docsPages;
@@ -2905,7 +3102,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
     if (changelogConfig.enabled) {
       const changelogPages = ctx.changelogDirs.flatMap((dir) =>
-        scanChangelogDir(dir, ctx.entryPath, changelogConfig.path, ctx.locale),
+        scanChangelogDir(dir, ctx.entryPath, changelogConfig.path, ctx.locale, ctx.publicPath),
       );
       next = [...next, ...changelogPages];
     }
@@ -2932,6 +3129,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
   async function getMarkdownDocument(ctx: DocsContext, requestedPath: string) {
     const normalizedRequest = normalizeRequestedMarkdownPath(ctx.entryPath, requestedPath);
+    const normalizedPublicRequest = normalizePublicRequestedMarkdownPath(ctx, requestedPath);
     const normalizedEntry = `/${normalizePathSegment(ctx.entryPath)}`;
     const relativeSlug =
       normalizedRequest === normalizedEntry
@@ -2945,24 +3143,28 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
     for (const source of getMarkdownSources(ctx)) {
       const page = findDocsMcpPage(ctx.entryPath, await source.getPages(), requestedPath);
-      if (page) return renderMarkdownDocument(page, { llmsEnabled: llmsConfig.enabled });
+      if (page)
+        return renderMarkdownDocument(withPublicDocsUrl(page, ctx), {
+          llmsEnabled: llmsConfig.enabled,
+        });
     }
 
-    const fallbackPage = getIndexes(ctx).find(
-      (page) => normalizeUrlPath(page.url) === normalizedRequest,
-    );
+    const fallbackPage = getIndexes(ctx).find((page) => {
+      const pageUrl = normalizeUrlPath(page.url);
+      return pageUrl === normalizedRequest || pageUrl === normalizedPublicRequest;
+    });
     if (fallbackPage)
-      return renderMarkdownDocument(fallbackPage, { llmsEnabled: llmsConfig.enabled });
+      return renderMarkdownDocument(withPublicDocsUrl(fallbackPage, ctx), {
+        llmsEnabled: llmsConfig.enabled,
+      });
 
+    const requestedSlug = normalizePublicDocsSlug(ctx, normalizedPublicRequest);
     for (const page of getIndexes(ctx)) {
-      const slug = normalizePathSegment(
-        page.url.replace(/^\/+/, "").replace(`${ctx.entryPath}/`, ""),
-      );
-      const requestedSlug = normalizePathSegment(
-        requestedPath.replace(/^\/+/, "").replace(/\.md$/i, ""),
-      );
+      const slug = normalizePublicDocsSlug(ctx, page.url);
       if (slug === requestedSlug)
-        return renderMarkdownDocument(page, { llmsEnabled: llmsConfig.enabled });
+        return renderMarkdownDocument(withPublicDocsUrl(page, ctx), {
+          llmsEnabled: llmsConfig.enabled,
+        });
     }
 
     return null;
@@ -3173,16 +3375,17 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       });
       if (sitemapResponse) return sitemapResponse;
 
-      const markdownRequest = resolveMarkdownRequest(entry, url, request);
+      const markdownRequest =
+        resolveMarkdownRequest(entry, url, request) ??
+        resolvePublicMarkdownRequest(entry, docsPath, url, request);
 
       if (markdownRequest) {
         const document = await getMarkdownDocument(ctx, markdownRequest.requestedPath);
         const varyHeader = getDocsMarkdownVaryHeader(request);
-        const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
+        const canonicalLinkHeader = getPublicMarkdownCanonicalLinkHeader({
           origin: url.origin,
-          entry: ctx.entryPath,
+          ctx,
           requestedPath: markdownRequest.requestedPath,
-          locale: ctx.locale,
         });
 
         if (!document) {

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -122,6 +122,7 @@ function hasChildPages(dir: string, excludedDirs: string[]): boolean {
 
 interface DocsLocaleContext {
   entryPath: string;
+  publicPath: string;
   docsDir: string;
   locale?: string;
 }
@@ -153,6 +154,7 @@ function resolveDocsI18nConfig(i18n?: DocsI18nLike | null) {
 
 function resolveDocsLocaleContext(config: DocsConfig, locale?: string): DocsLocaleContext {
   const entryBase = config.entry ?? "docs";
+  const publicPath = normalizeDocsPublicPath(config.docsPath, entryBase);
   const i18n = resolveDocsI18nConfig(getDocsI18n(config));
   const contentDir = (config as DocsConfig & { contentDir?: string }).contentDir;
 
@@ -169,6 +171,7 @@ function resolveDocsLocaleContext(config: DocsConfig, locale?: string): DocsLoca
   if (!i18n) {
     return {
       entryPath: entryBase,
+      publicPath,
       docsDir: resolveContentDir(),
     };
   }
@@ -177,9 +180,39 @@ function resolveDocsLocaleContext(config: DocsConfig, locale?: string): DocsLoca
   const entryPath = entryBase;
   return {
     entryPath,
+    publicPath,
     locale: resolvedLocale,
     docsDir: resolveContentDir(resolvedLocale),
   };
+}
+
+function normalizeDocsPublicPath(value: string | undefined, entry: string): string {
+  if (typeof value !== "string") return `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+
+  const cleaned = value.trim();
+  if (cleaned === "" || cleaned === "/") return "";
+
+  return `/${cleaned.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function publicDocsRoute(ctx: DocsLocaleContext, slugParts: string[] = []): string {
+  const slug = slugParts.join("/");
+  if (!slug) return ctx.publicPath || "/";
+  return ctx.publicPath ? `${ctx.publicPath}/${slug}` : `/${slug}`;
+}
+
+function toPublicDocsPath(pathname: string, ctx: DocsLocaleContext): string {
+  const normalizedEntry = `/${ctx.entryPath.replace(/^\/+|\/+$/g, "")}`;
+  const normalizedPath = pathname.replace(/\/+$/, "") || "/";
+
+  if (ctx.publicPath === normalizedEntry) return normalizedPath;
+  if (normalizedPath === normalizedEntry) return ctx.publicPath || "/";
+  if (normalizedPath.startsWith(`${normalizedEntry}/`)) {
+    const suffix = normalizedPath.slice(normalizedEntry.length + 1);
+    return publicDocsRoute(ctx, suffix.split("/").filter(Boolean));
+  }
+
+  return normalizedPath;
 }
 
 function getExcludedDocsDirs(config: DocsConfig, ctx: DocsLocaleContext): string[] {
@@ -245,7 +278,7 @@ function buildChangelogTree(
   const entries = readChangelogTreeEntries(config, ctx);
   if (entries.length === 0) return null;
 
-  const url = `/${ctx.entryPath}/${changelog.path}`;
+  const url = publicDocsRoute(ctx, [changelog.path]);
   const children: PageNode[] = entries.map((entry) => ({
     type: "page",
     name: entry.title,
@@ -278,7 +311,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
       rootChildren.push({
         type: "page",
         name: (data.title as string) ?? "Documentation",
-        url: `/${ctx.entryPath}`,
+        url: publicDocsRoute(ctx),
         icon: resolveIcon(data.icon as string | undefined, icons),
       });
     }
@@ -299,7 +332,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
 
     const data = readFrontmatter(pagePath);
     const slug = [...baseSlug, name];
-    const url = `/${ctx.entryPath}/${slug.join("/")}`;
+    const url = publicDocsRoute(ctx, slug);
     const icon = resolveIcon(data.icon as string | undefined, icons);
     const displayName = (data.title as string) ?? name.replace(/-/g, " ");
     const hasChildren = hasChildPages(full, excludedDirs);
@@ -456,8 +489,7 @@ function buildLastModifiedMap(config: DocsConfig, ctx: DocsLocaleContext): Recor
 
     const pagePath = path.join(dir, "page.mdx");
     if (fs.existsSync(pagePath)) {
-      const url =
-        slugParts.length === 0 ? `/${ctx.entryPath}` : `/${ctx.entryPath}/${slugParts.join("/")}`;
+      const url = publicDocsRoute(ctx, slugParts);
       const stat = fs.statSync(pagePath);
       map[url] = formatDate(stat.mtime);
     }
@@ -492,8 +524,7 @@ function buildDescriptionMap(config: DocsConfig, ctx: DocsLocaleContext): Record
       const data = readFrontmatter(pagePath);
       const desc = data.description as string | undefined;
       if (desc) {
-        const url =
-          slugParts.length === 0 ? `/${ctx.entryPath}` : `/${ctx.entryPath}/${slugParts.join("/")}`;
+        const url = publicDocsRoute(ctx, slugParts);
         map[url] = desc;
       }
     }
@@ -534,8 +565,7 @@ function buildReadingTimeMap(
       const minutes = resolvePageReadingTime(data as PageFrontmatter, humanContent, options);
 
       if (typeof minutes === "number") {
-        const url =
-          slugParts.length === 0 ? `/${ctx.entryPath}` : `/${ctx.entryPath}/${slugParts.join("/")}`;
+        const url = publicDocsRoute(ctx, slugParts);
         map[url] = minutes;
       }
     }
@@ -573,8 +603,7 @@ function buildStructuredDataMap(
     if (pagePath) {
       const source = fs.readFileSync(pagePath, "utf-8");
       const { data } = matter(source);
-      const route =
-        slugParts.length === 0 ? `/${ctx.entryPath}` : `/${ctx.entryPath}/${slugParts.join("/")}`;
+      const route = publicDocsRoute(ctx, slugParts);
       const title =
         typeof data.title === "string"
           ? data.title
@@ -870,11 +899,14 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const docsApiUrl = withLangInUrl("/api/docs", activeLocale);
   const changelogConfig = resolveChangelogConfig(config.changelog);
   const changelogBasePath = changelogConfig.enabled
-    ? `/${localeContext.entryPath}/${changelogConfig.path}`
+    ? publicDocsRoute(localeContext, [changelogConfig.path])
     : undefined;
   // Nav title: supports string or ReactNode (component)
   const navTitle = (config.nav?.title as ReactNode) ?? "Docs";
-  const navUrl = withLangInUrl(config.nav?.url ?? `/${localeContext.entryPath}`, activeLocale);
+  const configuredNavUrl = config.nav?.url
+    ? toPublicDocsPath(config.nav.url, localeContext)
+    : publicDocsRoute(localeContext);
+  const navUrl = withLangInUrl(configuredNavUrl, activeLocale);
 
   // Theme toggle
   const themeSwitch = resolveThemeSwitch(config.themeToggle);
@@ -1104,6 +1136,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             breadcrumbEnabled={breadcrumbEnabled}
             changelogBasePath={changelogBasePath}
             entry={localeContext.entryPath}
+            publicPath={localeContext.publicPath}
             locale={activeLocale}
             copyMarkdown={copyMarkdownEnabled}
             openDocs={openDocsEnabled}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -58,6 +58,8 @@ interface DocsPageClientProps {
   changelogBasePath?: string;
   /** The docs entry folder name (e.g. "docs") — used to strip from breadcrumb */
   entry?: string;
+  /** Public docs route prefix. Empty string means docs render from the site root. */
+  publicPath?: string;
   /** Active locale (used for llms.txt links) */
   locale?: string;
   copyMarkdown?: boolean;
@@ -122,17 +124,20 @@ interface DocsPageClientProps {
  */
 function PathBreadcrumb({
   pathname,
-  entry,
+  publicPath,
   locale,
 }: {
   pathname: string;
-  entry: string;
+  publicPath: string;
   locale?: string;
 }) {
   const router = useRouter();
   const segments = pathname.split("/").filter(Boolean);
-  const entryParts = entry.split("/").filter(Boolean);
-  const contentSegments = segments.slice(entryParts.length);
+  const publicParts = publicPath.split("/").filter(Boolean);
+  const hasPublicPrefix =
+    publicParts.length > 0 &&
+    segments.slice(0, publicParts.length).join("/") === publicParts.join("/");
+  const contentSegments = hasPublicPrefix ? segments.slice(publicParts.length) : segments;
 
   if (contentSegments.length < 2) return null;
 
@@ -144,7 +149,7 @@ function PathBreadcrumb({
   const currentLabel = currentSegment.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
   const parentUrl =
-    "/" + [...segments.slice(0, entryParts.length), ...contentSegments.slice(0, -1)].join("/");
+    "/" + [...publicParts, ...contentSegments.slice(0, -1)].filter(Boolean).join("/");
   const localizedParentUrl = withLangInUrl(parentUrl, locale);
 
   return (
@@ -228,6 +233,154 @@ function localizeInternalLinks(root: ParentNode, locale?: string) {
       // Ignore malformed links and leave them untouched.
     }
   }
+}
+
+function normalizePublicDocsPath(value: string | undefined, entry: string): string {
+  if (typeof value !== "string") return `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+  const cleaned = value.trim();
+  if (cleaned === "" || cleaned === "/") return "";
+  return `/${cleaned.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function toPublicDocsPath(pathname: string, entry: string, publicPath: string): string {
+  const normalizedEntry = `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+  const normalizedPath = pathname.replace(/\/+$/, "") || "/";
+
+  if (publicPath === normalizedEntry) return normalizedPath;
+  if (normalizedPath === normalizedEntry) return publicPath || "/";
+  if (normalizedPath.startsWith(`${normalizedEntry}/`)) {
+    const suffix = normalizedPath.slice(normalizedEntry.length + 1);
+    return publicPath ? `${publicPath}/${suffix}` : `/${suffix}`;
+  }
+
+  return normalizedPath;
+}
+
+function rewriteDocsPathLinks(root: ParentNode, entry: string, publicPath: string) {
+  const anchors = root.querySelectorAll<HTMLAnchorElement>(
+    'a[href]:not([data-fd-docspath="true"])',
+  );
+
+  for (const anchor of anchors) {
+    const href = anchor.getAttribute("href");
+    if (!href || href.startsWith("#")) continue;
+    if (/^(mailto:|tel:|javascript:)/i.test(href)) continue;
+
+    try {
+      const url = new URL(href, window.location.origin);
+      if (url.origin !== window.location.origin) continue;
+
+      const nextPath = toPublicDocsPath(url.pathname, entry, publicPath);
+      if (nextPath === url.pathname) continue;
+
+      anchor.href = `${nextPath}${url.search}${url.hash}`;
+      anchor.dataset.fdDocspath = "true";
+    } catch {
+      // Ignore malformed links and leave them untouched.
+    }
+  }
+}
+
+function normalizeCurrentPath(pathname: string): string {
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+function syncDocsPathActiveLinks(root: ParentNode, entry: string, publicPath: string) {
+  const currentPath = normalizeCurrentPath(window.location.pathname);
+  const anchors = root.querySelectorAll<HTMLAnchorElement>("a[data-active][href]");
+
+  for (const anchor of anchors) {
+    const href = anchor.getAttribute("href");
+    if (!href || href.startsWith("#")) continue;
+
+    try {
+      const url = new URL(href, window.location.origin);
+      if (url.origin !== window.location.origin) continue;
+      if (!isDocsNavigationPath(url.pathname, entry, publicPath)) continue;
+
+      const publicHrefPath = normalizeCurrentPath(
+        toPublicDocsPath(url.pathname, entry, publicPath),
+      );
+      anchor.dataset.active = publicHrefPath === currentPath ? "true" : "false";
+    } catch {
+      // Ignore malformed links and leave them untouched.
+    }
+  }
+}
+
+function isFrameworkPath(pathname: string): boolean {
+  return (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/.well-known") ||
+    pathname === "/mcp" ||
+    pathname === "/llms.txt" ||
+    pathname === "/llms-full.txt" ||
+    pathname === "/robots.txt" ||
+    pathname === "/sitemap.xml" ||
+    pathname === "/sitemap.md" ||
+    pathname === "/AGENTS.md" ||
+    pathname === "/AGENT.md" ||
+    pathname === "/skill.md" ||
+    /\/[^/]+\.[^/]+$/.test(pathname)
+  );
+}
+
+function isDocsNavigationPath(pathname: string, entry: string, publicPath: string): boolean {
+  if (isFrameworkPath(pathname)) return false;
+
+  const normalizedEntry = `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+  if (pathname === normalizedEntry || pathname.startsWith(`${normalizedEntry}/`)) return true;
+
+  if (publicPath === "") return pathname.startsWith("/");
+  return pathname === publicPath || pathname.startsWith(`${publicPath}/`);
+}
+
+function installDocsPathNavigationGuard(entry: string, publicPath: string) {
+  const normalizedEntry = `/${entry.replace(/^\/+|\/+$/g, "") || "docs"}`;
+  if (publicPath === normalizedEntry) return undefined;
+
+  function onClick(event: MouseEvent) {
+    if (event.defaultPrevented) return;
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    const target = event.target instanceof Element ? event.target : null;
+    const anchor = target?.closest<HTMLAnchorElement>("a[href]");
+    if (!anchor) return;
+    if (anchor.target && anchor.target !== "_self") return;
+    if (anchor.hasAttribute("download")) return;
+
+    const href = anchor.getAttribute("href");
+    if (!href || href.startsWith("#")) return;
+    if (/^(mailto:|tel:|javascript:)/i.test(href)) return;
+
+    try {
+      const url = new URL(href, window.location.origin);
+      if (url.origin !== window.location.origin) return;
+      if (!isDocsNavigationPath(url.pathname, entry, publicPath)) return;
+
+      const nextPath = toPublicDocsPath(url.pathname, entry, publicPath);
+      if (nextPath === url.pathname) return;
+
+      const nextHref = `${nextPath}${url.search}${url.hash}`;
+
+      if (
+        nextHref === `${window.location.pathname}${window.location.search}${window.location.hash}`
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      window.location.assign(nextHref);
+    } catch {
+      // Ignore malformed links and leave them untouched.
+    }
+  }
+
+  document.addEventListener("click", onClick, true);
+  return () => document.removeEventListener("click", onClick, true);
 }
 
 function decodeHashTarget(hash: string): string {
@@ -352,6 +505,7 @@ export function DocsPageClient({
   breadcrumbEnabled = true,
   changelogBasePath,
   entry = "docs",
+  publicPath,
   locale,
   copyMarkdown = false,
   openDocs = false,
@@ -392,6 +546,7 @@ export function DocsPageClient({
   const pathname = usePathname();
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
+  const resolvedPublicPath = normalizePublicDocsPath(publicPath, entry);
   const llmsLangQuery = activeLocale ? `?lang=${encodeURIComponent(activeLocale)}` : "";
 
   const pageDescription = description ?? descriptionMap?.[pathname.replace(/\/$/, "") || "/"];
@@ -418,6 +573,11 @@ export function DocsPageClient({
       },
     });
   }, [analytics, activeLocale, entry, isChangelogRoute, normalizedPath]);
+
+  useEffect(() => {
+    return installDocsPathNavigationGuard(entry, resolvedPublicPath);
+  }, [entry, resolvedPublicPath]);
+
   const resolvedReadingTime = !isChangelogRoute
     ? readingTimeProp !== undefined
       ? readingTimeProp
@@ -449,16 +609,17 @@ export function DocsPageClient({
   }, [effectiveTocEnabled, pathname]);
 
   useEffect(() => {
-    if (!activeLocale) return;
-
     const timer = requestAnimationFrame(() => {
-      const container = document.getElementById("nd-page");
-      if (!container) return;
-      localizeInternalLinks(container, activeLocale);
+      const root = document.body;
+      if (!root) return;
+      rewriteDocsPathLinks(root, entry, resolvedPublicPath);
+      syncDocsPathActiveLinks(root, entry, resolvedPublicPath);
+      if (!activeLocale) return;
+      localizeInternalLinks(root, activeLocale);
     });
 
     return () => cancelAnimationFrame(timer);
-  }, [activeLocale, children, pathname]);
+  }, [activeLocale, browserPath, children, entry, pathname, resolvedPublicPath]);
 
   useEffect(() => {
     setBrowserPath(window.location.pathname);
@@ -658,7 +819,11 @@ export function DocsPageClient({
         footer={{ enabled: !isChangelogRoute }}
       >
         {effectiveBreadcrumbEnabled && (
-          <PathBreadcrumb pathname={pathname} entry={entry} locale={activeLocale} />
+          <PathBreadcrumb
+            pathname={pathname}
+            publicPath={resolvedPublicPath}
+            locale={activeLocale}
+          />
         )}
         {showActionsAboveTitle && (
           <div className="fd-below-title-block not-prose">

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -51,6 +51,12 @@ function getAfterFilesRewrites(result: TestRewriteResult): TestRewrite[] {
 const DOCS_CONFIG = `export default { entry: "docs" };
 `;
 
+const DOCS_CONFIG_WITH_ROOT_DOCS_PATH = `export default {
+  entry: "docs",
+  docsPath: "",
+};
+`;
+
 const MARKDOWN_ACCEPT_HEADER = {
   type: "header",
   key: "accept",
@@ -417,6 +423,18 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
       ]),
     );
+    expect(beforeFiles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/",
+          destination: "/docs/",
+        }),
+        expect.objectContaining({
+          source: expect.stringContaining(":slug((?!"),
+          destination: "/docs/:slug",
+        }),
+      ]),
+    );
 
     const acceptPattern = new RegExp(MARKDOWN_ACCEPT_HEADER.value);
     expect(acceptPattern.test("text/markdown")).toBe(true);
@@ -425,6 +443,63 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(acceptPattern.test("application/json, text/markdown;profile=agent;q=0")).toBe(false);
     expect(acceptPattern.test("text/markdown-v2")).toBe(false);
     expect(acceptPattern.test("application/not-text/markdownish")).toBe(false);
+  });
+
+  it("exposes docs from the site root when docsPath is empty", async () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_ROOT_DOCS_PATH, "utf-8");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+
+    const rewritesResult = await readRewrites(nextConfig);
+    const beforeFiles = getBeforeFilesRewrites(rewritesResult);
+
+    expect(beforeFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/docs.md",
+          destination: "/api/docs?format=markdown",
+        }),
+        expect.objectContaining({
+          source: expect.stringContaining("\\.md"),
+          destination: "/api/docs?format=markdown&path=:slug",
+        }),
+        expect.objectContaining({
+          source: "/",
+          has: [MARKDOWN_ACCEPT_HEADER],
+          destination: "/api/docs?format=markdown",
+        }),
+        expect.objectContaining({
+          source: "/",
+          destination: "/docs/",
+        }),
+        expect.objectContaining({
+          source: expect.stringContaining(":slug((?!"),
+          destination: "/docs/:slug",
+        }),
+      ]),
+    );
+
+    const docsRootRewrite = beforeFiles.find((rewrite) => rewrite.destination === "/docs/:slug");
+    expect(docsRootRewrite?.source).toContain("docs(?:/|$)");
+
+    expect(beforeFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/AGENTS.md",
+          destination: "/api/docs?format=agents",
+        }),
+        expect.objectContaining({
+          source: "/sitemap.md",
+          destination: "/api/docs?format=sitemap-md",
+        }),
+        expect.objectContaining({
+          source: "/mcp",
+          destination: "/api/docs/mcp",
+        }),
+      ]),
+    );
   });
 
   it("routes sitemap rewrites through the shared docs api handler when enabled", async () => {
@@ -573,6 +648,36 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/docs/sending",
           destination: "/docs/sending/send-one",
+          permanent: false,
+        }),
+      ]),
+    );
+  });
+
+  it("redirects hidden folder parents through the public docsPath", async () => {
+    writeFileSync(join(tmpDir, "docs.config.ts"), DOCS_CONFIG_WITH_ROOT_DOCS_PATH, "utf-8");
+    mkdirSync(join(tmpDir, "app", "docs", "overview", "what-is-surge"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "page.mdx"),
+      "---\ntitle: Overview\nsidebar:\n  folderIndexBehavior: hidden\n---\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "overview", "what-is-surge", "page.mdx"),
+      "# What is Surge\n",
+      "utf-8",
+    );
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+    const redirects = await readRedirects(nextConfig);
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/overview",
+          destination: "/overview/what-is-surge",
           permanent: false,
         }),
       ]),

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -346,6 +346,22 @@ function readDocsContentDir(root: string): string | undefined {
   return undefined;
 }
 
+function readDocsPath(root: string): string | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = join(root, `docs.config.${ext}`);
+    if (!existsSync(configPath)) continue;
+
+    try {
+      const content = readFileSync(configPath, "utf-8");
+      return readTopLevelStringProperty(content, "docsPath");
+    } catch {
+      // fall through
+    }
+  }
+
+  return undefined;
+}
+
 function readDocsConfigPath(root: string): string {
   for (const ext of FILE_EXTS) {
     const relativePath = `docs.config.${ext}`;
@@ -1244,8 +1260,94 @@ type NextRewriteResult =
       fallback?: NextRewrite[];
     };
 
-function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
-  const normalizedEntry = entry.replace(/^\/+|\/+$/g, "") || "docs";
+function normalizeRouteSegment(value: string | undefined, fallback = "docs"): string {
+  return (value ?? fallback).replace(/^\/+|\/+$/g, "") || fallback;
+}
+
+function normalizeDocsPath(value: string | undefined, entry: string): string {
+  if (typeof value !== "string") return `/${normalizeRouteSegment(entry)}`;
+
+  const cleaned = value.trim();
+  if (cleaned === "" || cleaned === "/") return "";
+
+  return `/${cleaned.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function docsRootSource(entry: string): string {
+  const normalizedEntry = normalizeRouteSegment(entry);
+  return [
+    "/:slug((?!",
+    "_next/",
+    "|api/",
+    `|${normalizedEntry}(?:/|$)`,
+    "|favicon\\.ico",
+    "|robots\\.txt",
+    "|sitemap\\.xml",
+    "|sitemap\\.md",
+    "|docs\\.md",
+    "|llms\\.txt",
+    "|llms-full\\.txt",
+    "|mcp(?:/|$)",
+    "|AGENTS\\.md",
+    "|AGENT\\.md",
+    "|skill\\.md",
+    "|\\.well-known/",
+    "|.*\\..*",
+    ").*)",
+  ].join("");
+}
+
+function docsRootMarkdownSource(entry: string): string {
+  const normalizedEntry = normalizeRouteSegment(entry);
+  return [
+    "/:slug((?!",
+    "_next/",
+    "|api/",
+    `|${normalizedEntry}/`,
+    "|docs\\.md",
+    "|sitemap\\.md",
+    "|AGENTS\\.md",
+    "|AGENT\\.md",
+    "|skill\\.md",
+    "|\\.well-known/",
+    ").*)\\.md",
+  ].join("");
+}
+
+function buildDocsPathRewrites(entry: string, docsPath: string): NextRewrite[] {
+  const normalizedEntry = normalizeRouteSegment(entry);
+  const internalBase = `/${normalizedEntry}`;
+
+  if (docsPath === internalBase) return [];
+
+  if (docsPath === "") {
+    return [
+      {
+        source: "/",
+        destination: `${internalBase}/`,
+      },
+      {
+        source: docsRootSource(normalizedEntry),
+        destination: `${internalBase}/:slug`,
+      },
+    ];
+  }
+
+  return [
+    {
+      source: docsPath,
+      destination: internalBase,
+    },
+    {
+      source: `${docsPath}/:slug*`,
+      destination: `${internalBase}/:slug*`,
+    },
+  ];
+}
+
+function buildDocsMarkdownRewrites(entry: string, docsPath: string): NextRewrite[] {
+  const normalizedEntry = normalizeRouteSegment(entry);
+  const publicBase = docsPath || "";
   const markdownAcceptHeader = {
     type: "header",
     key: "accept",
@@ -1258,32 +1360,67 @@ function buildDocsMarkdownRewrites(entry: string): NextRewrite[] {
     value: ".+",
   };
 
+  if (publicBase === "") {
+    const rootPageSource = docsRootSource(normalizedEntry);
+
+    return [
+      {
+        source: `/${normalizedEntry}.md`,
+        destination: "/api/docs?format=markdown",
+      },
+      {
+        source: docsRootMarkdownSource(normalizedEntry),
+        destination: "/api/docs?format=markdown&path=:slug",
+      },
+      {
+        source: "/",
+        has: [markdownAcceptHeader],
+        destination: "/api/docs?format=markdown",
+      },
+      {
+        source: rootPageSource,
+        has: [markdownAcceptHeader],
+        destination: "/api/docs?format=markdown&path=:slug",
+      },
+      {
+        source: "/",
+        has: [markdownSignatureAgentHeader],
+        destination: "/api/docs?format=markdown",
+      },
+      {
+        source: rootPageSource,
+        has: [markdownSignatureAgentHeader],
+        destination: "/api/docs?format=markdown&path=:slug",
+      },
+    ];
+  }
+
   return [
     {
-      source: `/${normalizedEntry}.md`,
+      source: `${publicBase}.md`,
       destination: "/api/docs?format=markdown",
     },
     {
-      source: `/${normalizedEntry}/:slug*.md`,
+      source: `${publicBase}/:slug*.md`,
       destination: "/api/docs?format=markdown&path=:slug*",
     },
     {
-      source: `/${normalizedEntry}`,
+      source: publicBase,
       has: [markdownAcceptHeader],
       destination: "/api/docs?format=markdown",
     },
     {
-      source: `/${normalizedEntry}/:slug*`,
+      source: `${publicBase}/:slug*`,
       has: [markdownAcceptHeader],
       destination: "/api/docs?format=markdown&path=:slug*",
     },
     {
-      source: `/${normalizedEntry}`,
+      source: publicBase,
       has: [markdownSignatureAgentHeader],
       destination: "/api/docs?format=markdown",
     },
     {
-      source: `/${normalizedEntry}/:slug*`,
+      source: `${publicBase}/:slug*`,
       has: [markdownSignatureAgentHeader],
       destination: "/api/docs?format=markdown&path=:slug*",
     },
@@ -1308,7 +1445,7 @@ function buildAgentSpecRewrites(): NextRewrite[] {
 }
 
 function buildLlmsTxtRewrites(entry: string): NextRewrite[] {
-  const normalizedEntry = entry.replace(/^\/+|\/+$/g, "") || "docs";
+  const normalizedEntry = normalizeRouteSegment(entry);
 
   return [
     {
@@ -1548,7 +1685,13 @@ function findFirstVisibleDocsChildSlug(dir: string, slugParts: string[]): string
   return undefined;
 }
 
-function buildHiddenFolderRedirects(docsDir: string, entry: string): NextRedirect[] {
+function publicDocsRoute(docsPath: string, slugParts: string[] = []): string {
+  const slug = slugParts.join("/");
+  if (!slug) return docsPath || "/";
+  return docsPath ? `${docsPath}/${slug}` : `/${slug}`;
+}
+
+function buildHiddenFolderRedirects(docsDir: string, docsPath: string): NextRedirect[] {
   const redirects: NextRedirect[] = [];
 
   function scan(dir: string, slugParts: string[]) {
@@ -1560,9 +1703,8 @@ function buildHiddenFolderRedirects(docsDir: string, entry: string): NextRedirec
       if (resolveDocsPageFolderIndexBehavior(data) === "hidden") {
         const destinationSlug = findFirstVisibleDocsChildSlug(dir, slugParts);
         if (destinationSlug && destinationSlug.join("/") !== slugParts.join("/")) {
-          const source = slugParts.length > 0 ? `/${entry}/${slugParts.join("/")}` : `/${entry}`;
-          const destination =
-            destinationSlug.length > 0 ? `/${entry}/${destinationSlug.join("/")}` : `/${entry}`;
+          const source = publicDocsRoute(docsPath, slugParts);
+          const destination = publicDocsRoute(docsPath, destinationSlug);
 
           redirects.push({
             source,
@@ -1584,6 +1726,7 @@ function buildHiddenFolderRedirects(docsDir: string, entry: string): NextRedirec
 
 function mergeDocsMarkdownRewrites(
   entry: string,
+  docsPath: string,
   mcp: {
     enabled: boolean;
     route: string;
@@ -1610,7 +1753,8 @@ function mergeDocsMarkdownRewrites(
     ...buildSkillMdRewrites(),
     ...buildSitemapRewrites(sitemap),
     ...buildRobotsRewrites(robots),
-    ...buildDocsMarkdownRewrites(entry),
+    ...buildDocsMarkdownRewrites(entry, docsPath),
+    ...buildDocsPathRewrites(entry, docsPath),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
   const autoAfterFilesRewrites = buildLlmsTxtRewrites(entry);
@@ -1663,6 +1807,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
 
   // ── 2. Auto-generate app/{entry}/layout.tsx if missing (or src/app when using src dir) ──
   const entry = readDocsEntry(root);
+  const docsPath = normalizeDocsPath(readDocsPath(root), entry);
   const configuredContentDir = readDocsContentDir(root);
   const appDir = getNextAppDir(root);
   const docsContentDir = configuredContentDir ?? join(appDir, entry);
@@ -1831,7 +1976,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   }
   remarkPlugins.push([
     "@farming-labs/next/mdx-plugins/remark-markdown-alternate",
-    { entry, appDir, contentDir: docsContentDir, enabled: !isStaticExport },
+    { entry, appDir, contentDir: docsContentDir, docsPath, enabled: !isStaticExport },
   ]);
   remarkPlugins.push(
     ["remark-mdx-frontmatter", { name: "metadata" }],
@@ -1978,10 +2123,18 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     nextConfig.rewrites = async () => {
       const rewrites =
         typeof existingRewrites === "function" ? await existingRewrites() : existingRewrites;
-      return mergeDocsMarkdownRewrites(entry, mcp, sitemap, agentFeedback, robots, rewrites);
+      return mergeDocsMarkdownRewrites(
+        entry,
+        docsPath,
+        mcp,
+        sitemap,
+        agentFeedback,
+        robots,
+        rewrites,
+      );
     };
 
-    const autoRedirects = buildHiddenFolderRedirects(docsContentRoot, entry);
+    const autoRedirects = buildHiddenFolderRedirects(docsContentRoot, docsPath);
     if (autoRedirects.length > 0) {
       const existingRedirects = nextConfig.redirects as
         | NextRedirect[]

--- a/packages/next/src/mdx-plugins/remark-markdown-alternate.test.ts
+++ b/packages/next/src/mdx-plugins/remark-markdown-alternate.test.ts
@@ -25,6 +25,36 @@ describe("remarkMarkdownAlternate", () => {
     expect(tree.children[0]?.value).toContain('text/markdown: "/docs.md"');
   });
 
+  it("adds root-mounted markdown alternate URLs when docsPath is empty", () => {
+    const tree = {
+      children: [{ type: "yaml", value: 'title: "Install"' }],
+    };
+    const transform = remarkMarkdownAlternate({
+      entry: "docs",
+      contentDir: "app/docs",
+      docsPath: "",
+    });
+
+    transform(tree, { path: "/repo/app/docs/install/page.mdx" });
+
+    expect(tree.children[0]?.value).toContain('text/markdown: "/install.md"');
+  });
+
+  it("keeps /docs.md as the root markdown URL when docsPath is empty", () => {
+    const tree = {
+      children: [{ type: "yaml", value: 'title: "Docs"' }],
+    };
+    const transform = remarkMarkdownAlternate({
+      entry: "docs",
+      contentDir: "app/docs",
+      docsPath: "",
+    });
+
+    transform(tree, { path: "/repo/app/docs/page.mdx" });
+
+    expect(tree.children[0]?.value).toContain('text/markdown: "/docs.md"');
+  });
+
   it("handles relative source paths", () => {
     const tree = {
       children: [{ type: "yaml", value: 'title: "Quickstart"' }],

--- a/packages/next/src/mdx-plugins/remark-markdown-alternate.ts
+++ b/packages/next/src/mdx-plugins/remark-markdown-alternate.ts
@@ -4,6 +4,7 @@ interface RemarkMarkdownAlternateOptions {
   entry?: string;
   appDir?: string;
   contentDir?: string;
+  docsPath?: string;
   enabled?: boolean;
 }
 
@@ -23,6 +24,20 @@ function normalizePath(value: string): string {
 
 function normalizeSegment(value: string | undefined, fallback: string): string {
   return (value ?? fallback).replace(/^\/+|\/+$/g, "") || fallback;
+}
+
+function normalizeDocsPath(value: string | undefined, entry: string): string {
+  if (typeof value !== "string") return `/${entry}`;
+
+  const cleaned = value.trim();
+  if (cleaned === "" || cleaned === "/") return "";
+
+  return `/${cleaned.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function joinDocsPath(docsPath: string, slug: string): string {
+  if (!slug) return docsPath || "/";
+  return docsPath ? `${docsPath}/${slug}` : `/${slug}`;
 }
 
 function escapeYamlString(value: string): string {
@@ -57,7 +72,7 @@ function routeFromSourcePath(
     if (!relativePath.endsWith("page.mdx") && !relativePath.endsWith("page.md")) continue;
 
     const slug = relativePath.replace(/\/?page\.mdx?$/, "").replace(/^\/+|\/+$/g, "");
-    return slug ? `/${entry}/${slug}` : `/${entry}`;
+    return joinDocsPath(normalizeDocsPath(options.docsPath, entry), slug);
   }
 
   return null;
@@ -72,11 +87,11 @@ function hasAlternates(yaml: string): boolean {
 }
 
 function alternateYaml(url: string): string {
-  return [
-    "alternates:",
-    "  types:",
-    `    text/markdown: "${escapeYamlString(toDocsMarkdownUrl(url))}"`,
-  ].join("\n");
+  const markdownUrl = url === "/" ? "/docs.md" : toDocsMarkdownUrl(url);
+
+  return ["alternates:", "  types:", `    text/markdown: "${escapeYamlString(markdownUrl)}"`].join(
+    "\n",
+  );
 }
 
 export default function remarkMarkdownAlternate(options: RemarkMarkdownAlternateOptions = {}) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for a custom public docs path via a new `docsPath` config so docs can be served from the site root or a custom prefix without moving source files. All rewrites, .md routes, canonical links, search, redirects, and client navigation use the public path while the internal `entry` stays unchanged.

- **New Features**
  - Added `docsPath?: string` to `DocsConfig`; defaults to `entry`. Set to "" or "/" to mount at root.
  - Next `withDocs`: reads/normalizes `docsPath` from `docs.config.*`; rewrites map the public path (root or prefix) to internal `/<entry>`, expose `/docs.md` and `/:slug.md`, and route Accept/signature-agent requests at the public path. Hidden-folder redirects now point through the public docs path. Agent, sitemap, and robots endpoints remain at the root. `@farming-labs/next/mdx-plugins/remark-markdown-alternate` accepts `docsPath` and emits correct alternates (root page → `/docs.md`, others → `/:slug.md`).
  - Docs API: reads/normalizes `docsPath` (from options or `docs.config.*`), search index and changelog URLs use it, markdown requests resolve through the public path (root or prefix), rendered markdown URLs are rewritten to it, and canonical Link headers reflect it.
  - Layout/Client: nav URL, breadcrumbs, active states, internal links, and client-side routing honor the public path; adds a click guard and link rewriter so navigation works correctly in root-mounted and prefixed modes.
  - Tests: coverage for root-mounted rewrites, hidden-folder redirects via the public path, MDX alternates, and changelog markdown canonical links.

- **Migration**
  - To serve docs from the site root, set `docsPath: ""` (or "/") in `docs.config.*`; no content moves needed.
  - To use a custom prefix, set `docsPath: "/your-prefix"`.

<sup>Written for commit 990c204f76ed69580c53e45cf4f9245e393a234e. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

