### PR TITLE
fix: align markdown metadata base URLs

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@astrojs/vercel": "^9.0.4",
-    "@farming-labs/astro": "0.1.131",
-    "@farming-labs/astro-theme": "0.1.131",
-    "@farming-labs/docs": "0.1.131",
+    "@farming-labs/astro": "0.1.132",
+    "@farming-labs/astro-theme": "0.1.132",
+    "@farming-labs/docs": "0.1.132",
     "astro": "^5.7.0",
     "three": "^0.180.0"
   }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,9 +9,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.131",
-    "@farming-labs/theme": "0.1.131",
-    "@farming-labs/next": "0.1.131",
+    "@farming-labs/docs": "0.1.132",
+    "@farming-labs/theme": "0.1.132",
+    "@farming-labs/next": "0.1.132",
     "lucide-react": "^0.564.0",
     "next": "16.2.6",
     "react": "^19.0.0",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -10,9 +10,9 @@
     "preview": "nuxt preview"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.131",
-    "@farming-labs/nuxt": "0.1.131",
-    "@farming-labs/nuxt-theme": "0.1.131",
+    "@farming-labs/docs": "0.1.132",
+    "@farming-labs/nuxt": "0.1.132",
+    "@farming-labs/nuxt-theme": "0.1.132",
     "three": "^0.180.0"
   },
   "devDependencies": {

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.131",
-    "@farming-labs/svelte": "0.1.131",
-    "@farming-labs/svelte-theme": "0.1.131",
+    "@farming-labs/docs": "0.1.132",
+    "@farming-labs/svelte": "0.1.132",
+    "@farming-labs/svelte-theme": "0.1.132",
     "three": "^0.180.0"
   },
   "devDependencies": {

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -9,9 +9,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@farming-labs/docs": "0.1.131",
-    "@farming-labs/theme": "0.1.131",
-    "@farming-labs/tanstack-start": "0.1.131",
+    "@farming-labs/docs": "0.1.132",
+    "@farming-labs/theme": "0.1.132",
+    "@farming-labs/tanstack-start": "0.1.132",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "lucide-react": "^0.564.0",

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -861,6 +861,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1099,11 +1100,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(context.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1499,10 +1499,6 @@ function appendDocsMarkdownSitemapFooter(
   return `${markdown.replace(/\s+$/g, "")}\n\n${renderDocsMarkdownSitemapFooter(sitemap)}\n`;
 }
 
-function toDocsMarkdownYamlString(value: string): string {
-  return JSON.stringify(value);
-}
-
 function normalizeDocsMarkdownLastUpdated(value?: string): string | undefined {
   if (!value) return undefined;
   const trimmed = value.trim();
@@ -1538,11 +1534,11 @@ function renderDocsMarkdownFrontmatter({
 }): string {
   const lines = [
     "---",
-    `title: ${toDocsMarkdownYamlString(title)}`,
-    ...(description ? [`description: ${toDocsMarkdownYamlString(description)}`] : []),
-    `canonical_url: ${toDocsMarkdownYamlString(canonicalUrl)}`,
-    `markdown_url: ${toDocsMarkdownYamlString(markdownUrl)}`,
-    ...(lastUpdated ? [`last_updated: ${toDocsMarkdownYamlString(lastUpdated)}`] : []),
+    `title: ${toYamlString(title)}`,
+    ...(description ? [`description: ${toYamlString(description)}`] : []),
+    `canonical_url: ${toYamlString(canonicalUrl)}`,
+    `markdown_url: ${toYamlString(markdownUrl)}`,
+    ...(lastUpdated ? [`last_updated: ${toYamlString(lastUpdated)}`] : []),
     "---",
   ];
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1042,6 +1042,25 @@ Config content.
     );
     expect(fallbackDocument).not.toContain("<Agent>");
 
+    const { GET: getWithSitemapBaseUrl } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+    });
+    const sitemapBaseUrlResponse = await getWithSitemapBaseUrl(
+      new Request("http://localhost/api/docs?format=markdown&path=getting-started/quickstart"),
+    );
+    expect(sitemapBaseUrlResponse.headers.get("link")).toBe(
+      '<https://docs.example.com/docs/getting-started/quickstart>; rel="canonical"',
+    );
+    const sitemapBaseUrlDocument = await sitemapBaseUrlResponse.text();
+    expect(sitemapBaseUrlDocument).toContain(
+      'canonical_url: "https://docs.example.com/docs/getting-started/quickstart"',
+    );
+    expect(sitemapBaseUrlDocument).toContain(
+      'markdown_url: "https://docs.example.com/docs/getting-started/quickstart.md"',
+    );
+
     const { GET: getWithLlmsDisabled } = createDocsAPI({
       rootDir,
       entry: "docs",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -38,6 +38,7 @@ import {
   getDocsLlmsTxtMaxCharsIssue,
   renderDocsMarkdownNotFound,
   renderDocsMarkdownDocument,
+  resolveDocsMetadataBaseUrl,
   resolveDocsMarkdownRecovery,
   renderDocsLlmsTxt,
   resolveDocsI18n,
@@ -3000,6 +3001,14 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const llmsConfig = resolveLlmsTxtConfig(options?.llmsTxt, readLlmsTxtConfig(root));
   const sitemapConfig = options?.sitemap ?? readSitemapConfig(root);
   const robotsConfig = options?.robots ?? readRobotsConfig(root);
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl({
+    ...options,
+    entry,
+    ai: aiConfig,
+    llmsTxt: llmsConfig,
+    sitemap: sitemapConfig,
+    robots: robotsConfig,
+  } as DocsConfig);
   const apiReferenceConfig = options?.apiReference ?? readApiReferenceConfig(root);
   const apiReferenceDocsConfig = {
     ...options,
@@ -3413,7 +3422,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         resolvePublicMarkdownRequest(entry, docsPath, url, request);
 
       if (markdownRequest) {
-        const markdownOrigin = llmsConfig.baseUrl || url.origin;
+        const markdownOrigin = markdownMetadataBaseUrl || url.origin;
         const document = await getMarkdownDocument(
           ctx,
           markdownRequest.requestedPath,
@@ -3421,7 +3430,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         );
         const varyHeader = getDocsMarkdownVaryHeader(request);
         const canonicalLinkHeader = getPublicMarkdownCanonicalLinkHeader({
-          origin: url.origin,
+          origin: markdownOrigin,
           ctx,
           requestedPath: markdownRequest.requestedPath,
         });

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -851,6 +851,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1089,11 +1090,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, context.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(context.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -870,6 +870,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1107,11 +1108,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, event.url, event.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || event.url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || event.url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(event.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: event.url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -829,6 +829,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     | undefined;
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
+  const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1059,11 +1060,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
     const markdownRequest = resolveDocsMarkdownRequest(entry, url, event.request);
     if (markdownRequest) {
-      const markdownOrigin = llmsBaseUrl || url.origin;
+      const markdownOrigin = markdownMetadataBaseUrl || url.origin;
       const document = getMarkdownDocument(ctx, markdownRequest.requestedPath, markdownOrigin);
       const varyHeader = getDocsMarkdownVaryHeader(event.request);
       const canonicalLinkHeader = getDocsMarkdownCanonicalLinkHeader({
-        origin: url.origin,
+        origin: markdownOrigin,
         entry,
         requestedPath: markdownRequest.requestedPath,
         locale: ctx.locale,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,13 +75,13 @@ importers:
         specifier: ^9.0.4
         version: 9.0.4(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@6.4.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@5.17.3(@types/node@22.19.11)(@vercel/functions@2.2.13)(db0@0.3.4)(ioredis@5.9.3)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       '@farming-labs/astro':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/docs
       astro:
         specifier: ^5.7.0
@@ -93,13 +93,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -148,13 +148,13 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/nuxt-theme
       three:
         specifier: ^0.180.0
@@ -173,13 +173,13 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/svelte-theme
       three:
         specifier: ^0.180.0
@@ -207,13 +207,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.1.131
+        specifier: 0.1.132
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0


### PR DESCRIPTION
- **fix: align markdown metadata base urls**
- **fix: markdown frontmatter reviews**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown frontmatter and aligns metadata base URLs so canonical and markdown URLs are consistent across adapters and respect configured base URLs.

- **Bug Fixes**
  - Use `resolveDocsMetadataBaseUrl` for markdown origin in `@farming-labs/astro`, `@farming-labs/nuxt`, `@farming-labs/svelte`, `@farming-labs/tanstack-start`, and the Docs API.
  - Frontmatter now uses `toYamlString`; removes the local helper and fixes quoting for title, description, `canonical_url`, `markdown_url`, and `last_updated`.
  - Adds tests to confirm `sitemap.baseUrl` drives canonical Link headers and frontmatter URLs.

- **Dependencies**
  - Bump example apps to `0.1.132` for `@farming-labs/*`.

<sup>Written for commit df94ed28b1f1ccb20c154e52f75e6638bfff89a4. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

