### PR TITLE
feat: `getConfigSchema` mcp tool via query params

### DIFF
--- a/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/agent.md
@@ -114,6 +114,10 @@ MCP also exposes `get_code_examples` for fenced code blocks with metadata:
 Call it with filters such as `path`, `framework`, `packageManager`, `language`, `runnable`, `query`,
 `limit`, and `locale`. The tool returns structured JSON and does not change the rendered docs UI.
 
+MCP also exposes `get_config_schema` for `docs.config.ts` metadata. Call it with no arguments for
+the full schema, `option` for paths such as `mcp.tools.getConfigSchema`, or `query` for feature
+areas such as `llms` or `page actions`.
+
 ## Test Commands
 
 ```bash

--- a/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
@@ -184,6 +184,21 @@ An MCP client can request only matching examples:
 }
 ```
 
+The MCP server also exposes `get_config_schema` for agents that need to edit `docs.config.ts`
+without guessing option names or defaults:
+
+```json
+{
+  "name": "get_config_schema",
+  "arguments": {
+    "option": "mcp.tools.getConfigSchema"
+  }
+}
+```
+
+Use `query` instead of `option` when the agent only knows the feature area, such as `llms` or
+`page actions`.
+
 The response is JSON, so agents do not need to scrape rendered HTML:
 
 ```json

--- a/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
+++ b/examples/next/app/docs/getting-started/agent-ready-docs/page.mdx
@@ -184,6 +184,26 @@ An MCP client can request only matching examples:
 }
 ```
 
+The `get_code_examples` response is JSON, so agents do not need to scrape rendered HTML:
+
+```json
+{
+  "examples": [
+    {
+      "language": "ts",
+      "title": "docs.config.ts",
+      "framework": "nextjs",
+      "packageManager": "pnpm",
+      "runnable": true,
+      "page": {
+        "url": "/docs/getting-started/quickstart"
+      },
+      "code": "import { defineDocs } from \"@farming-labs/docs\";\\n..."
+    }
+  ]
+}
+```
+
 The MCP server also exposes `get_config_schema` for agents that need to edit `docs.config.ts`
 without guessing option names or defaults:
 
@@ -199,21 +219,23 @@ without guessing option names or defaults:
 Use `query` instead of `option` when the agent only knows the feature area, such as `llms` or
 `page actions`.
 
-The response is JSON, so agents do not need to scrape rendered HTML:
+A filtered `get_config_schema` response includes the matching option metadata:
 
 ```json
 {
-  "examples": [
+  "schemaVersion": 1,
+  "configFile": "docs.config.ts",
+  "filters": {
+    "option": "mcp.tools.getConfigSchema"
+  },
+  "resultCount": 1,
+  "options": [
     {
-      "language": "ts",
-      "title": "docs.config.ts",
-      "framework": "nextjs",
-      "packageManager": "pnpm",
-      "runnable": true,
-      "page": {
-        "url": "/docs/getting-started/quickstart"
-      },
-      "code": "import { defineDocs } from \"@farming-labs/docs\";\\n..."
+      "path": "mcp.tools.getConfigSchema",
+      "name": "getConfigSchema",
+      "type": "boolean",
+      "default": true,
+      "description": "Expose the get_config_schema tool."
     }
   ]
 }

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -173,6 +173,7 @@ export default defineDocs({
       searchDocs: true,
       readPage: true,
       getCodeExamples: true,
+      getConfigSchema: true,
     },
   },
 });
@@ -187,12 +188,16 @@ export default defineDocs({
 | `searchDocs`    | `boolean` | Expose the `search_docs` tool |
 | `readPage`      | `boolean` | Expose the `read_page` tool |
 | `getCodeExamples` | `boolean` | Expose the `get_code_examples` tool |
+| `getConfigSchema` | `boolean` | Expose the `get_config_schema` tool |
 
 Default MCP surface:
 
 - **HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`
+- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`, `get_config_schema`
+
+`get_config_schema` returns structured `docs.config.ts` option metadata. Agents can call it with
+`option`, such as `mcp.tools.getConfigSchema`, or with `query` for keyword filtering.
 
 Framework notes:
 

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -528,6 +528,7 @@ describe("agent route helpers", () => {
           searchDocs: true,
           getNavigation: true,
           getCodeExamples: true,
+          getConfigSchema: true,
         },
       },
       llms: {
@@ -571,6 +572,7 @@ describe("agent route helpers", () => {
           searchDocs: true,
           getNavigation: true,
           getCodeExamples: true,
+          getConfigSchema: true,
         },
       },
       feedback: {
@@ -618,6 +620,7 @@ describe("agent route helpers", () => {
           searchDocs: true,
           getNavigation: true,
           getCodeExamples: true,
+          getConfigSchema: true,
         },
       },
       llms: { enabled: true, siteTitle: "Docs" },

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -572,6 +572,7 @@ Allow: /
                 { name: "search_docs" },
                 { name: "read_page" },
                 { name: "get_code_examples" },
+                { name: "get_config_schema" },
               ],
             },
           });

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1506,6 +1506,7 @@ async function probeMcpRoute(
       "search_docs",
       "read_page",
       "get_code_examples",
+      "get_config_schema",
     ];
     const missingTools = expectedTools.filter((tool) => !toolNames.includes(tool));
 

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -60,6 +60,7 @@ function readMcpConfig(content: string): boolean | DocsMcpConfig | undefined {
       searchDocs: readBooleanProperty(block, "searchDocs"),
       getNavigation: readBooleanProperty(block, "getNavigation"),
       getCodeExamples: readBooleanProperty(block, "getCodeExamples"),
+      getConfigSchema: readBooleanProperty(block, "getConfigSchema"),
     },
   };
 }

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -560,6 +560,42 @@ sidebar:
       }),
     ]);
 
+    const ambiguousConfigSchemaResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+          "mcp-session-id": "stale-session",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 8,
+          method: "tools/call",
+          params: {
+            name: "get_config_schema",
+            arguments: {
+              option: "enabled",
+            },
+          },
+        }),
+      }),
+    });
+
+    const ambiguousConfigSchemaPayload = await parseMcpPayload<{
+      result?: { content?: Array<{ text?: string }> };
+    }>(ambiguousConfigSchemaResponse);
+    const ambiguousConfigSchemaText =
+      ambiguousConfigSchemaPayload.result?.content?.[0]?.text ?? "{}";
+    const ambiguousConfigSchema = JSON.parse(ambiguousConfigSchemaText) as {
+      resultCount?: number;
+      options?: unknown[];
+    };
+
+    expect(ambiguousConfigSchema.resultCount).toBe(0);
+    expect(ambiguousConfigSchema.options).toEqual([]);
+
     const deleteResponse = await handlers.DELETE({
       request: new Request("http://localhost/api/docs/mcp", {
         method: "DELETE",

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -46,6 +46,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         getNavigation: true,
         getCodeExamples: true,
+        getConfigSchema: true,
       },
     });
   });
@@ -62,6 +63,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         getNavigation: true,
         getCodeExamples: true,
+        getConfigSchema: true,
       },
     });
   });
@@ -82,6 +84,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         getNavigation: true,
         getCodeExamples: true,
+        getConfigSchema: true,
       },
     });
   });
@@ -346,6 +349,7 @@ sidebar:
         "search_docs",
         "read_page",
         "get_code_examples",
+        "get_config_schema",
       ]),
     );
 
@@ -507,6 +511,55 @@ sidebar:
       }),
     ]);
 
+    const configSchemaResponse = await handlers.POST({
+      request: new Request("http://localhost/api/docs/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": LATEST_PROTOCOL_VERSION,
+          "mcp-session-id": "stale-session",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: {
+            name: "get_config_schema",
+            arguments: {
+              option: "mcp.tools.getConfigSchema",
+            },
+          },
+        }),
+      }),
+    });
+
+    const configSchemaPayload = await parseMcpPayload<{
+      result?: { content?: Array<{ text?: string }> };
+    }>(configSchemaResponse);
+    const configSchemaText = configSchemaPayload.result?.content?.[0]?.text ?? "{}";
+    const configSchema = JSON.parse(configSchemaText) as {
+      resultCount?: number;
+      options?: Array<{
+        path?: string;
+        name?: string;
+        type?: string;
+        default?: boolean;
+        description?: string;
+      }>;
+    };
+
+    expect(configSchema.resultCount).toBe(1);
+    expect(configSchema.options).toEqual([
+      expect.objectContaining({
+        path: "mcp.tools.getConfigSchema",
+        name: "getConfigSchema",
+        type: "boolean",
+        default: true,
+        description: expect.stringContaining("get_config_schema"),
+      }),
+    ]);
+
     const deleteResponse = await handlers.DELETE({
       request: new Request("http://localhost/api/docs/mcp", {
         method: "DELETE",
@@ -562,6 +615,7 @@ sidebar:
         "search_docs",
         "read_page",
         "get_code_examples",
+        "get_config_schema",
       ]),
     );
 
@@ -594,6 +648,7 @@ sidebar:
         "search_docs",
         "read_page",
         "get_code_examples",
+        "get_config_schema",
       ]),
     );
   });
@@ -980,6 +1035,7 @@ sidebar:
         tools: {
           searchDocs: false,
           readPage: false,
+          getConfigSchema: false,
         },
       },
     });
@@ -1037,7 +1093,7 @@ sidebar:
       expect.arrayContaining(["list_pages", "get_navigation", "get_code_examples"]),
     );
     expect(toolsList.result?.tools?.map((tool) => tool.name)).not.toEqual(
-      expect.arrayContaining(["search_docs", "read_page"]),
+      expect.arrayContaining(["search_docs", "read_page", "get_config_schema"]),
     );
   });
 

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -62,6 +62,33 @@ export interface DocsMcpCodeExample {
   code: string;
 }
 
+export interface DocsMcpConfigSchemaOption {
+  path: string;
+  name: string;
+  type: string;
+  default?: string | boolean | number | null;
+  description: string;
+  docs?: string;
+  values?: string[];
+  children?: DocsMcpConfigSchemaOption[];
+}
+
+export interface DocsMcpConfigSchema {
+  schemaVersion: 1;
+  configFile: "docs.config.ts";
+  description: string;
+  filters?: {
+    option?: string;
+    query?: string;
+  };
+  resultCount: number;
+  options: DocsMcpConfigSchemaOption[];
+  examples: Array<{
+    title: string;
+    code: string;
+  }>;
+}
+
 export interface DocsMcpPageNode {
   type: "page";
   name: string;
@@ -103,6 +130,7 @@ export interface DocsMcpResolvedConfig {
     searchDocs: boolean;
     getNavigation: boolean;
     getCodeExamples: boolean;
+    getConfigSchema: boolean;
   };
 }
 
@@ -138,6 +166,435 @@ const DEFAULT_MCP_ROUTE = "/api/docs/mcp";
 const DEFAULT_MCP_VERSION = "0.0.0";
 const DEFAULT_MCP_NAME = "@farming-labs/docs";
 
+const DOCS_CONFIG_SCHEMA_OPTIONS: DocsMcpConfigSchemaOption[] = [
+  {
+    path: "entry",
+    name: "entry",
+    type: "string",
+    default: "docs",
+    description: 'URL path prefix for documentation routes, for example "docs" creates /docs.',
+    docs: "/docs/overview",
+  },
+  {
+    path: "contentDir",
+    name: "contentDir",
+    type: "string",
+    default: "same as entry",
+    description:
+      "Path to markdown content files. Adapters outside Next.js usually need this when content does not live under the route prefix.",
+    docs: "/docs/overview",
+  },
+  {
+    path: "staticExport",
+    name: "staticExport",
+    type: "boolean",
+    default: false,
+    description: "Enable full static builds. Search, AI, and runtime API routes are hidden.",
+    docs: "/docs/overview",
+  },
+  {
+    path: "theme",
+    name: "theme",
+    type: "DocsTheme",
+    description: "Theme instance from a theme factory such as fumadocs() or pixelBorder().",
+    docs: "/docs/customization/themes",
+  },
+  {
+    path: "nav",
+    name: "nav",
+    type: "{ title?: string; url?: string }",
+    description:
+      "Sidebar and discovery metadata for the docs site. Non-Next.js adapters usually require it.",
+    children: [
+      {
+        path: "nav.title",
+        name: "title",
+        type: "string",
+        description: "Human-readable docs site title.",
+      },
+      {
+        path: "nav.url",
+        name: "url",
+        type: "string",
+        description: "Public base URL for generated absolute links and metadata.",
+      },
+    ],
+  },
+  {
+    path: "github",
+    name: "github",
+    type: "string | GithubConfig",
+    description:
+      'GitHub repository metadata for "Edit on GitHub" links and page action prompt templates.',
+    docs: "/docs/customization/page-actions",
+  },
+  {
+    path: "themeToggle",
+    name: "themeToggle",
+    type: "boolean | ThemeToggleConfig",
+    default: true,
+    description: "Enable or customize the light/dark mode toggle.",
+  },
+  {
+    path: "breadcrumb",
+    name: "breadcrumb",
+    type: "boolean | BreadcrumbConfig",
+    default: true,
+    description: "Enable or customize breadcrumb navigation.",
+  },
+  {
+    path: "sidebar",
+    name: "sidebar",
+    type: "boolean | SidebarConfig",
+    default: true,
+    description: "Enable or customize the docs sidebar.",
+    children: [
+      {
+        path: "sidebar.style",
+        name: "style",
+        type: "string",
+        description: "Theme-specific sidebar style variant when supported.",
+      },
+      {
+        path: "sidebar.defaultOpen",
+        name: "defaultOpen",
+        type: "boolean",
+        description: "Whether collapsible sidebar groups start open by default.",
+      },
+    ],
+  },
+  {
+    path: "icons",
+    name: "icons",
+    type: "Record<string, Component>",
+    description: "Shared icon registry for frontmatter icon fields and built-in MDX components.",
+  },
+  {
+    path: "components",
+    name: "components",
+    type: "Record<string, Component>",
+    description: "Custom MDX component registry and built-in component overrides.",
+  },
+  {
+    path: "onCopyClick",
+    name: "onCopyClick",
+    type: "(data: CodeBlockCopyData) => void",
+    description:
+      "Callback fired when a visitor copies a code block, including title, content, url, and language.",
+  },
+  {
+    path: "feedback",
+    name: "feedback",
+    type: "boolean | FeedbackConfig",
+    default: false,
+    description:
+      "Human page feedback UI. Agent feedback endpoints remain default-on unless opted out.",
+    docs: "/docs/customization/feedback",
+  },
+  {
+    path: "readingTime",
+    name: "readingTime",
+    type: "boolean | ReadingTimeConfig",
+    default: false,
+    description: "Opt-in estimated reading time label with per-page overrides.",
+  },
+  {
+    path: "agent",
+    name: "agent",
+    type: "DocsAgentConfig",
+    description: "Defaults for docs agent compact and generated agent-facing files.",
+    docs: "/docs/getting-started/agent-ready-docs",
+  },
+  {
+    path: "pageActions",
+    name: "pageActions",
+    type: "PageActionsConfig",
+    description: "Copy Markdown and Open in LLM actions for docs pages.",
+    docs: "/docs/customization/page-actions",
+    children: [
+      {
+        path: "pageActions.copyMarkdown",
+        name: "copyMarkdown",
+        type: "boolean | PageActionConfig",
+        description: "Show a Copy Markdown action for the current page.",
+      },
+      {
+        path: "pageActions.openDocs",
+        name: "openDocs",
+        type: "boolean | OpenDocsActionConfig",
+        description: "Show provider actions that open the current docs page in an LLM.",
+        children: [
+          {
+            path: "pageActions.openDocs.target",
+            name: "target",
+            type: '"page" | "markdown"',
+            default: "page",
+            description:
+              "Whether provider URLs receive the rendered page URL or the .md markdown route.",
+          },
+          {
+            path: "pageActions.openDocs.providers",
+            name: "providers",
+            type: "Array<string | PromptProviderConfig>",
+            description:
+              "Provider IDs or provider objects. Built-ins include chatgpt, claude, cursor, and t3.",
+          },
+          {
+            path: "pageActions.openDocs.prompt",
+            name: "prompt",
+            type: "string",
+            description: "Prompt text prepended to the provider URL when opening docs.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: "ai",
+    name: "ai",
+    type: "AIConfig",
+    description: "RAG-powered Ask AI configuration.",
+    docs: "/docs/customization/ask-ai",
+    children: [
+      {
+        path: "ai.enabled",
+        name: "enabled",
+        type: "boolean",
+        description: "Enable or disable Ask AI.",
+      },
+      {
+        path: "ai.model",
+        name: "model",
+        type: "string | AIModelConfig",
+        description: "Model ID or model routing config.",
+      },
+      {
+        path: "ai.providers",
+        name: "providers",
+        type: "Record<string, AIProviderConfig>",
+        description: "Provider base URLs and optional API keys.",
+      },
+      {
+        path: "ai.systemPrompt",
+        name: "systemPrompt",
+        type: "string",
+        description: "Additional instruction text for generated answers.",
+      },
+      {
+        path: "ai.useMcp",
+        name: "useMcp",
+        type: "boolean | DocsAskAIMcpConfig",
+        description: "Use the built-in MCP search tool as Ask AI's retrieval provider.",
+      },
+    ],
+  },
+  {
+    path: "search",
+    name: "search",
+    type: "boolean | DocsSearchConfig",
+    default: true,
+    description: "Built-in simple search, Typesense, Algolia, MCP, or a custom adapter.",
+    docs: "/docs/customization/search",
+    children: [
+      {
+        path: "search.provider",
+        name: "provider",
+        type: '"simple" | "typesense" | "algolia" | "mcp" | "custom"',
+        default: "simple",
+        description: "Search backend used by the docs UI and MCP search tool.",
+      },
+      {
+        path: "search.maxResults",
+        name: "maxResults",
+        type: "number",
+        description: "Maximum result count returned by search requests.",
+      },
+    ],
+  },
+  {
+    path: "llmsTxt",
+    name: "llmsTxt",
+    type: "boolean | LlmsTxtConfig",
+    default: true,
+    description:
+      "Generated /llms.txt, /llms-full.txt, optional section files, and basePath-aware aliases.",
+    docs: "/docs/getting-started/agent-ready-docs",
+  },
+  {
+    path: "changelog",
+    name: "changelog",
+    type: "boolean | ChangelogConfig",
+    default: false,
+    description: "Generate changelog feed and entry pages from dated MDX entries.",
+    docs: "/docs/customization/changelog",
+  },
+  {
+    path: "mcp",
+    name: "mcp",
+    type: "boolean | DocsMcpConfig",
+    default: true,
+    description:
+      "Built-in MCP server over stdio plus HTTP routes at /mcp and /.well-known/mcp, backed by /api/docs/mcp.",
+    docs: "/docs/customization/mcp",
+    children: [
+      {
+        path: "mcp.enabled",
+        name: "enabled",
+        type: "boolean",
+        default: true,
+        description: "Enable the built-in MCP server.",
+      },
+      {
+        path: "mcp.route",
+        name: "route",
+        type: "string",
+        default: "/api/docs/mcp",
+        description: "Canonical Streamable HTTP route used by the MCP endpoint.",
+      },
+      {
+        path: "mcp.name",
+        name: "name",
+        type: "string",
+        default: "nav.title or @farming-labs/docs",
+        description: "Human-readable MCP server name reported to clients.",
+      },
+      {
+        path: "mcp.version",
+        name: "version",
+        type: "string",
+        default: "0.0.0",
+        description: "Version string reported to MCP clients.",
+      },
+      {
+        path: "mcp.tools",
+        name: "tools",
+        type: "DocsMcpToolsConfig",
+        default: "all enabled",
+        description: "Fine-grained built-in MCP tool toggles.",
+        children: [
+          {
+            path: "mcp.tools.listPages",
+            name: "listPages",
+            type: "boolean",
+            default: true,
+            description: "Expose the list_pages tool.",
+          },
+          {
+            path: "mcp.tools.getNavigation",
+            name: "getNavigation",
+            type: "boolean",
+            default: true,
+            description: "Expose the get_navigation tool.",
+          },
+          {
+            path: "mcp.tools.searchDocs",
+            name: "searchDocs",
+            type: "boolean",
+            default: true,
+            description: "Expose the search_docs tool.",
+          },
+          {
+            path: "mcp.tools.readPage",
+            name: "readPage",
+            type: "boolean",
+            default: true,
+            description: "Expose the read_page tool.",
+          },
+          {
+            path: "mcp.tools.getCodeExamples",
+            name: "getCodeExamples",
+            type: "boolean",
+            default: true,
+            description: "Expose the get_code_examples tool.",
+          },
+          {
+            path: "mcp.tools.getConfigSchema",
+            name: "getConfigSchema",
+            type: "boolean",
+            default: true,
+            description: "Expose the get_config_schema tool.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: "apiReference",
+    name: "apiReference",
+    type: "boolean | ApiReferenceConfig",
+    default: false,
+    description:
+      "Generated API reference pages from framework route conventions or a hosted OpenAPI document.",
+    docs: "/docs/customization/api-reference",
+    children: [
+      {
+        path: "apiReference.specUrl",
+        name: "specUrl",
+        type: "string",
+        description: "Remote OpenAPI JSON URL when the backend owns the schema.",
+      },
+      {
+        path: "apiReference.path",
+        name: "path",
+        type: "string",
+        description: "Docs route where the API reference is rendered.",
+      },
+    ],
+  },
+  {
+    path: "sitemap",
+    name: "sitemap",
+    type: "boolean | DocsSitemapConfig",
+    default: true,
+    description: "Generated sitemap.xml, sitemap.md, and /.well-known/sitemap.md.",
+  },
+  {
+    path: "robots",
+    name: "robots",
+    type: "boolean | DocsRobotsConfig",
+    default: true,
+    description:
+      "Runtime or generated robots.txt policy for docs routes, agent-readable files, and AI crawler user agents.",
+  },
+  {
+    path: "metadata",
+    name: "metadata",
+    type: "DocsMetadata",
+    description: "SEO and JSON-LD inputs such as titleTemplate and description.",
+  },
+  {
+    path: "og",
+    name: "og",
+    type: "OGConfig",
+    description: "Dynamic Open Graph image configuration.",
+  },
+];
+
+const DOCS_CONFIG_SCHEMA_EXAMPLES: DocsMcpConfigSchema["examples"] = [
+  {
+    title: "Minimal config",
+    code: `import { defineDocs } from "@farming-labs/docs";
+import { fumadocs } from "@farming-labs/theme";
+
+export default defineDocs({
+  entry: "docs",
+  theme: fumadocs(),
+});`,
+  },
+  {
+    title: "MCP tool toggles",
+    code: `export default defineDocs({
+  entry: "docs",
+  mcp: {
+    tools: {
+      getConfigSchema: true,
+      getCodeExamples: true,
+    },
+  },
+});`,
+  },
+];
+
 const searchDocsInputSchema = z.object({
   query: z.string().trim().min(1),
   limit: z.number().int().min(1).max(25).optional(),
@@ -155,6 +612,11 @@ const listPagesInputSchema = z.object({
 
 const getNavigationInputSchema = z.object({
   locale: z.string().min(1).optional(),
+});
+
+const getConfigSchemaInputSchema = z.object({
+  option: z.string().trim().min(1).optional(),
+  query: z.string().trim().min(1).optional(),
 });
 
 const getCodeExamplesInputSchema = z.object({
@@ -195,6 +657,7 @@ export function resolveDocsMcpConfig(
         searchDocs: true,
         getNavigation: true,
         getCodeExamples: true,
+        getConfigSchema: true,
       },
     };
   }
@@ -212,6 +675,7 @@ export function resolveDocsMcpConfig(
       searchDocs: config.tools?.searchDocs ?? true,
       getNavigation: config.tools?.getNavigation ?? true,
       getCodeExamples: config.tools?.getCodeExamples ?? true,
+      getConfigSchema: config.tools?.getConfigSchema ?? true,
     },
   };
 }
@@ -479,6 +943,89 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             locale,
             outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
             metadata: { tool: "get_navigation" },
+          });
+          throw error;
+        }
+      },
+    );
+  }
+
+  if (resolved.tools.getConfigSchema) {
+    server.registerTool(
+      "get_config_schema",
+      {
+        title: "Get docs config schema",
+        description:
+          "Return structured docs.config.ts option metadata, optionally filtered by option path or query.",
+        inputSchema: getConfigSchemaInputSchema,
+        annotations: { readOnlyHint: true },
+      },
+      async ({ option, query }) => {
+        const startedAt = nowMs();
+        const trace = createDocsAgentTraceContext("mcp.tool.get_config_schema");
+        const callSpanId = createDocsAgentTraceId("span");
+        await emitDocsAgentTraceEvent(options.observability, {
+          type: "tool.call",
+          source: "mcp",
+          traceId: trace.traceId,
+          spanId: callSpanId,
+          name: "get_config_schema",
+          startedAt: trace.startedAt,
+          status: "started",
+          inputPreview: { option, queryLength: query?.length },
+          metadata: { tool: "get_config_schema" },
+        });
+
+        try {
+          const schema = getDocsConfigSchema({ option, query });
+          const elapsed = durationMs(startedAt);
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "mcp_tool",
+            source: "mcp",
+            input: query ? { query } : undefined,
+            properties: {
+              tool: "get_config_schema",
+              option,
+              queryLength: query?.length,
+              resultCount: schema.resultCount,
+              durationMs: elapsed,
+            },
+          });
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.result",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "get_config_schema",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "success",
+            outputPreview: { resultCount: schema.resultCount },
+            metadata: { tool: "get_config_schema" },
+          });
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(schema, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          const elapsed = durationMs(startedAt);
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.error",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "get_config_schema",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "error",
+            outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
+            metadata: { tool: "get_config_schema" },
           });
           throw error;
         }
@@ -1406,6 +1953,124 @@ function toSearchSourcePages(pages: DocsMcpPage[]): DocsSearchSourcePage[] {
     description: page.description,
     related: page.related,
   }));
+}
+
+function getDocsConfigSchema(filters: { option?: string; query?: string }): DocsMcpConfigSchema {
+  const option = filters.option?.trim();
+  const query = filters.query?.trim();
+  let options = DOCS_CONFIG_SCHEMA_OPTIONS.map(cloneConfigSchemaOption);
+
+  if (option) {
+    options = selectConfigSchemaOptions(option);
+  }
+
+  if (query) {
+    options = filterConfigSchemaOptionsByQuery(options, query);
+  }
+
+  return {
+    schemaVersion: 1,
+    configFile: "docs.config.ts",
+    description:
+      "Configuration schema for @farming-labs/docs defineDocs(). Use option for an exact top-level or nested path, or query for keyword filtering.",
+    filters:
+      option || query
+        ? {
+            ...(option ? { option } : {}),
+            ...(query ? { query } : {}),
+          }
+        : undefined,
+    resultCount: countConfigSchemaOptions(options),
+    options,
+    examples: DOCS_CONFIG_SCHEMA_EXAMPLES,
+  };
+}
+
+function cloneConfigSchemaOption(option: DocsMcpConfigSchemaOption): DocsMcpConfigSchemaOption {
+  return {
+    ...option,
+    children: option.children?.map(cloneConfigSchemaOption),
+  };
+}
+
+function selectConfigSchemaOptions(optionPath: string): DocsMcpConfigSchemaOption[] {
+  const needle = normalizeConfigSchemaToken(optionPath);
+  return flattenConfigSchemaOptions(DOCS_CONFIG_SCHEMA_OPTIONS)
+    .filter((option) => {
+      const normalizedPath = normalizeConfigSchemaToken(option.path);
+      const normalizedName = normalizeConfigSchemaToken(option.name);
+      return (
+        normalizedPath === needle ||
+        normalizedName === needle ||
+        normalizedPath.split(".").includes(needle)
+      );
+    })
+    .map(cloneConfigSchemaOption);
+}
+
+function filterConfigSchemaOptionsByQuery(
+  options: DocsMcpConfigSchemaOption[],
+  query: string,
+): DocsMcpConfigSchemaOption[] {
+  return options.flatMap((option) => {
+    if (configSchemaOptionMatchesQuery(option, query)) {
+      return [cloneConfigSchemaOption(option)];
+    }
+
+    const children = option.children
+      ? filterConfigSchemaOptionsByQuery(option.children, query)
+      : [];
+    if (children.length === 0) return [];
+
+    return [
+      {
+        ...cloneConfigSchemaOption(option),
+        children,
+      },
+    ];
+  });
+}
+
+function configSchemaOptionMatchesQuery(option: DocsMcpConfigSchemaOption, query: string): boolean {
+  const searchText = [
+    option.path,
+    option.name,
+    option.type,
+    option.default,
+    option.description,
+    option.docs,
+    option.values?.join(" "),
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(" ");
+  const lowerSearchText = searchText.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  return (
+    lowerSearchText.includes(lowerQuery) ||
+    normalizeConfigSchemaToken(searchText).includes(normalizeConfigSchemaToken(query))
+  );
+}
+
+function flattenConfigSchemaOptions(
+  options: DocsMcpConfigSchemaOption[],
+): DocsMcpConfigSchemaOption[] {
+  return options.flatMap((option) => [
+    option,
+    ...(option.children ? flattenConfigSchemaOptions(option.children) : []),
+  ]);
+}
+
+function countConfigSchemaOptions(options: DocsMcpConfigSchemaOption[]): number {
+  return flattenConfigSchemaOptions(options).length;
+}
+
+function normalizeConfigSchemaToken(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^docs\.config\.?/, "")
+    .replace(/[`'"]/g, "")
+    .replace(/[_\-\s]+/g, "");
 }
 
 function isSelfMcpSearchEndpoint(search?: boolean | DocsSearchConfig, route?: string): boolean {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -1998,12 +1998,7 @@ function selectConfigSchemaOptions(optionPath: string): DocsMcpConfigSchemaOptio
   return flattenConfigSchemaOptions(DOCS_CONFIG_SCHEMA_OPTIONS)
     .filter((option) => {
       const normalizedPath = normalizeConfigSchemaToken(option.path);
-      const normalizedName = normalizeConfigSchemaToken(option.name);
-      return (
-        normalizedPath === needle ||
-        normalizedName === needle ||
-        normalizedPath.split(".").includes(needle)
-      );
+      return normalizedPath === needle;
     })
     .map(cloneConfigSchemaOption);
 }

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -90,6 +90,8 @@ export type {
 } from "./sitemap.js";
 export type {
   DocsMcpCodeExample,
+  DocsMcpConfigSchema,
+  DocsMcpConfigSchemaOption,
   DocsMcpHttpHandlers,
   DocsMcpNavigationNode,
   DocsMcpNavigationTree,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1116,6 +1116,8 @@ export interface DocsMcpToolsConfig {
   getNavigation?: boolean;
   /** Expose a `get_code_examples` tool for fenced code blocks and their metadata. */
   getCodeExamples?: boolean;
+  /** Expose a `get_config_schema` tool for docs.config option metadata. */
+  getConfigSchema?: boolean;
 }
 
 /**

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1945,6 +1945,7 @@ title: "Home"
         searchDocs: false,
         getNavigation: true,
         getCodeExamples: true,
+        getConfigSchema: true,
       },
     });
     expect(spec.feedback).toMatchObject({

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -906,6 +906,7 @@ function readMcpConfig(root: string): boolean | DocsMcpConfig | undefined {
           searchDocs: readBooleanFromBlock(block, "searchDocs"),
           getNavigation: readBooleanFromBlock(block, "getNavigation"),
           getCodeExamples: readBooleanFromBlock(block, "getCodeExamples"),
+          getConfigSchema: readBooleanFromBlock(block, "getConfigSchema"),
         },
       };
     } catch {

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -180,6 +180,7 @@ The built-in MCP surface currently includes:
 - `search_docs`
 - `read_page`
 - `get_code_examples`
+- `get_config_schema`
 
 `get_code_examples` parses fenced code block metadata from raw markdown/MDX and returns structured
 examples for agents. Use metadata like
@@ -188,6 +189,9 @@ examples for agents. Use metadata like
 ```ts title="docs.config.ts" framework="nextjs" packageManager="pnpm" runnable
 ```
 ````
+
+`get_config_schema` returns structured `docs.config.ts` option metadata. Use `option` for an exact
+path such as `mcp.tools.getConfigSchema`, or `query` for keyword filtering.
 
 when a snippet has a target file, framework, package manager, or is safe to copy as a complete
 example. This metadata is for markdown/MCP consumers and does not require a UI change.
@@ -512,7 +516,8 @@ With `--url`, `docs doctor --agent` also probes the deployed public agent surfac
 
 For hosted MCP, the command performs a Streamable HTTP initialize handshake, checks for
 `mcp-session-id`, calls `tools/list`, and expects `list_pages`, `get_navigation`, `search_docs`,
-`read_page`, and `get_code_examples`. Hosted checks raise the agent max score from `105` to `145`.
+`read_page`, `get_code_examples`, and `get_config_schema`. Hosted checks raise the agent max score
+from `105` to `145`.
 
 Hosted JSON check IDs include `hosted-agent-discovery`, `hosted-llms`, `hosted-sitemap`,
 `hosted-robots`, `hosted-skill`, `hosted-markdown`, and `hosted-mcp`.

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -660,7 +660,7 @@ Default behavior:
 - **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`
+- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`, `get_config_schema`
 
 `get_code_examples` returns fenced code blocks as structured JSON. It parses code-fence metadata
 such as `title`, `framework`, `packageManager`, and `runnable` from raw markdown/MDX and does not
@@ -691,6 +691,19 @@ MCP call example:
 ```
 
 Supported filters: `query`, `path`, `framework`, `packageManager`, `language`, `runnable`, `limit`, and `locale`.
+
+`get_config_schema` returns structured `docs.config.ts` option metadata for agents that need to
+write or update config safely. Call it with no arguments for the full schema, `option` for a
+specific top-level or nested path, or `query` for keyword filtering.
+
+```json
+{
+  "name": "get_config_schema",
+  "arguments": {
+    "option": "mcp.tools.getConfigSchema"
+  }
+}
+```
 
 Framework notes:
 - **Next.js:** `withDocs()` auto-generates the default `/api/docs/mcp` route and public `/mcp` plus `/.well-known/mcp` rewrites


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `get_config_schema` MCP tool to return structured `docs.config.ts` option metadata with `option` and `query` filters. It’s enabled by default, published over stdio/HTTP, documented with examples, and `docs doctor` now expects it in hosted MCP.

- **New Features**
  - `get_config_schema` returns `schemaVersion`, `configFile`, `options`, `examples`, `filters`, and `resultCount`.
  - Supports `option` paths (e.g., `mcp.tools.getConfigSchema`) and keyword `query`; ambiguous paths return zero results.
  - Toggle via `mcp.tools.getConfigSchema` (default true); config readers in `@farming-labs/docs` and `packages/fumadocs` parse it; included in `tools/list`.
  - Exported types `DocsMcpConfigSchema` and `DocsMcpConfigSchemaOption`; docs updated with call and JSON response examples.

- **Migration**
  - After upgrading `@farming-labs/docs`, ensure your MCP endpoint exposes `get_config_schema`. If you customize tool toggles, set `mcp.tools.getConfigSchema: true` and rerun `docs doctor --agent`.

<sup>Written for commit fccfbb3bccc09f50336de07997cce888e4b54741. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

