### PR TITLE
feat: auto-detect AI agents for markdown docs responses

### DIFF
--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDocsAgentDiscoverySpec,
   buildDocsMcpEndpointCandidates,
+  detectDocsMarkdownAgentRequest,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
@@ -373,6 +374,59 @@ describe("agent route helpers", () => {
       }),
     );
     expect(signatureAgentRoute).toEqual({ requestedPath: "install" });
+    expect(
+      detectDocsMarkdownAgentRequest(
+        new Request("https://example.com/docs/install", {
+          headers: { "Signature-Agent": "https://chatgpt.com" },
+        }),
+      ),
+    ).toEqual({ detected: true, method: "signature_agent" });
+
+    const userAgentRoute = resolveDocsMarkdownRequest(
+      "docs",
+      new URL("https://example.com/docs/install"),
+      new Request("https://example.com/docs/install", {
+        headers: { "user-agent": "ClaudeBot/1.0" },
+      }),
+    );
+    expect(userAgentRoute).toEqual({ requestedPath: "install" });
+    expect(
+      detectDocsMarkdownAgentRequest(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "ClaudeBot/1.0" },
+        }),
+      ),
+    ).toEqual({ detected: true, method: "user_agent" });
+
+    const heuristicAgentRoute = resolveDocsMarkdownRequest(
+      "docs",
+      new URL("https://example.com/docs/install"),
+      new Request("https://example.com/docs/install", {
+        headers: { "user-agent": "AcmeAgentFetcher/1.0" },
+      }),
+    );
+    expect(heuristicAgentRoute).toEqual({ requestedPath: "install" });
+    expect(
+      detectDocsMarkdownAgentRequest(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "AcmeAgentFetcher/1.0" },
+        }),
+      ),
+    ).toEqual({ detected: true, method: "heuristic" });
+    expect(
+      detectDocsMarkdownAgentRequest(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "AcmeAgentFetcher/1.0", "sec-fetch-mode": "navigate" },
+        }),
+      ),
+    ).toEqual({ detected: false, method: null });
+    expect(
+      detectDocsMarkdownAgentRequest(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "Googlebot/2.1" },
+        }),
+      ),
+    ).toEqual({ detected: false, method: null });
 
     expect(
       hasDocsMarkdownSignatureAgent(
@@ -395,6 +449,20 @@ describe("agent route helpers", () => {
         }),
       ),
     ).toBe("Accept, Signature-Agent");
+    expect(
+      getDocsMarkdownVaryHeader(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "ClaudeBot/1.0" },
+        }),
+      ),
+    ).toBe("User-Agent");
+    expect(
+      getDocsMarkdownVaryHeader(
+        new Request("https://example.com/docs/install", {
+          headers: { "user-agent": "AcmeAgentFetcher/1.0" },
+        }),
+      ),
+    ).toBe("User-Agent, Sec-Fetch-Mode");
     expect(getDocsMarkdownVaryHeader(new Request("https://example.com/docs/install"))).toBeNull();
 
     const apiFormatRoute = resolveDocsMarkdownRequest(

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -89,6 +89,72 @@ export const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
   required: ["task", "outcome"],
 };
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
+const DOCS_AI_AGENT_USER_AGENT_PATTERNS = [
+  "claudebot",
+  "claude-searchbot",
+  "claude-user",
+  "anthropic-ai",
+  "claude-web",
+  "chatgpt",
+  "gptbot",
+  "oai-searchbot",
+  "openai",
+  "gemini",
+  "bard",
+  "google-cloudvertexbot",
+  "google-extended",
+  "meta-externalagent",
+  "meta-externalfetcher",
+  "meta-webindexer",
+  "perplexity",
+  "youbot",
+  "you.com",
+  "deepseekbot",
+  "cursor",
+  "github-copilot",
+  "codeium",
+  "tabnine",
+  "sourcegraph",
+  "cohere-ai",
+  "bytespider",
+  "amazonbot",
+  "ai2bot",
+  "diffbot",
+  "omgili",
+  "omgilibot",
+] as const;
+const DOCS_TRADITIONAL_BOT_USER_AGENT_PATTERNS = [
+  "googlebot",
+  "bingbot",
+  "yandexbot",
+  "baiduspider",
+  "duckduckbot",
+  "slurp",
+  "msnbot",
+  "facebot",
+  "twitterbot",
+  "linkedinbot",
+  "whatsapp",
+  "telegrambot",
+  "pingdom",
+  "uptimerobot",
+  "newrelic",
+  "datadog",
+  "statuspage",
+  "site24x7",
+  "applebot",
+] as const;
+const DOCS_BOT_LIKE_USER_AGENT_PATTERN = /bot|agent|fetch|crawl|spider|search/i;
+const DOCS_BOT_LIKE_USER_AGENT_TERMS = ["bot", "agent", "fetch", "crawl", "spider", "search"];
+export const DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN = buildDocsUserAgentHeaderPattern(
+  DOCS_AI_AGENT_USER_AGENT_PATTERNS,
+);
+export const DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN = buildDocsUserAgentHeaderPattern(
+  DOCS_TRADITIONAL_BOT_USER_AGENT_PATTERNS,
+);
+export const DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN = buildDocsUserAgentHeaderPattern(
+  DOCS_BOT_LIKE_USER_AGENT_TERMS,
+);
 const DOCS_LLMS_TXT_DIRECTIVE_LINE = "LLM index: /llms.txt";
 
 const DOCS_MCP_SERVICE_SUBDOMAIN_LABELS = new Set([
@@ -1143,7 +1209,11 @@ export function resolveDocsMarkdownRequest(
     };
   }
 
-  if (acceptsMarkdown(request) || hasDocsMarkdownSignatureAgent(request)) {
+  if (
+    acceptsMarkdown(request) ||
+    hasDocsMarkdownSignatureAgent(request) ||
+    detectDocsMarkdownAgentRequest(request).detected
+  ) {
     if (pathname === normalizedEntry) {
       return { requestedPath: "" };
     }
@@ -1162,12 +1232,48 @@ export function hasDocsMarkdownSignatureAgent(request: Request): boolean {
   return Boolean(request.headers.get(DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER)?.trim());
 }
 
-export function getDocsMarkdownVaryHeader(request: Request): string | null {
-  if (hasDocsMarkdownSignatureAgent(request)) {
-    return `Accept, ${DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER}`;
+export type DocsMarkdownAgentDetection =
+  | { detected: true; method: "signature_agent" | "user_agent" | "heuristic" }
+  | { detected: false; method: null };
+
+export function detectDocsMarkdownAgentRequest(request: Request): DocsMarkdownAgentDetection {
+  if (hasDocsMarkdownSignatureAgent(request)) return { detected: true, method: "signature_agent" };
+
+  const userAgent = request.headers.get("user-agent")?.trim().toLowerCase() ?? "";
+  if (!userAgent) return { detected: false, method: null };
+
+  if (DOCS_AI_AGENT_USER_AGENT_PATTERNS.some((pattern) => userAgent.includes(pattern))) {
+    return { detected: true, method: "user_agent" };
   }
 
-  return acceptsMarkdown(request) ? "Accept" : null;
+  const secFetchMode = request.headers.get("sec-fetch-mode");
+  if (!secFetchMode && DOCS_BOT_LIKE_USER_AGENT_PATTERN.test(userAgent)) {
+    const isTraditionalBot = DOCS_TRADITIONAL_BOT_USER_AGENT_PATTERNS.some((pattern) =>
+      userAgent.includes(pattern),
+    );
+    if (!isTraditionalBot) return { detected: true, method: "heuristic" };
+  }
+
+  return { detected: false, method: null };
+}
+
+export function getDocsMarkdownVaryHeader(request: Request): string | null {
+  const values = new Set<string>();
+
+  if (acceptsMarkdown(request)) values.add("Accept");
+
+  if (hasDocsMarkdownSignatureAgent(request)) {
+    values.add("Accept");
+    values.add(DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER);
+  }
+
+  const agentDetection = detectDocsMarkdownAgentRequest(request);
+  if (agentDetection.detected && agentDetection.method !== "signature_agent") {
+    values.add("User-Agent");
+    if (agentDetection.method === "heuristic") values.add("Sec-Fetch-Mode");
+  }
+
+  return values.size > 0 ? Array.from(values).join(", ") : null;
 }
 
 export function renderDocsMarkdownNotFound({
@@ -1998,6 +2104,24 @@ function acceptsMarkdown(request: Request): boolean {
       const quality = Number.parseFloat(qualityValue);
       return Number.isFinite(quality) ? quality > 0 : true;
     });
+}
+
+function buildDocsUserAgentHeaderPattern(patterns: readonly string[]): string {
+  return `.*(?:${patterns.map(toCaseInsensitiveHeaderPattern).join("|")}).*`;
+}
+
+function toCaseInsensitiveHeaderPattern(value: string): string {
+  return value
+    .split("")
+    .map((char) => {
+      if (/^[a-z]$/i.test(char)) return `[${char.toLowerCase()}${char.toUpperCase()}]`;
+      return escapeRegex(char);
+    })
+    .join("");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
 function normalizeRequestedMarkdownPath(entry: string, requestedPath: string): string {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -58,6 +58,7 @@ export {
   stripGeneratedAgentProvenance,
 } from "./agent-provenance.js";
 export {
+  type DocsMarkdownAgentDetection,
   DEFAULT_AGENT_FEEDBACK_ROUTE,
   DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA,
   DEFAULT_AGENT_MD_ROUTE,
@@ -79,10 +80,14 @@ export {
   DEFAULT_MCP_WELL_KNOWN_ROUTE,
   DEFAULT_SKILL_MD_ROUTE,
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
+  DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
+  DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN,
   DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER,
+  DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
   buildDocsAgentDiscoverySpec,
   buildDocsAgentFeedbackSchema,
   buildDocsMcpEndpointCandidates,
+  detectDocsMarkdownAgentRequest,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1126,6 +1126,40 @@ Config content.
       "Use this page as the implementation map.\n",
     );
 
+    const userAgentPageResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { "user-agent": "ClaudeBot/1.0" },
+      }),
+    );
+    expect(userAgentPageResponse.status).toBe(200);
+    expect(userAgentPageResponse.headers.get("content-type")).toContain("text/markdown");
+    expect(userAgentPageResponse.headers.get("link")).toBe(
+      '<http://localhost/docs/overview>; rel="canonical"',
+    );
+    expect(userAgentPageResponse.headers.get("vary")).toBe("User-Agent");
+    expect(await userAgentPageResponse.text()).toBe("Use this page as the implementation map.\n");
+
+    const heuristicPageResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: { "user-agent": "AcmeAgentFetcher/1.0" },
+      }),
+    );
+    expect(heuristicPageResponse.status).toBe(200);
+    expect(heuristicPageResponse.headers.get("content-type")).toContain("text/markdown");
+    expect(heuristicPageResponse.headers.get("vary")).toBe("User-Agent, Sec-Fetch-Mode");
+    expect(await heuristicPageResponse.text()).toBe("Use this page as the implementation map.\n");
+
+    const browserLikeHeuristicResponse = await GET(
+      new Request("http://localhost/docs/overview", {
+        headers: {
+          "user-agent": "AcmeAgentFetcher/1.0",
+          "sec-fetch-mode": "navigate",
+        },
+      }),
+    );
+    expect(browserLikeHeuristicResponse.headers.get("content-type")).not.toContain("text/markdown");
+    expect(await browserLikeHeuristicResponse.text()).toBe("[]");
+
     const zeroQualityAcceptResponse = await GET(
       new Request("http://localhost/docs/overview", {
         headers: { accept: "application/json, text/markdown;profile=agent;q=0" },
@@ -1186,13 +1220,19 @@ Install the package.
         headers: { accept: "text/markdown" },
       }),
     );
+    await GET(
+      new Request("http://localhost/docs/guides/setup", {
+        headers: { "user-agent": "ClaudeBot/1.0" },
+      }),
+    );
 
     const agentReads = events.filter((event) => event.type === "agent_read");
-    expect(agentReads).toHaveLength(3);
+    expect(agentReads).toHaveLength(4);
     expect(agentReads.map((event) => event.properties?.delivery)).toEqual([
       "api_format",
       "md_route",
       "accept_header",
+      "user_agent",
     ]);
     expect(agentReads).toEqual(
       expect.arrayContaining([

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -31,6 +31,7 @@ import {
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
   createDocsRobotsResponse,
+  detectDocsMarkdownAgentRequest,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
   getDocsMarkdownVaryHeader,
@@ -1591,9 +1592,25 @@ function acceptsMarkdown(request: Request): boolean {
     });
 }
 
+function resolveMarkdownHeaderDelivery(request: Request): MarkdownRequest["delivery"] | null {
+  if (hasDocsMarkdownSignatureAgent(request)) return "signature_agent";
+  if (acceptsMarkdown(request)) return "accept_header";
+
+  const agentDetection = detectDocsMarkdownAgentRequest(request);
+  if (!agentDetection.detected) return null;
+
+  return agentDetection.method === "heuristic" ? "heuristic" : "user_agent";
+}
+
 type MarkdownRequest = {
   requestedPath: string;
-  delivery: "api_format" | "md_route" | "accept_header" | "signature_agent";
+  delivery:
+    | "api_format"
+    | "md_route"
+    | "accept_header"
+    | "signature_agent"
+    | "user_agent"
+    | "heuristic";
 };
 
 type DocsContext = {
@@ -1628,9 +1645,9 @@ function resolveMarkdownRequest(entry: string, url: URL, request: Request): Mark
     };
   }
 
-  const hasSignatureAgent = hasDocsMarkdownSignatureAgent(request);
-  if (acceptsMarkdown(request) || hasSignatureAgent) {
-    const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
+  const headerDelivery = resolveMarkdownHeaderDelivery(request);
+  if (headerDelivery) {
+    const delivery = headerDelivery;
 
     if (pathname === normalizedEntry) {
       return { requestedPath: "", delivery };
@@ -1731,9 +1748,9 @@ function resolvePublicMarkdownRequest(
       };
     }
 
-    const hasSignatureAgent = hasDocsMarkdownSignatureAgent(request);
-    if (acceptsMarkdown(request) || hasSignatureAgent) {
-      const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
+    const headerDelivery = resolveMarkdownHeaderDelivery(request);
+    if (headerDelivery) {
+      const delivery = headerDelivery;
       return {
         requestedPath: pathname === "/" ? "" : pathname.slice(1),
         delivery,
@@ -1755,9 +1772,9 @@ function resolvePublicMarkdownRequest(
     };
   }
 
-  const hasSignatureAgent = hasDocsMarkdownSignatureAgent(request);
-  if (acceptsMarkdown(request) || hasSignatureAgent) {
-    const delivery = hasSignatureAgent ? "signature_agent" : "accept_header";
+  const headerDelivery = resolveMarkdownHeaderDelivery(request);
+  if (headerDelivery) {
+    const delivery = headerDelivery;
 
     if (pathname === docsPath) {
       return { requestedPath: "", delivery };

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -10,12 +10,18 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import {
+  DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
+  DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN,
+  DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
+} from "@farming-labs/docs";
 import { withDocs } from "./config.js";
 
 type TestRewrite = {
   source: string;
   destination: string;
   has?: Array<Record<string, string>>;
+  missing?: Array<Record<string, string>>;
 };
 
 type TestRewriteResult =
@@ -80,6 +86,29 @@ const MARKDOWN_SIGNATURE_AGENT_HEADER = {
   type: "header",
   key: "signature-agent",
   value: ".+",
+};
+
+const MARKDOWN_AGENT_USER_AGENT_HEADER = {
+  type: "header",
+  key: "user-agent",
+  value: DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
+};
+
+const MARKDOWN_BOT_LIKE_USER_AGENT_HEADER = {
+  type: "header",
+  key: "user-agent",
+  value: DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN,
+};
+
+const MARKDOWN_TRADITIONAL_BOT_USER_AGENT_HEADER = {
+  type: "header",
+  key: "user-agent",
+  value: DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
+};
+
+const MARKDOWN_SEC_FETCH_MODE_HEADER = {
+  type: "header",
+  key: "sec-fetch-mode",
 };
 
 const DOCS_CONFIG_WITH_API_REFERENCE = `export default {
@@ -403,6 +432,28 @@ describe("withDocs (app dir: src/app vs app)", () => {
           has: [MARKDOWN_SIGNATURE_AGENT_HEADER],
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
+        expect.objectContaining({
+          source: "/docs",
+          has: [MARKDOWN_AGENT_USER_AGENT_HEADER],
+          destination: "/api/docs?format=markdown",
+        }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [MARKDOWN_AGENT_USER_AGENT_HEADER],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
+        expect.objectContaining({
+          source: "/docs",
+          has: [MARKDOWN_BOT_LIKE_USER_AGENT_HEADER],
+          missing: [MARKDOWN_TRADITIONAL_BOT_USER_AGENT_HEADER, MARKDOWN_SEC_FETCH_MODE_HEADER],
+          destination: "/api/docs?format=markdown",
+        }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [MARKDOWN_BOT_LIKE_USER_AGENT_HEADER],
+          missing: [MARKDOWN_TRADITIONAL_BOT_USER_AGENT_HEADER, MARKDOWN_SEC_FETCH_MODE_HEADER],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
       ]),
     );
     expect(afterFiles).toEqual(
@@ -461,6 +512,20 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(acceptPattern.test("application/json, text/markdown;profile=agent;q=0")).toBe(false);
     expect(acceptPattern.test("text/markdown-v2")).toBe(false);
     expect(acceptPattern.test("application/not-text/markdownish")).toBe(false);
+
+    const agentUserAgentPattern = new RegExp(MARKDOWN_AGENT_USER_AGENT_HEADER.value);
+    expect(agentUserAgentPattern.test("ClaudeBot/1.0")).toBe(true);
+    expect(agentUserAgentPattern.test("Mozilla/5.0")).toBe(false);
+
+    const botLikeUserAgentPattern = new RegExp(MARKDOWN_BOT_LIKE_USER_AGENT_HEADER.value);
+    expect(botLikeUserAgentPattern.test("AcmeAgentFetcher/1.0")).toBe(true);
+    expect(botLikeUserAgentPattern.test("Mozilla/5.0")).toBe(false);
+
+    const traditionalBotUserAgentPattern = new RegExp(
+      MARKDOWN_TRADITIONAL_BOT_USER_AGENT_HEADER.value,
+    );
+    expect(traditionalBotUserAgentPattern.test("Googlebot/2.1")).toBe(true);
+    expect(traditionalBotUserAgentPattern.test("AcmeAgentFetcher/1.0")).toBe(false);
   });
 
   it("exposes docs from the site root when docsPath is empty", async () => {
@@ -1207,6 +1272,17 @@ describe("withDocs (app dir: src/app vs app)", () => {
         expect.objectContaining({
           source: "/docs/:slug*",
           has: [MARKDOWN_SIGNATURE_AGENT_HEADER],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [MARKDOWN_AGENT_USER_AGENT_HEADER],
+          destination: "/api/docs?format=markdown&path=:slug*",
+        }),
+        expect.objectContaining({
+          source: "/docs/:slug*",
+          has: [MARKDOWN_BOT_LIKE_USER_AGENT_HEADER],
+          missing: [MARKDOWN_TRADITIONAL_BOT_USER_AGENT_HEADER, MARKDOWN_SEC_FETCH_MODE_HEADER],
           destination: "/api/docs?format=markdown&path=:slug*",
         }),
       ]),

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -32,6 +32,11 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
+  DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN,
+  DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
+} from "@farming-labs/docs";
 import { ensureDocsReviewWorkflow } from "@farming-labs/docs/server";
 import matter from "gray-matter";
 import type { NextConfig } from "next";
@@ -1366,6 +1371,25 @@ function buildDocsMarkdownRewrites(entry: string, docsPath: string): NextRewrite
     key: "signature-agent",
     value: ".+",
   };
+  const markdownAgentUserAgentHeader = {
+    type: "header",
+    key: "user-agent",
+    value: DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
+  };
+  const markdownBotLikeUserAgentHeader = {
+    type: "header",
+    key: "user-agent",
+    value: DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN,
+  };
+  const markdownTraditionalBotUserAgentHeader = {
+    type: "header",
+    key: "user-agent",
+    value: DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
+  };
+  const markdownSecFetchModeHeader = {
+    type: "header",
+    key: "sec-fetch-mode",
+  };
 
   if (publicBase === "") {
     const rootPageSource = docsRootSource(normalizedEntry);
@@ -1399,6 +1423,28 @@ function buildDocsMarkdownRewrites(entry: string, docsPath: string): NextRewrite
         has: [markdownSignatureAgentHeader],
         destination: "/api/docs?format=markdown&path=:slug",
       },
+      {
+        source: "/",
+        has: [markdownAgentUserAgentHeader],
+        destination: "/api/docs?format=markdown",
+      },
+      {
+        source: rootPageSource,
+        has: [markdownAgentUserAgentHeader],
+        destination: "/api/docs?format=markdown&path=:slug",
+      },
+      {
+        source: "/",
+        has: [markdownBotLikeUserAgentHeader],
+        missing: [markdownTraditionalBotUserAgentHeader, markdownSecFetchModeHeader],
+        destination: "/api/docs?format=markdown",
+      },
+      {
+        source: rootPageSource,
+        has: [markdownBotLikeUserAgentHeader],
+        missing: [markdownTraditionalBotUserAgentHeader, markdownSecFetchModeHeader],
+        destination: "/api/docs?format=markdown&path=:slug",
+      },
     ];
   }
 
@@ -1429,6 +1475,28 @@ function buildDocsMarkdownRewrites(entry: string, docsPath: string): NextRewrite
     {
       source: `${publicBase}/:slug*`,
       has: [markdownSignatureAgentHeader],
+      destination: "/api/docs?format=markdown&path=:slug*",
+    },
+    {
+      source: publicBase,
+      has: [markdownAgentUserAgentHeader],
+      destination: "/api/docs?format=markdown",
+    },
+    {
+      source: `${publicBase}/:slug*`,
+      has: [markdownAgentUserAgentHeader],
+      destination: "/api/docs?format=markdown&path=:slug*",
+    },
+    {
+      source: publicBase,
+      has: [markdownBotLikeUserAgentHeader],
+      missing: [markdownTraditionalBotUserAgentHeader, markdownSecFetchModeHeader],
+      destination: "/api/docs?format=markdown",
+    },
+    {
+      source: `${publicBase}/:slug*`,
+      has: [markdownBotLikeUserAgentHeader],
+      missing: [markdownTraditionalBotUserAgentHeader, markdownSecFetchModeHeader],
       destination: "/api/docs?format=markdown&path=:slug*",
     },
   ];

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -175,6 +175,7 @@ Default behavior:
 - **Nuxt:** current `init` scaffolds one `server/middleware/docs-public.ts` public forwarder for `/docs.md` and `/docs/<slug>.md`
 - **Next.js:** `Accept: text/markdown` on `/docs/<slug>` returns the same markdown response; other adapters should use the `.md` URL or API format route
 - Requests with `Signature-Agent` on normal docs URLs return the same markdown response, so agent fetchers can read canonical URLs without appending `.md`
+- Next.js also auto-serves markdown on normal docs URLs for known AI user agents and conservative bot-like agent heuristics
 - embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI and are included in the markdown fallback
 - if a page folder has `agent.md`, that file becomes the markdown response for that page
 - if `agent.md` is missing, the markdown response falls back to the normal page markdown
@@ -229,13 +230,14 @@ curl "http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart"
 curl "http://127.0.0.1:3000/docs/quickstart.md"
 curl "http://127.0.0.1:3000/docs/quickstart" -H "Accept: text/markdown" # Next.js
 curl "http://127.0.0.1:3000/docs/quickstart" -H "Signature-Agent: https://chatgpt.com"
+curl "http://127.0.0.1:3000/docs/quickstart" -H "User-Agent: ClaudeBot/1.0"
 curl "http://127.0.0.1:3000/docs/getting-started/agent-ready-docs.md"
 ```
 
 Call out content negotiation when relevant: in Next.js, `/docs/<slug>` remains the normal HTML page
-for browsers, but agents/scripts can send `Accept: text/markdown` to the same URL and receive the
-machine-readable markdown representation without appending `.md`. In other adapters, use
-`/docs/<slug>.md` or the API format route.
+for browsers, but agents/scripts can send `Accept: text/markdown`, send `Signature-Agent`, or use a
+known AI user agent to receive the machine-readable markdown representation without appending `.md`.
+In other adapters, use `/docs/<slug>.md` or the API format route.
 
 ---
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -343,6 +343,7 @@ No separate config flag is required for machine-readable page markdown.
 - Successful markdown responses include a `Link: <canonical-page-url>; rel="canonical"` response header so agents can read the markdown mirror but cite the normal docs page
 - In Next.js, sending `Accept: text/markdown` to `/docs/<slug>` returns the same markdown response
 - In Next.js, sending a non-empty `Signature-Agent` header to `/docs/<slug>` also returns the same markdown response
+- In Next.js, known AI user agents and conservative bot-like agent heuristics also receive markdown from normal docs URLs
 - These negotiated Next.js reads are handled by the existing `/api/docs` route; `withDocs()` does not create a separate `/api/docs/markdown` wrapper
 - Embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI but are included in the `.md` fallback and MCP `read_page`
 - When a page folder has `agent.md`, that file is returned instead of the normal page markdown
@@ -354,20 +355,23 @@ No separate config flag is required for machine-readable page markdown.
   ```bash
   curl "https://docs.example.com/docs/installation" -H "Accept: text/markdown"
   curl "https://docs.example.com/docs/installation" -H "Signature-Agent: https://chatgpt.com"
+  curl "https://docs.example.com/docs/installation" -H "User-Agent: ClaudeBot/1.0"
   ```
 
   In Next.js, browsers still receive HTML from `/docs/installation`; agents, scripts, and crawlers
-  that send `Accept: text/markdown` or `Signature-Agent` receive the same machine-readable output
-  as `/docs/installation.md`. The request is resolved by the shared `/api/docs` handler, so custom
-  apps should keep one docs API route instead of adding a second markdown-only wrapper. Other
-  adapters should use the `.md` URL or the API format route.
+  that send `Accept: text/markdown`, send `Signature-Agent`, identify as a known AI user agent, or
+  match a conservative bot-like agent heuristic receive the same machine-readable output as
+  `/docs/installation.md`. The request is resolved by the shared `/api/docs` handler, so custom apps
+  should keep one docs API route instead of adding a second markdown-only wrapper. Other adapters
+  should use the `.md` URL or the API format route.
 
   Successful markdown responses also include a canonical `Link` response header. The body is still
   the full markdown document; the header simply tells agents that `/docs/installation` is the
   source-of-truth URL for `/docs/installation.md` or a negotiated markdown read.
 
   Negotiated markdown responses include cache-safe `Vary` headers: `Accept` for
-  `Accept: text/markdown`, and `Accept, Signature-Agent` for `Signature-Agent`.
+  `Accept: text/markdown`, `Accept, Signature-Agent` for `Signature-Agent`, `User-Agent` for known
+  AI user agents, and `User-Agent, Sec-Fetch-Mode` for heuristic agent detection.
 
   That means a CDN can cache the HTML and markdown versions separately even though the URL is the
   same:
@@ -376,6 +380,7 @@ No separate config flag is required for machine-readable page markdown.
   /docs/installation + normal browser headers      -> cached HTML
   /docs/installation + Accept: text/markdown       -> cached markdown
   /docs/installation + Signature-Agent: <agent-id> -> cached markdown
+  /docs/installation + User-Agent: ClaudeBot/1.0   -> cached markdown
   ```
 
   If a markdown request misses, the 404 response is still markdown. It points agents at the agent

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -18,6 +18,7 @@ The same page model also powers the built-in machine-readable routes:
 - Next.js `withDocs()` and the generated TanStack Start, SvelteKit, Astro, and Nuxt forwarding layer serve `/docs.md` and `/docs/<slug>.md`
 - in Next.js, `Accept: text/markdown` on `/docs/<slug>` returns the same markdown
 - in Next.js, `Signature-Agent` on `/docs/<slug>` returns the same markdown for agents that fetch canonical URLs
+- in Next.js, known AI user agents and conservative bot-like agent heuristics also receive markdown from normal docs URLs
 - coding agents can fetch site-level instructions with `GET /AGENTS.md`, fall back to
   `GET /.well-known/AGENTS.md`, or use `GET /api/docs?format=agents`
 - agents can fetch the site skill with `GET /skill.md`, fall back to
@@ -27,9 +28,9 @@ The same page model also powers the built-in machine-readable routes:
 
 <Callout type="info" title="Same URL, different representation">
   `/docs/installation` stays the human HTML page by default. In Next.js, send
-  `Accept: text/markdown` or `Signature-Agent` to that same URL when an agent or script wants the
-  machine-readable version without appending `.md`. In the other adapters, use
-  `/docs/installation.md` or the `format=markdown` API route.
+  `Accept: text/markdown`, send `Signature-Agent`, or identify with a known AI user agent on that
+  same URL when an agent or script wants the machine-readable version without appending `.md`. In the
+  other adapters, use `/docs/installation.md` or the `format=markdown` API route.
 
   These reads go through the existing shared `/api/docs` handler. You do not need another
   markdown-specific API wrapper, and adding one usually makes discovery, caching, and 404 recovery
@@ -80,6 +81,7 @@ That gives you:
 - `/docs/installation.md` for machine-readable markdown that includes the `Agent` block
 - `/docs/installation` with `Accept: text/markdown` for the same machine-readable markdown
 - `/docs/installation` with `Signature-Agent` for agents that read the canonical URL
+- `/docs/installation` with `User-Agent: ClaudeBot/1.0` for AI user-agent auto-detection
 - MCP `read_page("/docs/installation")` with the same page-level machine context
 
 ## Bootstrap Agents With The Spec
@@ -120,7 +122,8 @@ available in the spec.
 
 This works well on `/docs` because many agents start there first. The instruction stays hidden from
 the human UI, but it appears when an agent reads `/docs.md`, requests `/docs` with
-`Accept: text/markdown` or `Signature-Agent`, or reads the page through MCP.
+`Accept: text/markdown`, sends `Signature-Agent`, identifies with a known AI user agent, or reads
+the page through MCP.
 
 ## Use `agent.md` For A Full Override
 
@@ -235,7 +238,7 @@ Agents should fetch it before choosing a transport. It tells them:
 - which agent discovery URL is the default and which public route to use as fallback
 - where to search the docs with a query
 - which markdown URL pattern to use for page reads
-- whether the same docs URLs support `Accept: text/markdown` or `Signature-Agent`
+- whether the same docs URLs support `Accept: text/markdown`, `Signature-Agent`, or AI user-agent detection
 - whether HTML pages include Schema.org `TechArticle` JSON-LD structured data
 - where to fetch `llms.txt` and `llms-full.txt` content, including the default public URLs and the
   public `/.well-known` aliases when available

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -120,7 +120,7 @@ whether the action completed.
 | `mcp_tool`                      | An MCP tool call was handled, such as `search_docs` or `read_page`.     |
 
 `agent_read` includes `properties.delivery` so you can see how the page was read: `md_route`,
-`accept_header`, `api_format`, or `mcp_tool`.
+`accept_header`, `signature_agent`, `user_agent`, `heuristic`, `api_format`, or `mcp_tool`.
 
 ## Input Privacy
 

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -212,6 +212,7 @@ Once `agent.md` exists, it becomes the source for:
 - `GET /api/docs?format=markdown&path=<slug>`
 - `{page}` with `Accept: text/markdown` in Next.js
 - `{page}` with `Signature-Agent` in Next.js
+- `{page}` with a known AI `User-Agent` in Next.js
 - MCP `read_page`
 
 So use it when that stronger machine contract is genuinely worth owning.
@@ -262,7 +263,8 @@ That gives agents a much better workflow:
 - HTML docs pages include Schema.org `TechArticle` JSON-LD with canonical URL, freshness, and breadcrumbs
 - when `apiReference` is enabled, `/api/docs?format=openapi` gives agents the OpenAPI schema before they scrape API reference pages
 - `{page}.md` gives them clean page markdown
-- canonical `{page}` URLs with `Signature-Agent` give agents the same markdown without appending `.md`
+- canonical `{page}` URLs with `Accept: text/markdown`, `Signature-Agent`, or a known AI user agent
+  give agents the same markdown without appending `.md`
 - MCP lets tool-enabled agents search and read docs semantically
 - `/api/docs/agent/feedback/schema` and `/api/docs/agent/feedback` let agents report missing context without enabling the human feedback UI
 
@@ -296,6 +298,9 @@ curl "https://docs.example.com/docs/installation" \
 
 curl "https://docs.example.com/docs/installation" \
   -H "Signature-Agent: https://chatgpt.com"
+
+curl "https://docs.example.com/docs/installation" \
+  -H "User-Agent: ClaudeBot/1.0"
 ```
 
 Both requests are served by the existing shared docs API. `withDocs()` forwards the request into the
@@ -308,6 +313,7 @@ That detail matters for agent-friendly docs because there is only one page resol
 - `/docs/installation.md` and `/api/docs?format=markdown&path=installation` are explicit markdown entry points
 - `/docs/installation` with `Accept: text/markdown` returns the same markdown and varies by `Accept`
 - `/docs/installation` with `Signature-Agent` returns the same markdown and varies by `Accept, Signature-Agent`
+- `/docs/installation` with `User-Agent: ClaudeBot/1.0` returns the same markdown and varies by `User-Agent`
 - `/docs/installation` without those headers remains the normal HTML page
 
 All successful markdown page responses include a canonical `Link` response header pointing back to
@@ -390,7 +396,9 @@ Example:
 - Open `http://localhost:3000/docs`
 - Fetch `http://localhost:3000/docs.md`
 - Fetch `http://localhost:3000/docs` with `Signature-Agent: https://chatgpt.com`
+- Fetch `http://localhost:3000/docs` with `User-Agent: ClaudeBot/1.0`
 - Confirm the `Signature-Agent` response is `text/markdown` and includes `Vary: Accept, Signature-Agent`
+- Confirm the AI user-agent response is `text/markdown` and includes `Vary: User-Agent`
 - Confirm successful markdown responses include `Link: <http://localhost:3000/docs>; rel="canonical"`
 - Fetch `http://localhost:3000/.well-known/agent.json`
 - Fetch `http://localhost:3000/sitemap.md`
@@ -399,7 +407,7 @@ Example:
 ## Troubleshooting
 
 - If `/docs.md` returns `404`, check the docs route wiring.
-- If `Signature-Agent` returns JSON or HTML in Next.js, check that the request is reaching the shared `/api/docs` handler and that no custom rewrite is shadowing the generated docs rewrites.
+- If `Signature-Agent` or AI user-agent requests return JSON or HTML in Next.js, check that the request is reaching the shared `/api/docs` handler and that no custom rewrite is shadowing the generated docs rewrites.
 - If `/.well-known/agent.json` is missing, confirm the docs API route is mounted.
 - If JSON-LD lacks `dateModified` in a preloaded adapter, run `docs sitemap generate` and make sure `/.farming-labs/sitemap-manifest.json` is included in `_preloadedContent`.
 - If the page renders but search is empty, verify the search provider config.
@@ -581,8 +589,8 @@ Before calling a page agent-friendly, ask:
 - should this page get an additive `<Agent>` block?
 - does it need a dedicated `agent.md`, or is the human page still canonical?
 - does this page need `agent.tokenBudget` before compaction?
-- can an agent find it through `.md`, `Signature-Agent`, JSON-LD structured data, `llms.txt` markdown links, OpenAPI schema discovery, sitemaps, `robots.txt`, `AGENTS.md`, MCP, and the discovery spec?
-- do canonical `Signature-Agent` reads use the existing `/api/docs` handler instead of a custom wrapper route?
+- can an agent find it through `.md`, `Signature-Agent`, AI user-agent detection, JSON-LD structured data, `llms.txt` markdown links, OpenAPI schema discovery, sitemaps, `robots.txt`, `AGENTS.md`, MCP, and the discovery spec?
+- do canonical `Signature-Agent` and AI user-agent reads use the existing `/api/docs` handler instead of a custom wrapper route?
 - if the adapter preloads content, is the sitemap manifest bundled so JSON-LD freshness stays stable?
 - if the site is static, does the build generate `sitemap.xml`, `sitemap.md`, `docs/sitemap.md`, `/.well-known/sitemap.md`, `robots.txt`, and `AGENTS.md`?
 - does `docs doctor --agent` agree with the state of the site?

--- a/website/app/docs/guides/agent-friendly-docs/page.mdx
+++ b/website/app/docs/guides/agent-friendly-docs/page.mdx
@@ -303,7 +303,7 @@ curl "https://docs.example.com/docs/installation" \
   -H "User-Agent: ClaudeBot/1.0"
 ```
 
-Both requests are served by the existing shared docs API. `withDocs()` forwards the request into the
+These requests are served by the existing shared docs API. `withDocs()` forwards the request into the
 same `/api/docs` handler that already powers search, markdown format routes, `llms.txt`, `AGENTS.md`, `skill.md`,
 sitemaps, MCP, and the agent discovery spec. It does not generate or require another
 `/api/docs/markdown` wrapper route.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-detects agent requests to serve docs markdown from normal URLs without requiring .md or Accept headers. Adds Next.js rewrites, safer caching via Vary, and analytics signals for these reads.

- New Features
  - Serve markdown on normal docs URLs when requests come from known agent user agents or via a conservative heuristic:
    - Known agents matched by `user-agent` (e.g., Claude, ChatGPT, Gemini, Perplexity, Copilot).
    - Heuristic: bot-like `user-agent` but not a traditional crawler, and missing `sec-fetch-mode` (avoids browsers).
  - `@farming-labs/docs`
    - Added `detectDocsMarkdownAgentRequest()` and exports: `DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN`, `DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN`, `DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN`, and `DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER`.
    - Markdown routing now honors agent detection in addition to `Accept: text/markdown` and `Signature-Agent`.
    - `Vary` now includes `User-Agent` (and `Sec-Fetch-Mode` for heuristic) when applicable.
  - `@farming-labs/next`
    - `withDocs()` adds rewrites that forward agent `user-agent` requests (including the heuristic with “missing” checks for traditional bots and `sec-fetch-mode`) to `/api/docs?format=markdown`, using the exported header patterns.
  - Analytics
    - `agent_read.delivery` now includes `user_agent` and `heuristic` in addition to existing values; events record `user_agent` and `heuristic` fields.
  - Docs and tests updated to cover detection rules, rewrites, `Vary` behavior, and agent guide wording.

<sup>Written for commit 10cc888db4c207645323256395ea0fe666cd6100. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

