### PR TITLE
feat: add enterprise support contact form

### DIFF
--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -110,7 +110,7 @@ export async function POST(request: Request) {
       try {
         new URL(docsUrl);
       } catch {
-        return NextResponse.json({ error: "Their website must be a valid URL" }, { status: 400 });
+        return NextResponse.json({ error: "Website URL must be a valid URL" }, { status: 400 });
       }
     }
 

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -1,0 +1,213 @@
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+type EnterpriseSupportBody = {
+  email?: string;
+  name?: string;
+  company?: string;
+  role?: string;
+  teamSize?: string;
+  docsUrl?: string;
+  supportNeeds?: string | string[];
+  timeline?: string;
+  message?: string;
+};
+
+function readString(
+  value: unknown,
+  { max, required = false }: { max: number; required?: boolean },
+) {
+  if (typeof value !== "string") return required ? null : undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return required ? null : undefined;
+
+  return trimmed.slice(0, max);
+}
+
+function readStringList(
+  value: unknown,
+  { maxItems, maxItem }: { maxItems: number; maxItem: number },
+) {
+  const items = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
+  const cleaned = items
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim().slice(0, maxItem))
+    .filter(Boolean)
+    .slice(0, maxItems);
+
+  return Array.from(new Set(cleaned));
+}
+
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function formatSupportMessage({
+  role,
+  teamSize,
+  docsUrl,
+  supportNeeds,
+  timeline,
+  message,
+}: {
+  role?: string;
+  teamSize?: string;
+  docsUrl?: string;
+  supportNeeds: string[];
+  timeline?: string;
+  message?: string;
+}) {
+  return [
+    "Enterprise support request",
+    role ? `Role: ${role}` : undefined,
+    teamSize ? `Team size: ${teamSize}` : undefined,
+    docsUrl ? `Docs URL: ${docsUrl}` : undefined,
+    supportNeeds.length ? `Support needed: ${supportNeeds.join(", ")}` : undefined,
+    timeline ? `Timeline: ${timeline}` : undefined,
+    message ? `Notes: ${message}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function POST(request: Request) {
+  try {
+    let body: EnterpriseSupportBody;
+
+    try {
+      body = (await request.json()) as EnterpriseSupportBody;
+    } catch {
+      return NextResponse.json(
+        { error: "Support request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    const emailInput = readString(body.email, { max: 320, required: true });
+    const companyInput = readString(body.company, { max: 160, required: true });
+    const email = emailInput?.toLowerCase();
+    const name = readString(body.name, { max: 120 }) ?? undefined;
+    const company = companyInput ?? undefined;
+    const role = readString(body.role, { max: 120 }) ?? undefined;
+    const teamSize = readString(body.teamSize, { max: 80 }) ?? undefined;
+    const docsUrl = readString(body.docsUrl, { max: 2048 }) ?? undefined;
+    const supportNeeds = readStringList(body.supportNeeds, { maxItems: 6, maxItem: 80 });
+    const timeline = readString(body.timeline, { max: 80 }) ?? undefined;
+    const message = readString(body.message, { max: 4000 }) ?? undefined;
+
+    if (!email) {
+      return NextResponse.json({ error: "Work email is required" }, { status: 400 });
+    }
+
+    if (!company) {
+      return NextResponse.json({ error: "Company is required" }, { status: 400 });
+    }
+
+    if (!isValidEmail(email)) {
+      return NextResponse.json({ error: "Please provide a valid work email" }, { status: 400 });
+    }
+
+    if (docsUrl) {
+      try {
+        new URL(docsUrl);
+      } catch {
+        return NextResponse.json(
+          { error: "Current docs URL must be a valid URL" },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (!process.env.DATABASE_URL) {
+      return NextResponse.json(
+        {
+          ok: true,
+          stored: false,
+          warning:
+            "Support request validated, but the enterprise support database is not configured yet.",
+        },
+        { status: 202 },
+      );
+    }
+
+    const interest = ["enterprise-support", ...supportNeeds, timeline]
+      .filter(Boolean)
+      .join(", ")
+      .slice(0, 320);
+    const supportMessage = formatSupportMessage({
+      role,
+      teamSize,
+      docsUrl,
+      supportNeeds,
+      timeline,
+      message,
+    }).slice(0, 4000);
+
+    try {
+      const entry = await prisma.cloudWaitlistEntry.upsert({
+        where: { email },
+        update: {
+          name,
+          company,
+          projectUrl: docsUrl,
+          interest,
+          message: supportMessage,
+        },
+        create: {
+          email,
+          name,
+          company,
+          projectUrl: docsUrl,
+          interest,
+          message: supportMessage,
+        },
+      });
+
+      return NextResponse.json({ ok: true, stored: true, id: entry.id }, { status: 201 });
+    } catch (error) {
+      if (
+        (error instanceof Prisma.PrismaClientKnownRequestError &&
+          (error.code === "P2021" || error.code === "P2022")) ||
+        error instanceof Prisma.PrismaClientValidationError
+      ) {
+        console.warn(
+          "[enterprise support POST] CloudWaitlistEntry schema or Prisma client is out of date.",
+        );
+
+        return NextResponse.json(
+          {
+            ok: true,
+            stored: false,
+            warning: "Enterprise support schema or Prisma client is out of date.",
+          },
+          { status: 202 },
+        );
+      }
+
+      if (error instanceof Prisma.PrismaClientInitializationError) {
+        console.warn("[enterprise support POST] Support database is currently unreachable.");
+
+        return NextResponse.json(
+          {
+            ok: true,
+            stored: false,
+            warning: "Enterprise support database is currently unreachable.",
+          },
+          { status: 202 },
+        );
+      }
+
+      throw error;
+    }
+  } catch (error) {
+    console.error("[enterprise support POST]", error);
+    return NextResponse.json(
+      { error: "Failed to submit enterprise support request" },
+      { status: 500 },
+    );
+  }
+}

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -12,7 +12,6 @@ type EnterpriseSupportBody = {
   teamSize?: string;
   docsUrl?: string;
   supportNeeds?: string | string[];
-  timeline?: string;
   message?: string;
 };
 
@@ -51,14 +50,12 @@ function formatSupportMessage({
   teamSize,
   docsUrl,
   supportNeeds,
-  timeline,
   message,
 }: {
   role?: string;
   teamSize?: string;
   docsUrl?: string;
   supportNeeds: string[];
-  timeline?: string;
   message?: string;
 }) {
   return [
@@ -67,7 +64,6 @@ function formatSupportMessage({
     teamSize ? `Team size: ${teamSize}` : undefined,
     docsUrl ? `Docs URL: ${docsUrl}` : undefined,
     supportNeeds.length ? `Support needed: ${supportNeeds.join(", ")}` : undefined,
-    timeline ? `Timeline: ${timeline}` : undefined,
     message ? `Notes: ${message}` : undefined,
   ]
     .filter(Boolean)
@@ -95,8 +91,7 @@ export async function POST(request: Request) {
     const role = readString(body.role, { max: 120 }) ?? undefined;
     const teamSize = readString(body.teamSize, { max: 80 }) ?? undefined;
     const docsUrl = readString(body.docsUrl, { max: 2048 }) ?? undefined;
-    const supportNeeds = readStringList(body.supportNeeds, { maxItems: 6, maxItem: 80 });
-    const timeline = readString(body.timeline, { max: 80 }) ?? undefined;
+    const supportNeeds = readStringList(body.supportNeeds, { maxItems: 12, maxItem: 80 });
     const message = readString(body.message, { max: 4000 }) ?? undefined;
 
     if (!email) {
@@ -134,7 +129,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const interest = ["enterprise-support", ...supportNeeds, timeline]
+    const interest = ["enterprise-support", ...supportNeeds]
       .filter(Boolean)
       .join(", ")
       .slice(0, 320);
@@ -143,7 +138,6 @@ export async function POST(request: Request) {
       teamSize,
       docsUrl,
       supportNeeds,
-      timeline,
       message,
     }).slice(0, 4000);
 

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -62,7 +62,7 @@ function formatSupportMessage({
     "Enterprise support request",
     role ? `Role: ${role}` : undefined,
     teamSize ? `Team size: ${teamSize}` : undefined,
-    docsUrl ? `Docs URL: ${docsUrl}` : undefined,
+    docsUrl ? `Website: ${docsUrl}` : undefined,
     supportNeeds.length ? `Support needed: ${supportNeeds.join(", ")}` : undefined,
     message ? `Notes: ${message}` : undefined,
   ]
@@ -110,10 +110,7 @@ export async function POST(request: Request) {
       try {
         new URL(docsUrl);
       } catch {
-        return NextResponse.json(
-          { error: "Current docs URL must be a valid URL" },
-          { status: 400 },
-        );
+        return NextResponse.json({ error: "Their website must be a valid URL" }, { status: 400 });
       }
     }
 

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -10,7 +10,6 @@ import {
   Github,
   GithubIcon,
   Headset,
-  MessageSquareText,
   type LucideIcon,
   Palette,
   ServerCog,
@@ -522,13 +521,6 @@ export default function CloudPage() {
                       <span>{signal}</span>
                     </div>
                   ))}
-                </div>
-
-                <div className="mt-6 flex items-center gap-3 border border-black/10 bg-black px-4 py-3 text-white dark:border-white/10 dark:bg-white dark:text-black">
-                  <MessageSquareText className="size-4 shrink-0" strokeWidth={1.8} />
-                  <p className="font-mono text-[10px] uppercase tracking-[0.18em]">
-                    Fill the form and we’ll get back to you fast.
-                  </p>
                 </div>
               </div>
 

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -5,7 +5,6 @@ import {
   ArrowUpRight,
   BadgeCheck,
   Building2,
-  Clock3,
   Cloud,
   Github,
   GithubIcon,
@@ -468,10 +467,6 @@ export default function CloudPage() {
                   <span className="inline-flex items-center gap-2 border border-black/10 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-black/45 dark:border-white/10 dark:text-white/45">
                     <Headset className="size-3.5" strokeWidth={1.8} />
                     Enterprise support
-                  </span>
-                  <span className="inline-flex items-center gap-2 border border-black/10 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-black/45 dark:border-white/10 dark:text-white/45">
-                    <Clock3 className="size-3.5" strokeWidth={1.8} />
-                    Fast response
                   </span>
                 </div>
 

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -3,12 +3,19 @@ import Link from "next/link";
 import {
   ArrowRight,
   ArrowUpRight,
+  BadgeCheck,
   Building2,
+  Clock3,
   Cloud,
   Github,
   GithubIcon,
+  Headset,
+  MessageSquareText,
   type LucideIcon,
   Palette,
+  ServerCog,
+  ShieldCheck,
+  Sparkles,
   Workflow,
 } from "lucide-react";
 import { AnimatedBackground } from "@/components/ui/animated-bg-black";
@@ -16,6 +23,7 @@ import { CloudDocsManageIllustration } from "@/components/ui/cloud-feature-illus
 import { CloudFeatures } from "@/components/ui/cloud-features";
 import { CloudTerminalDemo } from "@/components/ui/cloud-terminal-demo";
 import CloudWaitlistForm from "@/components/ui/cloud-waitlist-form";
+import { EnterpriseSupportForm } from "@/components/ui/enterprise-support-form";
 import PixelCard from "@/components/ui/pixel-card";
 import Shuffle from "@/components/ui/shuffle";
 import { SidebarThemeToggle } from "@/components/sidebar-theme-toggle";
@@ -126,6 +134,31 @@ const accessCards = [
   },
 ] as const;
 
+const enterpriseSupportItems = [
+  {
+    icon: ServerCog,
+    title: "Infrastructure support",
+    body: "Get help with cloud setup, routing, deployment shape, private docs, and production blockers.",
+  },
+  {
+    icon: Sparkles,
+    title: "Brand system support",
+    body: "Bring your own visual language, custom themes, docs IA, and launch polish without losing the open runtime.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Agent + human readiness",
+    body: "Tune markdown routes, MCP, llms.txt, search, recovery paths, and visible docs so both readers work.",
+  },
+] as const;
+
+const enterpriseTrustSignals = [
+  "Fast response for launch-blocking docs infra",
+  "Cloud support without forcing lock-in",
+  "Custom branding and migration help",
+  "Agent-readable and human-first docs",
+] as const;
+
 export default function CloudPage() {
   return (
     <div className="min-h-dvh overflow-x-hidden bg-white text-black dark:bg-black dark:text-white">
@@ -222,6 +255,13 @@ export default function CloudPage() {
                 >
                   Read Docs
                   <ArrowRight className="size-3.5 -rotate-45 transition-transform duration-300 group-hover:rotate-0" />
+                </a>
+                <a
+                  href="#enterprise-support"
+                  className="group inline-flex w-full items-center justify-center gap-2 border border-black/10 bg-white/80 px-5 py-3 font-mono text-[11px] uppercase tracking-[0.24em] text-black/65 transition-all hover:border-black/20 hover:bg-black/[0.03] hover:text-black hover:no-underline sm:w-auto sm:justify-start dark:border-white/10 dark:bg-black/40 dark:text-white/65 dark:hover:border-white/20 dark:hover:bg-white/[0.05] dark:hover:text-white"
+                >
+                  Enterprise support
+                  <Headset className="size-3.5" strokeWidth={1.8} />
                 </a>
               </div>
             </div>
@@ -419,6 +459,83 @@ export default function CloudPage() {
             <span className="hidden sm:inline-flex items-center gap-2">no forced upgrade path</span>
           </div>
 
+          <section
+            id="enterprise-support"
+            className="scroll-mt-20 border-y border-black/10 py-8 dark:border-white/10 sm:py-10"
+          >
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,0.96fr)_minmax(360px,0.78fr)] lg:items-start">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center gap-2 border border-black/10 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-black/45 dark:border-white/10 dark:text-white/45">
+                    <Headset className="size-3.5" strokeWidth={1.8} />
+                    Enterprise support
+                  </span>
+                  <span className="inline-flex items-center gap-2 border border-black/10 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.2em] text-black/45 dark:border-white/10 dark:text-white/45">
+                    <Clock3 className="size-3.5" strokeWidth={1.8} />
+                    Fast response
+                  </span>
+                </div>
+
+                <h2 className="mt-5 max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-black dark:text-white sm:text-4xl lg:text-5xl">
+                  Need docs infrastructure, cloud setup, or a branded agent-ready launch?
+                </h2>
+                <p className="mt-4 max-w-2xl text-sm leading-relaxed text-black/58 dark:text-white/48 sm:text-base">
+                  Tell us where your docs system is stuck. We can help with cloud infrastructure,
+                  migration, custom branding, private docs workflows, and docs that stay optimized
+                  for humans, agents, and AI retrieval.
+                </p>
+
+                <div className="mt-7 grid gap-3">
+                  {enterpriseSupportItems.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <div
+                        key={item.title}
+                        className="grid gap-4 border border-black/10 bg-black/[0.02] px-4 py-4 dark:border-white/10 dark:bg-white/[0.02] sm:grid-cols-[44px_minmax(0,1fr)] sm:items-start"
+                      >
+                        <div className="flex size-11 items-center justify-center border border-black/10 bg-white dark:border-white/10 dark:bg-black">
+                          <Icon
+                            className="size-[18px] text-black/60 dark:text-white/60"
+                            strokeWidth={1.8}
+                          />
+                        </div>
+                        <div className="min-w-0">
+                          <h3 className="font-pixel text-base font-medium tracking-normal text-black dark:text-white">
+                            {item.title}
+                          </h3>
+                          <p className="mt-1.5 text-sm leading-relaxed text-black/55 dark:text-white/45">
+                            {item.body}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="mt-6 grid gap-2 sm:grid-cols-2">
+                  {enterpriseTrustSignals.map((signal) => (
+                    <div
+                      key={signal}
+                      className="flex min-h-12 items-center gap-3 border border-black/10 px-3 py-2 text-sm text-black/58 dark:border-white/10 dark:text-white/48"
+                    >
+                      <BadgeCheck className="size-4 shrink-0 text-black/50 dark:text-white/50" />
+                      <span>{signal}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-6 flex items-center gap-3 border border-black/10 bg-black px-4 py-3 text-white dark:border-white/10 dark:bg-white dark:text-black">
+                  <MessageSquareText className="size-4 shrink-0" strokeWidth={1.8} />
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em]">
+                    Fill the form and we’ll get back to you fast.
+                  </p>
+                </div>
+              </div>
+
+              <EnterpriseSupportForm />
+            </div>
+          </section>
+
           <PixelCard className="border-black/10 bg-white/95 p-4 sm:p-0 dark:border-white/10 dark:bg-black/35">
             <div className="relative">
               <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(125%_125%_at_50%_0%,transparent_40%,rgba(0,0,0,0.03),white_125%)] dark:bg-[radial-gradient(125%_125%_at_50%_0%,transparent_40%,rgba(255,255,255,0.03),rgba(0,0,0,0.92)_125%)]" />
@@ -475,23 +592,23 @@ export default function CloudPage() {
             <div className="relative z-10 grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
               <div>
                 <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/55">
-                  Early access
+                  Enterprise path
                 </p>
                 <h2 className="mt-3 max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-black dark:text-white sm:text-4xl">
-                  Help shape the first release around the parts your team actually needs.
+                  Bring us the blocker. We’ll help you get the docs stack unstuck.
                 </h2>
                 <p className="mt-4 max-w-2xl text-sm leading-relaxed text-black/60 dark:text-white/70">
-                  Tell us which part of your docs stack is hardest today. We’re using that to shape
-                  the first release.
+                  Use the support form for infrastructure questions, cloud rollout, custom branding,
+                  migration planning, and docs that need to serve both humans and agents.
                 </p>
               </div>
 
               <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-8">
                 <a
-                  href="#waitlist"
+                  href="#enterprise-support"
                   className="group inline-flex items-center gap-2 border border-black bg-black px-5 py-3 font-mono text-[10px] uppercase tracking-normal text-white transition-all hover:bg-black/90 hover:no-underline dark:border-white dark:bg-white dark:text-black dark:hover:bg-white/90"
                 >
-                  Join waitlist
+                  Contact support
                   <ArrowRight className="size-3.5 -rotate-45 transition-transform duration-300 group-hover:rotate-0" />
                 </a>
                 <Link
@@ -624,6 +741,12 @@ function CloudFooterSection() {
                 className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
               >
                 Documentation
+              </Link>
+              <Link
+                href="/cloud#enterprise-support"
+                className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
+              >
+                Enterprise
               </Link>
               <Link
                 href="https://github.com/farming-labs/docs"

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -471,7 +471,7 @@ export default function CloudPage() {
                 </div>
 
                 <h2 className="mt-5 max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-black dark:text-white sm:text-4xl lg:text-5xl">
-                  Need docs infrastructure, cloud setup, or a branded agent-ready launch?
+                  Need enterprise docs support?
                 </h2>
                 <p className="mt-4 max-w-2xl text-sm leading-relaxed text-black/58 dark:text-white/48 sm:text-base">
                   Tell us where your docs system is stuck. We can help with cloud infrastructure,

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -256,7 +256,7 @@ export default function CloudPage() {
                 </a>
                 <a
                   href="#enterprise-support"
-                  className="group inline-flex w-full items-center justify-center gap-2 border border-black/10 bg-white/80 px-5 py-3 font-mono text-[11px] uppercase tracking-[0.24em] text-black/65 transition-all hover:border-black/20 hover:bg-black/[0.03] hover:text-black hover:no-underline sm:w-auto sm:justify-start dark:border-white/10 dark:bg-black/40 dark:text-white/65 dark:hover:border-white/20 dark:hover:bg-white/[0.05] dark:hover:text-white"
+                  className="group inline-flex w-full items-center justify-center gap-2 border border-b-black/25 border-black/10 bg-white/80 px-5 py-3 font-mono text-[11px] uppercase tracking-[0.24em] text-black/65 transition-all hover:border-black/20 hover:border-b-black/35 hover:bg-black/[0.03] hover:text-black hover:no-underline sm:w-auto sm:justify-start dark:border-white/10 dark:border-b-white/25 dark:bg-black/40 dark:text-white/65 dark:hover:border-white/20 dark:hover:border-b-white/35 dark:hover:bg-white/[0.05] dark:hover:text-white"
                 >
                   Enterprise support
                   <Headset className="size-3.5" strokeWidth={1.8} />

--- a/website/components/ui/enterprise-support-form.tsx
+++ b/website/components/ui/enterprise-support-form.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ArrowRight, Check, Loader2 } from "lucide-react";
+import PixelCard from "@/components/ui/pixel-card";
+
+const supportOptions = [
+  { value: "infrastructure", label: "Infrastructure support" },
+  { value: "cloud", label: "Docs Cloud setup" },
+  { value: "branding", label: "Custom branding" },
+  { value: "agent-human", label: "Agent + human optimization" },
+  { value: "migration", label: "Migration support" },
+  { value: "private-docs", label: "Private docs workflows" },
+] as const;
+
+const timelineOptions = ["This week", "Next 2 weeks", "This month", "Exploring"] as const;
+
+type SubmitState =
+  | { status: "idle"; message: null }
+  | { status: "success"; message: string }
+  | { status: "warning"; message: string }
+  | { status: "error"; message: string };
+
+type ButtonMode = "idle" | "loading" | "success";
+
+export function EnterpriseSupportForm() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [company, setCompany] = useState("");
+  const [role, setRole] = useState("");
+  const [teamSize, setTeamSize] = useState("");
+  const [docsUrl, setDocsUrl] = useState("");
+  const [supportNeeds, setSupportNeeds] = useState<string[]>(["infrastructure"]);
+  const [timeline, setTimeline] = useState<(typeof timelineOptions)[number]>("This week");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [buttonMode, setButtonMode] = useState<ButtonMode>("idle");
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [submitState, setSubmitState] = useState<SubmitState>({
+    status: "idle",
+    message: null,
+  });
+
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current);
+    };
+  }, []);
+
+  function toggleSupportNeed(value: string) {
+    setSupportNeeds((current) => {
+      if (current.includes(value)) return current.filter((item) => item !== value);
+      return [...current, value].slice(0, 4);
+    });
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (buttonMode === "success") return;
+
+    if (successTimeoutRef.current) {
+      clearTimeout(successTimeoutRef.current);
+      successTimeoutRef.current = null;
+    }
+
+    setLoading(true);
+    setButtonMode("loading");
+    setSubmitState({ status: "idle", message: null });
+
+    try {
+      const response = await fetch("/api/enterprise-support", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          email,
+          company,
+          role,
+          teamSize,
+          docsUrl,
+          supportNeeds,
+          timeline,
+          message,
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        error?: string;
+        warning?: string;
+        stored?: boolean;
+      };
+
+      if (!response.ok) {
+        setButtonMode("idle");
+        setSubmitState({
+          status: "error",
+          message: payload.error || "Support request failed. Please try again.",
+        });
+        return;
+      }
+
+      setName("");
+      setEmail("");
+      setCompany("");
+      setRole("");
+      setTeamSize("");
+      setDocsUrl("");
+      setSupportNeeds(["infrastructure"]);
+      setTimeline("This week");
+      setMessage("");
+
+      if (payload.stored === false && payload.warning) {
+        setButtonMode("idle");
+        setSubmitState({
+          status: "warning",
+          message: payload.warning,
+        });
+        return;
+      }
+
+      setButtonMode("success");
+      setSubmitState({
+        status: "success",
+        message: "Request received. We’ll get back to you fast with the right next step.",
+      });
+
+      successTimeoutRef.current = setTimeout(() => {
+        setButtonMode("idle");
+      }, 5000);
+    } catch {
+      setButtonMode("idle");
+      setSubmitState({
+        status: "error",
+        message: "Request failed before it reached support. Please try again.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <PixelCard className="border-black/10 bg-white/95 p-0 dark:border-white/10 dark:bg-black/35">
+      <div className="border-b border-black/10 px-5 py-4 dark:border-white/10">
+        <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45">
+          Enterprise support
+        </p>
+        <h2 className="mt-2 font-pixel text-xl font-normal tracking-normal text-black dark:text-white">
+          Tell us what you need.
+        </h2>
+        <p className="mt-2 text-sm leading-relaxed text-black/55 dark:text-white/45">
+          Infrastructure, cloud setup, branding, private docs, and agent-ready docs support.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 p-5">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field
+            id="enterprise-support-name"
+            label="Name"
+            value={name}
+            onChange={setName}
+            placeholder="Mekonnen"
+          />
+          <Field
+            id="enterprise-support-company"
+            label="Company"
+            value={company}
+            onChange={setCompany}
+            placeholder="Acme"
+            required
+          />
+        </div>
+
+        <Field
+          id="enterprise-support-email"
+          label="Work email"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          placeholder="team@company.com"
+          required
+        />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field
+            id="enterprise-support-role"
+            label="Role"
+            value={role}
+            onChange={setRole}
+            placeholder="Head of engineering"
+          />
+          <Field
+            id="enterprise-support-team-size"
+            label="Team size"
+            value={teamSize}
+            onChange={setTeamSize}
+            placeholder="25 engineers"
+          />
+        </div>
+
+        <Field
+          id="enterprise-support-docs-url"
+          label="Current docs URL"
+          type="url"
+          value={docsUrl}
+          onChange={setDocsUrl}
+          placeholder="https://docs.company.com"
+        />
+
+        <SupportNeedList value={supportNeeds} onToggle={toggleSupportNeed} />
+
+        <TimelinePicker value={timeline} onChange={setTimeline} />
+
+        <div>
+          <label
+            htmlFor="enterprise-support-message"
+            className="mb-1 block font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45"
+          >
+            What should we know?
+          </label>
+          <textarea
+            id="enterprise-support-message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder="Tell us what is blocked, what stack you run, what kind of support you need, and when you want to launch."
+            rows={5}
+            className="w-full resize-none rounded-none border border-black/10 bg-transparent px-3 py-2 text-sm leading-relaxed text-black outline-none transition-colors focus:border-black/30 dark:border-white/10 dark:text-white dark:focus:border-white/25"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || buttonMode === "success"}
+          className="group inline-flex w-full items-center justify-center gap-2 border border-black bg-black px-4 py-3 font-mono text-[11px] uppercase tracking-wide text-white transition-all hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-70 dark:border-white dark:bg-white dark:text-black dark:hover:bg-white/90"
+        >
+          <span className="relative h-4 overflow-hidden">
+            <span
+              className="flex flex-col transition-transform duration-500 ease-out"
+              style={{
+                transform:
+                  buttonMode === "idle"
+                    ? "translateY(0)"
+                    : buttonMode === "loading"
+                      ? "translateY(-1rem)"
+                      : "translateY(-2rem)",
+              }}
+            >
+              <span className="flex h-4 items-center justify-center gap-2">
+                Contact support
+                <ArrowRight className="size-3.5 -rotate-45 transition-transform duration-300 group-hover:rotate-0" />
+              </span>
+              <span className="flex h-4 items-center justify-center gap-2">
+                <Loader2 className="size-3.5 animate-spin" />
+                Sending
+              </span>
+              <span className="flex h-4 items-center justify-center gap-2">
+                <Check className="size-3.5" />
+                Sent
+              </span>
+            </span>
+          </span>
+        </button>
+
+        {submitState.message ? (
+          <p
+            className={[
+              "border px-3 py-2 text-[11px] leading-relaxed",
+              submitState.status === "success"
+                ? "border-black/15 bg-black/[0.03] text-black/60 dark:border-white/15 dark:bg-white/[0.04] dark:text-white/60"
+                : submitState.status === "warning"
+                  ? "border-black/12 bg-black/[0.02] text-black/55 dark:border-white/12 dark:bg-white/[0.03] dark:text-white/55"
+                  : "border-black/12 bg-black/[0.015] text-black/55 dark:border-white/12 dark:bg-white/[0.02] dark:text-white/55",
+            ].join(" ")}
+          >
+            {submitState.message}
+          </p>
+        ) : null}
+
+        <p className="text-[11px] leading-relaxed text-black/45 dark:text-white/40">
+          We prioritize infrastructure and launch-blocking requests from teams moving docs into
+          production.
+        </p>
+      </form>
+    </PixelCard>
+  );
+}
+
+function Field({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  type = "text",
+  required = false,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type?: "email" | "text" | "url";
+  required?: boolean;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45"
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        className="w-full rounded-none border border-black/10 bg-transparent px-3 py-2.5 text-sm text-black outline-none transition-colors placeholder:text-black/25 focus:border-black/30 dark:border-white/10 dark:text-white dark:placeholder:text-white/25 dark:focus:border-white/25"
+      />
+    </div>
+  );
+}
+
+function SupportNeedList({
+  value,
+  onToggle,
+}: {
+  value: string[];
+  onToggle: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45">
+        Support needed
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {supportOptions.map((option, index) => {
+          const selected = value.includes(option.value);
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onToggle(option.value)}
+              aria-pressed={selected}
+              className={[
+                "flex min-h-11 items-center gap-2 border px-3 py-2 text-left text-[12px] leading-tight transition-colors",
+                selected
+                  ? "border-black bg-black text-white dark:border-white dark:bg-white dark:text-black"
+                  : "border-black/10 bg-black/[0.015] text-black/60 hover:border-black/20 dark:border-white/10 dark:bg-white/[0.015] dark:text-white/55 dark:hover:border-white/20",
+              ].join(" ")}
+            >
+              <span
+                className={[
+                  "shrink-0 font-mono text-[10px] uppercase tracking-[0.16em]",
+                  selected
+                    ? "text-white/70 dark:text-black/60"
+                    : "text-black/35 dark:text-white/35",
+                ].join(" ")}
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span>{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TimelinePicker({
+  value,
+  onChange,
+}: {
+  value: (typeof timelineOptions)[number];
+  onChange: (value: (typeof timelineOptions)[number]) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45">
+        Timeline
+      </p>
+      <div className="grid grid-cols-2 gap-2">
+        {timelineOptions.map((option) => {
+          const selected = value === option;
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onChange(option)}
+              aria-pressed={selected}
+              className={[
+                "min-h-10 border px-3 py-2 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors",
+                selected
+                  ? "border-black bg-black text-white dark:border-white dark:bg-white dark:text-black"
+                  : "border-black/10 bg-black/[0.015] text-black/50 hover:border-black/20 dark:border-white/10 dark:bg-white/[0.015] dark:text-white/45 dark:hover:border-white/20",
+              ].join(" ")}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/website/components/ui/enterprise-support-form.tsx
+++ b/website/components/ui/enterprise-support-form.tsx
@@ -186,7 +186,7 @@ export function EnterpriseSupportForm() {
             onChange={setRole}
             placeholder="Head of engineering"
           />
-          <SelectField
+          <SingleSelectDropdown
             id="enterprise-support-team-size"
             label="Team size"
             value={teamSize}
@@ -198,7 +198,7 @@ export function EnterpriseSupportForm() {
 
         <Field
           id="enterprise-support-docs-url"
-          label="Their website"
+          label="Website URL"
           type="url"
           value={docsUrl}
           onChange={setDocsUrl}
@@ -319,7 +319,7 @@ function Field({
   );
 }
 
-function SelectField({
+function SingleSelectDropdown({
   id,
   label,
   value,
@@ -334,34 +334,109 @@ function SelectField({
   placeholder: string;
   options: readonly string[];
 }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   return (
-    <div>
-      <label
-        htmlFor={id}
-        className="mb-1 block font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45"
-      >
+    <div ref={rootRef} className="min-w-0 space-y-1">
+      <label className="block font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45">
         {label}
       </label>
       <div className="relative">
-        <select
+        <button
           id={id}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          className="w-full appearance-none rounded-none border border-black/10 bg-transparent px-3 py-2.5 pr-9 text-sm text-black outline-none transition-colors focus:border-black/30 dark:border-white/10 dark:text-white dark:focus:border-white/25"
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={() => setOpen((current) => !current)}
+          className="flex w-full touch-manipulation items-center justify-between gap-3 border border-black/10 bg-transparent px-3 py-2.5 text-left text-sm text-black outline-none transition-colors hover:border-black/20 focus:border-black/30 dark:border-white/10 dark:text-white dark:hover:border-white/20 dark:focus:border-white/25"
         >
-          <option value="" disabled>
-            {placeholder}
-          </option>
-          {options.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
-        <ChevronDown
-          className="pointer-events-none absolute right-3 top-1/2 size-3.5 -translate-y-1/2 text-black/35 dark:text-white/35"
-          strokeWidth={1.8}
-        />
+          <span
+            className={value ? "text-black dark:text-white" : "text-black/25 dark:text-white/25"}
+          >
+            {value || placeholder}
+          </span>
+          <ChevronDown
+            className={[
+              "size-3.5 shrink-0 text-black/35 transition-transform dark:text-white/35",
+              open ? "rotate-180" : "",
+            ].join(" ")}
+            strokeWidth={1.8}
+          />
+        </button>
+
+        {open ? (
+          <div className="relative z-30 mt-2 border border-black/10 bg-white shadow-[0_16px_40px_rgba(0,0,0,0.08)] sm:absolute sm:left-0 sm:right-0 sm:top-[calc(100%+0.4rem)] sm:mt-0 dark:border-white/10 dark:bg-black">
+            <div
+              role="listbox"
+              aria-label={label}
+              className="max-h-72 overflow-y-auto overscroll-contain p-1.5"
+            >
+              {options.map((option, index) => {
+                const selected = value === option;
+                return (
+                  <button
+                    key={option}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => {
+                      onChange(option);
+                      setOpen(false);
+                    }}
+                    className={[
+                      "flex w-full touch-manipulation items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors",
+                      selected
+                        ? "bg-black/[0.04] dark:bg-white/[0.06]"
+                        : "hover:bg-black/[0.025] dark:hover:bg-white/[0.04]",
+                    ].join(" ")}
+                  >
+                    <span className="min-w-0 text-sm leading-snug text-black dark:text-white">
+                      <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-black/40 dark:text-white/40">
+                        {String(index + 1).padStart(2, "0")}.
+                      </span>{" "}
+                      {option}
+                    </span>
+                    <span
+                      className={[
+                        "flex size-5 shrink-0 items-center justify-center border transition-colors",
+                        selected
+                          ? "border-black/20 bg-black text-white dark:border-white/20 dark:bg-white dark:text-black"
+                          : "border-black/10 text-transparent dark:border-white/10",
+                      ].join(" ")}
+                    >
+                      <Check className="size-3" strokeWidth={2} />
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/website/components/ui/enterprise-support-form.tsx
+++ b/website/components/ui/enterprise-support-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ArrowRight, Check, Loader2 } from "lucide-react";
+import { ArrowRight, Check, ChevronDown, Loader2 } from "lucide-react";
 import PixelCard from "@/components/ui/pixel-card";
 
 const supportOptions = [
@@ -12,6 +12,8 @@ const supportOptions = [
   { value: "migration", label: "Migration support" },
   { value: "private-docs", label: "Private docs workflows" },
 ] as const;
+
+const teamSizeOptions = ["1-10", "10-30", "30-50", "50-100", "100+"] as const;
 
 type SubmitState =
   | { status: "idle"; message: null }
@@ -184,22 +186,23 @@ export function EnterpriseSupportForm() {
             onChange={setRole}
             placeholder="Head of engineering"
           />
-          <Field
+          <SelectField
             id="enterprise-support-team-size"
             label="Team size"
             value={teamSize}
             onChange={setTeamSize}
-            placeholder="25 engineers"
+            placeholder="Select range"
+            options={teamSizeOptions}
           />
         </div>
 
         <Field
           id="enterprise-support-docs-url"
-          label="Current docs URL"
+          label="Their website"
           type="url"
           value={docsUrl}
           onChange={setDocsUrl}
-          placeholder="https://docs.company.com"
+          placeholder="https://company.com"
         />
 
         <SupportNeedList value={supportNeeds} onToggle={toggleSupportNeed} />
@@ -312,6 +315,54 @@ function Field({
         required={required}
         className="w-full rounded-none border border-black/10 bg-transparent px-3 py-2.5 text-sm text-black outline-none transition-colors placeholder:text-black/25 focus:border-black/30 dark:border-white/10 dark:text-white dark:placeholder:text-white/25 dark:focus:border-white/25"
       />
+    </div>
+  );
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  options,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  options: readonly string[];
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45"
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className="w-full appearance-none rounded-none border border-black/10 bg-transparent px-3 py-2.5 pr-9 text-sm text-black outline-none transition-colors focus:border-black/30 dark:border-white/10 dark:text-white dark:focus:border-white/25"
+        >
+          <option value="" disabled>
+            {placeholder}
+          </option>
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-3 top-1/2 size-3.5 -translate-y-1/2 text-black/35 dark:text-white/35"
+          strokeWidth={1.8}
+        />
+      </div>
     </div>
   );
 }

--- a/website/components/ui/enterprise-support-form.tsx
+++ b/website/components/ui/enterprise-support-form.tsx
@@ -13,8 +13,6 @@ const supportOptions = [
   { value: "private-docs", label: "Private docs workflows" },
 ] as const;
 
-const timelineOptions = ["This week", "Next 2 weeks", "This month", "Exploring"] as const;
-
 type SubmitState =
   | { status: "idle"; message: null }
   | { status: "success"; message: string }
@@ -31,7 +29,6 @@ export function EnterpriseSupportForm() {
   const [teamSize, setTeamSize] = useState("");
   const [docsUrl, setDocsUrl] = useState("");
   const [supportNeeds, setSupportNeeds] = useState<string[]>(["infrastructure"]);
-  const [timeline, setTimeline] = useState<(typeof timelineOptions)[number]>("This week");
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
   const [buttonMode, setButtonMode] = useState<ButtonMode>("idle");
@@ -50,7 +47,7 @@ export function EnterpriseSupportForm() {
   function toggleSupportNeed(value: string) {
     setSupportNeeds((current) => {
       if (current.includes(value)) return current.filter((item) => item !== value);
-      return [...current, value].slice(0, 4);
+      return [...current, value];
     });
   }
 
@@ -79,7 +76,6 @@ export function EnterpriseSupportForm() {
           teamSize,
           docsUrl,
           supportNeeds,
-          timeline,
           message,
         }),
       });
@@ -106,7 +102,6 @@ export function EnterpriseSupportForm() {
       setTeamSize("");
       setDocsUrl("");
       setSupportNeeds(["infrastructure"]);
-      setTimeline("This week");
       setMessage("");
 
       if (payload.stored === false && payload.warning) {
@@ -208,8 +203,6 @@ export function EnterpriseSupportForm() {
         />
 
         <SupportNeedList value={supportNeeds} onToggle={toggleSupportNeed} />
-
-        <TimelinePicker value={timeline} onChange={setTimeline} />
 
         <div>
           <label
@@ -362,43 +355,6 @@ function SupportNeedList({
                 {String(index + 1).padStart(2, "0")}
               </span>
               <span>{option.label}</span>
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function TimelinePicker({
-  value,
-  onChange,
-}: {
-  value: (typeof timelineOptions)[number];
-  onChange: (value: (typeof timelineOptions)[number]) => void;
-}) {
-  return (
-    <div className="space-y-2">
-      <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-black/45 dark:text-white/45">
-        Timeline
-      </p>
-      <div className="grid grid-cols-2 gap-2">
-        {timelineOptions.map((option) => {
-          const selected = value === option;
-          return (
-            <button
-              key={option}
-              type="button"
-              onClick={() => onChange(option)}
-              aria-pressed={selected}
-              className={[
-                "min-h-10 border px-3 py-2 font-mono text-[10px] uppercase tracking-[0.16em] transition-colors",
-                selected
-                  ? "border-black bg-black text-white dark:border-white dark:bg-white dark:text-black"
-                  : "border-black/10 bg-black/[0.015] text-black/50 hover:border-black/20 dark:border-white/10 dark:bg-white/[0.015] dark:text-white/45 dark:hover:border-white/20",
-              ].join(" ")}
-            >
-              {option}
             </button>
           );
         })}


### PR DESCRIPTION
## Summary
- add an enterprise support section to the Cloud page with high-intent placement after the cloud/enterprise positioning cards
- add a dedicated enterprise support form for infrastructure, Docs Cloud, custom branding, migration, private docs, and agent/human docs optimization requests
- add an API route that validates support requests and stores them through the existing cloud lead pipeline

## Verification
- pnpm --dir website exec tsc --noEmit
- pnpm exec oxlint website/app/cloud/page.tsx website/components/ui/enterprise-support-form.tsx website/app/api/enterprise-support/route.ts
- git diff --check
- local browser check at http://127.0.0.1:3000/cloud#enterprise-support for desktop and mobile widths
- POST /api/enterprise-support locally, then removed the test entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an enterprise support section and contact form to the Cloud page, plus an API that validates and stores requests in the existing cloud lead pipeline. The UI is simplified with refined fields and copy updates to help teams request infra, Docs Cloud, branding, migration, private docs, and agent/human optimization support.

- **New Features**
  - New enterprise section at /cloud with trust signals and `EnterpriseSupportForm` featuring clearer submit states and refined fields (role, custom team size dropdown, curated support needs); shortened section heading, removed the “fast response” label, updated CTAs to “Enterprise support”/“Contact support”, and strengthened the hero CTA border.
  - API: POST /api/enterprise-support with JSON, server-side validation (email, company, URL), normalization, and upsert to Prisma `cloudWaitlistEntry` via `@prisma/client`.
  - Graceful fallbacks: when `DATABASE_URL` is missing, the schema/client is out of date, or the database is temporarily unreachable, the API returns 202 with a warning.

- **Migration**
  - Set `DATABASE_URL` to enable storing requests; otherwise the API will accept but not persist.
  - Ensure Prisma client is generated and the `CloudWaitlistEntry` model matches the expected schema.

<sup>Written for commit 0d8c4b38da7ad400ed0e45f25194d6eae7eedb61. Summary will update on new commits. <a href="https://cubic.dev/pr/farming-labs/docs/pull/227?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

