### PR TITLE
feat: generic codeblock verify via sandbox runner and planner

### DIFF
--- a/packages/docs/src/cli/codeblocks.ts
+++ b/packages/docs/src/cli/codeblocks.ts
@@ -248,9 +248,17 @@ function readStaticRunnerConfig(
   const teamIdEnv = readStringProperty(block, "teamIdEnv");
   const projectJson = readStringProperty(block, "projectJson");
   const runtime = readStringProperty(block, "runtime");
+  const apiUrlEnv = readStringProperty(block, "apiUrlEnv");
+  const targetEnv = readStringProperty(block, "targetEnv");
   const timeoutMs = readNumberProperty(block, "timeoutMs");
 
-  if (provider !== "local" && provider !== "vercel-sandbox" && provider !== "cloud") {
+  if (
+    provider !== "local" &&
+    provider !== "vercel-sandbox" &&
+    provider !== "e2b" &&
+    provider !== "daytona" &&
+    provider !== "cloud"
+  ) {
     return undefined;
   }
 
@@ -263,6 +271,8 @@ function readStaticRunnerConfig(
     ...(runtime === "node24" || runtime === "node22" || runtime === "python3.13"
       ? { runtime }
       : {}),
+    ...(apiUrlEnv ? { apiUrlEnv } : {}),
+    ...(targetEnv ? { targetEnv } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
   };
 }

--- a/packages/docs/src/code-blocks.test.ts
+++ b/packages/docs/src/code-blocks.test.ts
@@ -25,6 +25,10 @@ describe("code block validation", () => {
     delete process.env.VERCEL_TOKEN;
     delete process.env.VERCEL_PROJECT_ID;
     delete process.env.VERCEL_TEAM_ID;
+    delete process.env.E2B_API_KEY;
+    delete process.env.DAYTONA_API_KEY;
+    delete process.env.DAYTONA_API_URL;
+    delete process.env.DAYTONA_TARGET;
   });
 
   it("resolves disabled and enabled validate config", () => {
@@ -60,6 +64,22 @@ describe("code block validation", () => {
     });
     expect(config.env).toEqual({
       OPENAI_API_KEY: "OPENAI_TEST_API_KEY",
+    });
+
+    expect(
+      resolveDocsCodeBlocksValidateConfig({
+        runner: { provider: "e2b" },
+      }).runner.tokenEnv,
+    ).toBe("E2B_API_KEY");
+    expect(
+      resolveDocsCodeBlocksValidateConfig({
+        runner: { provider: "daytona" },
+      }).runner,
+    ).toMatchObject({
+      provider: "daytona",
+      tokenEnv: "DAYTONA_API_KEY",
+      apiUrlEnv: "DAYTONA_API_URL",
+      targetEnv: "DAYTONA_TARGET",
     });
   });
 
@@ -354,5 +374,173 @@ describe("code block validation", () => {
       fail: 0,
     });
     expect(report.results[0]?.stdout).toBe("sandbox\n");
+  });
+
+  it("does not fall back to local execution for unavailable cloud runner", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "docs-codeblocks-cloud-"));
+    writeFileSync(
+      path.join(rootDir, "page.mdx"),
+      ['```js title="cloud.js" runnable', 'throw new Error("should not run locally")', "```"].join(
+        "\n",
+      ),
+      "utf-8",
+    );
+
+    const report = await validateCodeBlocks({
+      rootDir,
+      contentDir: ".",
+      config: resolveDocsCodeBlocksValidateConfig({
+        runner: {
+          provider: "cloud",
+        },
+      }),
+    });
+
+    expect(report.summary).toMatchObject({
+      pass: 0,
+      skip: 1,
+      fail: 0,
+    });
+    expect(report.results[0]?.reason).toBe(
+      "cloud runner is not available in this package yet",
+    );
+  });
+
+  it("skips E2B when its token is missing", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "docs-codeblocks-e2b-missing-"));
+    writeFileSync(
+      path.join(rootDir, "page.mdx"),
+      ['```js title="e2b.js" runnable', 'console.log("e2b")', "```"].join("\n"),
+      "utf-8",
+    );
+
+    const report = await validateCodeBlocks({
+      rootDir,
+      contentDir: ".",
+      config: resolveDocsCodeBlocksValidateConfig({
+        runner: {
+          provider: "e2b",
+        },
+      }),
+    });
+
+    expect(report.summary).toMatchObject({
+      pass: 0,
+      skip: 1,
+      fail: 0,
+    });
+    expect(report.results[0]?.reason).toBe("missing E2B_API_KEY");
+  });
+
+  it("runs executable plans through the E2B adapter", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "docs-codeblocks-e2b-"));
+    writeFileSync(
+      path.join(rootDir, "page.mdx"),
+      ['```js title="e2b.js" runnable', 'console.log("e2b")', "```"].join("\n"),
+      "utf-8",
+    );
+
+    process.env.E2B_API_KEY = "test-e2b-token";
+    const run = vi.fn(async () => ({
+      stdout: "e2b ok\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const kill = vi.fn(async () => {});
+    const create = vi.fn(async () => {
+      expect(process.env.E2B_API_KEY).toBe("test-e2b-token");
+      return {
+        commands: { run },
+        kill,
+      };
+    });
+    vi.stubGlobal("__DOCS_CODE_BLOCKS_MODULE_IMPORTER__", async (specifier: string) => {
+      expect(specifier).toBe("e2b");
+      return {
+        default: { create },
+      };
+    });
+
+    const report = await validateCodeBlocks({
+      rootDir,
+      contentDir: ".",
+      config: resolveDocsCodeBlocksValidateConfig({
+        runner: {
+          provider: "e2b",
+        },
+      }),
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith(expect.stringContaining("'node'"), {
+      envs: {},
+      timeoutMs: 60000,
+    });
+    expect(run).toHaveBeenCalledWith(
+      expect.stringContaining("'snippet-page-mdx-code-1.js'"),
+      expect.any(Object),
+    );
+    expect(kill).toHaveBeenCalledOnce();
+    expect(report.summary).toMatchObject({
+      pass: 1,
+      skip: 0,
+      fail: 0,
+    });
+    expect(report.results[0]?.stdout).toBe("e2b ok\n");
+  });
+
+  it("runs executable plans through the Daytona adapter", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "docs-codeblocks-daytona-"));
+    writeFileSync(
+      path.join(rootDir, "page.mdx"),
+      ['```js title="daytona.js" runnable', 'console.log("daytona")', "```"].join("\n"),
+      "utf-8",
+    );
+
+    process.env.DAYTONA_API_KEY = "test-daytona-token";
+    process.env.DAYTONA_TARGET = "us";
+    const executeCommand = vi.fn(async () => ({
+      result: "daytona ok\n",
+      exitCode: 0,
+    }));
+    const stop = vi.fn(async () => {});
+    const create = vi.fn(async () => ({
+      process: { executeCommand },
+      stop,
+    }));
+    const Daytona = vi.fn().mockImplementation((input) => {
+      expect(input).toMatchObject({
+        apiKey: "test-daytona-token",
+        target: "us",
+      });
+      return { create };
+    });
+    vi.stubGlobal("__DOCS_CODE_BLOCKS_MODULE_IMPORTER__", async (specifier: string) => {
+      expect(specifier).toBe("@daytona/sdk");
+      return { Daytona };
+    });
+
+    const report = await validateCodeBlocks({
+      rootDir,
+      contentDir: ".",
+      config: resolveDocsCodeBlocksValidateConfig({
+        runner: {
+          provider: "daytona",
+        },
+      }),
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      ephemeral: true,
+      language: "typescript",
+    });
+    expect(executeCommand).toHaveBeenCalledWith(expect.stringContaining("'node'"));
+    expect(stop).toHaveBeenCalledOnce();
+    expect(report.summary).toMatchObject({
+      pass: 1,
+      skip: 0,
+      fail: 0,
+    });
+    expect(report.results[0]?.stdout).toBe("daytona ok\n");
   });
 });

--- a/packages/docs/src/code-blocks.test.ts
+++ b/packages/docs/src/code-blocks.test.ts
@@ -401,9 +401,7 @@ describe("code block validation", () => {
       skip: 1,
       fail: 0,
     });
-    expect(report.results[0]?.reason).toBe(
-      "cloud runner is not available in this package yet",
-    );
+    expect(report.results[0]?.reason).toBe("cloud runner is not available in this package yet");
   });
 
   it("skips E2B when its token is missing", async () => {

--- a/packages/docs/src/code-blocks.ts
+++ b/packages/docs/src/code-blocks.ts
@@ -63,6 +63,8 @@ export interface DocsCodeBlocksResolvedRunnerConfig {
   teamIdEnv: string;
   projectJson: string | false;
   runtime: "node24" | "node22" | "python3.13";
+  apiUrlEnv: string;
+  targetEnv: string;
   timeoutMs: number;
 }
 
@@ -139,6 +141,12 @@ interface VercelSandboxCredentials {
   missing: string[];
 }
 
+type OptionalModuleImporter = (specifier: string) => Promise<unknown>;
+
+declare global {
+  var __DOCS_CODE_BLOCKS_MODULE_IMPORTER__: OptionalModuleImporter | undefined;
+}
+
 export function resolveDocsCodeBlocksValidateConfig(
   input?: boolean | DocsCodeBlocksValidateConfig,
 ): DocsCodeBlocksResolvedValidateConfig {
@@ -153,6 +161,8 @@ export function resolveDocsCodeBlocksValidateConfig(
         teamIdEnv: "VERCEL_TEAM_ID",
         projectJson: ".vercel/project.json",
         runtime: "node24",
+        apiUrlEnv: "DAYTONA_API_URL",
+        targetEnv: "DAYTONA_TARGET",
         timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
       },
       envFile: DEFAULT_ENV_FILES,
@@ -313,10 +323,12 @@ export async function validateCodeBlockPlans(input: {
     return skippedOrFailed;
   }
 
-  const runResults =
-    input.config.runner.provider === "vercel-sandbox"
-      ? await runPlansInVercelSandbox(plansToRun, input.rootDir, input.config, validationEnv.env)
-      : await runPlansLocally(plansToRun, input.config, validationEnv.env);
+  const runResults = await runPlansWithConfiguredRunner(
+    plansToRun,
+    input.rootDir,
+    input.config,
+    validationEnv.env,
+  );
 
   return [...skippedOrFailed, ...runResults].sort((a, b) => a.id.localeCompare(b.id));
 }
@@ -380,15 +392,24 @@ function normalizeRunnerConfig(
   input?: DocsCodeBlocksRunnerProvider | DocsCodeBlocksRunnerConfig,
 ): DocsCodeBlocksResolvedRunnerConfig {
   const config = typeof input === "string" ? { provider: input } : (input ?? {});
+  const provider = config.provider ?? "local";
   return {
-    provider: config.provider ?? "local",
-    tokenEnv: config.tokenEnv ?? "VERCEL_TOKEN",
+    provider,
+    tokenEnv: config.tokenEnv ?? defaultRunnerTokenEnv(provider),
     projectIdEnv: config.projectIdEnv ?? "VERCEL_PROJECT_ID",
     teamIdEnv: config.teamIdEnv ?? "VERCEL_TEAM_ID",
     projectJson: config.projectJson === undefined ? ".vercel/project.json" : config.projectJson,
     runtime: config.runtime ?? "node24",
+    apiUrlEnv: config.apiUrlEnv ?? "DAYTONA_API_URL",
+    targetEnv: config.targetEnv ?? "DAYTONA_TARGET",
     timeoutMs: config.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS,
   };
+}
+
+function defaultRunnerTokenEnv(provider: DocsCodeBlocksRunnerProvider): string {
+  if (provider === "e2b") return "E2B_API_KEY";
+  if (provider === "daytona") return "DAYTONA_API_KEY";
+  return "VERCEL_TOKEN";
 }
 
 function buildMetadataExecutionPlan(
@@ -818,6 +839,28 @@ async function runPlansLocally(
   }
 }
 
+async function runPlansWithConfiguredRunner(
+  plans: DocsCodeBlockExecutionPlan[],
+  rootDir: string,
+  config: DocsCodeBlocksResolvedValidateConfig,
+  env: Record<string, string>,
+): Promise<DocsCodeBlockValidationResult[]> {
+  switch (config.runner.provider) {
+    case "local":
+      return runPlansLocally(plans, config, env);
+    case "vercel-sandbox":
+      return runPlansInVercelSandbox(plans, rootDir, config, env);
+    case "e2b":
+      return runPlansInE2B(plans, config, env);
+    case "daytona":
+      return runPlansInDaytona(plans, config, env);
+    case "cloud":
+      return plans.map((plan) =>
+        skippedResult(plan, "cloud runner is not available in this package yet"),
+      );
+  }
+}
+
 async function runPlansInVercelSandbox(
   plans: DocsCodeBlockExecutionPlan[],
   rootDir: string,
@@ -911,6 +954,133 @@ async function runPlansInVercelSandbox(
   }
 }
 
+async function runPlansInE2B(
+  plans: DocsCodeBlockExecutionPlan[],
+  config: DocsCodeBlocksResolvedValidateConfig,
+  env: Record<string, string>,
+): Promise<DocsCodeBlockValidationResult[]> {
+  const token = process.env[config.runner.tokenEnv];
+  if (!token) {
+    return plans.map((plan) => skippedResult(plan, `missing ${config.runner.tokenEnv}`));
+  }
+
+  const module = await importOptionalModule("e2b");
+  if (!module) {
+    return plans.map((plan) =>
+      skippedResult(plan, 'e2b unavailable: install the "e2b" package'),
+    );
+  }
+
+  try {
+    const E2BSandbox =
+      readProviderExport(module, "default") ?? readProviderExport(module, "Sandbox");
+    if (!hasCreateMethod(E2BSandbox)) {
+      return plans.map((plan) => skippedResult(plan, "e2b unavailable: missing Sandbox.create"));
+    }
+
+    const sandbox = await withTemporaryEnv("E2B_API_KEY", token, () => E2BSandbox.create());
+    try {
+      return await Promise.all(
+        plans.map(async (plan) => {
+          if (!plan.command || !plan.filePath) {
+            return skippedResult(plan, "no executable command in plan");
+          }
+
+          const command = buildSandboxShellCommand(plan);
+          const runner = readObject(sandbox).commands;
+          if (!hasRunMethod(runner)) {
+            return skippedResult(plan, "e2b unavailable: missing commands.run");
+          }
+
+          try {
+            const result = await runner.run(command, {
+              envs: env,
+              timeoutMs: config.runner.timeoutMs,
+            });
+            return sandboxCommandResult(plan, result);
+          } catch (error) {
+            return failedSandboxResult(plan, error);
+          }
+        }),
+      );
+    } finally {
+      await cleanupProviderSandbox(sandbox);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return plans.map((plan) => skippedResult(plan, `e2b unavailable: ${message}`));
+  }
+}
+
+async function runPlansInDaytona(
+  plans: DocsCodeBlockExecutionPlan[],
+  config: DocsCodeBlocksResolvedValidateConfig,
+  env: Record<string, string>,
+): Promise<DocsCodeBlockValidationResult[]> {
+  const token = process.env[config.runner.tokenEnv];
+  if (!token) {
+    return plans.map((plan) => skippedResult(plan, `missing ${config.runner.tokenEnv}`));
+  }
+
+  const module = await importOptionalModule("@daytona/sdk");
+  if (!module) {
+    return plans.map((plan) =>
+      skippedResult(plan, 'daytona unavailable: install the "@daytona/sdk" package'),
+    );
+  }
+
+  try {
+    const Daytona = readProviderExport(module, "Daytona");
+    if (!hasConstructor(Daytona)) {
+      return plans.map((plan) => skippedResult(plan, "daytona unavailable: missing Daytona SDK"));
+    }
+
+    const apiUrl = process.env[config.runner.apiUrlEnv];
+    const target = process.env[config.runner.targetEnv];
+    const daytona = new Daytona({
+      apiKey: token,
+      ...(apiUrl ? { apiUrl } : {}),
+      ...(target ? { target } : {}),
+    });
+    if (!hasCreateMethod(daytona)) {
+      return plans.map((plan) => skippedResult(plan, "daytona unavailable: missing create"));
+    }
+
+    const sandbox = await daytona.create({
+      ephemeral: true,
+      language: "typescript",
+      ...(Object.keys(env).length > 0 ? { envVars: env } : {}),
+    });
+    try {
+      return await Promise.all(
+        plans.map(async (plan) => {
+          if (!plan.command || !plan.filePath) {
+            return skippedResult(plan, "no executable command in plan");
+          }
+
+          const processApi = readObject(sandbox).process;
+          if (!hasExecuteCommandMethod(processApi)) {
+            return skippedResult(plan, "daytona unavailable: missing process.executeCommand");
+          }
+
+          try {
+            const result = await processApi.executeCommand(buildSandboxShellCommand(plan));
+            return sandboxCommandResult(plan, result);
+          } catch (error) {
+            return failedSandboxResult(plan, error);
+          }
+        }),
+      );
+    } finally {
+      await cleanupProviderSandbox(sandbox);
+      await cleanupProviderSandbox(daytona);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return plans.map((plan) => skippedResult(plan, `daytona unavailable: ${message}`));
+  }
+}
+
 async function resolveVercelSandboxCredentials(
   rootDir: string,
   config: DocsCodeBlocksResolvedValidateConfig,
@@ -987,6 +1157,171 @@ function readVercelProjectJson(
   } catch {
     return undefined;
   }
+}
+
+async function importOptionalModule(specifier: string): Promise<unknown | undefined> {
+  const importer =
+    globalThis.__DOCS_CODE_BLOCKS_MODULE_IMPORTER__ ??
+    ((id: string) => import(id) as Promise<unknown>);
+
+  try {
+    return await importer(specifier);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildSandboxShellCommand(plan: DocsCodeBlockExecutionPlan): string {
+  const command = plan.command;
+  const filePath = plan.filePath;
+  if (!command || !filePath) return "";
+
+  const sandboxDir = "/tmp/docs-codeblocks";
+  const encodedCode = Buffer.from(plan.target.code, "utf-8").toString("base64");
+  const writeFileCommand = [
+    "printf",
+    "%s",
+    encodedCode,
+    "|",
+    "base64",
+    "-d",
+    ">",
+    filePath,
+  ]
+    .map((part) => (part === "|" || part === ">" ? part : shellEscape(part)))
+    .join(" ");
+
+  return [
+    `mkdir -p ${shellEscape(sandboxDir)}`,
+    `cd ${shellEscape(sandboxDir)}`,
+    writeFileCommand,
+    shellJoin([command.cmd, ...command.args]),
+  ].join(" && ");
+}
+
+function shellJoin(parts: string[]): string {
+  return parts.map(shellEscape).join(" ");
+}
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function withTemporaryEnv<T>(
+  key: string,
+  value: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previous = process.env[key];
+  process.env[key] = value;
+  try {
+    return await callback();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+}
+
+function sandboxCommandResult(
+  plan: DocsCodeBlockExecutionPlan,
+  result: unknown,
+): DocsCodeBlockValidationResult {
+  const record = readObject(result);
+  const error = readStringValue(record.error);
+  const exitCode =
+    readNumberValue(record.exitCode) ??
+    readNumberValue(record.code) ??
+    readNumberValue(record.exit_code) ??
+    (error ? 1 : 0);
+  const stdout =
+    readStringValue(record.stdout) ??
+    readStringValue(record.result) ??
+    readStringValue(record.text) ??
+    "";
+  const stderr = readStringValue(record.stderr) ?? error ?? "";
+
+  return {
+    id: plan.id,
+    target: plan.target,
+    plan,
+    status: exitCode === 0 ? ("PASS" as const) : ("FAIL" as const),
+    stdout,
+    stderr,
+    exitCode,
+    reason: exitCode === 0 ? undefined : `exit code ${exitCode}`,
+  };
+}
+
+function failedSandboxResult(
+  plan: DocsCodeBlockExecutionPlan,
+  error: unknown,
+): DocsCodeBlockValidationResult {
+  const record = readObject(error);
+  return {
+    id: plan.id,
+    target: plan.target,
+    plan,
+    status: "FAIL",
+    stdout: readStringValue(record.stdout),
+    stderr: readStringValue(record.stderr),
+    exitCode: readNumberValue(record.exitCode) ?? readNumberValue(record.code) ?? null,
+    reason: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function cleanupProviderSandbox(value: unknown): Promise<void> {
+  const record = readObject(value);
+  for (const methodName of ["kill", "close", "stop", "delete", "remove", "destroy"]) {
+    const method = record[methodName];
+    if (typeof method !== "function") continue;
+    await Promise.resolve(method.call(value)).catch(() => {});
+    return;
+  }
+}
+
+function readProviderExport(module: unknown, name: string): unknown {
+  return readObject(module)[name];
+}
+
+function readObject(value: unknown): Record<string, unknown> {
+  return value !== null && (typeof value === "object" || typeof value === "function")
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readStringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumberValue(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function hasCreateMethod(value: unknown): value is {
+  create(input?: unknown): Promise<unknown>;
+} {
+  return typeof readObject(value).create === "function";
+}
+
+function hasRunMethod(value: unknown): value is {
+  run(command: string, options?: unknown): Promise<unknown>;
+} {
+  return typeof readObject(value).run === "function";
+}
+
+function hasExecuteCommandMethod(value: unknown): value is {
+  executeCommand(command: string): Promise<unknown>;
+} {
+  return typeof readObject(value).executeCommand === "function";
+}
+
+function hasConstructor(value: unknown): value is new (input?: unknown) => {
+  create(input?: unknown): Promise<unknown>;
+} {
+  return typeof value === "function";
 }
 
 function loadValidationEnv(

--- a/packages/docs/src/code-blocks.ts
+++ b/packages/docs/src/code-blocks.ts
@@ -966,9 +966,7 @@ async function runPlansInE2B(
 
   const module = await importOptionalModule("e2b");
   if (!module) {
-    return plans.map((plan) =>
-      skippedResult(plan, 'e2b unavailable: install the "e2b" package'),
-    );
+    return plans.map((plan) => skippedResult(plan, 'e2b unavailable: install the "e2b" package'));
   }
 
   try {
@@ -1178,16 +1176,7 @@ function buildSandboxShellCommand(plan: DocsCodeBlockExecutionPlan): string {
 
   const sandboxDir = "/tmp/docs-codeblocks";
   const encodedCode = Buffer.from(plan.target.code, "utf-8").toString("base64");
-  const writeFileCommand = [
-    "printf",
-    "%s",
-    encodedCode,
-    "|",
-    "base64",
-    "-d",
-    ">",
-    filePath,
-  ]
+  const writeFileCommand = ["printf", "%s", encodedCode, "|", "base64", "-d", ">", filePath]
     .map((part) => (part === "|" || part === ">" ? part : shellEscape(part)))
     .join(" ");
 

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -605,10 +605,10 @@ const DOCS_CONFIG_SCHEMA_OPTIONS: DocsMcpConfigSchemaOption[] = [
       {
         path: "codeBlocks.validate.runner",
         name: "runner",
-        type: '"local" | "vercel-sandbox" | "cloud" | DocsCodeBlocksRunnerConfig',
+        type: '"local" | "vercel-sandbox" | "e2b" | "daytona" | "cloud" | DocsCodeBlocksRunnerConfig',
         default: "local",
         description:
-          "Runner used to execute planned snippets. The Vercel Sandbox runner can work from `VERCEL_TOKEN` alone by auto-discovering an accessible project.",
+          "Runner used to execute planned snippets. Vercel Sandbox, E2B, and Daytona use provider tokens from env vars.",
       },
       {
         path: "codeBlocks.validate.env",

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2329,7 +2329,12 @@ export interface DocsReviewConfig {
 
 export type DocsCodeBlocksPlannerProvider = "metadata" | "openai" | "openai-compatible" | "cloud";
 
-export type DocsCodeBlocksRunnerProvider = "local" | "vercel-sandbox" | "cloud";
+export type DocsCodeBlocksRunnerProvider =
+  | "local"
+  | "vercel-sandbox"
+  | "e2b"
+  | "daytona"
+  | "cloud";
 
 export type DocsCodeBlocksValidationMode = "plan" | "report";
 
@@ -2366,7 +2371,7 @@ export interface DocsCodeBlocksRunnerConfig {
    * @default "local"
    */
   provider?: DocsCodeBlocksRunnerProvider;
-  /** Environment variable containing the Vercel token for `provider: "vercel-sandbox"`. */
+  /** Environment variable containing the sandbox provider token. */
   tokenEnv?: string;
   /** Advanced override for the Vercel project id env var used by `provider: "vercel-sandbox"`. */
   projectIdEnv?: string;
@@ -2383,6 +2388,10 @@ export interface DocsCodeBlocksRunnerConfig {
   projectJson?: string | false;
   /** Vercel Sandbox runtime. */
   runtime?: "node24" | "node22" | "python3.13";
+  /** Daytona API URL env var used by `provider: "daytona"`. */
+  apiUrlEnv?: string;
+  /** Daytona target/region env var used by `provider: "daytona"`. */
+  targetEnv?: string;
   /** Per-command timeout in milliseconds. */
   timeoutMs?: number;
 }

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2329,12 +2329,7 @@ export interface DocsReviewConfig {
 
 export type DocsCodeBlocksPlannerProvider = "metadata" | "openai" | "openai-compatible" | "cloud";
 
-export type DocsCodeBlocksRunnerProvider =
-  | "local"
-  | "vercel-sandbox"
-  | "e2b"
-  | "daytona"
-  | "cloud";
+export type DocsCodeBlocksRunnerProvider = "local" | "vercel-sandbox" | "e2b" | "daytona" | "cloud";
 
 export type DocsCodeBlocksValidationMode = "plan" | "report";
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -206,6 +206,8 @@ Use the docs config `mcp` block when you also want the HTTP route version at `/m
 
 Use `docs codeblocks validate` to scan MD/MDX fences, build execution plans from code fence metadata,
 and run executable snippets when `codeBlocks.validate` is enabled in `docs.config.ts`.
+Supported runners are `local`, `vercel-sandbox`, `e2b`, `daytona`, and the reserved `cloud` runner.
+E2B requires `e2b`; Daytona requires `@daytona/sdk`.
 
 ```bash
 pnpm exec docs codeblocks validate --plan

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -80,6 +80,8 @@ review: {
 ## Code block validation
 
 Use `codeBlocks.validate` when docs code fences should be planned and checked by the CLI.
+Runner providers can be `local`, `vercel-sandbox`, `e2b`, `daytona`, or reserved `cloud`.
+E2B expects the `e2b` package, and Daytona expects `@daytona/sdk`, to be available to the CLI.
 
 ```ts
 codeBlocks: {

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -987,6 +987,10 @@ const apiKey = process.env.OPENAI_API_KEY;
 ```
 ````
 
+Runner providers can be `local`, `vercel-sandbox`, `e2b`, `daytona`, or the reserved `cloud`
+runner. Remote runners skip with a clear reason when their token or optional SDK is missing instead
+of running the snippet locally.
+
 See [Configuration](/docs/configuration#code-block-validation) for the config fields.
 
 ## Docs Review

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -154,7 +154,7 @@ All configuration lives in a single `docs.config.ts` file.
 ## Code block validation
 
 `codeBlocks.validate` lets the CLI inspect fenced MDX code blocks, build an execution plan from
-metadata, and optionally run executable snippets in a sandbox.
+metadata, and optionally run executable snippets with a local or sandbox runner.
 
 ```ts title="docs.config.ts"
 import { defineDocs } from "@farming-labs/docs";
@@ -227,6 +227,40 @@ The planner never writes secrets into docs. The `env` map means the snippet can 
 `OPENAI_TEST_API_KEY`. For Vercel Sandbox, `VERCEL_TOKEN` is enough in most projects; the runner
 uses `.vercel/project.json` when present and can auto-discover an accessible Vercel project from
 the token.
+
+Runner providers are explicit, so a remote sandbox never silently falls back to local execution:
+
+```ts title="docs.config.ts"
+codeBlocks: {
+  validate: {
+    runner: { provider: "vercel-sandbox", tokenEnv: "VERCEL_TOKEN" },
+  },
+}
+```
+
+```ts title="docs.config.ts"
+codeBlocks: {
+  validate: {
+    runner: { provider: "e2b", tokenEnv: "E2B_API_KEY" },
+  },
+}
+```
+
+```ts title="docs.config.ts"
+codeBlocks: {
+  validate: {
+    runner: {
+      provider: "daytona",
+      tokenEnv: "DAYTONA_API_KEY",
+      targetEnv: "DAYTONA_TARGET",
+      apiUrlEnv: "DAYTONA_API_URL",
+    },
+  },
+}
+```
+
+E2B uses the `e2b` package and Daytona uses `@daytona/sdk`. Install the provider SDK in the
+project that runs the CLI when you choose one of those runners.
 
 ## Public docs path
 


### PR DESCRIPTION
- **feat: codeblock verifier via planner and runner on sandbox**
- **chore: fmt**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add E2B and Daytona sandbox runners for docs code block validation, with strict no-fallback behavior and clear skip reasons. Updates include new env config, robust adapter logic, tests, and docs.

- **New Features**
  - Add `e2b` and `daytona` runner providers; keep `cloud` as a reserved provider that always skips.
  - Default token envs by provider: `E2B_API_KEY`, `DAYTONA_API_KEY`, `VERCEL_TOKEN`.
  - Daytona runner supports `apiUrlEnv` and `targetEnv` (e.g., `DAYTONA_API_URL`, `DAYTONA_TARGET`).
  - Remote runners never fall back to local; missing token/SDK yields a clear skip reason.
  - Introduce `__DOCS_CODE_BLOCKS_MODULE_IMPORTER__` for optional dynamic imports and test stubbing.
  - New runner flow `runPlansWithConfiguredRunner` plus adapters for E2B and Daytona.
  - Shell command builder writes the snippet in-sandbox and executes with the selected runtime.
  - Update schema/types and CLI config parsing to accept `e2b` and `daytona`.
  - Add tests for E2B/Daytona happy paths and `cloud` skip; update docs in `skills` and `website` with usage and env details.
  - Notes: `e2b` and `@daytona/sdk` must be present when using their respective providers.

<sup>Written for commit 1462eb737470cf16f3b8ed3f63c40f45b3e97536. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/216?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

