### PR TITLE
feat: agent prompt tab

### DIFF
--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -13,6 +13,7 @@ order: 1
 ---
 
 import { WebsiteThemePrompt } from "@/components/website-theme-prompt";
+import { AGENT_FRIENDLY_DOCS_PROMPT } from "@/lib/agent-friendly-docs-prompt";
 
 # How to Write Agent-Friendly Docs
 
@@ -49,57 +50,11 @@ When authoring agent-friendly docs with `@farming-labs/docs`, prioritize these i
 </Agent>
 
 <WebsiteThemePrompt
-  title="Bootstrap agent-friendly docs from my website"
-  description="Copy this into your coding agent when you want docs that are structured for humans and agents."
-  dialogTitle="Create an agent-friendly docs prompt"
-  dialogDescription="Add your website URL and we will fetch Brandfetch details before copying it."
+  copyMode="raw"
+  title="Copy the agent-friendly docs prompt"
+  description="Paste this into your coding agent when you want docs that are structured for humans and agents."
 >
-Create or update an `@farming-labs/docs` documentation site so it is agent-friendly while staying
-clear and useful for humans.
-
-Inputs:
-- Website URL: [WEBSITE_URL]
-- Docs entry folder: [DOCS_ENTRY]
-- Framework: [FRAMEWORK]
-- Brandfetch brand context:
-[BRAND_CONTEXT]
-
-Use the @farming-labs/docs website as implementation context before coding:
-- Framework docs: https://docs.farming-labs.dev
-- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs
-- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive
-- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt
-- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps
-- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp
-- CLI guide: https://docs.farming-labs.dev/docs/cli
-
-Use the Brandfetch brand context as product and brand context, then inspect the existing website
-directly to understand the product, audience, terminology, visual tone, navigation, core features,
-and support or conversion paths.
-
-Then build or update the docs:
-- configure `entry: "[DOCS_ENTRY]"` in `docs.config.ts[x]`
-- use the detected framework conventions for [FRAMEWORK]
-- write clear page frontmatter with `title`, `description`, and `related`
-- add hidden `<Agent>` blocks where agents need implementation hints, verification steps, or recovery
-  guidance
-- add sibling `agent.md` only when a page needs a separate machine-readable contract
-- preserve or enable agent-ready surfaces such as `.md` routes, `llms.txt`, `AGENTS.md`, `skill.md`,
-  sitemap, `robots.txt`, MCP, JSON-LD, OpenAPI schema discovery, and markdown alternate links
-- keep the visible docs human-first; do not turn pages into keyword dumps or duplicate machine-only
-  context in the article body
-- include task contracts for important pages: exact files, commands, success criteria, troubleshooting,
-  and related pages
-
-Verification:
-- run the docs dev server
-- open the docs home page and at least one important task page
-- fetch a `.md` route and confirm it returns clean markdown
-- fetch `/.well-known/agent.json` or the fallback agent route when enabled
-- check `llms.txt`, sitemap, robots, MCP, and page metadata routes according to the project config
-- run `docs doctor --agent`, `docs sitemap generate --check`, and `docs robots generate --check`
-  where available
-- list the files changed and explain which agent-ready surfaces were added or improved
+{AGENT_FRIENDLY_DOCS_PROMPT}
 </WebsiteThemePrompt>
 
 ## Start With The Human Page

--- a/website/components/ui/copy-command.tsx
+++ b/website/components/ui/copy-command.tsx
@@ -1,20 +1,30 @@
 "use client";
 
 import { useState } from "react";
-import { Terminal, Copy, Check } from "lucide-react";
+import { Terminal, Copy, Check, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface CopyCommandProps {
   command: string;
   className?: string;
+  copyText?: string;
+  icon?: "terminal" | "sparkles";
 }
 
-export default function CopyCommand({ command, className = "" }: CopyCommandProps) {
+export default function CopyCommand({
+  command,
+  className = "",
+  copyText,
+  icon = "terminal",
+}: CopyCommandProps) {
   const [copied, setCopied] = useState(false);
   const parts = command.split(" ");
+  const textToCopy = copyText ?? command;
+  const LeadingIcon = icon === "sparkles" ? Sparkles : Terminal;
+
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(command);
+      await navigator.clipboard.writeText(textToCopy);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}
@@ -29,7 +39,7 @@ export default function CopyCommand({ command, className = "" }: CopyCommandProp
       )}
       title={copied ? "Copied!" : "Copy to clipboard"}
     >
-      <Terminal className="h-3.5 w-3.5 shrink-0 text-black/40 dark:text-white/40" />
+      <LeadingIcon className="h-3.5 w-3.5 shrink-0 text-black/40 dark:text-white/40" />
       <span className="min-w-0 flex-1 select-all truncate flex items-center gap-2">
         {parts.map((item, index) => (
           <span

--- a/website/components/ui/init-block-tabs.tsx
+++ b/website/components/ui/init-block-tabs.tsx
@@ -4,47 +4,46 @@ import { useState } from "react";
 import { AnimatedBackground } from "@/components/ui/animated-bg-black";
 import CopyCommand from "@/components/ui/copy-command";
 import CopyCommandTemplate from "@/components/ui/copy-command-template";
+import { AGENT_FRIENDLY_DOCS_PROMPT } from "@/lib/agent-friendly-docs-prompt";
 
 const TAB_EXISTING = "existing";
 const TAB_SCRATCH = "scratch";
+const TAB_AGENT_PROMPT = "agent-prompt";
+
+const TABS = [
+  { id: TAB_AGENT_PROMPT, label: "Agent prompt" },
+  { id: TAB_EXISTING, label: "Existing project" },
+  { id: TAB_SCRATCH, label: "From scratch" },
+] as const;
+
+type QuickStartTab = (typeof TABS)[number]["id"];
 
 export default function InitBlockTabs() {
-  const [active, setActive] = useState<typeof TAB_EXISTING | typeof TAB_SCRATCH>(TAB_EXISTING);
+  const [active, setActive] = useState<QuickStartTab>(TAB_AGENT_PROMPT);
 
   return (
     <>
-      <div className="flex items-center gap-0 border border-b-0 border-black/[8%] dark:border-white/[8%] w-full -mb-px">
-        <button
-          type="button"
-          onClick={() => setActive(TAB_EXISTING)}
-          className={`px-4 mx-1 py-2 text-[11px] font-mono uppercase tracking-wider transition-colors relative ${
-            active === TAB_EXISTING
-              ? "text-black dark:text-white"
-              : "text-black/30 dark:text-white/30 hover:text-black/60 dark:hover:text-white/60"
-          }`}
-        >
-          Existing project
-          {active === TAB_EXISTING && (
-            <span className="absolute bottom-0 left-0 right-0 h-px bg-black dark:bg-white" />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => setActive(TAB_SCRATCH)}
-          className={`px-4 py-2 text-[11px] font-mono uppercase tracking-wider transition-colors relative ${
-            active === TAB_SCRATCH
-              ? "text-black dark:text-white"
-              : "text-black/30 dark:text-white/30 hover:text-black/60 dark:hover:text-white/60"
-          }`}
-        >
-          From scratch
-          {active === TAB_SCRATCH && (
-            <span className="absolute bottom-0 left-0 right-0 h-px bg-black dark:bg-white" />
-          )}
-        </button>
+      <div className="flex w-full items-center gap-0 overflow-x-auto border border-b-0 border-black/[8%] dark:border-white/[8%] -mb-px">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActive(tab.id)}
+            className={`relative shrink-0 px-4 py-2 text-[11px] font-mono uppercase tracking-wider transition-colors ${
+              active === tab.id
+                ? "text-black dark:text-white"
+                : "text-black/30 dark:text-white/30 hover:text-black/60 dark:hover:text-white/60"
+            }`}
+          >
+            {tab.label}
+            {active === tab.id && (
+              <span className="absolute bottom-0 left-0 right-0 h-px bg-black dark:bg-white" />
+            )}
+          </button>
+        ))}
       </div>
 
-      <div className="relative border border-t-black/5 dark:border-t-white/5 border-t-black/[8%] dark:border-t-white/[8%] border-black/[8%] dark:border-white/[8%] bg-black/[0.02] dark:bg-white/[0.02] overflow-hidden">
+      <div className="relative flex min-h-[126px] flex-col overflow-hidden border border-t-black/[8%] border-black/[8%] bg-black/[0.02] dark:border-t-white/[8%] dark:border-white/[8%] dark:bg-white/[0.02]">
         <div className="-pl-20 dark:block hidden">
           <AnimatedBackground />
         </div>
@@ -72,7 +71,7 @@ export default function InitBlockTabs() {
                 </div>
               </div>
             </div>
-            <div className="relative z-[999] flex justify-end mt-4">
+            <div className="relative z-[999] mt-auto flex justify-end">
               <CopyCommand
                 className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b"
                 command="pnpx @farming-labs/docs init"
@@ -97,8 +96,33 @@ export default function InitBlockTabs() {
                 </div>
               </div>
             </div>
-            <div className="relative z-[999] flex justify-end mt-4">
+            <div className="relative z-[999] mt-auto flex justify-end">
               <CopyCommandTemplate className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b" />
+            </div>
+          </>
+        )}
+        {active === TAB_AGENT_PROMPT && (
+          <>
+            <div className="relative z-[999] p-5 sm:p-4 pb-0 sm:pb-0">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-6">
+                <div className="flex-1">
+                  <p className="text-sm text-black/60 dark:text-white/60 mb-1">
+                    Copy a ready-to-paste prompt for agent-friendly docs that stay human-first and
+                    expose the right machine-readable surfaces.
+                  </p>
+                  <p className="text-[11px] font-mono text-black/30 dark:text-white/30 uppercase tracking-wider">
+                    Raw prompt, no website or brand inputs
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="relative z-[999] mt-auto flex justify-end">
+              <CopyCommand
+                className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b"
+                command="Copy agent-friendly docs prompt"
+                copyText={AGENT_FRIENDLY_DOCS_PROMPT}
+                icon="sparkles"
+              />
             </div>
           </>
         )}

--- a/website/components/ui/init-block-tabs.tsx
+++ b/website/components/ui/init-block-tabs.tsx
@@ -71,7 +71,7 @@ export default function InitBlockTabs() {
                 </div>
               </div>
             </div>
-            <div className="relative z-[999] mt-auto flex justify-end">
+            <div className="relative z-[999] -mb-px mt-auto flex justify-end">
               <CopyCommand
                 className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b"
                 command="pnpx @farming-labs/docs init"
@@ -96,7 +96,7 @@ export default function InitBlockTabs() {
                 </div>
               </div>
             </div>
-            <div className="relative z-[999] mt-auto flex justify-end">
+            <div className="relative z-[999] -mb-px mt-auto flex justify-end">
               <CopyCommandTemplate className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b" />
             </div>
           </>
@@ -116,7 +116,7 @@ export default function InitBlockTabs() {
                 </div>
               </div>
             </div>
-            <div className="relative z-[999] mt-auto flex justify-end">
+            <div className="relative z-[999] -mb-px mt-auto flex justify-end">
               <CopyCommand
                 className="backdrop-blur-sm md:backdrop-blur-none border-r-0 border-b-0 sm:border-b"
                 command="Copy agent-friendly docs prompt"

--- a/website/components/website-theme-prompt.tsx
+++ b/website/components/website-theme-prompt.tsx
@@ -16,6 +16,7 @@ interface WebsiteThemePromptProps {
   description?: string;
   dialogTitle?: string;
   dialogDescription?: string;
+  copyMode?: "filled" | "raw";
   children?: React.ReactNode;
 }
 
@@ -156,6 +157,7 @@ export function WebsiteThemePrompt({
   description = "Copy this into your coding agent when you want docs that match an existing site.",
   dialogTitle = "Create a website-matching docs prompt",
   dialogDescription = "Add your website URL and we will fetch Brandfetch details before copying it.",
+  copyMode = "filled",
   children,
 }: WebsiteThemePromptProps) {
   const [open, setOpen] = useState(false);
@@ -166,6 +168,7 @@ export function WebsiteThemePrompt({
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
   const [brandError, setBrandError] = useState<string | null>(null);
   const promptSourceRef = useRef<HTMLDivElement>(null);
+  const isRawCopy = copyMode === "raw";
   const isSubmitting = submitState !== "idle";
   const submitLabel =
     submitState === "bootstrapping"
@@ -213,6 +216,17 @@ export function WebsiteThemePrompt({
     [docsEntry, framework, websiteUrl],
   );
 
+  const handleRawCopy = useCallback(async () => {
+    const promptText = extractPromptTextFromElement(promptSourceRef.current);
+    if (!promptText) return;
+
+    const didCopy = await copyText(promptText);
+    if (!didCopy) return;
+
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }, []);
+
   return (
     <>
       <div className="fd-prompt" data-prompt-card style={{ borderRadius: 0 }}>
@@ -231,7 +245,7 @@ export function WebsiteThemePrompt({
             type="button"
             className="fd-prompt-action-btn"
             data-copied={copied}
-            onClick={() => setOpen(true)}
+            onClick={isRawCopy ? handleRawCopy : () => setOpen(true)}
             style={{ borderRadius: 0 }}
           >
             {copied ? <Check size={14} /> : <Copy size={14} />}
@@ -244,94 +258,98 @@ export function WebsiteThemePrompt({
         {children}
       </div>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-[30rem] rounded-none border-[var(--color-fd-border)] bg-[var(--color-fd-popover)] text-[var(--color-fd-popover-foreground)] shadow-[3px_3px_0_color-mix(in_srgb,var(--color-fd-border)_65%,transparent)] sm:rounded-none">
-          <form onSubmit={handleSubmit}>
-            <DialogHeader>
-              <DialogTitle className="text-[var(--color-fd-foreground)]">{dialogTitle}</DialogTitle>
-              <DialogDescription className="text-[var(--color-fd-muted-foreground)]">
-                {dialogDescription}
-              </DialogDescription>
-            </DialogHeader>
+      {!isRawCopy ? (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent className="max-w-[30rem] rounded-none border-[var(--color-fd-border)] bg-[var(--color-fd-popover)] text-[var(--color-fd-popover-foreground)] shadow-[3px_3px_0_color-mix(in_srgb,var(--color-fd-border)_65%,transparent)] sm:rounded-none">
+            <form onSubmit={handleSubmit}>
+              <DialogHeader>
+                <DialogTitle className="text-[var(--color-fd-foreground)]">
+                  {dialogTitle}
+                </DialogTitle>
+                <DialogDescription className="text-[var(--color-fd-muted-foreground)]">
+                  {dialogDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <div className="mt-5 grid gap-4">
-              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
-                Website URL
-                <input
-                  type="url"
-                  required
-                  placeholder="https://example.com"
-                  value={websiteUrl}
-                  onChange={(event) => setWebsiteUrl(event.target.value)}
-                  className={fieldControlClassName}
-                />
-                <span className="text-xs font-normal leading-5 text-[var(--color-fd-muted-foreground)]">
-                  Used to fetch logos, colors, fonts, and brand metadata from Brandfetch.
-                </span>
-              </label>
-
-              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
-                Docs entry folder
-                <input
-                  type="text"
-                  required
-                  value={docsEntry}
-                  onChange={(event) => setDocsEntry(event.target.value)}
-                  className={fieldControlClassName}
-                />
-              </label>
-
-              <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
-                Framework
-                <span className="relative">
-                  <select
+              <div className="mt-5 grid gap-4">
+                <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                  Website URL
+                  <input
+                    type="url"
                     required
-                    value={framework}
-                    onChange={(event) =>
-                      setFramework(event.target.value as (typeof FRAMEWORK_OPTIONS)[number])
-                    }
-                    className={`${fieldControlClassName} w-full appearance-none pr-9`}
-                  >
-                    {FRAMEWORK_OPTIONS.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown
-                    aria-hidden="true"
-                    className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-fd-muted-foreground)]"
+                    placeholder="https://example.com"
+                    value={websiteUrl}
+                    onChange={(event) => setWebsiteUrl(event.target.value)}
+                    className={fieldControlClassName}
                   />
-                </span>
-              </label>
+                  <span className="text-xs font-normal leading-5 text-[var(--color-fd-muted-foreground)]">
+                    Used to fetch logos, colors, fonts, and brand metadata from Brandfetch.
+                  </span>
+                </label>
 
-              {brandError ? (
-                <p className="border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 py-2 text-xs leading-5 text-[var(--color-fd-muted-foreground)]">
-                  {brandError}
-                </p>
-              ) : null}
-            </div>
+                <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                  Docs entry folder
+                  <input
+                    type="text"
+                    required
+                    value={docsEntry}
+                    onChange={(event) => setDocsEntry(event.target.value)}
+                    className={fieldControlClassName}
+                  />
+                </label>
 
-            <DialogFooter className="mt-5 gap-2 sm:space-x-0">
-              <button
-                type="button"
-                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 text-sm font-medium text-[var(--color-fd-muted-foreground)] transition-colors hover:bg-[var(--color-fd-accent)] hover:text-[var(--color-fd-accent-foreground)]"
-                onClick={() => setOpen(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-primary)] bg-[var(--color-fd-primary)] px-3 text-sm font-medium text-[var(--color-fd-primary-foreground)] transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
-              >
-                {submitState === "done" ? <Check className="mr-1.5 size-3.5" /> : null}
-                {submitLabel}
-              </button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+                <label className="grid gap-2 text-sm font-medium text-[var(--color-fd-foreground)]">
+                  Framework
+                  <span className="relative">
+                    <select
+                      required
+                      value={framework}
+                      onChange={(event) =>
+                        setFramework(event.target.value as (typeof FRAMEWORK_OPTIONS)[number])
+                      }
+                      className={`${fieldControlClassName} w-full appearance-none pr-9`}
+                    >
+                      {FRAMEWORK_OPTIONS.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown
+                      aria-hidden="true"
+                      className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-fd-muted-foreground)]"
+                    />
+                  </span>
+                </label>
+
+                {brandError ? (
+                  <p className="border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 py-2 text-xs leading-5 text-[var(--color-fd-muted-foreground)]">
+                    {brandError}
+                  </p>
+                ) : null}
+              </div>
+
+              <DialogFooter className="mt-5 gap-2 sm:space-x-0">
+                <button
+                  type="button"
+                  className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-border)] bg-[var(--color-fd-secondary)] px-3 text-sm font-medium text-[var(--color-fd-muted-foreground)] transition-colors hover:bg-[var(--color-fd-accent)] hover:text-[var(--color-fd-accent-foreground)]"
+                  onClick={() => setOpen(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="inline-flex h-9 items-center justify-center rounded-none border border-[var(--color-fd-primary)] bg-[var(--color-fd-primary)] px-3 text-sm font-medium text-[var(--color-fd-primary-foreground)] transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
+                >
+                  {submitState === "done" ? <Check className="mr-1.5 size-3.5" /> : null}
+                  {submitLabel}
+                </button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      ) : null}
     </>
   );
 }

--- a/website/lib/agent-friendly-docs-prompt.ts
+++ b/website/lib/agent-friendly-docs-prompt.ts
@@ -1,0 +1,39 @@
+export const AGENT_FRIENDLY_DOCS_PROMPT = `Create or update an \`@farming-labs/docs\` documentation site so it is agent-friendly while staying
+clear and useful for humans.
+
+Before coding:
+- inspect the current project structure, package manager, framework, docs source folder, and
+  \`docs.config.ts[x]\`
+- preserve the existing product voice, page hierarchy, component conventions, and framework routing
+- use the @farming-labs/docs website as implementation context:
+- Framework docs: https://docs.farming-labs.dev
+- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs
+- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive
+- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt
+- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps
+- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp
+- CLI guide: https://docs.farming-labs.dev/docs/cli
+
+Then build or update the docs:
+- configure or preserve the docs \`entry\` in \`docs.config.ts[x]\`
+- use the detected framework conventions
+- write clear page frontmatter with \`title\`, \`description\`, and \`related\`
+- add hidden \`<Agent>\` blocks where agents need implementation hints, verification steps, or recovery
+  guidance
+- add sibling \`agent.md\` only when a page needs a separate machine-readable contract
+- preserve or enable agent-ready surfaces such as \`.md\` routes, \`llms.txt\`, \`AGENTS.md\`, \`skill.md\`,
+  sitemap, \`robots.txt\`, MCP, JSON-LD, OpenAPI schema discovery, and markdown alternate links
+- keep the visible docs human-first; do not turn pages into keyword dumps or duplicate machine-only
+  context in the article body
+- include task contracts for important pages: exact files, commands, success criteria, troubleshooting,
+  and related pages
+
+Verification:
+- run the docs dev server
+- open the docs home page and at least one important task page
+- fetch a \`.md\` route and confirm it returns clean markdown
+- fetch \`/.well-known/agent.json\` or the fallback agent route when enabled
+- check \`llms.txt\`, sitemap, robots, MCP, and page metadata routes according to the project config
+- run \`docs doctor --agent\`, \`docs sitemap generate --check\`, and \`docs robots generate --check\`
+  where available
+- list the files changed and explain which agent-ready surfaces were added or improved`;


### PR DESCRIPTION
- **feat: agent prompt tab**
- **chore: format**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent prompt tab with one-click copy of a ready-to-paste prompt for agent-friendly docs, plus a raw-copy mode that skips the input dialog. Centralizes the prompt text and updates the docs guide to use it.

- **New Features**
  - Added “Agent prompt” tab in Quick Start with copy action using a sparkles icon.
  - Added `copyMode="raw"` to `WebsiteThemePrompt` for instant copy without opening the dialog.
  - Enhanced `CopyCommand` to support custom `copyText` and a selectable leading icon.
  - Created `AGENT_FRIENDLY_DOCS_PROMPT` in `website/lib/agent-friendly-docs-prompt.ts` and wired it into the guide and init tabs.
  - Minor UI polish: scrollable tab bar, stable footer copy bar, improved layout.

- **Refactors**
  - Switched init tabs to a typed `TABS` config and set default to the new Agent prompt tab.
  - Replaced inline prompt in the guide with the shared constant.
  - Updated `WebsiteThemePrompt` to handle raw-copy flow and simplified dialog rendering paths.

<sup>Written for commit 6258f6258bdcb5cf3cfbbbcabf3d3dd88818febd. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

