### PR TITLE
feat: brandfetch based prompt dialog

### DIFF
--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -13,7 +13,7 @@ order: 1
 ---
 
 import { WebsiteThemePrompt } from "@/components/website-theme-prompt";
-import { AGENT_FRIENDLY_DOCS_PROMPT } from "@/lib/agent-friendly-docs-prompt";
+import { AGENT_FRIENDLY_DOCS_WEBSITE_PROMPT } from "@/lib/agent-friendly-docs-prompt";
 
 # How to Write Agent-Friendly Docs
 
@@ -50,12 +50,16 @@ When authoring agent-friendly docs with `@farming-labs/docs`, prioritize these i
 </Agent>
 
 <WebsiteThemePrompt
-  copyMode="raw"
-  title="Copy the agent-friendly docs prompt"
-  description="Paste this into your coding agent when you want docs that are structured for humans and agents."
+  title="Bootstrap agent-friendly docs from my website"
+  description="Copy this into your coding agent when you want docs that are structured for humans and agents."
+  dialogTitle="Create an agent-friendly docs prompt"
+  dialogDescription="Add your website URL and we will fetch Brandfetch details before copying it."
 >
-{AGENT_FRIENDLY_DOCS_PROMPT}
+{AGENT_FRIENDLY_DOCS_WEBSITE_PROMPT}
 </WebsiteThemePrompt>
+
+The copy button asks for the website URL, docs entry folder, and framework, then fills those
+details into the prompt before copying.
 
 ## Start With The Human Page
 

--- a/website/lib/agent-friendly-docs-prompt.ts
+++ b/website/lib/agent-friendly-docs-prompt.ts
@@ -37,3 +37,53 @@ Verification:
 - run \`docs doctor --agent\`, \`docs sitemap generate --check\`, and \`docs robots generate --check\`
   where available
 - list the files changed and explain which agent-ready surfaces were added or improved`;
+
+export const AGENT_FRIENDLY_DOCS_WEBSITE_PROMPT = `Create or update an \`@farming-labs/docs\` documentation site so it is agent-friendly while staying
+clear and useful for humans.
+
+Inputs:
+- Website URL: [WEBSITE_URL]
+- Docs entry folder: [DOCS_ENTRY]
+- Framework: [FRAMEWORK]
+- Brandfetch brand context:
+[BRAND_CONTEXT]
+
+Before coding:
+- inspect the current project structure, package manager, framework, docs source folder, and
+  \`docs.config.ts[x]\`
+- use the website and Brandfetch brand context as product context, then inspect the existing website
+  directly to understand the product, audience, terminology, visual tone, navigation, core features,
+  and support or conversion paths
+- preserve the existing product voice, page hierarchy, component conventions, and framework routing
+- use the @farming-labs/docs markdown routes as implementation context:
+- Framework docs: https://docs.farming-labs.dev/docs.md
+- Agent-friendly docs guide: https://docs.farming-labs.dev/docs/guides/agent-friendly-docs.md
+- Agent primitive guide: https://docs.farming-labs.dev/docs/customization/agent-primitive.md
+- llms.txt guide: https://docs.farming-labs.dev/docs/customization/llms-txt.md
+- Sitemaps guide: https://docs.farming-labs.dev/docs/customization/sitemaps.md
+- MCP guide: https://docs.farming-labs.dev/docs/customization/mcp.md
+- CLI guide: https://docs.farming-labs.dev/docs/cli.md
+
+Then build or update the docs:
+- configure or preserve the docs \`entry\` in \`docs.config.ts[x]\`
+- use the detected framework conventions for [FRAMEWORK]
+- write clear page frontmatter with \`title\`, \`description\`, and \`related\`
+- add hidden \`<Agent>\` blocks where agents need implementation hints, verification steps, or recovery
+  guidance
+- add sibling \`agent.md\` only when a page needs a separate machine-readable contract
+- preserve or enable agent-ready surfaces such as \`.md\` routes, \`llms.txt\`, \`AGENTS.md\`, \`skill.md\`,
+  sitemap, \`robots.txt\`, MCP, JSON-LD, OpenAPI schema discovery, and markdown alternate links
+- keep the visible docs human-first; do not turn pages into keyword dumps or duplicate machine-only
+  context in the article body
+- include task contracts for important pages: exact files, commands, success criteria, troubleshooting,
+  and related pages
+
+Verification:
+- run the docs dev server
+- open the docs home page and at least one important task page
+- fetch a \`.md\` route and confirm it returns clean markdown
+- fetch \`/.well-known/agent.json\` or the fallback agent route when enabled
+- check \`llms.txt\`, sitemap, robots, MCP, and page metadata routes according to the project config
+- run \`docs doctor --agent\`, \`docs sitemap generate --check\`, and \`docs robots generate --check\`
+  where available
+- list the files changed and explain which agent-ready surfaces were added or improved`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Brandfetch-powered prompt dialog to bootstrap agent-friendly docs from a website. The docs guide now collects site details and copies a filled prompt for `@farming-labs/docs`.

- **New Features**
  - Added `AGENT_FRIENDLY_DOCS_WEBSITE_PROMPT` that uses Brandfetch brand context plus Website URL, Docs entry, and Framework to generate tailored instructions.
  - Updated the guide to open a prompt dialog (with title/description) that asks for inputs, fetches Brandfetch details, then copies the completed prompt.

<sup>Written for commit 23142fd30e4b86d755cdd4ec9ad45a300e0bd2a3. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/205?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

