### PR TITLE
feat: .md route port for agent prompt

### DIFF
--- a/website/app/docs/themes/creating-themes/page.mdx
+++ b/website/app/docs/themes/creating-themes/page.mdx
@@ -71,11 +71,11 @@ Inputs:
 - Brandfetch brand context:
 [BRAND_CONTEXT]
 
-Use the @farming-labs/docs website as implementation context before coding:
-- Framework docs: https://docs.farming-labs.dev
-- Theme guide: https://docs.farming-labs.dev/docs/themes/creating-themes
-- Components guide: https://docs.farming-labs.dev/docs/customization/components
-- CLI guide: https://docs.farming-labs.dev/docs/cli
+Use the @farming-labs/docs markdown routes as implementation context before coding:
+- Framework docs: https://docs.farming-labs.dev/docs.md
+- Theme guide: https://docs.farming-labs.dev/docs/themes/creating-themes.md
+- Components guide: https://docs.farming-labs.dev/docs/customization/components.md
+- CLI guide: https://docs.farming-labs.dev/docs/cli.md
 
 Use the Brandfetch brand context as brand hints, then inspect the existing website directly and
 extract its design system:

--- a/website/lib/agent-friendly-docs-prompt.ts
+++ b/website/lib/agent-friendly-docs-prompt.ts
@@ -5,14 +5,14 @@ Before coding:
 - inspect the current project structure, package manager, framework, docs source folder, and
   \`docs.config.ts[x]\`
 - preserve the existing product voice, page hierarchy, component conventions, and framework routing
-- use the @farming-labs/docs website as implementation context:
-- Framework docs: https://docs.farming-labs.dev
-- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs
-- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive
-- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt
-- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps
-- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp
-- CLI guide: https://docs.farming-labs.dev/docs/cli
+- use the @farming-labs/docs markdown routes as implementation context:
+- Framework docs: https://docs.farming-labs.dev/docs.md
+- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs.md
+- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive.md
+- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt.md
+- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps.md
+- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp.md
+- CLI guide: https://docs.farming-labs.dev/docs/cli.md
 
 Then build or update the docs:
 - configure or preserve the docs \`entry\` in \`docs.config.ts[x]\`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Port links in the agent-friendly docs prompt and related docs content to `@farming-labs/docs` markdown routes (.md) instead of HTML paths, so links resolve under the new routing. Updates the prompt helper and the themes/creating-themes page to prevent broken links.

<sup>Written for commit 2798c22555235d0729128f55b194d18b9a28f761. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

