### PR TITLE
feat: codeblock metadata for agents

### DIFF
--- a/examples/next/app/docs/create-content/code-blocks/page.mdx
+++ b/examples/next/app/docs/create-content/code-blocks/page.mdx
@@ -57,6 +57,36 @@ export default function Page() {
 ```
 ````
 
+## Agent Metadata
+
+Code fences can include extra metadata for agents and MCP tools. The rendered code block keeps the
+same visual treatment; the metadata is only parsed from the raw markdown and MCP source.
+
+````markdown
+```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+});
+```
+````
+
+Agents reading `/docs/<slug>.md` see the metadata directly on the code fence. MCP clients can call
+`get_code_examples` to receive the same example as structured JSON:
+
+```json
+{
+  "language": "ts",
+  "title": "docs.config.ts",
+  "framework": "nextjs",
+  "packageManager": "pnpm",
+  "runnable": true
+}
+```
+
+Use `runnable` only when the snippet is complete enough to copy into the named file or terminal.
+
 ## Line Numbers
 
 Enable line numbers for longer code blocks:

--- a/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
@@ -104,6 +104,16 @@ surface for both cases:
 - `agent.md` when present
 - normal page markdown when `agent.md` is missing
 
+MCP also exposes `get_code_examples` for fenced code blocks with metadata:
+
+````md
+```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+```
+````
+
+Call it with filters such as `path`, `framework`, `packageManager`, `language`, `runnable`, `query`,
+`limit`, and `locale`. The tool returns structured JSON and does not change the rendered docs UI.
+
 ## Test Commands
 
 ```bash

--- a/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
@@ -153,6 +153,57 @@ export const { GET, POST, DELETE } = createDocsMCPAPI(docsConfig);
 When `agent.md` exists, the `.md` route returns that file. MCP remains available for tool-based
 access and parity checks, but the HTTP `.md` route is the simple public contract.
 
+## MCP Code Examples
+
+The MCP server also exposes `get_code_examples`. It scans fenced code blocks from the raw markdown
+source and returns parsed metadata without changing the rendered code block UI.
+
+Use metadata on examples that agents should treat as implementation-ready:
+
+````md
+```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+});
+```
+````
+
+An MCP client can request only matching examples:
+
+```json
+{
+  "name": "get_code_examples",
+  "arguments": {
+    "path": "getting-started/quickstart",
+    "framework": "nextjs",
+    "packageManager": "pnpm",
+    "runnable": true
+  }
+}
+```
+
+The response is JSON, so agents do not need to scrape rendered HTML:
+
+```json
+{
+  "examples": [
+    {
+      "language": "ts",
+      "title": "docs.config.ts",
+      "framework": "nextjs",
+      "packageManager": "pnpm",
+      "runnable": true,
+      "page": {
+        "url": "/docs/getting-started/quickstart"
+      },
+      "code": "import { defineDocs } from \"@farming-labs/docs\";\\n..."
+    }
+  ]
+}
+```
+
 ## Docs Config
 
 The example app does not need any MCP flag. `withDocs()` picks up the default MCP surface

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -172,6 +172,7 @@ export default defineDocs({
       getNavigation: true,
       searchDocs: true,
       readPage: true,
+      getCodeExamples: true,
     },
   },
 });
@@ -185,12 +186,13 @@ export default defineDocs({
 | `getNavigation` | `boolean` | Expose the `get_navigation` tool |
 | `searchDocs`    | `boolean` | Expose the `search_docs` tool |
 | `readPage`      | `boolean` | Expose the `read_page` tool |
+| `getCodeExamples` | `boolean` | Expose the `get_code_examples` tool |
 
 Default MCP surface:
 
 - **HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
+- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`
 
 Framework notes:
 

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -527,6 +527,7 @@ describe("agent route helpers", () => {
           readPage: true,
           searchDocs: true,
           getNavigation: true,
+          getCodeExamples: true,
         },
       },
       llms: {
@@ -569,6 +570,7 @@ describe("agent route helpers", () => {
           readPage: true,
           searchDocs: true,
           getNavigation: true,
+          getCodeExamples: true,
         },
       },
       feedback: {
@@ -615,6 +617,7 @@ describe("agent route helpers", () => {
           readPage: true,
           searchDocs: true,
           getNavigation: true,
+          getCodeExamples: true,
         },
       },
       llms: { enabled: true, siteTitle: "Docs" },

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -571,6 +571,7 @@ Allow: /
                 { name: "get_navigation" },
                 { name: "search_docs" },
                 { name: "read_page" },
+                { name: "get_code_examples" },
               ],
             },
           });

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1500,7 +1500,13 @@ async function probeMcpRoute(
     const toolNames = Array.isArray(tools)
       ? tools.map((tool) => tool.name).filter((name): name is string => typeof name === "string")
       : [];
-    const expectedTools = ["list_pages", "get_navigation", "search_docs", "read_page"];
+    const expectedTools = [
+      "list_pages",
+      "get_navigation",
+      "search_docs",
+      "read_page",
+      "get_code_examples",
+    ];
     const missingTools = expectedTools.filter((tool) => !toolNames.includes(tool));
 
     if (missingTools.length > 0) {

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -59,6 +59,7 @@ function readMcpConfig(content: string): boolean | DocsMcpConfig | undefined {
       readPage: readBooleanProperty(block, "readPage"),
       searchDocs: readBooleanProperty(block, "searchDocs"),
       getNavigation: readBooleanProperty(block, "getNavigation"),
+      getCodeExamples: readBooleanProperty(block, "getCodeExamples"),
     },
   };
 }

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -45,6 +45,7 @@ describe("resolveDocsMcpConfig", () => {
         readPage: true,
         searchDocs: true,
         getNavigation: true,
+        getCodeExamples: true,
       },
     });
   });
@@ -60,6 +61,7 @@ describe("resolveDocsMcpConfig", () => {
         readPage: true,
         searchDocs: true,
         getNavigation: true,
+        getCodeExamples: true,
       },
     });
   });
@@ -79,6 +81,7 @@ describe("resolveDocsMcpConfig", () => {
         readPage: true,
         searchDocs: true,
         getNavigation: true,
+        getCodeExamples: true,
       },
     });
   });
@@ -151,6 +154,14 @@ related:
 # Quickstart
 
 Build your first app.
+
+\`\`\`ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+});
+\`\`\`
 
 <Agent>
 Validate the generated example paths before editing this guide.
@@ -329,7 +340,13 @@ sidebar:
     }>(toolsListResponse);
 
     expect(toolsList.result?.tools?.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["list_pages", "get_navigation", "search_docs", "read_page"]),
+      expect.arrayContaining([
+        "list_pages",
+        "get_navigation",
+        "search_docs",
+        "read_page",
+        "get_code_examples",
+      ]),
     );
 
     const searchResponse = await handlers.POST({
@@ -429,6 +446,67 @@ sidebar:
     );
     expect(quickstartPayload.result?.content?.[0]?.text).not.toContain("<Agent>");
 
+    const codeExamplesResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+          "mcp-session-id": "stale-session",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 6,
+          method: "tools/call",
+          params: {
+            name: "get_code_examples",
+            arguments: {
+              path: "guides/quickstart",
+              framework: "nextjs",
+              packageManager: "pnpm",
+              runnable: true,
+            },
+          },
+        }),
+      }),
+    });
+
+    const codeExamplesPayload = await parseMcpPayload<{
+      result?: { content?: Array<{ text?: string }> };
+    }>(codeExamplesResponse);
+    const codeExamplesText = codeExamplesPayload.result?.content?.[0]?.text ?? "{}";
+    const codeExamples = JSON.parse(codeExamplesText) as {
+      examples?: Array<{
+        language?: string;
+        title?: string;
+        framework?: string;
+        packageManager?: string;
+        runnable?: boolean;
+        meta?: Record<string, unknown>;
+        code?: string;
+        page?: { url?: string };
+      }>;
+    };
+
+    expect(codeExamples.examples).toEqual([
+      expect.objectContaining({
+        language: "ts",
+        title: "docs.config.ts",
+        framework: "nextjs",
+        packageManager: "pnpm",
+        runnable: true,
+        page: expect.objectContaining({ url: "/docs/guides/quickstart" }),
+        meta: expect.objectContaining({
+          title: "docs.config.ts",
+          framework: "nextjs",
+          packageManager: "pnpm",
+          runnable: true,
+        }),
+        code: expect.stringContaining("defineDocs"),
+      }),
+    ]);
+
     const deleteResponse = await handlers.DELETE({
       request: new Request("http://localhost/api/docs/mcp", {
         method: "DELETE",
@@ -478,7 +556,13 @@ sidebar:
       result?: { tools?: Array<{ name: string }> };
     }>(missingSessionResponse);
     expect(missingSessionPayload.result?.tools?.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["list_pages", "get_navigation", "search_docs", "read_page"]),
+      expect.arrayContaining([
+        "list_pages",
+        "get_navigation",
+        "search_docs",
+        "read_page",
+        "get_code_examples",
+      ]),
     );
 
     const expiredSessionResponse = await handlers.POST({
@@ -504,7 +588,13 @@ sidebar:
       result?: { tools?: Array<{ name: string }> };
     }>(expiredSessionResponse);
     expect(expiredSessionPayload.result?.tools?.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["list_pages", "get_navigation", "search_docs", "read_page"]),
+      expect.arrayContaining([
+        "list_pages",
+        "get_navigation",
+        "search_docs",
+        "read_page",
+        "get_code_examples",
+      ]),
     );
   });
 
@@ -944,7 +1034,7 @@ sidebar:
     }>(toolsListResponse);
 
     expect(toolsList.result?.tools?.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["list_pages", "get_navigation"]),
+      expect.arrayContaining(["list_pages", "get_navigation", "get_code_examples"]),
     );
     expect(toolsList.result?.tools?.map((tool) => tool.name)).not.toEqual(
       expect.arrayContaining(["search_docs", "read_page"]),

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -43,6 +43,25 @@ export interface DocsMcpPage {
   agentFallbackRawContent?: string;
 }
 
+export interface DocsMcpCodeExample {
+  id: string;
+  page: {
+    slug: string;
+    url: string;
+    title: string;
+    description?: string;
+    sourcePath?: string;
+    lastModified?: string;
+  };
+  language?: string;
+  title?: string;
+  framework?: string;
+  packageManager?: string;
+  runnable: boolean;
+  meta: Record<string, string | boolean>;
+  code: string;
+}
+
 export interface DocsMcpPageNode {
   type: "page";
   name: string;
@@ -83,6 +102,7 @@ export interface DocsMcpResolvedConfig {
     readPage: boolean;
     searchDocs: boolean;
     getNavigation: boolean;
+    getCodeExamples: boolean;
   };
 }
 
@@ -137,6 +157,17 @@ const getNavigationInputSchema = z.object({
   locale: z.string().min(1).optional(),
 });
 
+const getCodeExamplesInputSchema = z.object({
+  query: z.string().trim().min(1).optional(),
+  path: z.string().min(1).optional(),
+  framework: z.string().trim().min(1).optional(),
+  packageManager: z.string().trim().min(1).optional(),
+  language: z.string().trim().min(1).optional(),
+  runnable: z.boolean().optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+  locale: z.string().min(1).optional(),
+});
+
 export function normalizeDocsMcpRoute(route?: string): string {
   if (!route || route.trim().length === 0) return DEFAULT_MCP_ROUTE;
 
@@ -163,6 +194,7 @@ export function resolveDocsMcpConfig(
         readPage: true,
         searchDocs: true,
         getNavigation: true,
+        getCodeExamples: true,
       },
     };
   }
@@ -179,6 +211,7 @@ export function resolveDocsMcpConfig(
       readPage: config.tools?.readPage ?? true,
       searchDocs: config.tools?.searchDocs ?? true,
       getNavigation: config.tools?.getNavigation ?? true,
+      getCodeExamples: config.tools?.getCodeExamples ?? true,
     },
   };
 }
@@ -541,6 +574,131 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             locale,
             outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
             metadata: { tool: "search_docs" },
+          });
+          throw error;
+        }
+      },
+    );
+  }
+
+  if (resolved.tools.getCodeExamples) {
+    server.registerTool(
+      "get_code_examples",
+      {
+        title: "Get docs code examples",
+        description:
+          "Return fenced code examples from the docs with parsed metadata such as title, framework, packageManager, and runnable.",
+        inputSchema: getCodeExamplesInputSchema,
+        annotations: { readOnlyHint: true },
+      },
+      async ({
+        query,
+        path: requestedPath,
+        framework,
+        packageManager,
+        language,
+        runnable,
+        limit,
+        locale,
+      }) => {
+        const startedAt = nowMs();
+        const resolvedLimit = limit ?? 25;
+        const trace = createDocsAgentTraceContext("mcp.tool.get_code_examples");
+        const callSpanId = createDocsAgentTraceId("span");
+        await emitDocsAgentTraceEvent(options.observability, {
+          type: "tool.call",
+          source: "mcp",
+          traceId: trace.traceId,
+          spanId: callSpanId,
+          name: "get_code_examples",
+          startedAt: trace.startedAt,
+          status: "started",
+          locale,
+          inputPreview: {
+            queryLength: query?.length,
+            path: requestedPath,
+            framework,
+            packageManager,
+            language,
+            runnable,
+            limit: resolvedLimit,
+          },
+          metadata: { tool: "get_code_examples" },
+        });
+
+        try {
+          const pages = dedupePages(await options.source.getPages(locale));
+          const matchedPage = requestedPath
+            ? findDocsPage(pages, requestedPath, options.source.entry)
+            : null;
+          const scopedPages = requestedPath ? (matchedPage ? [matchedPage] : []) : pages;
+          const examples = filterDocsCodeExamples(
+            scopedPages.flatMap((page) => extractDocsMcpCodeExamples(page)),
+            {
+              query,
+              framework,
+              packageManager,
+              language,
+              runnable,
+              limit: resolvedLimit,
+            },
+          );
+          const elapsed = durationMs(startedAt);
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "mcp_tool",
+            source: "mcp",
+            locale,
+            input: query ? { query } : undefined,
+            properties: {
+              tool: "get_code_examples",
+              queryLength: query?.length,
+              path: requestedPath,
+              framework,
+              packageManager,
+              language,
+              runnable,
+              limit: resolvedLimit,
+              resultCount: examples.length,
+              durationMs: elapsed,
+            },
+          });
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.result",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "get_code_examples",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "success",
+            locale,
+            outputPreview: { resultCount: examples.length },
+            metadata: { tool: "get_code_examples" },
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ examples }, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          const elapsed = durationMs(startedAt);
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.error",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "get_code_examples",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "error",
+            locale,
+            outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
+            metadata: { tool: "get_code_examples" },
           });
           throw error;
         }
@@ -1284,6 +1442,161 @@ function toPageSummaries(pages: DocsMcpPage[]) {
     description: page.description,
     icon: page.icon,
   }));
+}
+
+function extractDocsMcpCodeExamples(page: DocsMcpPage): DocsMcpCodeExample[] {
+  const source = page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent;
+  if (!source) return [];
+
+  const examples: DocsMcpCodeExample[] = [];
+  const lines = source.split("\n");
+  let index = 0;
+  let openFence: { marker: string; info: string; code: string[] } | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!openFence) {
+      const openMatch = trimmed.match(/^(`{3,}|~{3,})(.*)$/);
+      if (!openMatch) continue;
+
+      openFence = {
+        marker: openMatch[1],
+        info: openMatch[2]?.trim() ?? "",
+        code: [],
+      };
+      continue;
+    }
+
+    if (isClosingFence(trimmed, openFence.marker)) {
+      const parsed = parseCodeFenceInfo(openFence.info);
+      const meta = parsed.meta;
+      const title = readStringMeta(meta, "title");
+      const framework = readStringMeta(meta, "framework");
+      const packageManager = readStringMeta(meta, "packageManager");
+      const runnable = readBooleanMeta(meta, "runnable") ?? false;
+
+      index += 1;
+      examples.push({
+        id: `${page.url}#code-${index}`,
+        page: {
+          slug: page.slug,
+          url: page.url,
+          title: page.title,
+          description: page.description,
+          sourcePath: page.sourcePath,
+          lastModified: page.lastModified,
+        },
+        language: parsed.language,
+        title,
+        framework,
+        packageManager,
+        runnable,
+        meta,
+        code: openFence.code.join("\n"),
+      });
+      openFence = null;
+      continue;
+    }
+
+    openFence.code.push(line);
+  }
+
+  return examples;
+}
+
+function filterDocsCodeExamples(
+  examples: DocsMcpCodeExample[],
+  filters: {
+    query?: string;
+    framework?: string;
+    packageManager?: string;
+    language?: string;
+    runnable?: boolean;
+    limit: number;
+  },
+): DocsMcpCodeExample[] {
+  const query = filters.query?.toLowerCase();
+  const framework = filters.framework?.toLowerCase();
+  const packageManager = filters.packageManager?.toLowerCase();
+  const language = filters.language?.toLowerCase();
+
+  return examples
+    .filter((example) => {
+      if (framework && example.framework?.toLowerCase() !== framework) return false;
+      if (packageManager && example.packageManager?.toLowerCase() !== packageManager) return false;
+      if (language && example.language?.toLowerCase() !== language) return false;
+      if (filters.runnable !== undefined && example.runnable !== filters.runnable) return false;
+      if (!query) return true;
+      return getCodeExampleSearchText(example).toLowerCase().includes(query);
+    })
+    .slice(0, filters.limit);
+}
+
+function isClosingFence(trimmedLine: string, marker: string): boolean {
+  if (!trimmedLine.startsWith(marker)) return false;
+  return trimmedLine.slice(marker.length).trim().length === 0;
+}
+
+function parseCodeFenceInfo(info: string): {
+  language?: string;
+  meta: Record<string, string | boolean>;
+} {
+  const trimmed = info.trim();
+  if (!trimmed) return { meta: {} };
+
+  const firstTokenMatch = trimmed.match(/^(\S+)/);
+  const firstToken = firstTokenMatch?.[1] ?? "";
+  const language = firstToken && !firstToken.includes("=") ? firstToken : undefined;
+  const attributeSource = language ? trimmed.slice(firstToken.length).trim() : trimmed;
+  const meta: Record<string, string | boolean> = {};
+  const attributePattern = /([A-Za-z_:][\w:.-]*)(?:=(?:"([^"]*)"|'([^']*)'|([^\s"']+)))?/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = attributePattern.exec(attributeSource))) {
+    const key = match[1];
+    const value = match[2] ?? match[3] ?? match[4];
+    meta[key] = value ?? true;
+  }
+
+  return { language, meta };
+}
+
+function readStringMeta(meta: Record<string, string | boolean>, key: string): string | undefined {
+  const value = meta[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readBooleanMeta(meta: Record<string, string | boolean>, key: string): boolean | undefined {
+  const value = meta[key];
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized || normalized === "true" || normalized === "1" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0" || normalized === "no") return false;
+  return true;
+}
+
+function getCodeExampleSearchText(example: DocsMcpCodeExample): string {
+  return [
+    example.id,
+    example.page.slug,
+    example.page.url,
+    example.page.title,
+    example.page.description,
+    example.page.sourcePath,
+    example.language,
+    example.title,
+    example.framework,
+    example.packageManager,
+    ...Object.entries(example.meta).map(([key, value]) => `${key} ${String(value)}`),
+    example.code,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
 }
 
 function findDocsPage(

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -89,6 +89,7 @@ export type {
   DocsSitemapResolvedConfig,
 } from "./sitemap.js";
 export type {
+  DocsMcpCodeExample,
   DocsMcpHttpHandlers,
   DocsMcpNavigationNode,
   DocsMcpNavigationTree,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1114,6 +1114,8 @@ export interface DocsMcpToolsConfig {
   searchDocs?: boolean;
   /** Expose a `get_navigation` tool for the docs tree. */
   getNavigation?: boolean;
+  /** Expose a `get_code_examples` tool for fenced code blocks and their metadata. */
+  getCodeExamples?: boolean;
 }
 
 /**

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1944,6 +1944,7 @@ title: "Home"
         readPage: true,
         searchDocs: false,
         getNavigation: true,
+        getCodeExamples: true,
       },
     });
     expect(spec.feedback).toMatchObject({

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -905,6 +905,7 @@ function readMcpConfig(root: string): boolean | DocsMcpConfig | undefined {
           readPage: readBooleanFromBlock(block, "readPage"),
           searchDocs: readBooleanFromBlock(block, "searchDocs"),
           getNavigation: readBooleanFromBlock(block, "getNavigation"),
+          getCodeExamples: readBooleanFromBlock(block, "getCodeExamples"),
         },
       };
     } catch {

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -181,6 +181,17 @@ The built-in MCP surface currently includes:
 - `read_page`
 - `get_code_examples`
 
+`get_code_examples` parses fenced code block metadata from raw markdown/MDX and returns structured
+examples for agents. Use metadata like
+
+````md
+```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+```
+````
+
+when a snippet has a target file, framework, package manager, or is safe to copy as a complete
+example. This metadata is for markdown/MCP consumers and does not require a UI change.
+
 Use the docs config `mcp` block when you also want the HTTP route version at `/mcp` or `/.well-known/mcp`.
 
 ## Search Sync

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -179,6 +179,7 @@ The built-in MCP surface currently includes:
 - `get_navigation`
 - `search_docs`
 - `read_page`
+- `get_code_examples`
 
 Use the docs config `mcp` block when you also want the HTTP route version at `/mcp` or `/.well-known/mcp`.
 
@@ -500,7 +501,7 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 
 For hosted MCP, the command performs a Streamable HTTP initialize handshake, checks for
 `mcp-session-id`, calls `tools/list`, and expects `list_pages`, `get_navigation`, `search_docs`,
-and `read_page`. Hosted checks raise the agent max score from `105` to `145`.
+`read_page`, and `get_code_examples`. Hosted checks raise the agent max score from `105` to `145`.
 
 Hosted JSON check IDs include `hosted-agent-discovery`, `hosted-llms`, `hosted-sitemap`,
 `hosted-robots`, `hosted-skill`, `hosted-markdown`, and `hosted-mcp`.

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -662,6 +662,36 @@ Default behavior:
 - **stdio command:** `pnpx @farming-labs/docs mcp`
 - **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`
 
+`get_code_examples` returns fenced code blocks as structured JSON. It parses code-fence metadata
+such as `title`, `framework`, `packageManager`, and `runnable` from raw markdown/MDX and does not
+change the rendered code block UI.
+
+Authoring example:
+
+````md
+```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
+export default defineDocs({
+  entry: "docs",
+});
+```
+````
+
+MCP call example:
+
+```json
+{
+  "name": "get_code_examples",
+  "arguments": {
+    "path": "getting-started/quickstart",
+    "framework": "nextjs",
+    "packageManager": "pnpm",
+    "runnable": true
+  }
+}
+```
+
+Supported filters: `query`, `path`, `framework`, `packageManager`, `language`, `runnable`, `limit`, and `locale`.
+
 Framework notes:
 - **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites
 - **TanStack Start:** current `init` scaffolds one `src/routes/$.ts` public forwarder for `/api/docs/mcp`, `/mcp`, and `/.well-known/mcp`

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -660,7 +660,7 @@ Default behavior:
 - **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
+- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`
 
 Framework notes:
 - **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new MCP tool, `get_code_examples`, that lets agents fetch fenced code blocks from docs with metadata (title, framework, packageManager, runnable). It’s enabled by default and supports filters for path, query, framework, packageManager, language, runnable, locale, and a limit.

- **New Features**
  - Added `get_code_examples` MCP tool. Returns code examples as JSON with metadata; supports filters and a limit.
  - Introduced `mcp.tools.getCodeExamples` config (default true). Parsed in the CLI and `fumadocs`; added authoring guidance and request/response examples in the Next.js example and skills docs.
  - `docs doctor` now expects `get_code_examples` in `tools/list`. Exported `DocsMcpCodeExample` type. Added tracing and analytics for the new tool.

<sup>Written for commit 922140c09b07b90df7e517c5ca8324aa1132fc43. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

