### PR TITLE
feat: deploy ci via api keys

### DIFF
--- a/examples/frameworkless/README.md
+++ b/examples/frameworkless/README.md
@@ -56,6 +56,9 @@ Current example config:
     "preview": {
       "enabled": false
     },
+    "deploy": {
+      "enabled": false
+    },
     "publish": {
       "mode": "draft-pr",
       "baseBranch": "main"

--- a/examples/frameworkless/README.md
+++ b/examples/frameworkless/README.md
@@ -53,9 +53,6 @@ Current example config:
     "apiKey": {
       "env": "DOCS_CLOUD_API_KEY"
     },
-    "preview": {
-      "enabled": false
-    },
     "deploy": {
       "enabled": false
     },

--- a/examples/frameworkless/docs.json
+++ b/examples/frameworkless/docs.json
@@ -32,6 +32,9 @@
     "preview": {
       "enabled": false
     },
+    "deploy": {
+      "enabled": false
+    },
     "publish": {
       "mode": "draft-pr",
       "baseBranch": "main"

--- a/examples/frameworkless/docs.json
+++ b/examples/frameworkless/docs.json
@@ -29,9 +29,6 @@
     "apiKey": {
       "env": "DOCS_CLOUD_API_KEY"
     },
-    "preview": {
-      "enabled": false
-    },
     "deploy": {
       "enabled": false
     },

--- a/examples/frameworkless/docs/index.mdx
+++ b/examples/frameworkless/docs/index.mdx
@@ -32,6 +32,9 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
     "preview": {
       "enabled": false
     },
+    "deploy": {
+      "enabled": false
+    },
     "analytics": {
       "enabled": true,
       "console": "info",
@@ -45,10 +48,11 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
 - `docs.runtime` is the generated docs runtime choice
 - `cloud.apiKey.env` tells CLI/CI where to read the Docs Cloud API key without writing secrets to JSON
 - `cloud.preview.enabled` controls whether Docs Cloud should request live preview deployments
+- `cloud.deploy.enabled` controls whether `docs deploy` can create hosted preview docs
 - `cloud.analytics` is the Docs Cloud analytics contract for the serializable runtime subset
 
-Even with `cloud.preview.enabled: false`, frameworkless local preview can still materialize the serializable
-`cloud.analytics` subset into the generated hidden runtime.
+Even with `cloud.preview.enabled: false` and `cloud.deploy.enabled: false`, frameworkless local preview
+can still materialize the serializable `cloud.analytics` subset into the generated hidden runtime.
 
 See the full contract in the
 [`docs.json` guide](https://docs.farming-labs.dev/docs/guides/docs-json).

--- a/examples/frameworkless/docs/index.mdx
+++ b/examples/frameworkless/docs/index.mdx
@@ -29,9 +29,6 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
     "apiKey": {
       "env": "DOCS_CLOUD_API_KEY"
     },
-    "preview": {
-      "enabled": false
-    },
     "deploy": {
       "enabled": false
     },
@@ -47,12 +44,11 @@ In this example, `docs.json` separates the docs project from the hosted cloud la
 - `docs.mode` describes how the project is authored
 - `docs.runtime` is the generated docs runtime choice
 - `cloud.apiKey.env` tells CLI/CI where to read the Docs Cloud API key without writing secrets to JSON
-- `cloud.preview.enabled` controls whether Docs Cloud should request live preview deployments
 - `cloud.deploy.enabled` controls whether `docs deploy` can create hosted preview docs
 - `cloud.analytics` is the Docs Cloud analytics contract for the serializable runtime subset
 
-Even with `cloud.preview.enabled: false` and `cloud.deploy.enabled: false`, frameworkless local preview
-can still materialize the serializable `cloud.analytics` subset into the generated hidden runtime.
+Even with `cloud.deploy.enabled: false`, frameworkless local preview can still materialize the
+serializable `cloud.analytics` subset into the generated hidden runtime.
 
 See the full contract in the
 [`docs.json` guide](https://docs.farming-labs.dev/docs/guides/docs-json).

--- a/examples/next/app/docs/getting-started/deploy-preview/page.mdx
+++ b/examples/next/app/docs/getting-started/deploy-preview/page.mdx
@@ -40,9 +40,6 @@ export default defineDocs({
     apiKey: {
       env: "DOCS_CLOUD_API_KEY",
     },
-    preview: {
-      enabled: true,
-    },
     deploy: {
       enabled: true,
     },
@@ -54,8 +51,7 @@ export default defineDocs({
 });
 ```
 
-`cloud.preview.enabled` controls whether hosted preview URLs can be requested. `cloud.deploy.enabled`
-is the command-level toggle for `docs deploy`.
+`cloud.deploy.enabled` is the command-level toggle for `docs deploy`.
 
 ## 4. Run the Deploy Command
 

--- a/examples/next/app/docs/getting-started/deploy-preview/page.mdx
+++ b/examples/next/app/docs/getting-started/deploy-preview/page.mdx
@@ -1,0 +1,90 @@
+---
+title: Deploy Preview Docs
+description: Publish a hosted preview deployment from the @farming-labs/docs CLI.
+order: 25
+---
+
+# Deploy Preview Docs
+
+Use `docs deploy` when you want Docs Cloud to build your docs app, upload the prebuilt output to
+Vercel, and return a live preview URL.
+
+## 1. Create an API Key
+
+Create a Docs Cloud API key with these scopes:
+
+- `project:read`
+- `preview:write`
+- `jobs:read`
+
+Add `docs:write` too if the same key will also create generated docs changes or draft PRs.
+
+## 2. Store the Key Locally
+
+Put the key in your local environment. Do not commit this file.
+
+```bash title=".env.local"
+DOCS_CLOUD_API_KEY="fl_key_..."
+```
+
+## 3. Enable Cloud Deployments
+
+Add the cloud block to `docs.config.ts`.
+
+```ts title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  cloud: {
+    apiKey: {
+      env: "DOCS_CLOUD_API_KEY",
+    },
+    preview: {
+      enabled: true,
+    },
+    deploy: {
+      enabled: true,
+    },
+    publish: {
+      mode: "draft-pr",
+      baseBranch: "main",
+    },
+  },
+});
+```
+
+`cloud.preview.enabled` controls whether hosted preview URLs can be requested. `cloud.deploy.enabled`
+is the command-level toggle for `docs deploy`.
+
+## 4. Run the Deploy Command
+
+From the docs project root:
+
+```bash title="terminal"
+pnpm exec docs deploy
+```
+
+For one-off usage with the published package:
+
+```bash title="terminal"
+npx @farming-labs/docs deploy
+```
+
+The command syncs cloud settings into `docs.json`, validates the API key, creates a preview job, and
+polls until Docs Cloud returns a live URL.
+
+## CI Usage
+
+Use the same command in CI after exposing `DOCS_CLOUD_API_KEY` as a secret.
+
+```bash title="terminal"
+pnpm exec docs deploy --json
+```
+
+`--json` prints the deployment URL and job response in a machine-readable shape.
+
+## Compatibility
+
+`docs preview` and `docs cloud preview` still work as compatibility aliases, but new scripts should
+prefer `docs deploy`.

--- a/examples/next/app/docs/getting-started/quickstart/page.mdx
+++ b/examples/next/app/docs/getting-started/quickstart/page.mdx
@@ -55,5 +55,6 @@ Hello, world!
 ## Next Steps
 
 - Configure your [sidebar navigation](/docs/organize/navigation)
+- Deploy a [hosted preview](/docs/getting-started/deploy-preview)
 - Add [custom themes](/docs/customize/themes)
 - Set up [AI-powered search](/docs/getting-started/ai-native)

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -89,9 +89,6 @@ export default defineDocs({
     apiKey: {
       env: "DOCS_CLOUD_API_KEY",
     },
-    preview: {
-      enabled: true,
-    },
     deploy: {
       enabled: true,
     },

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -92,6 +92,9 @@ export default defineDocs({
     preview: {
       enabled: true,
     },
+    deploy: {
+      enabled: true,
+    },
     publish: {
       mode: "draft-pr",
       baseBranch: "main",

--- a/examples/next/docs.json
+++ b/examples/next/docs.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.farming-labs.dev/schema/docs.json",
+  "version": 1,
+  "docs": {
+    "mode": "framework",
+    "runtime": "nextjs",
+    "root": "."
+  },
+  "content": {
+    "docsRoot": "app/docs",
+    "apiReferenceRoot": "api-reference"
+  },
+  "site": {
+    "name": "Docs/Example Next"
+  },
+  "cloud": {
+    "apiKey": {
+      "env": "DOCS_CLOUD_API_KEY"
+    },
+    "publish": {
+      "mode": "draft-pr",
+      "baseBranch": "main"
+    },
+    "deploy": {
+      "enabled": true
+    }
+  }
+}

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { materializeCloudConfig, runCloudPreview } from "./cloud.js";
+import { materializeCloudConfig, runCloudDeploy, runCloudPreview } from "./cloud.js";
 
 describe("cloud cli", () => {
   const originalEnv = { ...process.env };
@@ -165,7 +165,7 @@ void missing;
     });
   });
 
-  it("validates the configured API key and prints the preview URL", async () => {
+  it("validates the configured API key and prints the deployment URL", async () => {
     writePackageJson();
     execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
     execFileSync("git", ["checkout", "-b", "preview-branch"], { cwd: tmpDir, stdio: "ignore" });
@@ -199,7 +199,7 @@ void missing;
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },
-            apiKey: { id: "key_1", scopes: ["project:read", "preview:write"] },
+            apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -241,6 +241,187 @@ void missing;
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("deploy command requests the hosted preview deployment", async () => {
+    writePackageJson();
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-b", "deploy-branch"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/docs-app.git"], {
+      cwd: tmpDir,
+      stdio: "ignore",
+    });
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    preview: { enabled: true },
+    deploy: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://cloud.example.com/api/cloud/me") {
+        return new Response(
+          JSON.stringify({
+            workspace: { id: "workspace_1", name: "Acme" },
+            apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url === "https://cloud.example.com/api/cloud/preview") {
+        return new Response(JSON.stringify({ url: "https://docs-cloud-acme.preview.test" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCloudDeploy({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      json: true,
+    });
+
+    expect(result.url).toBe("https://docs-cloud-acme.preview.test");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("polls queued previews until the live URL is ready", async () => {
+    writePackageJson();
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-b", "queued-preview"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/docs-app.git"], {
+      cwd: tmpDir,
+      stdio: "ignore",
+    });
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    preview: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://cloud.example.com/api/cloud/me") {
+        return new Response(
+          JSON.stringify({
+            workspace: { id: "workspace_1", name: "Acme" },
+            apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url === "https://cloud.example.com/api/cloud/preview") {
+        return new Response(
+          JSON.stringify({
+            status: "queued",
+            statusUrl: "/api/cloud/preview/job_1",
+            preview: { status: "queued", url: null },
+          }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url === "https://cloud.example.com/api/cloud/preview/job_1") {
+        return new Response(
+          JSON.stringify({
+            job: { id: "job_1", status: "SUCCEEDED" },
+            url: "https://docs-cloud-acme.preview.test",
+            preview: { status: "ready", url: "https://docs-cloud-acme.preview.test" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runCloudPreview({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      json: true,
+      pollIntervalMs: 1,
+    });
+
+    expect(result.url).toBe("https://docs-cloud-acme.preview.test");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("requires jobs:read so preview polling can use the API key", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    preview: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://cloud.example.com/api/cloud/me") {
+        return new Response(
+          JSON.stringify({
+            workspace: { id: "workspace_1", name: "Acme" },
+            apiKey: { id: "key_1", scopes: ["project:read", "preview:write"] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      runCloudPreview({
+        rootDir: tmpDir,
+        apiBaseUrl: "https://cloud.example.com",
+        json: true,
+      }),
+    ).rejects.toThrow("jobs:read");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("fails before preview when the configured API key env var is missing", async () => {
     writePackageJson();
     writeFileSync(
@@ -264,7 +445,7 @@ void missing;
     ).rejects.toThrow("Missing Docs Cloud API key");
   });
 
-  it("fails clearly when preview is disabled in cloud config", async () => {
+  it("fails clearly when preview deployment is disabled in cloud config", async () => {
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
@@ -293,7 +474,40 @@ void missing;
         apiBaseUrl: "https://cloud.example.com",
         json: true,
       }),
-    ).rejects.toThrow("Docs Cloud preview is disabled");
+    ).rejects.toThrow("Docs Cloud preview deployments are disabled");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails clearly when deploy is disabled in cloud config", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    deploy: { enabled: false },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      runCloudDeploy({
+        rootDir: tmpDir,
+        apiBaseUrl: "https://cloud.example.com",
+        json: true,
+      }),
+    ).rejects.toThrow("Docs Cloud deployment is disabled");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -87,7 +87,7 @@ describe("cloud cli", () => {
     expect(JSON.stringify(docsJson)).not.toContain("sk-");
   });
 
-  it("auto-initializes docs.json for preview commands when docs.json is missing", async () => {
+  it("auto-initializes docs.json for cloud commands when docs.json is missing", async () => {
     writePackageJson({ "@sveltejs/kit": "2.0.0" });
     mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
 
@@ -101,6 +101,7 @@ describe("cloud cli", () => {
       root: ".",
     });
     expect(docsJson.cloud.apiKey.env).toBe("DOCS_CLOUD_API_KEY");
+    expect(docsJson.cloud.preview).toBeUndefined();
   });
 
   it("preserves boolean analytics.console values when static config parsing is used", async () => {
@@ -259,7 +260,6 @@ void missing;
       `export default {
   entry: "docs",
   cloud: {
-    preview: { enabled: true },
     deploy: { enabled: true },
   },
 };

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -376,6 +376,74 @@ void missing;
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("fails when a nested preview job reaches a terminal failure state", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    preview: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === "https://cloud.example.com/api/cloud/me") {
+        return new Response(
+          JSON.stringify({
+            workspace: { id: "workspace_1", name: "Acme" },
+            apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url === "https://cloud.example.com/api/cloud/preview") {
+        return new Response(
+          JSON.stringify({
+            status: "queued",
+            statusUrl: "/api/cloud/preview/job_1",
+          }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url === "https://cloud.example.com/api/cloud/preview/job_1") {
+        return new Response(
+          JSON.stringify({
+            status: "queued",
+            job: { id: "job_1", status: "FAILED" },
+            error: "Build failed",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      runCloudPreview({
+        rootDir: tmpDir,
+        apiBaseUrl: "https://cloud.example.com",
+        json: true,
+        pollIntervalMs: 1,
+      }),
+    ).rejects.toThrow("Build failed");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("requires jobs:read so preview polling can use the API key", async () => {
     writePackageJson();
     writeFileSync(

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -422,7 +422,24 @@ void missing;
         return new Response(
           JSON.stringify({
             status: "queued",
-            job: { id: "job_1", status: "FAILED" },
+            job: {
+              id: "job_1",
+              status: "FAILED",
+              runs: [
+                {
+                  name: "Build",
+                  status: "FAILED",
+                  steps: [
+                    { name: "Install dependencies", status: "SUCCEEDED" },
+                    {
+                      name: "Compile docs",
+                      status: "FAILED",
+                      message: "next build exited with code 1",
+                    },
+                  ],
+                },
+              ],
+            },
             error: "Build failed",
           }),
           { status: 200, headers: { "content-type": "application/json" } },
@@ -440,7 +457,9 @@ void missing;
         json: true,
         pollIntervalMs: 1,
       }),
-    ).rejects.toThrow("Build failed");
+    ).rejects.toThrow(
+      "Docs Cloud preview failed at job_1 > Build > Compile docs (FAILED): next build exited with code 1",
+    );
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -22,6 +22,7 @@ const DOCS_CLOUD_DEFAULT_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
 const DEFAULT_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PREVIEW_POLL_INTERVAL_MS = 2000;
+const REQUIRED_PREVIEW_API_KEY_SCOPES = ["project:read", "preview:write", "jobs:read"] as const;
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue | undefined };
@@ -625,6 +626,44 @@ function readStatusUrl(body: unknown, apiBaseUrl: string): string | undefined {
 function readPreviewStatus(body: unknown): string | undefined {
   if (!isRecord(body)) return undefined;
   const status = body.status;
+  if (typeof status === "string") return status;
+
+  const job = body.job;
+  if (isRecord(job) && typeof job.status === "string") return job.status;
+
+  const preview = body.preview;
+  if (isRecord(preview) && typeof preview.status === "string") return preview.status;
+
+  return undefined;
+}
+
+function readApiKeyScopes(body: unknown): string[] {
+  if (!isRecord(body)) return [];
+  const apiKey = body.apiKey;
+  if (!isRecord(apiKey) || !Array.isArray(apiKey.scopes)) return [];
+
+  return apiKey.scopes.filter((scope): scope is string => typeof scope === "string");
+}
+
+function assertPreviewApiKeyScopes(identity: unknown) {
+  const scopes = readApiKeyScopes(identity);
+  const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter((scope) => !scopes.includes(scope));
+  if (missing.length > 0) {
+    throw new Error(
+      `Docs Cloud API key is missing required preview scope${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}.`,
+    );
+  }
+
+  return scopes;
+}
+
+function isTerminalFailureStatus(status: string | undefined): boolean {
+  const normalized = status?.toLowerCase();
+  return normalized === "failed" || normalized === "error" || normalized === "canceled";
+}
+
+function readStatusLabel(body: unknown): string | undefined {
+  const status = readPreviewStatus(body);
   return typeof status === "string" ? status : undefined;
 }
 
@@ -673,8 +712,8 @@ async function requestPreview(params: {
     const url = readPreviewUrl(statusBody);
     if (url) return { url, response: statusBody };
 
-    const status = readPreviewStatus(statusBody);
-    if (status === "failed" || status === "error") {
+    const status = readStatusLabel(statusBody);
+    if (isTerminalFailureStatus(status)) {
       throw new Error(readResponseMessage(statusBody, "Docs Cloud preview failed."));
     }
   }
@@ -750,9 +789,9 @@ export async function syncCloudConfig(options: CloudCommandOptions = {}) {
   return result;
 }
 
-export async function runCloudPreview(options: CloudCommandOptions = {}) {
+async function runCloudDeployment(options: CloudCommandOptions = {}) {
   const rootDir = options.rootDir ?? process.cwd();
-  const spinner = createSpinner("Preparing Docs Cloud preview", options);
+  const spinner = createSpinner("Preparing Docs Cloud deployment", options);
 
   try {
     const materialized = await materializeCloudConfig({ ...options, rootDir });
@@ -766,7 +805,13 @@ export async function runCloudPreview(options: CloudCommandOptions = {}) {
 
     if (materialized.config.cloud?.preview?.enabled === false) {
       throw new Error(
-        "Docs Cloud preview is disabled in cloud.preview.enabled. Set it to true before requesting a preview.",
+        "Docs Cloud preview deployments are disabled in cloud.preview.enabled. Set it to true before deploying hosted preview docs.",
+      );
+    }
+
+    if (materialized.config.cloud?.deploy?.enabled === false) {
+      throw new Error(
+        "Docs Cloud deployment is disabled in cloud.deploy.enabled. Set it to true before deploying hosted preview docs.",
       );
     }
 
@@ -778,8 +823,9 @@ export async function runCloudPreview(options: CloudCommandOptions = {}) {
       url: `${apiBaseUrl}/api/cloud/me`,
       apiKey,
     });
+    assertPreviewApiKeyScopes(identity);
 
-    spinner.update("Requesting Docs Cloud preview deployment");
+    spinner.update("Requesting Docs Cloud deployment");
     const preview = await requestPreview({
       apiBaseUrl,
       apiKey,
@@ -791,7 +837,7 @@ export async function runCloudPreview(options: CloudCommandOptions = {}) {
       pollIntervalMs: options.pollIntervalMs ?? DEFAULT_PREVIEW_POLL_INTERVAL_MS,
     });
 
-    spinner.succeed("Docs Cloud preview is ready");
+    spinner.succeed("Docs Cloud deployment is ready");
 
     const result = {
       url: preview.url,
@@ -804,7 +850,7 @@ export async function runCloudPreview(options: CloudCommandOptions = {}) {
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
-      console.log(`${pc.bold("Preview")} ${pc.cyan(preview.url)}`);
+      console.log(`${pc.bold("Deployment")} ${pc.cyan(preview.url)}`);
     }
 
     return result;
@@ -817,13 +863,23 @@ export async function runCloudPreview(options: CloudCommandOptions = {}) {
   }
 }
 
+export async function runCloudDeploy(options: CloudCommandOptions = {}) {
+  return runCloudDeployment(options);
+}
+
+export async function runCloudPreview(options: CloudCommandOptions = {}) {
+  return runCloudDeployment(options);
+}
+
 export function printCloudHelp() {
   console.log(`
 ${pc.bold("@farming-labs/docs cloud")}
 
 ${pc.dim("Usage:")}
-  ${pc.cyan("docs preview")}              Sync ${pc.dim("docs.config.ts")} to ${pc.dim("docs.json")} and request a cloud preview
-  ${pc.cyan("docs cloud preview")}        Same as ${pc.cyan("docs preview")}
+  ${pc.cyan("docs deploy")}               Sync ${pc.dim("docs.config.ts")} to ${pc.dim("docs.json")} and deploy hosted preview docs
+  ${pc.cyan("docs cloud deploy")}         Same as ${pc.cyan("docs deploy")}
+  ${pc.cyan("docs preview")}              Compatibility alias for ${pc.cyan("docs deploy")}
+  ${pc.cyan("docs cloud preview")}        Compatibility alias for ${pc.cyan("docs cloud deploy")}
   ${pc.cyan("docs cloud sync")}           Only materialize cloud settings into ${pc.dim("docs.json")}
 
 ${pc.dim("Options:")}
@@ -831,6 +887,9 @@ ${pc.dim("Options:")}
   ${pc.cyan("--api-base-url <url>")}      Override Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}           Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--json")}                    Print machine-readable output
+
+${pc.dim("API key scopes:")}
+  ${REQUIRED_PREVIEW_API_KEY_SCOPES.join(", ")}
 
 ${pc.dim("Config example:")}
   cloud: {

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -568,6 +568,91 @@ function readResponseMessage(body: unknown, fallback: string): string {
   return fallback;
 }
 
+const FAILURE_DETAIL_OBJECT_KEYS = ["job", "run", "preview", "deployment", "build"] as const;
+const FAILURE_DETAIL_ARRAY_KEYS = ["jobs", "runs", "steps", "tasks", "stages", "checks"] as const;
+const FAILURE_DETAIL_MESSAGE_KEYS = ["error", "message", "detail", "reason", "summary"] as const;
+const FAILURE_DETAIL_LABEL_KEYS = [
+  "name",
+  "title",
+  "label",
+  "step",
+  "phase",
+  "stage",
+  "id",
+] as const;
+const FAILURE_DETAIL_STATUS_KEYS = ["status", "state", "conclusion", "result", "outcome"] as const;
+
+type PreviewFailureDetail = {
+  message?: string;
+  path: string[];
+  status?: string;
+};
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readFirstString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = readTrimmedString(record[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function singularizeKey(key: string): string {
+  return key.endsWith("s") ? key.slice(0, -1) : key;
+}
+
+function findPreviewFailureDetail(
+  value: unknown,
+  parentPath: string[] = [],
+  fallbackLabel?: string,
+): PreviewFailureDetail | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const label = readFirstString(value, FAILURE_DETAIL_LABEL_KEYS) ?? fallbackLabel;
+  const path = label ? [...parentPath, label] : parentPath;
+
+  for (const key of FAILURE_DETAIL_OBJECT_KEYS) {
+    const detail = findPreviewFailureDetail(value[key], path, key);
+    if (detail) return detail;
+  }
+
+  for (const key of FAILURE_DETAIL_ARRAY_KEYS) {
+    const children = value[key];
+    if (!Array.isArray(children)) continue;
+    for (const child of children) {
+      const detail = findPreviewFailureDetail(child, path, singularizeKey(key));
+      if (detail) return detail;
+    }
+  }
+
+  const status = readFirstString(value, FAILURE_DETAIL_STATUS_KEYS);
+  if (!isTerminalFailureStatus(status)) return undefined;
+
+  return {
+    message: readFirstString(value, FAILURE_DETAIL_MESSAGE_KEYS),
+    path,
+    status,
+  };
+}
+
+function readPreviewFailureMessage(body: unknown, fallback: string): string {
+  const detail = findPreviewFailureDetail(body);
+  if (!detail) return readResponseMessage(body, fallback);
+
+  const prefix = fallback.replace(/\.+$/g, "");
+  const location = detail.path.length > 0 ? ` at ${detail.path.join(" > ")}` : "";
+  const status = detail.status ? ` (${detail.status})` : "";
+  const message = detail.message ?? readResponseMessage(body, "");
+
+  return message ? `${prefix}${location}${status}: ${message}` : `${prefix}${location}${status}.`;
+}
+
 async function fetchCloudJson(params: {
   url: string;
   apiKey: string;
@@ -662,7 +747,15 @@ function assertPreviewApiKeyScopes(identity: unknown) {
 
 function isTerminalFailureStatus(status: string | undefined): boolean {
   const normalized = status?.toLowerCase();
-  return normalized === "failed" || normalized === "error" || normalized === "canceled";
+  return (
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "error" ||
+    normalized === "canceled" ||
+    normalized === "cancelled" ||
+    normalized === "timed_out" ||
+    normalized === "timeout"
+  );
 }
 
 function readStatusLabel(body: unknown): string | undefined {
@@ -717,7 +810,7 @@ async function requestPreview(params: {
 
     const status = readStatusLabel(statusBody);
     if (isTerminalFailureStatus(status)) {
-      throw new Error(readResponseMessage(statusBody, "Docs Cloud preview failed."));
+      throw new Error(readPreviewFailureMessage(statusBody, "Docs Cloud preview failed."));
     }
   }
 

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -279,7 +279,6 @@ function normalizeAnalyticsConfig(
 function normalizeCloudConfig(cloud: DocsCloudConfig | undefined): DocsCloudConfig {
   const normalized: DocsCloudConfig = {
     apiKey: normalizeApiKeyConfig(cloud?.apiKey),
-    preview: normalizePreviewConfig(cloud?.preview),
     publish: normalizePublishConfig(cloud?.publish),
   };
 
@@ -297,6 +296,10 @@ function normalizeCloudConfig(cloud: DocsCloudConfig | undefined): DocsCloudConf
 
   const deploy = normalizeFeatureConfig(cloud?.deploy);
   if (deploy) normalized.deploy = deploy;
+
+  if (cloud?.preview) {
+    normalized.preview = normalizePreviewConfig(cloud.preview);
+  }
 
   return normalized;
 }
@@ -799,13 +802,13 @@ async function runCloudDeployment(options: CloudCommandOptions = {}) {
 
     if (materialized.config.cloud?.enabled === false) {
       throw new Error(
-        "Docs Cloud is disabled in cloud.enabled. Remove that override or set cloud.enabled: true before requesting a preview.",
+        "Docs Cloud is disabled in cloud.enabled. Remove that override or set cloud.enabled: true before deploying hosted preview docs.",
       );
     }
 
     if (materialized.config.cloud?.preview?.enabled === false) {
       throw new Error(
-        "Docs Cloud preview deployments are disabled in cloud.preview.enabled. Set it to true before deploying hosted preview docs.",
+        "Docs Cloud preview deployments are disabled in cloud.preview.enabled. Remove that legacy override before deploying hosted preview docs.",
       );
     }
 
@@ -894,7 +897,7 @@ ${pc.dim("API key scopes:")}
 ${pc.dim("Config example:")}
   cloud: {
     apiKey: { env: "DOCS_CLOUD_API_KEY" },
-    preview: { enabled: true },
+    deploy: { enabled: true },
     publish: { mode: "draft-pr", baseBranch: "main" },
   }
 `);

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -628,14 +628,14 @@ function readStatusUrl(body: unknown, apiBaseUrl: string): string | undefined {
 
 function readPreviewStatus(body: unknown): string | undefined {
   if (!isRecord(body)) return undefined;
-  const status = body.status;
-  if (typeof status === "string") return status;
-
   const job = body.job;
   if (isRecord(job) && typeof job.status === "string") return job.status;
 
   const preview = body.preview;
   if (isRecord(preview) && typeof preview.status === "string") return preview.status;
+
+  const status = body.status;
+  if (typeof status === "string") return status;
 
   return undefined;
 }

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -423,7 +423,7 @@ function resolveSiteConfig(
   if (!name && !description && !existingSite) return undefined;
 
   return {
-    ...(existingSite ?? {}),
+    ...existingSite,
     ...(typeof name === "string" ? { name } : {}),
     ...(typeof description === "string" ? { description } : {}),
   };
@@ -475,13 +475,13 @@ function materializeDocsJsonObject(params: {
   const site = resolveSiteConfig(params.rootDir, params.snapshot, params.existing);
 
   const content: ManagedDocsJson["content"] = {
-    ...(existingContent ?? {}),
+    ...existingContent,
     docsRoot,
     ...(apiReferenceRoot ? { apiReferenceRoot } : {}),
   };
 
   return {
-    ...(params.existing ?? {}),
+    ...params.existing,
     $schema: params.existing?.$schema ?? DOCS_CLOUD_SCHEMA_URL,
     version: 1,
     docs: resolveDocsBlock(params.rootDir, params.snapshot, params.existing),

--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -51,9 +51,9 @@ describe("parseFlags", () => {
     expect(flags.collection).toBe("docs");
   });
 
-  it("parses cloud preview flags", () => {
+  it("parses cloud deploy flags", () => {
     const flags = parseFlags([
-      "preview",
+      "deploy",
       "--config",
       "src/lib/docs.config.ts",
       "--api-base-url",

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -117,9 +117,15 @@ async function main() {
   } else if (parsedCommand.command === "dev") {
     const { dev } = await import("./dev.js");
     await dev(devOptions);
+  } else if (parsedCommand.command === "deploy") {
+    const { runCloudDeploy } = await import("./cloud.js");
+    await runCloudDeploy(cloudOptions);
   } else if (parsedCommand.command === "preview") {
     const { runCloudPreview } = await import("./cloud.js");
     await runCloudPreview(cloudOptions);
+  } else if (parsedCommand.command === "cloud" && subcommand === "deploy") {
+    const { runCloudDeploy } = await import("./cloud.js");
+    await runCloudDeploy(cloudOptions);
   } else if (parsedCommand.command === "cloud" && subcommand === "preview") {
     const { runCloudPreview } = await import("./cloud.js");
     await runCloudPreview(cloudOptions);
@@ -287,8 +293,9 @@ ${pc.dim("Usage:")}
 ${pc.dim("Commands:")}
   ${pc.cyan("init")}     Scaffold docs in your project (default)
   ${pc.cyan("dev")}      Run frameworkless docs locally from ${pc.dim("docs.json")}
-  ${pc.cyan("preview")}  Sync cloud config and request a hosted Docs Cloud preview
-  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("preview")}, ${pc.dim("sync")})
+  ${pc.cyan("deploy")}   Sync cloud config and deploy hosted preview docs
+  ${pc.cyan("preview")}  Alias for ${pc.cyan("deploy")}
+  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("deploy")}, ${pc.dim("preview")}, ${pc.dim("sync")})
   ${pc.cyan("agent")}    Agent utilities (${pc.dim("compact")} to generate sibling agent.md files)
   ${pc.cyan("agents")}   AGENTS.md utilities (${pc.dim("generate")} for static agent instructions)
   ${pc.cyan("doctor")}   Inspect and score agent or reader-facing docs quality
@@ -322,14 +329,17 @@ ${pc.dim("Options for dev:")}
   ${pc.cyan("--host [host]")}       Expose the preview on your network; optionally pass a host value
   ${pc.cyan("--verbose")}           Show raw runtime logs in addition to branded CLI output
 
-${pc.dim("Options for cloud preview:")}
-  ${pc.cyan("preview")}                              Sync ${pc.dim("docs.config.ts")} into ${pc.dim("docs.json")} and request a hosted preview
-  ${pc.cyan("cloud preview")}                        Same as ${pc.cyan("preview")}
+${pc.dim("Options for cloud deploy:")}
+  ${pc.cyan("deploy")}                               Sync ${pc.dim("docs.config.ts")} into ${pc.dim("docs.json")} and deploy hosted preview docs
+  ${pc.cyan("cloud deploy")}                         Same as ${pc.cyan("deploy")}
+  ${pc.cyan("preview")}                              Alias for ${pc.cyan("deploy")}
+  ${pc.cyan("cloud preview")}                        Compatibility alias for ${pc.cyan("cloud deploy")}
   ${pc.cyan("cloud sync")}                           Only materialize cloud settings into ${pc.dim("docs.json")}
   ${pc.cyan("--config <path>")}                      Use a custom docs config path
   ${pc.cyan("--api-base-url <url>")}                 Override the Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}                      Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--json")}                              Print machine-readable output
+  ${pc.dim("required scopes")}                       project:read, preview:write, jobs:read
 
 ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact <page...>")}             Compact pages and write sibling ${pc.dim("agent.md")} files

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -457,13 +457,6 @@ const DOCS_CONFIG_SCHEMA_OPTIONS: DocsMcpConfigSchemaOption[] = [
           "Environment variable that stores the Docs Cloud API key. The key value is never written to docs.json.",
       },
       {
-        path: "cloud.preview.enabled",
-        name: "enabled",
-        type: "boolean",
-        default: true,
-        description: "Allow hosted preview deployments for docs deploy.",
-      },
-      {
         path: "cloud.deploy.enabled",
         name: "enabled",
         type: "boolean",

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -461,7 +461,14 @@ const DOCS_CONFIG_SCHEMA_OPTIONS: DocsMcpConfigSchemaOption[] = [
         name: "enabled",
         type: "boolean",
         default: true,
-        description: "Request hosted preview deployments when running docs preview.",
+        description: "Allow hosted preview deployments for docs deploy.",
+      },
+      {
+        path: "cloud.deploy.enabled",
+        name: "enabled",
+        type: "boolean",
+        default: true,
+        description: "Enable the docs deploy command for hosted preview docs.",
       },
       {
         path: "cloud.publish.mode",

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -883,7 +883,13 @@ export interface DocsCloudApiKeyConfig {
 }
 
 export interface DocsCloudPreviewConfig {
-  /** Whether Docs Cloud should request live preview deployments. @default true */
+  /**
+   * Legacy hosted preview deployment gate.
+   *
+   * Prefer `cloud.deploy.enabled` in new configs.
+   *
+   * @default true when this legacy object is provided
+   */
   enabled?: boolean;
 }
 
@@ -910,7 +916,7 @@ export interface DocsCloudConfig {
   enabled?: boolean;
   /** API key lookup used by `docs deploy` and other cloud CLI commands. */
   apiKey?: DocsCloudApiKeyConfig;
-  /** Hosted preview deployment settings. */
+  /** Legacy hosted preview deployment settings. Prefer `deploy` in new configs. */
   preview?: DocsCloudPreviewConfig;
   /** Generated docs publishing settings. */
   publish?: DocsCloudPublishConfig;
@@ -2557,7 +2563,7 @@ export interface DocsConfig {
   /**
    * Docs Cloud integration settings.
    *
-   * Use this to configure the API key env var and cloud preview defaults once
+   * Use this to configure the API key env var and cloud deploy defaults once
    * in `docs.config.ts`; cloud CLI commands mirror the serializable subset into
    * `docs.json` automatically.
    *
@@ -2565,7 +2571,7 @@ export interface DocsConfig {
    * ```ts
    * cloud: {
    *   apiKey: { env: "DOCS_CLOUD_API_KEY" },
-   *   preview: { enabled: true },
+   *   deploy: { enabled: true },
    *   publish: { mode: "draft-pr", baseBranch: "main" },
    * }
    * ```

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -908,7 +908,7 @@ export interface DocsCloudConfig {
    * compatibility with older docs.json files.
    */
   enabled?: boolean;
-  /** API key lookup used by `docs preview` and other cloud CLI commands. */
+  /** API key lookup used by `docs deploy` and other cloud CLI commands. */
   apiKey?: DocsCloudApiKeyConfig;
   /** Hosted preview deployment settings. */
   preview?: DocsCloudPreviewConfig;
@@ -918,7 +918,7 @@ export interface DocsCloudConfig {
   analytics?: boolean | Omit<DocsAnalyticsConfig, "onEvent">;
   /** Hosted AI feature toggle. */
   ai?: DocsCloudFeatureConfig;
-  /** Hosted deployment feature toggle. */
+  /** Hosted deployment feature toggle used by `docs deploy`. */
   deploy?: DocsCloudFeatureConfig;
 }
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, deploy, cloud deploy, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, preview, deploy, cloud preview, cloud deploy, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
@@ -9,7 +9,7 @@ The `@farming-labs/docs` CLI scaffolds, upgrades, downgrades, audits agent and r
 page-level agent docs, validates fenced code blocks, reviews docs PR changes, generates `AGENTS.md`, syncs external search indexes, generates robots.txt policy files, deploys hosted Docs Cloud previews, and can
 run the built-in MCP server for documentation projects. Use this skill when the user asks about CLI
 commands, init, upgrade, downgrade, `doctor`, `agent compact`, `codeblocks validate`, `agents generate`, `sitemap generate`, `robots generate`, search
-sync, mcp, review, cloud deploy, cloud sync, or scaffolding.
+sync, mcp, review, preview, deploy, cloud preview, cloud deploy, cloud sync, or scaffolding.
 
 ---
 
@@ -209,7 +209,9 @@ Use `docs deploy` from a docs project root to sync the serializable `cloud` bloc
 
 ```bash
 pnpm exec docs deploy
+pnpm exec docs preview
 pnpm exec docs cloud deploy
+pnpm exec docs cloud preview
 pnpm exec docs cloud sync
 ```
 
@@ -225,6 +227,7 @@ cloud: {
 
 - `docs cloud sync` only writes or updates `docs.json`.
 - `docs deploy` auto-creates `docs.json` if the project has not run a cloud command before.
+- `docs preview` and `docs cloud preview` remain compatibility aliases for hosted preview deployment.
 - The API key value must live in the named env var, `.env.local`, or CI secrets. Never write the raw key into config.
 - Use `--config <path>` when `docs.config.ts` lives outside the project root.
 - Use `--api-base-url <url>` for staging/self-hosted cloud API testing.

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, request Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, preview, cloud preview, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, deploy, cloud deploy, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
 
 The `@farming-labs/docs` CLI scaffolds, upgrades, downgrades, audits agent and reader readiness, compacts
-page-level agent docs, validates fenced code blocks, reviews docs PR changes, generates `AGENTS.md`, syncs external search indexes, generates robots.txt policy files, requests Docs Cloud previews, and can
+page-level agent docs, validates fenced code blocks, reviews docs PR changes, generates `AGENTS.md`, syncs external search indexes, generates robots.txt policy files, deploys hosted Docs Cloud previews, and can
 run the built-in MCP server for documentation projects. Use this skill when the user asks about CLI
 commands, init, upgrade, downgrade, `doctor`, `agent compact`, `codeblocks validate`, `agents generate`, `sitemap generate`, `robots generate`, search
-sync, mcp, review, cloud preview, cloud sync, or scaffolding.
+sync, mcp, review, cloud deploy, cloud sync, or scaffolding.
 
 ---
 
@@ -202,15 +202,14 @@ example. This metadata is for markdown/MCP consumers and does not require a UI c
 
 Use the docs config `mcp` block when you also want the HTTP route version at `/mcp` or `/.well-known/mcp`.
 
-## Docs Cloud preview
+## Docs Cloud deploy
 
-Use `docs preview` from a docs project root to sync the serializable `cloud` block from
-`docs.config.ts` into `docs.json`, validate the configured API key, and request a hosted Docs Cloud
-preview.
+Use `docs deploy` from a docs project root to sync the serializable `cloud` block from
+`docs.config.ts` into `docs.json`, validate the configured API key, and deploy hosted preview docs.
 
 ```bash
-pnpm exec docs preview
-pnpm exec docs cloud preview
+pnpm exec docs deploy
+pnpm exec docs cloud deploy
 pnpm exec docs cloud sync
 ```
 
@@ -219,13 +218,13 @@ Config shape:
 ```ts
 cloud: {
   apiKey: { env: "DOCS_CLOUD_API_KEY" },
-  preview: { enabled: true },
+  deploy: { enabled: true },
   publish: { mode: "draft-pr", baseBranch: "main" },
 }
 ```
 
 - `docs cloud sync` only writes or updates `docs.json`.
-- `docs preview` auto-creates `docs.json` if the project has not run a cloud command before.
+- `docs deploy` auto-creates `docs.json` if the project has not run a cloud command before.
 - The API key value must live in the named env var, `.env.local`, or CI secrets. Never write the raw key into config.
 - Use `--config <path>` when `docs.config.ts` lives outside the project root.
 - Use `--api-base-url <url>` for staging/self-hosted cloud API testing.

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -132,13 +132,13 @@ Cloud-aware CLI commands read a serializable `cloud` block from `docs.config.ts`
 ```ts
 cloud: {
   apiKey: { env: "DOCS_CLOUD_API_KEY" },
-  preview: { enabled: true },
+  deploy: { enabled: true },
   publish: { mode: "draft-pr", baseBranch: "main" },
 }
 ```
 
-Run `docs cloud sync` to only update `docs.json`, or `docs preview` to sync, validate the API key,
-and request a hosted preview. The API key value belongs in `.env.local`, CI secrets, or the shell,
+Run `docs cloud sync` to only update `docs.json`, or `docs deploy` to sync, validate the API key,
+and deploy hosted preview docs. The API key value belongs in `.env.local`, CI secrets, or the shell,
 never directly in `docs.config.ts` or `docs.json`.
 
 ---

--- a/website/app/docs/cloud/page.mdx
+++ b/website/app/docs/cloud/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Docs Cloud"
-description: "Connect your docs project to Docs Cloud previews, API keys, and publish workflows"
+description: "Connect your docs project to Docs Cloud deployments, API keys, and publish workflows"
 icon: "infrastructure"
 order: 3.6
 related:
@@ -13,22 +13,22 @@ related:
 # Docs Cloud
 
 <Agent>
-Use this page when the user asks about this topic: Connect an @farming-labs/docs project to Docs Cloud, create and store a Docs Cloud API key, sync docs.config.ts to docs.json, request hosted previews, or configure publish defaults.
+Use this page when the user asks about this topic: Connect an @farming-labs/docs project to Docs Cloud, create and store a Docs Cloud API key, sync docs.config.ts to docs.json, deploy hosted preview docs, or configure publish defaults.
 Keep answers grounded in the exact commands and config shown here. Never suggest committing raw API key values to docs.config.ts, docs.json, or source control.
 If the request is about the docs.json contract itself, point to /docs/guides/docs-json. If the request is about every config option, point to /docs/configuration.
 </Agent>
 
 Docs Cloud is the hosted layer around `@farming-labs/docs`. Your repo stays the source of truth,
-your app still owns the runtime, and Cloud adds managed previews, publish workflows, analytics, AI,
+your app still owns the runtime, and Cloud adds managed deployments, publish workflows, analytics, AI,
 search, and agent operations on top.
 
-The first integration surface is the Cloud preview flow:
+The first integration surface is the Cloud deploy flow:
 
 1. create a Docs Cloud API key
 2. store the key in an environment variable
 3. add a serializable `cloud` block to `docs.config.ts`
 4. sync that config into `docs.json`
-5. request a hosted preview
+5. deploy hosted preview docs
 
 <Callout type="info" title="Cloud access">
   Docs Cloud is rolling out gradually. If your workspace does not have access yet, join the
@@ -39,7 +39,7 @@ The first integration surface is the Cloud preview flow:
 ## Create An API Key
 
 In Docs Cloud, open your workspace, choose the docs project, then create a project API key from the
-project settings. For previews, the key needs access to read the project and request previews.
+project settings. For deployments, the key needs access to read the project and request previews.
 
 Copy the key once and put it in your local environment:
 
@@ -47,7 +47,7 @@ Copy the key once and put it in your local environment:
 DOCS_CLOUD_API_KEY=docs_cloud_...
 ```
 
-Use the same environment variable name as a CI secret when previews should run from GitHub Actions
+Use the same environment variable name as a CI secret when deployments should run from GitHub Actions
 or another build system.
 
 <Callout type="caution" title="Do not commit secrets">
@@ -66,7 +66,7 @@ export default defineDocs({
   entry: "docs",
   cloud: {
     apiKey: { env: "DOCS_CLOUD_API_KEY" },
-    preview: { enabled: true },
+    deploy: { enabled: true },
     publish: { mode: "draft-pr", baseBranch: "main" },
   },
 });
@@ -111,7 +111,7 @@ This creates or updates `docs.json`:
     "apiKey": {
       "env": "DOCS_CLOUD_API_KEY"
     },
-    "preview": {
+    "deploy": {
       "enabled": true
     },
     "publish": {
@@ -129,15 +129,15 @@ The generated `cloud` block intentionally omits `enabled`. The block itself opts
 Cloud-aware CLI flows; set `"enabled": false` only when you need to disable Cloud operations while
 keeping the rest of the contract in place.
 
-## Request A Preview
+## Deploy Preview Docs
 
-Use `docs preview` from the project root:
+Use `docs deploy` from the project root:
 
 ```bash title="terminal"
-pnpm exec docs preview
+pnpm exec docs deploy
 ```
 
-`docs preview` does three things:
+`docs deploy` does three things:
 
 1. syncs `docs.config.ts` into `docs.json`
 2. validates the configured API key with Docs Cloud
@@ -146,13 +146,13 @@ pnpm exec docs preview
 The explicit Cloud command is equivalent:
 
 ```bash title="terminal"
-pnpm exec docs cloud preview
+pnpm exec docs cloud deploy
 ```
 
 Use JSON output when another tool or CI job needs to read the preview URL:
 
 ```bash title="terminal"
-pnpm exec docs preview --json
+pnpm exec docs deploy --json
 ```
 
 ## Useful Options
@@ -160,11 +160,11 @@ pnpm exec docs preview --json
 | Command                              | Use it when                                      |
 | ------------------------------------ | ------------------------------------------------ |
 | `pnpm exec docs cloud sync`          | You only want to update `docs.json`              |
-| `pnpm exec docs preview`             | You want to sync, validate the key, and preview  |
-| `pnpm exec docs cloud preview`       | You prefer the explicit Cloud namespace          |
-| `pnpm exec docs preview --json`      | CI or automation needs machine-readable output   |
-| `pnpm exec docs preview --config <path>` | Your config file is outside the project root |
-| `pnpm exec docs preview --api-base-url <url>` | You are testing a staging or self-hosted Cloud API |
+| `pnpm exec docs deploy`              | You want to sync, validate the key, and deploy   |
+| `pnpm exec docs cloud deploy`        | You prefer the explicit Cloud namespace          |
+| `pnpm exec docs deploy --json`       | CI or automation needs machine-readable output   |
+| `pnpm exec docs deploy --config <path>` | Your config file is outside the project root  |
+| `pnpm exec docs deploy --api-base-url <url>` | You are testing a staging or self-hosted Cloud API |
 
 `--api-key <key>` also exists for local testing, but prefer `cloud.apiKey.env` plus an environment
 variable so the key does not end up in shell history, logs, or docs.
@@ -181,9 +181,9 @@ export DOCS_CLOUD_API_KEY=docs_cloud_...
 
 or add it to `.env.local`.
 
-**Preview disabled**
+**Deploy disabled**
 
-If `cloud.preview.enabled` is `false`, `docs preview` stops before making a hosted preview request.
+If `cloud.deploy.enabled` is `false`, `docs deploy` stops before making a hosted deployment request.
 Set it back to `true` or remove the override.
 
 **Wrong Cloud host**
@@ -191,7 +191,7 @@ Set it back to `true` or remove the override.
 For staging or self-hosted testing, pass:
 
 ```bash title="terminal"
-pnpm exec docs preview --api-base-url https://cloud.example.com
+pnpm exec docs deploy --api-base-url https://cloud.example.com
 ```
 
 You can also set `DOCS_CLOUD_API_URL` in the environment.

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -141,7 +141,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `pageActions` | `PageActionsConfig`            | —               | Copy Markdown, Open in LLM buttons                 |
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
-| `cloud`       | `DocsCloudConfig`              | —               | Docs Cloud API key env, preview, and publish defaults mirrored into `docs.json` |
+| `cloud`       | `DocsCloudConfig`              | —               | Docs Cloud API key env, deploy, and publish defaults mirrored into `docs.json` |
 | `llmsTxt`     | `boolean \| LlmsTxtConfig`     | `true`          | Generated root and optional section-level `llms.txt` files with markdown page links |
 | `changelog`   | `boolean \| ChangelogConfig`   | `false`         | Generated changelog feed and entry pages from dated MDX entries (Next.js) |
 | `mcp`         | `boolean \| DocsMcpConfig`     | enabled         | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp` |

--- a/website/app/docs/guides/docs-json/page.mdx
+++ b/website/app/docs/guides/docs-json/page.mdx
@@ -75,9 +75,6 @@ Hosted features live under `cloud`:
       "console": "info",
       "includeInputs": false
     },
-    "preview": {
-      "enabled": true
-    },
     "publish": {
       "mode": "draft-pr",
       "baseBranch": "main"
@@ -140,10 +137,10 @@ apps, `docs.config.ts` remains the canonical place for advanced runtime analytic
 
 The presence of a `cloud` block opts the project into Cloud-aware CLI flows. Leave
 `cloud.enabled` unset for normal connected projects. Set it to `false` only when the repo is using
-`docs.json` as a local project contract and should explicitly disable Cloud previews and publish
+`docs.json` as a local project contract and should explicitly disable Cloud deploy and publish
 commands.
 
-To connect a repo, create an API key, and request hosted previews, see
+To connect a repo, create an API key, and deploy hosted preview docs, see
 [Docs Cloud](/docs/cloud).
 
 ## Current Note

--- a/website/app/docs/page.mdx
+++ b/website/app/docs/page.mdx
@@ -74,7 +74,7 @@ Git as the source of truth.
 [Join the waitlist to be an early user →](/cloud#waitlist)
 
 Already have access? Start with the [Docs Cloud integration guide](/docs/cloud) to create an API
-key, sync `docs.json`, and request a hosted preview.
+key, sync `docs.json`, and deploy hosted preview docs.
 
 ## other docs frameworks?
 

--- a/website/public/schema/cloud.json
+++ b/website/public/schema/cloud.json
@@ -599,14 +599,16 @@
         "preview": {
           "type": "object",
           "additionalProperties": false,
+          "deprecated": true,
           "default": {
             "enabled": true
           },
+          "description": "Legacy hosted preview deployment gate. Prefer cloud.deploy.enabled in new configs.",
           "properties": {
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Whether Docs Cloud should request preview deployments."
+              "description": "Legacy toggle for hosted preview deployments."
             }
           }
         },
@@ -858,9 +860,6 @@
           "console": "info",
           "includeInputs": false
         },
-        "preview": {
-          "enabled": true
-        },
         "publish": {
           "mode": "draft-pr",
           "baseBranch": "main"
@@ -897,9 +896,6 @@
       "cloud": {
         "enabled": true,
         "analytics": true,
-        "preview": {
-          "enabled": true
-        },
         "publish": {
           "mode": "draft-pr",
           "baseBranch": "main"

--- a/website/public/schema/docs.json
+++ b/website/public/schema/docs.json
@@ -599,14 +599,16 @@
         "preview": {
           "type": "object",
           "additionalProperties": false,
+          "deprecated": true,
           "default": {
             "enabled": true
           },
+          "description": "Legacy hosted preview deployment gate. Prefer cloud.deploy.enabled in new configs.",
           "properties": {
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Whether Docs Cloud should request preview deployments."
+              "description": "Legacy toggle for hosted preview deployments."
             }
           }
         },
@@ -858,9 +860,6 @@
           "console": "info",
           "includeInputs": false
         },
-        "preview": {
-          "enabled": true
-        },
         "publish": {
           "mode": "draft-pr",
           "baseBranch": "main"
@@ -897,9 +896,6 @@
       "cloud": {
         "enabled": true,
         "analytics": true,
-        "preview": {
-          "enabled": true
-        },
         "publish": {
           "mode": "draft-pr",
           "baseBranch": "main"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `docs deploy` to sync config and deploy hosted preview docs via Docs Cloud using API keys. Deprecates legacy `cloud.preview`, keeps `preview` commands as aliases, enforces API scopes, improves polling, and reports nested failure details.

- **New Features**
  - Primary commands: `docs deploy` and `docs cloud deploy`; `preview` and `cloud preview` are compatibility aliases.
  - Required scopes: `project:read`, `preview:write`, `jobs:read`; CLI help lists them; clear errors when missing.
  - Better polling for queued jobs; nested job/run/step failures show path and status; supports `--json`.
  - Config: adds `cloud.deploy.enabled`; honors but deprecates `cloud.preview` (deprecated in schemas).
  - Docs/examples updated, including a new “Deploy Preview Docs” guide; tests cover deploy flow, queued polling, nested failures, missing scopes, and disabled flags.

- **Migration**
  - Set `cloud.apiKey.env` (e.g., `DOCS_CLOUD_API_KEY`) and enable `cloud.deploy.enabled: true` in `docs.config.ts`.
  - Remove legacy `cloud.preview` overrides; `cloud.preview.enabled: false` now blocks deployments with guidance.
  - Use `pnpm exec docs deploy` or `npx @farming-labs/docs deploy`; in CI, pass `--json` and provide the API key as a secret.

<sup>Written for commit 32e11d3cb46cee069fa4c83ed44cca16606a0f81. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

