### PR TITLE
fix: align markdown metadata base URLs

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -861,6 +861,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1099,11 +1100,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(context.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1499,10 +1499,6 @@ function appendDocsMarkdownSitemapFooter(
   return `${markdown.replace(/\s+$/g, "")}\n\n${renderDocsMarkdownSitemapFooter(sitemap)}\n`;
 }
 
-function toDocsMarkdownYamlString(value: string): string {
-  return JSON.stringify(value);
-}
-
 function normalizeDocsMarkdownLastUpdated(value?: string): string | undefined {
   if (!value) return undefined;
   const trimmed = value.trim();
@@ -1538,11 +1534,11 @@ function renderDocsMarkdownFrontmatter({
 }): string {
   const lines = [
     "---",
-    `title: ${toDocsMarkdownYamlString(title)}`,
-    ...(description ? [`description: ${toDocsMarkdownYamlString(description)}`] : []),
-    `canonical_url: ${toDocsMarkdownYamlString(canonicalUrl)}`,
-    `markdown_url: ${toDocsMarkdownYamlString(markdownUrl)}`,
-    ...(lastUpdated ? [`last_updated: ${toDocsMarkdownYamlString(lastUpdated)}`] : []),
+    `title: ${toYamlString(title)}`,
+    ...(description ? [`description: ${toYamlString(description)}`] : []),
+    `canonical_url: ${toYamlString(canonicalUrl)}`,
+    `markdown_url: ${toYamlString(markdownUrl)}`,
+    ...(lastUpdated ? [`last_updated: ${toYamlString(lastUpdated)}`] : []),
     "---",
   ];
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1042,6 +1042,25 @@ Config content.
     );
     expect(fallbackDocument).not.toContain("<Agent>");
 
+    const { GET: getWithSitemapBaseUrl } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+    });
+    const sitemapBaseUrlResponse = await getWithSitemapBaseUrl(
+      new Request("http://localhost/api/docs?format=markdown&path=getting-started/quickstart"),
+    );
+    expect(sitemapBaseUrlResponse.headers.get("link")).toBe(
+      '<https://docs.example.com/docs/getting-started/quickstart>; rel="canonical"',
+    );
+    const sitemapBaseUrlDocument = await sitemapBaseUrlResponse.text();
+    expect(sitemapBaseUrlDocument).toContain(
+      'canonical_url: "https://docs.example.com/docs/getting-started/quickstart"',
+    );
+    expect(sitemapBaseUrlDocument).toContain(
+      'markdown_url: "https://docs.example.com/docs/getting-started/quickstart.md"',
+    );
+
     const { GET: getWithLlmsDisabled } = createDocsAPI({
       rootDir,
       entry: "docs",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -38,6 +38,7 @@ import {
   getDocsLlmsTxtMaxCharsIssue,
   renderDocsMarkdownNotFound,
   renderDocsMarkdownDocument,
+  resolveDocsMetadataBaseUrl,
   resolveDocsMarkdownRecovery,
   renderDocsLlmsTxt,
   resolveDocsI18n,
@@ -3000,6 +3001,14 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const llmsConfig = resolveLlmsTxtConfig(options?.llmsTxt, readLlmsTxtConfig(root));
   const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
   const robotsConfig = options?.robots ?? readRobotsConfig(root);
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl({
+    ...options,
+    entry,
+    ai: aiConfig,
+    llmsTxt: llmsConfig,
+    sitemap: sitemapConfig,
+    robots: robotsConfig,
+  } as DocsConfig);
   const apiReferenceConfig = options?.apiReference ?? readApiReferenceConfig(root);
   const apiReferenceDocsConfig = {
     ...options,
@@ -3413,7 +3422,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         resolvePublicMarkdownRequest(entry, docsPath, url, request);
 
       if (markdownRequest) {
-        const markdownOrigin = llmsConfig.baseUrl || url.origin;
+        const markdownOrigin = markdownMetadataBaseUrl || url.origin;
         const document = await getMarkdownDocument(
           ctx,
           markdownRequest.requestedPath,
@@ -3421,7 +3430,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         );
         const varyHeader = getDocsMarkdownVaryHeader(request);
         const canonicalLinkHeader = getPublicMarkdownCanonicalLinkHeader({
-          origin: url.origin,
+          origin: markdownOrigin,
           ctx,
           requestedPath: markdownRequest.requestedPath,
         });

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -851,6 +851,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1089,11 +1090,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(context.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -870,6 +870,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1107,11 +1108,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, event.url, event.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || event.url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || event.url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(event.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: event.url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -829,6 +829,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1059,11 +1060,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, event.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(event.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,


### PR DESCRIPTION
## Summary
- reuse the existing YAML string serializer for markdown frontmatter
- derive markdown frontmatter and canonical Link header origins from the shared docs metadata base-url resolver
- cover sitemap.baseUrl-driven markdown metadata in the Fumadocs API test

## Verification
- pnpm exec oxfmt --ignore-path .oxfmtignore packages/docs/src/agent.ts packages/fumadocs/src/docs-api.ts packages/fumadocs/src/docs-api.test.ts packages/tanstack-start/src/server.ts packages/astro/src/server.ts packages/svelte/src/server.ts packages/nuxt/src/server.ts
- pnpm --filter @farming-labs/docs exec vitest run src/agent.test.ts
- pnpm --filter @farming-labs/docs run build
- pnpm --filter @farming-labs/theme exec vitest run src/docs-api.test.ts
- pnpm --filter @farming-labs/docs run typecheck
- pnpm --filter @farming-labs/theme run typecheck
- pnpm --filter @farming-labs/tanstack-start run typecheck
- pnpm --filter @farming-labs/astro run typecheck
- pnpm --filter @farming-labs/svelte run typecheck
- pnpm --filter @farming-labs/nuxt run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns markdown metadata base URLs across all adapters and the Docs API so canonical and markdown URLs use the shared docs metadata base URL. Fixes mismatched origins when `sitemap.baseUrl` or LLM settings are set.

- **Bug Fixes**
  - Use the shared base-url resolver for frontmatter and Link headers in `packages/astro`, `packages/nuxt`, `packages/svelte`, `packages/tanstack-start`, and the `fumadocs` API.
  - Replace the custom YAML stringifier with the shared serializer for markdown frontmatter.
  - Add a test asserting `sitemap.baseUrl` drives canonical and `.md` URLs.

<sup>Written for commit 599cbc60d8eb05af854ab74aa7a0538af1483712. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/224?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

