### PR TITLE
feat: docs review ci label config

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   docs-review:
+    name: "docs-review"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/docs/src/review.test.ts
+++ b/packages/docs/src/review.test.ts
@@ -26,6 +26,7 @@ describe("docs review helpers", () => {
     expect(review.enabled).toBe(true);
     expect(review.ci).toMatchObject({
       enabled: true,
+      name: "docs-review",
       mode: "warn",
       annotations: true,
       comment: true,
@@ -42,7 +43,7 @@ describe("docs review helpers", () => {
           logo: <Logo />,
         },
         review: {
-          ci: { mode: "block" },
+          ci: { name: "agent-docs-review", mode: "block" },
           score: { threshold: 90 },
           rules: {
             agentContext: "warn",
@@ -53,7 +54,7 @@ describe("docs review helpers", () => {
 
     expect(resolveDocsReviewConfig(review)).toMatchObject({
       enabled: true,
-      ci: { mode: "block", enabled: true },
+      ci: { name: "agent-docs-review", mode: "block", enabled: true },
       score: { threshold: 90 },
       rules: { agentContext: "warn" },
     });
@@ -83,6 +84,7 @@ describe("docs review helpers", () => {
 
     const workflow = readFileSync(workflowPath, "utf-8");
     expect(workflow).toContain("name: Docs Review");
+    expect(workflow).toContain('    name: "docs-review"');
     expect(workflow).toContain('      - "website/docs.config.ts"');
     expect(workflow).toContain('      - "website/app/docs/**"');
     expect(workflow).toContain("pnpm exec docs review --ci --config docs.config.ts");
@@ -115,6 +117,33 @@ describe("docs review helpers", () => {
       "node ../packages/docs/dist/cli/index.mjs review --ci --config docs.config.ts",
     );
     expect(workflow.indexOf("Build docs CLI")).toBeLessThan(workflow.indexOf("Review docs"));
+  });
+
+  it("uses the configured docs review CI check name", () => {
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+    mkdirSync(join(tmpDir, "website", "app", "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf-8");
+    writeFileSync(
+      join(tmpDir, "website", "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  review: {
+    ci: {
+      name: "agent-docs-review",
+    },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    ensureDocsReviewWorkflow({
+      rootDir: join(tmpDir, "website"),
+      configPath: "docs.config.ts",
+    });
+
+    const workflow = readFileSync(join(tmpDir, DEFAULT_DOCS_REVIEW_WORKFLOW_PATH), "utf-8");
+    expect(workflow).toContain('    name: "agent-docs-review"');
   });
 
   it("does not create a workflow when review is disabled", () => {

--- a/packages/docs/src/review.ts
+++ b/packages/docs/src/review.ts
@@ -11,11 +11,13 @@ import type {
 
 export const DEFAULT_DOCS_REVIEW_WORKFLOW_PATH = ".github/workflows/docs-review.yml";
 export const DEFAULT_DOCS_REVIEW_SCORE_THRESHOLD = 80;
+export const DEFAULT_DOCS_REVIEW_CI_NAME = "docs-review";
 
 export interface ResolvedDocsReviewConfig {
   enabled: boolean;
   ci: {
     enabled: boolean;
+    name: string;
     mode: DocsReviewCiMode;
     annotations: boolean;
     comment: boolean;
@@ -33,6 +35,7 @@ export interface ResolvedDocsReviewConfig {
 
 export interface DocsReviewWorkflowOptions {
   packageManager?: "npm" | "pnpm" | "yarn" | "bun";
+  ciName?: string;
   projectDir?: string;
   configPath?: string;
   buildCommand?: string;
@@ -81,7 +84,13 @@ export function resolveDocsReviewConfig(
   if (review === false) {
     return {
       enabled: false,
-      ci: { enabled: false, mode: "off", annotations: false, comment: false },
+      ci: {
+        enabled: false,
+        name: DEFAULT_DOCS_REVIEW_CI_NAME,
+        mode: "off",
+        annotations: false,
+        comment: false,
+      },
       score: { threshold: DEFAULT_DOCS_REVIEW_SCORE_THRESHOLD, weights: DEFAULT_REVIEW_WEIGHTS },
       rules: DEFAULT_REVIEW_RULES,
     };
@@ -100,6 +109,7 @@ export function resolveDocsReviewConfig(
     enabled,
     ci: {
       enabled: ciEnabled,
+      name: normalizeCiName(ciObject.name),
       mode: ciEnabled ? mode : "off",
       annotations: ciObject.annotations !== false,
       comment: ciObject.comment !== false,
@@ -124,6 +134,7 @@ export function resolveDocsReviewConfig(
 
 export function buildDocsReviewWorkflow(options: DocsReviewWorkflowOptions = {}): string {
   const packageManager = options.packageManager ?? "npm";
+  const ciName = normalizeCiName(options.ciName);
   const projectDir = normalizeProjectDir(options.projectDir);
   const configArg = options.configPath ? ` --config ${shellQuote(options.configPath)}` : "";
   const reviewCommand = `${options.reviewCommand ?? reviewCommandForPackageManager(packageManager)} review --ci${configArg}`;
@@ -150,6 +161,7 @@ permissions:
 
 jobs:
   docs-review:
+    name: ${JSON.stringify(ciName)}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -193,6 +205,7 @@ export function ensureDocsReviewWorkflow(
   const packageManager = detectPackageManager(repoRoot);
   const workflow = buildDocsReviewWorkflow({
     packageManager,
+    ciName: review.ci.name,
     projectDir,
     configPath,
     buildCommand: detectLocalDocsCliBuildCommand(repoRoot, packageManager),
@@ -303,6 +316,11 @@ function normalizeWeight(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
+function normalizeCiName(value: string | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed || DEFAULT_DOCS_REVIEW_CI_NAME;
+}
+
 function clampScoreThreshold(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value))
     return DEFAULT_DOCS_REVIEW_SCORE_THRESHOLD;
@@ -317,6 +335,7 @@ function readReviewCiObject(source: string, cursor: number): DocsReviewConfig["c
   const mode = readTopLevelString(block, "mode");
   return {
     enabled: readTopLevelBoolean(block, "enabled"),
+    name: readTopLevelString(block, "name"),
     mode:
       mode && REVIEW_CI_MODES.has(mode as DocsReviewCiMode)
         ? (mode as DocsReviewCiMode)

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2280,6 +2280,12 @@ export interface DocsReviewCiConfig {
    */
   enabled?: boolean;
   /**
+   * GitHub Actions job/check name for the generated workflow.
+   *
+   * @default "docs-review"
+   */
+  name?: string;
+  /**
    * How CI should treat unhealthy review results.
    *
    * - `"off"`: do not create/report CI output

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -218,7 +218,8 @@ pnpm exec docs review setup
 `review` config is enabled by default; use `review: false` to opt out.
 
 Use `review.ci.mode: "block"` and `review.score.threshold` when the team wants CI to fail below a
-score threshold.
+score threshold. Use `review.ci.name` to customize the GitHub Actions job/check name; it defaults
+to `docs-review`.
 
 ## Search Sync
 

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -59,6 +59,22 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 
 ---
 
+## Docs Review CI
+
+`review` is enabled by default. Use `review.ci.name` to customize the generated GitHub Actions
+job/check name; it defaults to `docs-review`.
+
+```ts
+review: {
+  ci: {
+    name: "agent-docs-review",
+    mode: "warn",
+  },
+}
+```
+
+---
+
 ## Static export
 
 For fully static builds (e.g. Cloudflare Pages, no server):

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -965,7 +965,8 @@ pnpm exec docs review setup
 ```
 
 The workflow is repository-root aware. If your docs app lives in `website/`, the workflow still
-lives at `.github/workflows/docs-review.yml` and runs the review command from `website/`.
+lives at `.github/workflows/docs-review.yml` and runs the review command from `website/`. Set
+`review.ci.name` when the GitHub check should use a name other than `docs-review`.
 
 ## Supported Frameworks
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -634,7 +634,8 @@ export default defineDocs({
 
 The generated workflow only triggers on docs-related PR changes such as `docs.config.*`,
 `app/docs/**`, `src/app/docs/**`, `content/docs/**`, and the workflow file itself. By default it
-runs in `warn` mode, posts GitHub annotations, and keeps CI green.
+runs in `warn` mode, posts GitHub annotations, uses `docs-review` as the GitHub check name, and
+keeps CI green.
 
 Use `block` mode when the team wants docs PRs to fail below the configured score threshold or when
 error-level findings exist:
@@ -643,7 +644,10 @@ error-level findings exist:
 export default defineDocs({
   entry: "docs",
   review: {
-    ci: { mode: "block" },
+    ci: {
+      name: "agent-docs-review",
+      mode: "block",
+    },
     score: { threshold: 90 },
     rules: {
       brokenLinks: "error",

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -411,6 +411,7 @@ export default defineDocs({
   entry: "docs",
   review: {
     ci: {
+      name: "agent-docs-review",
       mode: "warn",
       annotations: true,
       comment: true,
@@ -427,6 +428,7 @@ export default defineDocs({
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `enabled` | `boolean` | `true` | Enable review CI workflow generation |
+| `name` | `string` | `"docs-review"` | GitHub Actions job/check name for the generated workflow |
 | `mode` | `"off" \| "warn" \| "block"` | `"warn"` | Report only, warn without failing, or block unhealthy PRs |
 | `annotations` | `boolean` | `true` | Emit GitHub workflow annotations |
 | `comment` | `boolean` | `true` | Reserved for PR comments from the official action/bot |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for customizing the GitHub Actions job/check name for Docs Review CI. Defaults to "docs-review" and enables teams to match required checks or avoid name collisions.

- **New Features**
  - Introduced `review.ci.name` with default `"docs-review"` in config and types.
  - Workflow generator emits the configured job name and `ensureDocsReviewWorkflow` uses it.
  - Added CI name normalization and tests for config resolution and workflow output.
  - Updated docs and examples to show how to set a custom check name.

<sup>Written for commit 33b8ab8b0741e353d13520ff93c62d72418c40b2. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

