### PR TITLE
chore: `list_docs` and `getSchemaConfig` mcp tools docs

### DIFF
--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -592,10 +592,13 @@ The hosted pass probes:
 For MCP, the doctor performs a Streamable HTTP `initialize` request, reuses `mcp-session-id` when
 the server returns one, sends `tools/list`, and expects the built-in docs tools:
 
+- `list_docs`
 - `list_pages`
 - `get_navigation`
 - `search_docs`
 - `read_page`
+- `get_code_examples`
+- `get_config_schema`
 
 Hosted checks add extra weighted checks, but the top-level score stays normalized to `100%`. The
 JSON report also includes the normalized `url` field and hosted check IDs such as
@@ -926,10 +929,17 @@ pnpm exec docs mcp --config src/lib/docs.config.ts
 
 The current built-in MCP surface includes:
 
+- `list_docs`
 - `list_pages`
 - `get_navigation`
 - `search_docs`
 - `read_page`
+- `get_code_examples`
+- `get_config_schema`
+
+`list_docs` returns page summaries grouped by docs section, optionally narrowed by `section`.
+`get_code_examples` extracts fenced code block metadata for agents, and `get_config_schema`
+returns structured `docs.config.ts` option metadata.
 
 For the HTTP endpoint version, see [MCP Server](/docs/customization/mcp).
 

--- a/website/app/docs/configuration/agent.md
+++ b/website/app/docs/configuration/agent.md
@@ -35,13 +35,16 @@ Use this machine-oriented page when the user needs implementation guidance for `
 - When they want AI-facing behavior, distinguish between:
   - `ai` for Ask AI / chat
   - `agent.compact` for defaults used by `docs agent compact`
-  - `mcp` for the built-in MCP server
+  - `mcp` for the built-in MCP server, including default tools like `list_docs`, `search_docs`,
+    `read_page`, `get_code_examples`, and `get_config_schema`
   - `llmsTxt` for crawler-friendly site summaries
   - `sitemap` for XML and Markdown maps with canonical URLs and freshness dates
   - `robots` plus `docs robots generate` for a static crawler and AI-agent access policy
   - markdown routes for page-level machine-readable content
 - When they ask about generated API docs, use `apiReference`.
 - When they ask about static hosting, mention `staticExport: true`.
+- When they need to edit `docs.config.ts` through MCP, prefer `get_config_schema` before suggesting
+  config changes.
 
 ## Framework notes
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -598,7 +598,13 @@ Default behavior:
 - **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
+- **Built-in tools:** `list_docs`, `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`, `get_config_schema`
+
+Useful built-in tool calls:
+
+- `list_docs` returns page summaries grouped by docs section, with optional `section` filtering
+- `get_code_examples` returns fenced code blocks plus parsed metadata such as `title`, `framework`, `packageManager`, and `runnable`
+- `get_config_schema` returns structured `docs.config.ts` option metadata for agents editing config safely
 
 Framework notes:
 

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -13,14 +13,17 @@ Keep answers grounded in the exact options, routes, commands, and examples docum
 If the request moves beyond this page, point to the closest related docs instead of inventing config.
 </Agent>
 
-`@farming-labs/docs` can expose your docs as a built-in MCP server, so AI clients can search the docs, read pages, and inspect the nav tree without scraping HTML.
+`@farming-labs/docs` can expose your docs as a built-in MCP server, so AI clients can search the docs, read pages, list sections, inspect code examples, and understand config options without scraping HTML.
 
 The current built-in surface includes:
 
+- `list_docs`
 - `list_pages`
 - `get_navigation`
 - `search_docs`
 - `read_page`
+- `get_code_examples`
+- `get_config_schema`
 
 It also exposes resources for:
 
@@ -392,19 +395,25 @@ http://127.0.0.1:3000/.well-known/mcp
 
 The built-in HTTP route exposes the full MCP surface:
 
+- `list_docs`
 - `list_pages`
 - `get_navigation`
 - `search_docs`
 - `read_page`
+- `get_code_examples`
+- `get_config_schema`
 
 ## What to ask it
 
 Once your MCP client is connected, these are good first checks:
 
+- `list_docs` for `getting-started` before deciding which page to read
 - `search_docs` for `feedback`, `page actions`, or `mcp`
 - `read_page` for `/docs/configuration` or `installation`
 - `get_navigation` to inspect the docs tree
 - `list_pages` to confirm the server is loading the expected docs set
+- `get_code_examples` for runnable Next.js or pnpm snippets
+- `get_config_schema` for `mcp.tools` before editing `docs.config.ts`
 
 In Cursor or VS Code, natural prompts like these work well too:
 
@@ -414,12 +423,45 @@ In Cursor or VS Code, natural prompts like these work well too:
 
 ## What the tools return
 
+- `list_docs` returns page summaries grouped by section; pass `section` such as `getting-started` to narrow the result
 - `list_pages` returns page titles, slugs, and URLs
 - `get_navigation` returns the docs tree in a readable text outline
 - `search_docs` ranks pages by title, description, and content matches
 - `read_page` accepts either a slug like `installation` or a full docs path like `/docs/installation`
+- `get_code_examples` returns fenced code blocks with parsed metadata like `title`, `framework`, `packageManager`, and `runnable`
+- `get_config_schema` returns `docs.config.ts` option metadata with paths, types, defaults, descriptions, and examples
 
-The built-in resources mirror that same data:
+Example tool calls:
+
+```json title="list_docs"
+{
+  "name": "list_docs",
+  "arguments": {
+    "section": "getting-started"
+  }
+}
+```
+
+```json title="get_code_examples"
+{
+  "name": "get_code_examples",
+  "arguments": {
+    "topic": "docs.config.ts",
+    "framework": "nextjs"
+  }
+}
+```
+
+```json title="get_config_schema"
+{
+  "name": "get_config_schema",
+  "arguments": {
+    "option": "mcp.tools.listDocs"
+  }
+}
+```
+
+The built-in resources mirror the navigation and page content data:
 
 - `docs://navigation`
 - `docs://docs`

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -349,10 +349,13 @@ export default defineDocs({
     route: "/api/docs/mcp",
     name: "My Docs MCP",
     tools: {
+      listDocs: true,
       listPages: true,
       getNavigation: true,
       searchDocs: true,
       readPage: true,
+      getCodeExamples: true,
+      getConfigSchema: true,
     },
   },
 });
@@ -360,12 +363,15 @@ export default defineDocs({
 
 ### `DocsMcpToolsConfig`
 
-| Property        | Type      | Description |
-| --------------- | --------- | ----------- |
-| `listPages`     | `boolean` | Expose the `list_pages` tool |
-| `getNavigation` | `boolean` | Expose the `get_navigation` tool |
-| `searchDocs`    | `boolean` | Expose the `search_docs` tool |
-| `readPage`      | `boolean` | Expose the `read_page` tool |
+| Property            | Type      | Description |
+| ------------------- | --------- | ----------- |
+| `listDocs`          | `boolean` | Expose the `list_docs` tool |
+| `listPages`         | `boolean` | Expose the `list_pages` tool |
+| `getNavigation`     | `boolean` | Expose the `get_navigation` tool |
+| `searchDocs`        | `boolean` | Expose the `search_docs` tool |
+| `readPage`          | `boolean` | Expose the `read_page` tool |
+| `getCodeExamples`   | `boolean` | Expose the `get_code_examples` tool |
+| `getConfigSchema`   | `boolean` | Expose the `get_config_schema` tool |
 
 Default MCP surface:
 
@@ -373,7 +379,7 @@ Default MCP surface:
 - **Well-known HTTP route:** `/.well-known/mcp`
 - **Canonical HTTP route:** `/api/docs/mcp`
 - **stdio command:** `pnpx @farming-labs/docs mcp`
-- **Built-in tools:** `list_pages`, `get_navigation`, `search_docs`, `read_page`
+- **Built-in tools:** `list_docs`, `list_pages`, `get_navigation`, `search_docs`, `read_page`, `get_code_examples`, `get_config_schema`
 
 Framework notes:
 

--- a/website/skill.md
+++ b/website/skill.md
@@ -17,4 +17,4 @@ Use this skill when reading or implementing from the hosted Farming Labs docs we
 - Search with `/api/docs?query={query}` when the right page is unknown.
 - Use `/llms.txt` for a compact index and `/llms-full.txt` for full markdown context.
 - Use `/api/docs?format=openapi` for the machine-readable API schema when API routes matter.
-- Use `/mcp` or `/.well-known/mcp` when MCP is available.
+- Use `/mcp` or `/.well-known/mcp` when MCP is available. Prefer `list_docs` to inspect sections, `search_docs` to find a topic, `read_page` to fetch a page, `get_code_examples` to extract runnable snippets, and `get_config_schema` before editing `docs.config.ts`.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documents new MCP tools `list_docs`, `get_code_examples`, and `get_config_schema` in `@farming-labs/docs`, and updates examples, config, and CLI doctor to match the expanded MCP surface. This lets clients list sections, pull runnable code snippets, and safely read the config schema.

- **New Features**
  - Added the three tools to built-in MCP tool lists and defaults across the docs.
  - Described outputs and added JSON example calls.
  - Updated `DocsMcpToolsConfig` with `listDocs`, `getCodeExamples`, and `getConfigSchema`.
  - Updated CLI doctor and guidance (`agent.md`, `skill.md`) to use these tools, preferring `get_config_schema` before editing `docs.config.ts`.

<sup>Written for commit 05f156fb7c0cb1ed23a5468179deb875ae8b12bc. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

