### PR TITLE
feat: llms.txt alternate optional route

### DIFF
--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -24,7 +24,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
 
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt)
+    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry)
   ) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;

--- a/examples/sveltekit/src/hooks.server.js
+++ b/examples/sveltekit/src/hooks.server.js
@@ -23,7 +23,7 @@ export async function handle({ event, resolve }) {
 
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt)
+    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry)
   ) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -1135,7 +1135,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
-    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig);
+    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig, entry);
     if (llmsRequest) {
       if (!llmsEnabled) {
         return new Response("Not Found", {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -51,10 +51,27 @@ describe("agent route helpers", () => {
     expect(resolveDocsLlmsTxtFormat(new URL("https://example.com/.well-known/llms-full.txt"))).toBe(
       "llms-full",
     );
+    expect(resolveDocsLlmsTxtFormat(new URL("https://example.com/docs/llms.txt"), "docs")).toBe(
+      "llms",
+    );
+    expect(
+      resolveDocsLlmsTxtFormat(new URL("https://example.com/docs/llms-full.txt"), "docs"),
+    ).toBe("llms-full");
     expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/llms.txt"))).toBe(true);
     expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/.well-known/llms.txt"))).toBe(
       true,
     );
+    expect(
+      isDocsLlmsTxtPublicRequest(new URL("https://example.com/docs/llms.txt"), undefined, "docs"),
+    ).toBe(true);
+    expect(
+      isDocsPublicGetRequest(
+        "docs",
+        new URL("https://example.com/docs/llms.txt"),
+        new Request("https://example.com/docs/llms.txt"),
+        {},
+      ),
+    ).toBe(true);
     expect(isDocsLlmsTxtPublicRequest(new URL("https://example.com/api/docs?format=llms"))).toBe(
       false,
     );

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -613,6 +613,16 @@ function deriveLlmsTxtSectionFullRoute(route: string): string {
   return joinDocsPublicRoute(normalized, "llms-full.txt");
 }
 
+function resolveDocsBaseLlmsTxtRoute(basePath?: string): string | null {
+  if (!basePath) return null;
+  return joinDocsPublicRoute(normalizeDocsPathSegment(basePath) || "docs", "llms.txt");
+}
+
+function resolveDocsBaseLlmsFullTxtRoute(basePath?: string): string | null {
+  const route = resolveDocsBaseLlmsTxtRoute(basePath);
+  return route ? deriveLlmsTxtSectionFullRoute(route) : null;
+}
+
 function normalizeLlmsTxtMaxChars(
   value: LlmsTxtMaxCharsConfig | undefined,
   fallback?: DocsLlmsTxtResolvedMaxChars,
@@ -675,6 +685,7 @@ export function matchesDocsLlmsTxtSection(pageUrl: string, section: DocsLlmsTxtR
 export function resolveDocsLlmsTxtRequest(
   url: URL,
   llms?: boolean | DocsLlmsDiscoveryConfig | LlmsTxtConfig,
+  basePath?: string,
 ): DocsLlmsTxtRequest | null {
   const pathname = normalizeDocsUrlPath(url.pathname);
   const sections = resolveDocsLlmsTxtSections(llms);
@@ -708,10 +719,18 @@ export function resolveDocsLlmsTxtRequest(
     return { format: "llms" };
   }
 
+  if (pathname === resolveDocsBaseLlmsTxtRoute(basePath)) {
+    return { format: "llms" };
+  }
+
   if (
     pathname === DEFAULT_LLMS_FULL_TXT_ROUTE ||
     pathname === DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE
   ) {
+    return { format: "llms-full" };
+  }
+
+  if (pathname === resolveDocsBaseLlmsFullTxtRoute(basePath)) {
     return { format: "llms-full" };
   }
 
@@ -1076,7 +1095,7 @@ export function isDocsPublicGetRequest(
     isDocsSkillRequest(url) ||
     (pathname === DEFAULT_AGENT_DISCOVERY_ROBOTS_TXT_ROUTE &&
       isRobotsDiscoveryEnabled(options.robots)) ||
-    resolveDocsLlmsTxtRequest(url, options.llms) !== null ||
+    resolveDocsLlmsTxtRequest(url, options.llms, entry) !== null ||
     resolveDocsSitemapRequest(url, options.sitemap) !== null ||
     resolveDocsMarkdownRequest(entry, url, request) !== null
   );
@@ -1085,13 +1104,16 @@ export function isDocsPublicGetRequest(
 export function isDocsLlmsTxtPublicRequest(
   url: URL,
   llms?: boolean | DocsLlmsDiscoveryConfig | LlmsTxtConfig,
+  basePath?: string,
 ): boolean {
   const pathname = normalizeDocsUrlPath(url.pathname);
-  return pathname !== DEFAULT_DOCS_API_ROUTE && resolveDocsLlmsTxtRequest(url, llms) !== null;
+  return (
+    pathname !== DEFAULT_DOCS_API_ROUTE && resolveDocsLlmsTxtRequest(url, llms, basePath) !== null
+  );
 }
 
-export function resolveDocsLlmsTxtFormat(url: URL): "llms" | "llms-full" | null {
-  return resolveDocsLlmsTxtRequest(url)?.format ?? null;
+export function resolveDocsLlmsTxtFormat(url: URL, basePath?: string): "llms" | "llms-full" | null {
+  return resolveDocsLlmsTxtRequest(url, undefined, basePath)?.format ?? null;
 }
 
 export function resolveDocsMarkdownRequest(

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -428,7 +428,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingHandle: Handle =");
     expect(out).toContain("const docsPublicHandle: Handle =");
-    expect(out).toContain("isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt)");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry)");
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain("export const handle = sequence(docsPublicHandle, existingHandle);");
@@ -467,7 +467,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     expect(out).not.toBeNull();
     expect(out).toContain("const existingOnRequest: MiddlewareHandler =");
     expect(out).toContain("const docsPublicMiddleware: MiddlewareHandler =");
-    expect(out).toContain("isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt)");
+    expect(out).toContain("isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry)");
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain(

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1700,7 +1700,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt)) {
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry)) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;
   }
@@ -1770,7 +1770,7 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt)) {
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry)) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;
   }
@@ -2253,7 +2253,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt)) {
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry)) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;
   }
@@ -2325,7 +2325,7 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt)) {
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry)) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;
   }

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -473,7 +473,7 @@ Install the package.
     );
     expect(llmsApiText).not.toContain("(https://docs.example.com/docs/installation):");
 
-    for (const path of ["/llms.txt", "/.well-known/llms.txt"]) {
+    for (const path of ["/llms.txt", "/.well-known/llms.txt", "/docs/llms.txt"]) {
       const response = await GET(new Request(`http://localhost${path}`));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/plain");
@@ -485,7 +485,7 @@ Install the package.
     expect(llmsFullApi.status).toBe(200);
     expect(llmsFullApiText).toContain("Welcome to the docs.");
 
-    for (const path of ["/llms-full.txt", "/.well-known/llms-full.txt"]) {
+    for (const path of ["/llms-full.txt", "/.well-known/llms-full.txt", "/docs/llms-full.txt"]) {
       const response = await GET(new Request(`http://localhost${path}`));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/plain");
@@ -657,11 +657,57 @@ Start here.
       entry: "docs",
     });
 
-    const response = await GET(new Request("http://localhost/llms.txt"));
+    const response = await GET(new Request("http://localhost/docs/llms.txt"));
     const text = await response.text();
     expect(response.status).toBe(200);
     expect(text).toContain("# Default Docs");
     expect(text).toContain("- [Getting Started](/docs/getting-started.md): First steps");
+  });
+
+  it("serves llms.txt through a custom public docsPath", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-llms-docspath-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "api"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "api", "page.mdx"),
+      `---
+title: "API"
+description: "Endpoint docs"
+---
+
+# API
+
+Use the API.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `export default {
+  docsPath: "/guides",
+  llmsTxt: {
+    enabled: true,
+    siteTitle: "Guide Docs",
+  },
+};`,
+    );
+
+    process.chdir(rootDir);
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    const response = await GET(new Request("http://localhost/guides/llms.txt"));
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(text).toContain("# Guide Docs");
+    expect(text).toContain("- [API](/guides/api.md): Endpoint docs");
+
+    const rootResponse = await GET(new Request("http://localhost/llms.txt"));
+    expect(await rootResponse.text()).toBe(text);
   });
 
   it("serves an OpenAPI schema through the shared docs api handler", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -3470,7 +3470,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         });
       }
 
-      const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsConfig);
+      const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsConfig, docsPath);
       if (llmsRequest) {
         if (!llmsConfig.enabled) {
           return new Response("Not Found", {

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -420,6 +420,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
           destination: "/api/docs?format=llms-full",
         }),
         expect.objectContaining({
+          source: "/docs/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/docs/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
           source: "/docs/:section*/llms.txt",
           destination: "/api/docs?format=llms&section=/docs/:section*/llms.txt",
         }),
@@ -781,7 +789,9 @@ describe("withDocs (app dir: src/app vs app)", () => {
     process.chdir(tmpDir);
 
     const nextConfig = withDocs({});
-    const beforeFiles = getBeforeFilesRewrites(await readRewrites(nextConfig));
+    const rewrites = await readRewrites(nextConfig);
+    const beforeFiles = getBeforeFilesRewrites(rewrites);
+    const afterFiles = getAfterFilesRewrites(rewrites);
 
     expect(beforeFiles).toEqual(
       expect.arrayContaining([
@@ -797,6 +807,26 @@ describe("withDocs (app dir: src/app vs app)", () => {
           source: "/guides/docs",
           has: [MARKDOWN_ACCEPT_HEADER],
           destination: "/api/docs?format=markdown",
+        }),
+      ]),
+    );
+    expect(afterFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "/guides/docs/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/guides/docs/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/guides/docs/:section*/llms.txt",
+          destination: "/api/docs?format=llms&section=/guides/docs/:section*/llms.txt",
+        }),
+        expect.objectContaining({
+          source: "/docs/llms.txt",
+          destination: "/api/docs?format=llms",
         }),
       ]),
     );
@@ -1189,6 +1219,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
         }),
         expect.objectContaining({
           source: "/.well-known/llms-full.txt",
+          destination: "/api/docs?format=llms-full",
+        }),
+        expect.objectContaining({
+          source: "/docs/llms.txt",
+          destination: "/api/docs?format=llms",
+        }),
+        expect.objectContaining({
+          source: "/docs/llms-full.txt",
           destination: "/api/docs?format=llms-full",
         }),
         expect.objectContaining({

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -1447,8 +1447,11 @@ function buildAgentSpecRewrites(): NextRewrite[] {
   ];
 }
 
-function buildLlmsTxtRewrites(entry: string): NextRewrite[] {
+function buildLlmsTxtRewrites(entry: string, docsPath: string): NextRewrite[] {
   const normalizedEntry = normalizeRouteSegment(entry);
+  const internalBase = `/${normalizedEntry}`;
+  const publicBase = docsPath;
+  const baseRoutes = Array.from(new Set([internalBase, publicBase].filter(Boolean)));
 
   return [
     {
@@ -1467,14 +1470,24 @@ function buildLlmsTxtRewrites(entry: string): NextRewrite[] {
       source: DEFAULT_LLMS_FULL_TXT_WELL_KNOWN_ROUTE,
       destination: "/api/docs?format=llms-full",
     },
-    {
-      source: `/${normalizedEntry}/:section*/llms.txt`,
-      destination: `/api/docs?format=llms&section=/${normalizedEntry}/:section*/llms.txt`,
-    },
-    {
-      source: `/${normalizedEntry}/:section*/llms-full.txt`,
-      destination: `/api/docs?format=llms-full&section=/${normalizedEntry}/:section*/llms-full.txt`,
-    },
+    ...baseRoutes.flatMap((baseRoute) => [
+      {
+        source: `${baseRoute}/llms.txt`,
+        destination: "/api/docs?format=llms",
+      },
+      {
+        source: `${baseRoute}/llms-full.txt`,
+        destination: "/api/docs?format=llms-full",
+      },
+      {
+        source: `${baseRoute}/:section*/llms.txt`,
+        destination: `/api/docs?format=llms&section=${baseRoute}/:section*/llms.txt`,
+      },
+      {
+        source: `${baseRoute}/:section*/llms-full.txt`,
+        destination: `/api/docs?format=llms-full&section=${baseRoute}/:section*/llms-full.txt`,
+      },
+    ]),
   ];
 }
 
@@ -1760,7 +1773,7 @@ function mergeDocsMarkdownRewrites(
     ...buildDocsPathRewrites(entry, docsPath),
     ...buildAgentFeedbackRewrites(agentFeedback),
   ];
-  const autoAfterFilesRewrites = buildLlmsTxtRewrites(entry);
+  const autoAfterFilesRewrites = buildLlmsTxtRewrites(entry, docsPath);
 
   if (!result) {
     return {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -1125,7 +1125,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
-    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig);
+    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig, entry);
     if (llmsRequest) {
       if (!llmsEnabled) {
         return new Response("Not Found", {
@@ -1985,7 +1985,7 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
     if (method === "GET" || method === "HEAD") {
       const request = new Request(url.href, { method, headers });
       if (
-        isDocsLlmsTxtPublicRequest(url, config.llmsTxt) &&
+        isDocsLlmsTxtPublicRequest(url, config.llmsTxt, entry) &&
         hasNativeNuxtPublicFile(url.pathname)
       ) {
         return undefined;

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -1143,7 +1143,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       });
     }
 
-    const llmsRequest = resolveDocsLlmsTxtRequest(event.url, llmsTxtConfig);
+    const llmsRequest = resolveDocsLlmsTxtRequest(event.url, llmsTxtConfig, entry);
     if (llmsRequest) {
       if (!llmsEnabled) {
         return new Response("Not Found", {

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -1095,7 +1095,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       });
     }
 
-    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig);
+    const llmsRequest = resolveDocsLlmsTxtRequest(url, llmsTxtConfig, entry);
     if (llmsRequest) {
       if (!llmsEnabled) {
         return new Response("Not Found", {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds alternate public routes for llms.txt and llms-full.txt under the docs base path (e.g. `/docs/llms.txt` or a custom `docsPath`) alongside existing root and `/.well-known` endpoints. Backward-compatible and enabled across adapters and the shared API.

- **New Features**
  - Match and serve `/[entry]/llms.txt` and `/[entry]/llms-full.txt`, plus the same under a custom `docsPath` (e.g. `/guides/llms.txt`), in addition to `/llms*.txt` and `/.well-known/llms*.txt`.
  - Extend helpers to accept a base path: `resolveDocsLlmsTxtRequest(url, llms, basePath)`, `isDocsLlmsTxtPublicRequest(url, llms, basePath)`, `resolveDocsLlmsTxtFormat(url, basePath)`.
  - Pass `entry`/`docsPath` through framework servers and examples (Astro, Nuxt, Svelte, TanStack Start).
  - Update `fumadocs` API to handle the new routes; add tests for `/docs/llms*.txt` and custom `docsPath`.
  - Add Next.js rewrites for both `/{entry}` and public `docsPath` routes, including sectioned variants; expand tests.
  - Update CLI templates to include `docsEntry` when calling `isDocsLlmsTxtPublicRequest`.

<sup>Written for commit 36ba09d28e94d2220130b0d0480e90be4ac7300c. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

