### PR TITLE
feat: code group alternative built-in component

### DIFF
--- a/examples/next/app/docs/create-content/code-blocks/page.mdx
+++ b/examples/next/app/docs/create-content/code-blocks/page.mdx
@@ -57,6 +57,59 @@ export default function Page() {
 ```
 ````
 
+## Code Groups
+
+Group related code blocks into tabs with the Mintlify-style `<CodeGroup>` syntax. The tab label can
+come from a bare filename after the language, `title`, or `filename`.
+
+<CodeGroup dropdown>
+
+```bash npm
+npm install better-auth
+```
+
+```bash pnpm
+pnpm add better-auth
+```
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+```
+
+</CodeGroup>
+
+The authoring syntax is just regular fenced code inside the group:
+
+````mdx
+<CodeGroup dropdown>
+
+```bash npm
+npm install better-auth
+```
+
+```bash pnpm
+pnpm add better-auth
+```
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+  },
+});
+```
+
+</CodeGroup>
+````
+
 ## Agent Metadata
 
 Code fences can include extra metadata for agents and MCP tools. The rendered code block keeps the

--- a/examples/next/app/docs/create-content/code-blocks/page.mdx
+++ b/examples/next/app/docs/create-content/code-blocks/page.mdx
@@ -60,7 +60,8 @@ export default function Page() {
 ## Code Groups
 
 Group related code blocks into tabs with the Mintlify-style `<CodeGroup>` syntax. The tab label can
-come from a bare filename after the language, `title`, or `filename`.
+come from a bare filename after the language, `title`, or `filename`. `CodeGroup` is built in, so
+you do not need to import it or register it in `docs.config.ts`.
 
 <CodeGroup dropdown>
 

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -419,9 +419,43 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
 }
 
 function parseMeta(meta: string): { lang: string; title: string | null } {
-  const lang = (meta.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = meta.match(/title=["']([^"']+)["']/);
+  const trimmed = meta.trim();
+  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
   return { lang, title: titleMatch ? titleMatch[1] : null };
+}
+
+function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
+  const parsed = parseMeta(meta);
+  if (parsed.title) return parsed;
+
+  const trimmed = meta.trim();
+  const language = trimmed.split(/\s+/, 1)[0] ?? "";
+  const bareTitle = trimmed
+    .slice(language.length)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find((part) => part && !part.includes("="));
+
+  return {
+    ...parsed,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
+
+function createCodeGroupTabValue(label: string, used: Set<string>): string {
+  const slug = slugify(label) || `code-${used.size + 1}`;
+  let value = slug;
+  let suffix = 2;
+
+  while (used.has(value)) {
+    value = `${slug}-${suffix}`;
+    suffix += 1;
+  }
+
+  used.add(value);
+  return value;
 }
 
 function wrapCodeWithCopy(
@@ -471,8 +505,51 @@ export async function renderMarkdown(
   const hl = await getHighlighter();
   let result = resolveDocsAgentMdxContent(content, "human");
 
-  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
+  // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
+  result = result.replace(
+    /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
+    (_: string, attrSource: string | undefined, body: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const dropdown = toBoolean(attrs.dropdown, false);
+      const usedValues = new Set<string>();
+      const panels: { label: string; value: string; html: string }[] = [];
+      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
+      let codeMatch: RegExpExecArray | null;
+
+      while ((codeMatch = codeRegex.exec(body)) !== null) {
+        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+        const label = title || lang || `Code ${panels.length + 1}`;
+        const value = createCodeGroupTabValue(label, usedValues);
+        const dedented = dedentCode(codeMatch[2]);
+        const { html, raw } = highlightCode(hl, dedented, lang);
+        panels.push({
+          label,
+          value,
+          html: wrapCodeWithCopy(html, raw, null, lang),
+        });
+      }
+
+      if (panels.length === 0) return body;
+
+      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+      }
+      tabsHtml += `</div>`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+      }
+      tabsHtml += `</div>`;
+
+      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
+      tabsBlocks.push(tabsHtml);
+      return placeholder;
+    },
+  );
+
+  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   result = result.replace(
     /<Tabs\s+items=\{?\[([^\]]+)\]\}?>([\s\S]*?)<\/Tabs>/g,
     (_: string, itemsStr: string, body: string) => {

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -450,9 +450,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .split(/\s+/)
     .find(
       (part) =>
-        part &&
-        !part.includes("=") &&
-        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
     );
 
   return {

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -425,6 +425,18 @@ function parseMeta(meta: string): { lang: string; title: string | null } {
   return { lang, title: titleMatch ? titleMatch[1] : null };
 }
 
+const ignoredCodeGroupBareTitleTokens = new Set([
+  "copy",
+  "no-copy",
+  "nocopy",
+  "line-numbers",
+  "linenumbers",
+  "runnable",
+  "show-line-numbers",
+  "showlinenumbers",
+  "wrap",
+]);
+
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
   if (parsed.title) return parsed;
@@ -436,7 +448,12 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .trim()
     .replace(/\{[^}]*\}/g, " ")
     .split(/\s+/)
-    .find((part) => part && !part.includes("="));
+    .find(
+      (part) =>
+        part &&
+        !part.includes("=") &&
+        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
 
   return {
     ...parsed,
@@ -469,10 +486,10 @@ function wrapCodeWithCopy(
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-  const dataLang = language ? ` data-language="${String(language).replace(/"/g, "&quot;")}"` : "";
+  const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
   const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${title}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
   }
   return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
 }

--- a/packages/docs/src/code-group-mdx.test.ts
+++ b/packages/docs/src/code-group-mdx.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { remarkCodeGroup } from "./code-group-mdx.js";
+
+describe("remarkCodeGroup", () => {
+  it("adds title metadata from Mintlify-style bare filenames inside CodeGroup", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "mdxJsxFlowElement",
+          name: "CodeGroup",
+          children: [
+            {
+              type: "code",
+              lang: "javascript",
+              meta: "helloWorld.js",
+              value: "console.log('Hello World')",
+            },
+          ],
+        },
+      ],
+    };
+
+    remarkCodeGroup()(tree);
+
+    expect(tree.children[0].children[0].meta).toBe('title="helloWorld.js" helloWorld.js');
+  });
+
+  it("uses filename-style metadata as the CodeGroup title while preserving the original meta", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "mdxJsxFlowElement",
+          name: "CodeGroup",
+          children: [
+            {
+              type: "code",
+              lang: "bash",
+              meta: 'filename="pnpm"',
+              value: "pnpm add @farming-labs/docs",
+            },
+          ],
+        },
+      ],
+    };
+
+    remarkCodeGroup()(tree);
+
+    expect(tree.children[0].children[0].meta).toBe('title="pnpm" filename="pnpm"');
+  });
+
+  it("leaves regular code blocks and existing titles alone", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "code",
+          lang: "ts",
+          meta: "docs.config.ts",
+          value: "export default {};",
+        },
+        {
+          type: "mdxJsxFlowElement",
+          name: "CodeGroup",
+          children: [
+            {
+              type: "code",
+              lang: "ts",
+              meta: 'title="docs.config.ts"',
+              value: "export default {};",
+            },
+          ],
+        },
+      ],
+    };
+
+    remarkCodeGroup()(tree);
+
+    const codeGroup = tree.children[1] as { children?: Array<{ meta?: string | null }> };
+
+    expect(tree.children[0].meta).toBe("docs.config.ts");
+    expect(codeGroup.children?.[0]?.meta).toBe('title="docs.config.ts"');
+  });
+});

--- a/packages/docs/src/code-group-mdx.test.ts
+++ b/packages/docs/src/code-group-mdx.test.ts
@@ -50,6 +50,30 @@ describe("remarkCodeGroup", () => {
     expect(tree.children[0].children[0].meta).toBe('title="pnpm" filename="pnpm"');
   });
 
+  it("does not treat code fence option flags as bare CodeGroup titles", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "mdxJsxFlowElement",
+          name: "CodeGroup",
+          children: [
+            {
+              type: "code",
+              lang: "ts",
+              meta: "copy lineNumbers runnable",
+              value: "console.log('Hello World')",
+            },
+          ],
+        },
+      ],
+    };
+
+    remarkCodeGroup()(tree);
+
+    expect(tree.children[0].children[0].meta).toBe("copy lineNumbers runnable");
+  });
+
   it("leaves regular code blocks and existing titles alone", () => {
     const tree = {
       type: "root",

--- a/packages/docs/src/code-group-mdx.ts
+++ b/packages/docs/src/code-group-mdx.ts
@@ -36,9 +36,7 @@ function readBareCodeGroupTitle(meta: string): string | undefined {
   const token = meta
     .replace(/\{[^}]*\}/g, " ")
     .split(/\s+/)
-    .find(
-      (part) => part && !part.includes("=") && !ignoredBareMetaTokens.has(part.toLowerCase()),
-    );
+    .find((part) => part && !part.includes("=") && !ignoredBareMetaTokens.has(part.toLowerCase()));
 
   return token?.replace(/^["']|["']$/g, "");
 }

--- a/packages/docs/src/code-group-mdx.ts
+++ b/packages/docs/src/code-group-mdx.ts
@@ -10,9 +10,13 @@ const codeGroupTitleAttributes = ["title", "filename", "file", "name", "label"] 
 const ignoredBareMetaTokens = new Set([
   "copy",
   "no-copy",
-  "lineNumbers",
+  "nocopy",
+  "line-numbers",
+  "linenumbers",
   "runnable",
-  "showLineNumbers",
+  "show-line-numbers",
+  "showlinenumbers",
+  "wrap",
 ]);
 
 function escapeMetaAttribute(value: string): string {
@@ -32,7 +36,9 @@ function readBareCodeGroupTitle(meta: string): string | undefined {
   const token = meta
     .replace(/\{[^}]*\}/g, " ")
     .split(/\s+/)
-    .find((part) => part && !part.includes("=") && !ignoredBareMetaTokens.has(part));
+    .find(
+      (part) => part && !part.includes("=") && !ignoredBareMetaTokens.has(part.toLowerCase()),
+    );
 
   return token?.replace(/^["']|["']$/g, "");
 }

--- a/packages/docs/src/code-group-mdx.ts
+++ b/packages/docs/src/code-group-mdx.ts
@@ -1,0 +1,71 @@
+interface MarkdownNode {
+  type: string;
+  name?: string;
+  children?: MarkdownNode[];
+  lang?: string | null;
+  meta?: string | null;
+}
+
+const codeGroupTitleAttributes = ["title", "filename", "file", "name", "label"] as const;
+const ignoredBareMetaTokens = new Set([
+  "copy",
+  "no-copy",
+  "lineNumbers",
+  "runnable",
+  "showLineNumbers",
+]);
+
+function escapeMetaAttribute(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function readCodeGroupTitleAttribute(meta: string): string | undefined {
+  for (const name of codeGroupTitleAttributes) {
+    const match = meta.match(new RegExp(`(?:^|\\s)${name}=["']([^"']+)["']`));
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+
+  return undefined;
+}
+
+function readBareCodeGroupTitle(meta: string): string | undefined {
+  const token = meta
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find((part) => part && !part.includes("=") && !ignoredBareMetaTokens.has(part));
+
+  return token?.replace(/^["']|["']$/g, "");
+}
+
+function resolveCodeGroupCodeTitle(meta: string | null | undefined): string | undefined {
+  const trimmed = meta?.trim();
+  if (!trimmed) return undefined;
+
+  return readCodeGroupTitleAttribute(trimmed) ?? readBareCodeGroupTitle(trimmed);
+}
+
+function ensureCodeGroupCodeTitle(node: MarkdownNode) {
+  const title = resolveCodeGroupCodeTitle(node.meta);
+  if (!title) return;
+
+  const meta = node.meta?.trim() ?? "";
+  if (/(?:^|\s)title=["']/.test(meta)) return;
+
+  node.meta = `title="${escapeMetaAttribute(title)}"${meta ? ` ${meta}` : ""}`;
+}
+
+function visitCodeGroups(node: MarkdownNode) {
+  if (node.type === "mdxJsxFlowElement" && node.name === "CodeGroup") {
+    for (const child of node.children ?? []) {
+      if (child.type === "code") ensureCodeGroupCodeTitle(child);
+    }
+  }
+
+  for (const child of node.children ?? []) visitCodeGroups(child);
+}
+
+export function remarkCodeGroup() {
+  return (tree: MarkdownNode) => {
+    visitCodeGroups(tree);
+  };
+}

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -1,4 +1,5 @@
 export { createDocsCloudAnalytics } from "./cloud-analytics.js";
+export { remarkCodeGroup } from "./code-group-mdx.js";
 export {
   DOCS_AGENT_TRACE_EVENT_TYPES,
   createDocsAgentTraceContext,

--- a/packages/fumadocs/src/index.ts
+++ b/packages/fumadocs/src/index.ts
@@ -129,7 +129,7 @@ export {
   CodeBlockTabsTrigger,
   Pre,
 } from "fumadocs-ui/components/codeblock";
-export { Agent } from "./mdx.js";
+export { Agent, CodeGroup } from "./mdx.js";
 export { HoverLink } from "./hover-link.js";
 export type { HoverLinkProps } from "./hover-link.js";
 export { Prompt } from "./prompt.js";

--- a/packages/fumadocs/src/mdx.test.ts
+++ b/packages/fumadocs/src/mdx.test.ts
@@ -45,7 +45,7 @@ describe("getMDXComponents", () => {
 
     expect(html).toContain("data-fd-code-group");
     expect(html).toContain("data-dropdown");
-    expect(html).toContain("hidden data-[state=active]:block");
+    expect(html).toContain("fd-code-group-panel");
     expect(html).toContain(">npm</button>");
     expect(html).toContain(">pnpm</button>");
     expect(html).toContain("npm install @farming-labs/docs");

--- a/packages/fumadocs/src/mdx.test.ts
+++ b/packages/fumadocs/src/mdx.test.ts
@@ -13,7 +13,7 @@ describe("getMDXComponents", () => {
     expect(AgentComponent({ children: "hidden agent-only context" })).toBeNull();
   });
 
-  it("includes a Mintlify-compatible CodeGroup primitive", () => {
+  it("includes a Mintlify-compatible CodeGroup primitive by default without user registration", () => {
     const components = getMDXComponents();
 
     expect(typeof components.CodeGroup).toBe("function");

--- a/packages/fumadocs/src/mdx.test.ts
+++ b/packages/fumadocs/src/mdx.test.ts
@@ -13,6 +13,80 @@ describe("getMDXComponents", () => {
     expect(AgentComponent({ children: "hidden agent-only context" })).toBeNull();
   });
 
+  it("includes a Mintlify-compatible CodeGroup primitive", () => {
+    const components = getMDXComponents();
+
+    expect(typeof components.CodeGroup).toBe("function");
+
+    const CodeGroup = components.CodeGroup as React.ComponentType<{
+      children?: React.ReactNode;
+      dropdown?: boolean;
+    }>;
+    const Pre = components.pre as React.ComponentType<React.ComponentPropsWithoutRef<"pre">>;
+
+    const html = renderToStaticMarkup(
+      React.createElement(
+        CodeGroup,
+        { dropdown: true },
+        React.createElement(
+          Pre,
+          { title: "npm" },
+          React.createElement("code", null, "npm install @farming-labs/docs"),
+        ),
+        React.createElement(
+          Pre,
+          { filename: "pnpm" } as React.ComponentPropsWithoutRef<"pre"> & {
+            filename: string;
+          },
+          React.createElement("code", null, "pnpm add @farming-labs/docs"),
+        ),
+      ),
+    );
+
+    expect(html).toContain("data-fd-code-group");
+    expect(html).toContain("data-dropdown");
+    expect(html).toContain("hidden data-[state=active]:block");
+    expect(html).toContain(">npm</button>");
+    expect(html).toContain(">pnpm</button>");
+    expect(html).toContain("npm install @farming-labs/docs");
+    expect(html).toContain("pnpm add @farming-labs/docs");
+  });
+
+  it("uses bare code fence metadata as CodeGroup tab labels", () => {
+    const components = getMDXComponents({
+      pre: (props: React.ComponentPropsWithoutRef<"pre"> & { metastring?: string }) =>
+        React.createElement("pre", props),
+    });
+    const CodeGroup = components.CodeGroup as React.ComponentType<{
+      children?: React.ReactNode;
+    }>;
+    const Pre = components.pre as React.ComponentType<
+      React.ComponentPropsWithoutRef<"pre"> & { metastring?: string }
+    >;
+
+    const html = renderToStaticMarkup(
+      React.createElement(
+        CodeGroup,
+        null,
+        React.createElement(
+          Pre,
+          { metastring: "javascript helloWorld.js", className: "language-javascript" },
+          React.createElement("code", null, "console.log('Hello World');"),
+        ),
+        React.createElement(
+          Pre,
+          { metastring: "python hello_world.py", className: "language-python" },
+          React.createElement("code", null, "print('Hello World!')"),
+        ),
+      ),
+    );
+
+    expect(html).toContain(">helloWorld.js</button>");
+    expect(html).toContain(">hello_world.py</button>");
+    expect(html).toContain("console.log");
+    expect(html).toContain("print");
+  });
+
   it("includes the Prompt primitive by default and applies shared defaults", () => {
     const components = getMDXComponents(undefined, {
       theme: {

--- a/packages/fumadocs/src/mdx.ts
+++ b/packages/fumadocs/src/mdx.ts
@@ -258,7 +258,7 @@ function CodeGroup({
           key: item.value,
           value: item.value,
           forceMount: true,
-          className: "hidden data-[state=active]:block",
+          className: "fd-code-group-panel",
         },
         item.child,
       ),

--- a/packages/fumadocs/src/mdx.ts
+++ b/packages/fumadocs/src/mdx.ts
@@ -20,6 +20,12 @@
 import React from "react";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import {
+  CodeBlockTab,
+  CodeBlockTabs,
+  CodeBlockTabsList,
+  CodeBlockTabsTrigger,
+} from "fumadocs-ui/components/codeblock";
 import { MDXImg } from "./mdx-img.js";
 import { createPreWithCodeSpacing } from "./code-block-spacing.js";
 import { createPreWithCopyCallback } from "./code-block-copy-wrapper.js";
@@ -47,11 +53,225 @@ function Agent(_props: { children?: React.ReactNode }) {
   return null;
 }
 
+type ReactElementProps = Record<string, unknown> & {
+  children?: React.ReactNode;
+};
+
+export interface CodeGroupProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof CodeBlockTabs>,
+  "children"
+> {
+  children?: React.ReactNode;
+  /**
+   * Mintlify-compatible prop. The current renderer keeps the same code tab UI
+   * and exposes this as a data attribute for theme overrides.
+   */
+  dropdown?: boolean;
+}
+
+const codeGroupLabelProps = [
+  "title",
+  "filename",
+  "file",
+  "name",
+  "label",
+  "value",
+  "data-title",
+  "data-filename",
+  "data-file",
+] as const;
+
+function cx(...values: Array<string | false | null | undefined>) {
+  const className = values.filter(Boolean).join(" ");
+  return className || undefined;
+}
+
+function getElementProps(node: React.ReactNode): ReactElementProps | undefined {
+  if (!React.isValidElement(node)) return undefined;
+  return node.props && typeof node.props === "object"
+    ? (node.props as ReactElementProps)
+    : undefined;
+}
+
+function readStringProp(props: ReactElementProps | undefined, key: string): string | undefined {
+  const value = props?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parseCodeMetaLabel(meta: string | undefined): string | undefined {
+  if (!meta) return undefined;
+  const trimmed = meta.trim();
+  if (!trimmed) return undefined;
+
+  const namedMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
+  if (namedMatch?.[1]?.trim()) return namedMatch[1].trim();
+
+  const language = trimmed.split(/\s+/, 1)[0] ?? "";
+  const rest = trimmed.slice(language.length).trim();
+  if (!rest) return undefined;
+
+  const bareLabel = rest
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find((part) => part && !part.includes("="));
+
+  return bareLabel?.replace(/^["']|["']$/g, "");
+}
+
+function parseLanguageFromProps(props: ReactElementProps | undefined): string | undefined {
+  const language = readStringProp(props, "language");
+  if (language) return language;
+
+  const className = readStringProp(props, "className");
+  const match = className?.match(/language-([^\s]+)/);
+  return match?.[1];
+}
+
+function getCodeGroupLabelFromNode(node: React.ReactNode): string | undefined {
+  const props = getElementProps(node);
+  if (!props) return undefined;
+
+  for (const key of codeGroupLabelProps) {
+    const value = readStringProp(props, key);
+    if (value) return value;
+  }
+
+  const meta =
+    readStringProp(props, "metastring") ??
+    readStringProp(props, "meta") ??
+    readStringProp(props, "data-meta");
+  const metaLabel = parseCodeMetaLabel(meta);
+  if (metaLabel) return metaLabel;
+
+  const nested = React.Children.toArray(props.children).find((child) => {
+    return getCodeGroupLabelFromNode(child) !== undefined;
+  });
+  const nestedLabel = getCodeGroupLabelFromNode(nested);
+  if (nestedLabel) return nestedLabel;
+
+  return parseLanguageFromProps(props);
+}
+
+function getCodeGroupItems(children: React.ReactNode): React.ReactNode[] {
+  const items: React.ReactNode[] = [];
+
+  React.Children.forEach(children, (child) => {
+    if (child === null || child === undefined || typeof child === "boolean") return;
+    if (typeof child === "string" && child.trim() === "") return;
+
+    const props = getElementProps(child);
+    if (props && React.isValidElement(child) && child.type === React.Fragment) {
+      items.push(...getCodeGroupItems(props.children));
+      return;
+    }
+
+    items.push(child);
+  });
+
+  return items;
+}
+
+function toTabValue(label: string, index: number, used: Set<string>): string {
+  const slug =
+    label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || `code-${index + 1}`;
+  let value = slug;
+  let suffix = 2;
+
+  while (used.has(value)) {
+    value = `${slug}-${suffix}`;
+    suffix += 1;
+  }
+
+  used.add(value);
+  return value;
+}
+
+function stripCodeGroupLabelProps(child: React.ReactNode): React.ReactNode {
+  if (!React.isValidElement(child)) return child;
+
+  return React.cloneElement(child as React.ReactElement<ReactElementProps>, {
+    title: undefined,
+    filename: undefined,
+    file: undefined,
+    name: undefined,
+    label: undefined,
+    value: undefined,
+    "data-title": undefined,
+    "data-filename": undefined,
+    "data-file": undefined,
+  });
+}
+
+function CodeGroup({
+  children,
+  defaultValue,
+  dropdown = false,
+  className,
+  ...props
+}: CodeGroupProps) {
+  const usedValues = new Set<string>();
+  const items = getCodeGroupItems(children).map((child, index) => {
+    const label = getCodeGroupLabelFromNode(child) ?? `Code ${index + 1}`;
+    return {
+      child: stripCodeGroupLabelProps(child),
+      label,
+      value: toTabValue(label, index, usedValues),
+    };
+  });
+
+  if (items.length === 0) return null;
+
+  const CodeBlockTabsComponent = CodeBlockTabs as React.ComponentType<
+    React.ComponentPropsWithoutRef<typeof CodeBlockTabs> & {
+      "data-dropdown"?: string;
+      "data-fd-code-group"?: string;
+    }
+  >;
+
+  return React.createElement(
+    CodeBlockTabsComponent,
+    {
+      ...props,
+      "data-fd-code-group": "",
+      "data-dropdown": dropdown ? "" : undefined,
+      className: cx("fd-code-group", dropdown && "fd-code-group-dropdown", className),
+      defaultValue: defaultValue ?? items[0]?.value,
+    },
+    React.createElement(
+      CodeBlockTabsList,
+      null,
+      items.map((item) =>
+        React.createElement(
+          CodeBlockTabsTrigger,
+          { key: item.value, value: item.value },
+          item.label,
+        ),
+      ),
+    ),
+    items.map((item) =>
+      React.createElement(
+        CodeBlockTab,
+        {
+          key: item.value,
+          value: item.value,
+          forceMount: true,
+          className: "hidden data-[state=active]:block",
+        },
+        item.child,
+      ),
+    ),
+  );
+}
+
 const extendedMdxComponents = {
   ...defaultMdxComponents,
   img: MDXImg,
   table: Table,
   Agent,
+  CodeGroup,
   HoverLink,
   Prompt,
   Tab,
@@ -177,4 +397,13 @@ export function getMDXComponents<T extends Record<string, unknown> = Record<stri
   return base;
 }
 
-export { Agent, defaultMdxComponents, extendedMdxComponents, HoverLink, Prompt, Tab, Tabs };
+export {
+  Agent,
+  CodeGroup,
+  defaultMdxComponents,
+  extendedMdxComponents,
+  HoverLink,
+  Prompt,
+  Tab,
+  Tabs,
+};

--- a/packages/fumadocs/styles/base.css
+++ b/packages/fumadocs/styles/base.css
@@ -175,6 +175,14 @@ figure.shiki pre > code > [data-line] {
   padding: 0 0.25rem;
 }
 
+.fd-code-group-panel[data-state="inactive"] {
+  display: none;
+}
+
+.fd-code-group-panel[data-state="active"] {
+  display: block;
+}
+
 /* Titled code blocks: diagonal stripe background on the title bar */
 figure.shiki:has(figcaption) > div:first-child {
   position: relative;

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -59,6 +59,11 @@
       "import": "./dist/mdx-plugins/remark-heading.mjs",
       "default": "./dist/mdx-plugins/remark-heading.mjs"
     },
+    "./mdx-plugins/remark-code-group": {
+      "types": "./dist/mdx-plugins/remark-code-group.d.mts",
+      "import": "./dist/mdx-plugins/remark-code-group.mjs",
+      "default": "./dist/mdx-plugins/remark-code-group.mjs"
+    },
     "./mdx-plugins/rehype-toc": {
       "types": "./dist/mdx-plugins/rehype-toc.d.mts",
       "import": "./dist/mdx-plugins/rehype-toc.mjs",

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -284,6 +284,8 @@ function createDocsWorkspaceAliases(): Record<string, string> {
     "@farming-labs/next/layout": "./packages/next/src/layout.tsx",
     "@farming-labs/next/mdx-plugins/rehype-code": "./packages/next/src/mdx-plugins/rehype-code.ts",
     "@farming-labs/next/mdx-plugins/rehype-toc": "./packages/next/src/mdx-plugins/rehype-toc.ts",
+    "@farming-labs/next/mdx-plugins/remark-code-group":
+      "./packages/next/src/mdx-plugins/remark-code-group.ts",
     "@farming-labs/next/mdx-plugins/remark-heading":
       "./packages/next/src/mdx-plugins/remark-heading.ts",
     "@farming-labs/next/mdx-plugins/remark-og": "./packages/next/src/mdx-plugins/remark-og.ts",
@@ -2015,6 +2017,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   ]);
   remarkPlugins.push(
     ["remark-mdx-frontmatter", { name: "metadata" }],
+    "@farming-labs/next/mdx-plugins/remark-code-group",
     "@farming-labs/next/mdx-plugins/remark-heading",
   );
   const rehypePlugins: MdxPluginEntry[] = [

--- a/packages/next/src/mdx-plugins/remark-code-group.ts
+++ b/packages/next/src/mdx-plugins/remark-code-group.ts
@@ -1,0 +1,1 @@
+export { remarkCodeGroup as default } from "@farming-labs/docs/server";

--- a/packages/next/tsdown.config.ts
+++ b/packages/next/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/config.ts",
     "src/layout.tsx",
     "src/mdx-plugins/remark-heading.ts",
+    "src/mdx-plugins/remark-code-group.ts",
     "src/mdx-plugins/rehype-toc.ts",
     "src/mdx-plugins/rehype-code.ts",
     "src/mdx-plugins/remark-og.ts",

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -419,9 +419,43 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
 }
 
 function parseMeta(meta: string): { lang: string; title: string | null } {
-  const lang = (meta.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = meta.match(/title=["']([^"']+)["']/);
+  const trimmed = meta.trim();
+  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
   return { lang, title: titleMatch ? titleMatch[1] : null };
+}
+
+function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
+  const parsed = parseMeta(meta);
+  if (parsed.title) return parsed;
+
+  const trimmed = meta.trim();
+  const language = trimmed.split(/\s+/, 1)[0] ?? "";
+  const bareTitle = trimmed
+    .slice(language.length)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find((part) => part && !part.includes("="));
+
+  return {
+    ...parsed,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
+
+function createCodeGroupTabValue(label: string, used: Set<string>): string {
+  const slug = slugify(label) || `code-${used.size + 1}`;
+  let value = slug;
+  let suffix = 2;
+
+  while (used.has(value)) {
+    value = `${slug}-${suffix}`;
+    suffix += 1;
+  }
+
+  used.add(value);
+  return value;
 }
 
 function wrapCodeWithCopy(
@@ -471,8 +505,51 @@ export async function renderMarkdown(
   const hl = await getHighlighter();
   let result = resolveDocsAgentMdxContent(content, "human");
 
-  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
+  // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
+  result = result.replace(
+    /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
+    (_: string, attrSource: string | undefined, body: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const dropdown = toBoolean(attrs.dropdown, false);
+      const usedValues = new Set<string>();
+      const panels: { label: string; value: string; html: string }[] = [];
+      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
+      let codeMatch: RegExpExecArray | null;
+
+      while ((codeMatch = codeRegex.exec(body)) !== null) {
+        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+        const label = title || lang || `Code ${panels.length + 1}`;
+        const value = createCodeGroupTabValue(label, usedValues);
+        const dedented = dedentCode(codeMatch[2]);
+        const { html, raw } = highlightCode(hl, dedented, lang);
+        panels.push({
+          label,
+          value,
+          html: wrapCodeWithCopy(html, raw, null, lang),
+        });
+      }
+
+      if (panels.length === 0) return body;
+
+      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+      }
+      tabsHtml += `</div>`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+      }
+      tabsHtml += `</div>`;
+
+      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
+      tabsBlocks.push(tabsHtml);
+      return placeholder;
+    },
+  );
+
+  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   result = result.replace(
     /<Tabs\s+items=\{?\[([^\]]+)\]\}?>([\s\S]*?)<\/Tabs>/g,
     (_: string, itemsStr: string, body: string) => {

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -450,9 +450,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .split(/\s+/)
     .find(
       (part) =>
-        part &&
-        !part.includes("=") &&
-        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
     );
 
   return {

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -425,6 +425,18 @@ function parseMeta(meta: string): { lang: string; title: string | null } {
   return { lang, title: titleMatch ? titleMatch[1] : null };
 }
 
+const ignoredCodeGroupBareTitleTokens = new Set([
+  "copy",
+  "no-copy",
+  "nocopy",
+  "line-numbers",
+  "linenumbers",
+  "runnable",
+  "show-line-numbers",
+  "showlinenumbers",
+  "wrap",
+]);
+
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
   if (parsed.title) return parsed;
@@ -436,7 +448,12 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .trim()
     .replace(/\{[^}]*\}/g, " ")
     .split(/\s+/)
-    .find((part) => part && !part.includes("="));
+    .find(
+      (part) =>
+        part &&
+        !part.includes("=") &&
+        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
 
   return {
     ...parsed,
@@ -469,10 +486,10 @@ function wrapCodeWithCopy(
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-  const dataLang = language ? ` data-language="${String(language).replace(/"/g, "&quot;")}"` : "";
+  const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
   const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${title}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
   }
   return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
 }

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -419,9 +419,43 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
 }
 
 function parseMeta(meta: string): { lang: string; title: string | null } {
-  const lang = (meta.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = meta.match(/title=["']([^"']+)["']/);
+  const trimmed = meta.trim();
+  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
   return { lang, title: titleMatch ? titleMatch[1] : null };
+}
+
+function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
+  const parsed = parseMeta(meta);
+  if (parsed.title) return parsed;
+
+  const trimmed = meta.trim();
+  const language = trimmed.split(/\s+/, 1)[0] ?? "";
+  const bareTitle = trimmed
+    .slice(language.length)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find((part) => part && !part.includes("="));
+
+  return {
+    ...parsed,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
+
+function createCodeGroupTabValue(label: string, used: Set<string>): string {
+  const slug = slugify(label) || `code-${used.size + 1}`;
+  let value = slug;
+  let suffix = 2;
+
+  while (used.has(value)) {
+    value = `${slug}-${suffix}`;
+    suffix += 1;
+  }
+
+  used.add(value);
+  return value;
 }
 
 function wrapCodeWithCopy(
@@ -471,8 +505,51 @@ export async function renderMarkdown(
   const hl = await getHighlighter();
   let result = resolveDocsAgentMdxContent(content, "human");
 
-  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
+  // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
+  result = result.replace(
+    /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
+    (_: string, attrSource: string | undefined, body: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const dropdown = toBoolean(attrs.dropdown, false);
+      const usedValues = new Set<string>();
+      const panels: { label: string; value: string; html: string }[] = [];
+      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
+      let codeMatch: RegExpExecArray | null;
+
+      while ((codeMatch = codeRegex.exec(body)) !== null) {
+        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+        const label = title || lang || `Code ${panels.length + 1}`;
+        const value = createCodeGroupTabValue(label, usedValues);
+        const dedented = dedentCode(codeMatch[2]);
+        const { html, raw } = highlightCode(hl, dedented, lang);
+        panels.push({
+          label,
+          value,
+          html: wrapCodeWithCopy(html, raw, null, lang),
+        });
+      }
+
+      if (panels.length === 0) return body;
+
+      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+      }
+      tabsHtml += `</div>`;
+      for (let i = 0; i < panels.length; i++) {
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+      }
+      tabsHtml += `</div>`;
+
+      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
+      tabsBlocks.push(tabsHtml);
+      return placeholder;
+    },
+  );
+
+  // ── Tabs blocks: <Tabs items={[...]}> ... </Tabs> ──
   result = result.replace(
     /<Tabs\s+items=\{?\[([^\]]+)\]\}?>([\s\S]*?)<\/Tabs>/g,
     (_: string, itemsStr: string, body: string) => {

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -450,9 +450,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .split(/\s+/)
     .find(
       (part) =>
-        part &&
-        !part.includes("=") &&
-        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
     );
 
   return {

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -425,6 +425,18 @@ function parseMeta(meta: string): { lang: string; title: string | null } {
   return { lang, title: titleMatch ? titleMatch[1] : null };
 }
 
+const ignoredCodeGroupBareTitleTokens = new Set([
+  "copy",
+  "no-copy",
+  "nocopy",
+  "line-numbers",
+  "linenumbers",
+  "runnable",
+  "show-line-numbers",
+  "showlinenumbers",
+  "wrap",
+]);
+
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
   if (parsed.title) return parsed;
@@ -436,7 +448,12 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
     .trim()
     .replace(/\{[^}]*\}/g, " ")
     .split(/\s+/)
-    .find((part) => part && !part.includes("="));
+    .find(
+      (part) =>
+        part &&
+        !part.includes("=") &&
+        !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
 
   return {
     ...parsed,
@@ -469,10 +486,10 @@ function wrapCodeWithCopy(
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-  const dataLang = language ? ` data-language="${String(language).replace(/"/g, "&quot;")}"` : "";
+  const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
   const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${title}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
   }
   return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
 }

--- a/packages/tanstack-start/src/vite.ts
+++ b/packages/tanstack-start/src/vite.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import mdx from "@mdx-js/rollup";
+import { remarkCodeGroup } from "@farming-labs/docs/server";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
@@ -141,6 +142,7 @@ export function docsMdx(): PluginOption {
         remarkGfm,
         remarkFrontmatter,
         [remarkMdxFrontmatter, { name: "metadata" }],
+        remarkCodeGroup,
         remarkHeading,
       ],
       rehypePlugins: [

--- a/website/app/docs/customization/components/page.mdx
+++ b/website/app/docs/customization/components/page.mdx
@@ -101,7 +101,39 @@ The following components are available by default (from `fumadocs-ui`):
 - `HoverLink` — hover-triggered popover link card with title, description, and CTA
 - `Prompt` — reusable AI prompt card with copy/open actions
 - `Tab`, `Tabs` — tabbed content
+- `CodeGroup` — Mintlify-compatible tabbed code groups powered by the built-in code block UI
 - `Callout` — callout/admonition boxes
+
+### Example: Use `CodeGroup`
+
+`CodeGroup` lets you wrap multiple fenced code blocks in one tabbed block. The tab label comes from
+`title`, `filename`, or the bare filename after the language, so Mintlify-style docs can move over
+without custom components.
+
+````mdx title="page.mdx"
+<CodeGroup>
+
+```bash npm
+npm install @farming-labs/docs
+```
+
+```bash pnpm
+pnpm add @farming-labs/docs
+```
+
+```ts title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "app/docs",
+});
+```
+
+</CodeGroup>
+````
+
+Use `<CodeGroup dropdown>` when you want to preserve Mintlify-authored MDX that includes the
+`dropdown` prop. It is accepted by the renderer and exposed as a data attribute for theme styling.
 
 ### Example: Use `HoverLink`
 

--- a/website/app/docs/customization/components/page.mdx
+++ b/website/app/docs/customization/components/page.mdx
@@ -89,7 +89,8 @@ You can replace any built-in MDX component by registering one with the **same na
 
 ### Available built-in components
 
-The following components are available by default (from `fumadocs-ui`):
+The following components are available by default through `getMDXComponents()`. You can use them in
+MDX without imports or `docs.config.ts` registration:
 
 - `h1`, `h2`, `h3`, `h4`, `h5`, `h6` — heading elements
 - `p`, `a`, `ul`, `ol`, `li` — text and list elements
@@ -108,7 +109,7 @@ The following components are available by default (from `fumadocs-ui`):
 
 `CodeGroup` lets you wrap multiple fenced code blocks in one tabbed block. The tab label comes from
 `title`, `filename`, or the bare filename after the language, so Mintlify-style docs can move over
-without custom components.
+without custom components or MDX component registration.
 
 ````mdx title="page.mdx"
 <CodeGroup>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a built-in, Mintlify-compatible `CodeGroup` for tabbed code blocks across Next, Astro, Nuxt, Svelte, and React MDX. Ensures only the active panel is visible and updates examples/docs.

- New Features
  - Added `CodeGroup` in `fumadocs` using `fumadocs-ui` code tabs; supports `dropdown`, exposes `data-fd-code-group`/`data-dropdown`, and creates unique tab values.
  - Introduced `remarkCodeGroup` in `@farming-labs/docs/server` to infer tab labels from `title|filename|file|name|label` or bare filenames (ignores common flags); wired into `@farming-labs/next/mdx-plugins/remark-code-group`, TanStack Start, and Astro/Nuxt/Svelte to parse `<CodeGroup>` with fenced code. Updated examples and site docs.

- Bug Fixes
  - Hide inactive panels via `.fd-code-group-panel[data-state]`.
  - Escape code block titles and language in static renderers.

<sup>Written for commit df802b55b2cdb84c862fb864398b7a7384c5bd50. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

