### PR TITLE
fix: send email port to low effort bg process

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -14,7 +14,7 @@
 # Enterprise support form notifications.
 # RESEND_API_KEY=re_...
 # RESEND_FROM_EMAIL="Docs Cloud <docs@notifications.example.com>"
-# ENTERPRISE_SUPPORT_TO_EMAIL=kinfetare83@gmail.com
+# ENTERPRISE_SUPPORT_TO_EMAIL=support@example.com
 # Optional: protects the enterprise support email worker when called outside Vercel Cron.
 # CRON_SECRET=...
 

--- a/website/.env.example
+++ b/website/.env.example
@@ -15,6 +15,8 @@
 # RESEND_API_KEY=re_...
 # RESEND_FROM_EMAIL="Docs Cloud <docs@notifications.example.com>"
 # ENTERPRISE_SUPPORT_TO_EMAIL=kinfetare83@gmail.com
+# Optional: protects the enterprise support email worker when called outside Vercel Cron.
+# CRON_SECRET=...
 
 # Optional: switch docs search to Algolia for the website.
 # DOCS_SEARCH_PROVIDER=algolia

--- a/website/app/api/enterprise-support/email/process/route.ts
+++ b/website/app/api/enterprise-support/email/process/route.ts
@@ -14,8 +14,7 @@ const MAX_LIMIT = 25;
 
 function getWorkerSecret() {
   return (
-    process.env.ENTERPRISE_SUPPORT_EMAIL_WORKER_SECRET?.trim() ||
-    process.env.CRON_SECRET?.trim()
+    process.env.ENTERPRISE_SUPPORT_EMAIL_WORKER_SECRET?.trim() || process.env.CRON_SECRET?.trim()
   );
 }
 
@@ -23,7 +22,7 @@ function isAuthorized(request: Request) {
   const secret = getWorkerSecret();
 
   if (!secret) {
-    return true;
+    return false;
   }
 
   return request.headers.get("authorization") === `Bearer ${secret}`;
@@ -154,7 +153,12 @@ async function processQueuedEmails(request: Request) {
       continue;
     }
 
-    const result = await sendEnterpriseSupportEmail(payload, notification.recipient);
+    const result = await sendEnterpriseSupportEmail(payload, notification.recipient).catch(
+      (error: unknown) => ({
+        sent: false,
+        error: error instanceof Error ? error.message : "Unknown email transport error",
+      }),
+    );
 
     if (result.sent) {
       sent += 1;

--- a/website/app/api/enterprise-support/email/process/route.ts
+++ b/website/app/api/enterprise-support/email/process/route.ts
@@ -1,0 +1,198 @@
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+import {
+  sendEnterpriseSupportEmail,
+  type EnterpriseSupportEmailPayload,
+} from "@/lib/enterprise-support-email";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 25;
+
+function getWorkerSecret() {
+  return (
+    process.env.ENTERPRISE_SUPPORT_EMAIL_WORKER_SECRET?.trim() ||
+    process.env.CRON_SECRET?.trim()
+  );
+}
+
+function isAuthorized(request: Request) {
+  const secret = getWorkerSecret();
+
+  if (!secret) {
+    return true;
+  }
+
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+function readLimit(request: Request) {
+  const url = new URL(request.url);
+  const parsed = Number(url.searchParams.get("limit"));
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.floor(parsed), MAX_LIMIT);
+}
+
+function nextAttemptDate(attempts: number) {
+  const minutes = Math.min(60, 2 ** Math.max(attempts - 1, 0) * 5);
+
+  return new Date(Date.now() + minutes * 60_000);
+}
+
+function truncateError(value?: string) {
+  return value ? value.slice(0, 1000) : "Unknown delivery error";
+}
+
+function optionalString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readPayload(value: Prisma.JsonValue): EnterpriseSupportEmailPayload | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const data = value as Record<string, unknown>;
+  const supportNeeds = Array.isArray(data.supportNeeds)
+    ? data.supportNeeds.filter((item): item is string => typeof item === "string")
+    : [];
+
+  if (
+    typeof data.email !== "string" ||
+    typeof data.company !== "string" ||
+    typeof data.submittedAt !== "string" ||
+    typeof data.origin !== "string" ||
+    typeof data.userAgent !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    email: data.email,
+    company: data.company,
+    name: optionalString(data.name),
+    role: optionalString(data.role),
+    teamSize: optionalString(data.teamSize),
+    websiteUrl: optionalString(data.websiteUrl),
+    supportNeeds,
+    message: optionalString(data.message),
+    submittedAt: data.submittedAt,
+    origin: data.origin,
+    userAgent: data.userAgent,
+  };
+}
+
+async function processQueuedEmails(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json(
+      { error: "Enterprise support database is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const limit = readLimit(request);
+  const now = new Date();
+  const candidates = await prisma.enterpriseSupportEmailNotification.findMany({
+    where: {
+      nextAttemptAt: { lte: now },
+      status: { in: ["PENDING", "FAILED"] },
+    },
+    orderBy: [{ nextAttemptAt: "asc" }, { createdAt: "asc" }],
+    take: limit * 3,
+  });
+  const notifications = candidates
+    .filter((notification) => notification.attempts < notification.maxAttempts)
+    .slice(0, limit);
+  let sent = 0;
+  let failed = 0;
+  let skipped = candidates.length - notifications.length;
+
+  for (const notification of notifications) {
+    const attempts = notification.attempts + 1;
+    const reservedUntil = nextAttemptDate(attempts);
+    const claim = await prisma.enterpriseSupportEmailNotification.updateMany({
+      where: {
+        id: notification.id,
+        attempts: notification.attempts,
+        nextAttemptAt: { lte: now },
+        status: { in: ["PENDING", "FAILED"] },
+      },
+      data: {
+        attempts,
+        nextAttemptAt: reservedUntil,
+      },
+    });
+
+    if (claim.count === 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const payload = readPayload(notification.payload);
+
+    if (!payload) {
+      skipped += 1;
+      await prisma.enterpriseSupportEmailNotification.update({
+        where: { id: notification.id },
+        data: {
+          status: "EXHAUSTED",
+          lastError: "Notification payload is invalid.",
+          nextAttemptAt: reservedUntil,
+        },
+      });
+      continue;
+    }
+
+    const result = await sendEnterpriseSupportEmail(payload, notification.recipient);
+
+    if (result.sent) {
+      sent += 1;
+      await prisma.enterpriseSupportEmailNotification.update({
+        where: { id: notification.id },
+        data: {
+          status: "SENT",
+          sentAt: new Date(),
+          lastError: null,
+        },
+      });
+      continue;
+    }
+
+    failed += 1;
+    await prisma.enterpriseSupportEmailNotification.update({
+      where: { id: notification.id },
+      data: {
+        status: attempts >= notification.maxAttempts ? "EXHAUSTED" : "FAILED",
+        lastError: truncateError(result.error),
+        nextAttemptAt: reservedUntil,
+      },
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    processed: notifications.length,
+    sent,
+    failed,
+    skipped,
+  });
+}
+
+export async function GET(request: Request) {
+  return processQueuedEmails(request);
+}
+
+export async function POST(request: Request) {
+  return processQueuedEmails(request);
+}

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -101,7 +101,14 @@ export async function POST(request: Request) {
 
     if (websiteUrl) {
       try {
-        new URL(websiteUrl);
+        const parsedWebsiteUrl = new URL(websiteUrl);
+
+        if (!["http:", "https:"].includes(parsedWebsiteUrl.protocol)) {
+          return NextResponse.json(
+            { error: "Website URL must start with http:// or https://" },
+            { status: 400 },
+          );
+        }
       } catch {
         return NextResponse.json({ error: "Website URL must be a valid URL" }, { status: 400 });
       }
@@ -120,14 +127,8 @@ export async function POST(request: Request) {
 
     if (!process.env.DATABASE_URL) {
       return NextResponse.json(
-        {
-          ok: true,
-          stored: false,
-          queuedEmail: false,
-          warning:
-            "Support request validated, but the enterprise support database is not configured yet.",
-        },
-        { status: 202 },
+        { error: "Enterprise support database is not configured" },
+        { status: 503 },
       );
     }
 
@@ -188,14 +189,8 @@ export async function POST(request: Request) {
         );
 
         return NextResponse.json(
-          {
-            ok: true,
-            stored: false,
-            queuedEmail: false,
-            warning:
-              "Enterprise support request received, but the dedicated support schema is not synced yet.",
-          },
-          { status: 202 },
+          { error: "Enterprise support database schema is not synced yet" },
+          { status: 503 },
         );
       }
 
@@ -203,13 +198,8 @@ export async function POST(request: Request) {
         console.warn("[enterprise support POST] Support database is currently unreachable.");
 
         return NextResponse.json(
-          {
-            ok: true,
-            stored: false,
-            queuedEmail: false,
-            warning: "Enterprise support database is currently unreachable.",
-          },
-          { status: 202 },
+          { error: "Enterprise support database is currently unreachable" },
+          { status: 503 },
         );
       }
 

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -1,13 +1,14 @@
 import { Prisma } from "@prisma/client";
 import { NextResponse } from "next/server";
+import {
+  buildEnterpriseSupportEmail,
+  createEnterpriseSupportEmailPayload,
+  getEnterpriseSupportRecipient,
+} from "@/lib/enterprise-support-email";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
-
-const ENTERPRISE_SUPPORT_TO_EMAIL =
-  process.env.ENTERPRISE_SUPPORT_TO_EMAIL?.trim() || "kinfetare83@gmail.com";
-const RESEND_ENDPOINT = "https://api.resend.com/emails";
 
 type EnterpriseSupportBody = {
   email?: string;
@@ -60,158 +61,6 @@ function readStringList(
 
 function isValidEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
-function escapeHtml(value: string) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function formatValue(value?: string) {
-  return value ? escapeHtml(value) : '<span style="color:#7a7a7a">Not provided</span>';
-}
-
-function formatTextValue(value?: string) {
-  return value || "Not provided";
-}
-
-function formatLabel(value: string) {
-  return value
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function detailsRows(data: EnterpriseSupportRequest) {
-  const rows: Array<[string, string]> = [
-    ["Name", formatValue(data.name)],
-    ["Company", escapeHtml(data.company)],
-    [
-      "Email",
-      `<a href="mailto:${escapeHtml(data.email)}" style="color:#000;text-decoration:underline">${escapeHtml(data.email)}</a>`,
-    ],
-    ["Role", formatValue(data.role)],
-    ["Team size", formatValue(data.teamSize)],
-    [
-      "Website",
-      data.websiteUrl
-        ? `<a href="${escapeHtml(data.websiteUrl)}" style="color:#000;text-decoration:underline">${escapeHtml(data.websiteUrl)}</a>`
-        : '<span style="color:#7a7a7a">Not provided</span>',
-    ],
-    [
-      "Support needs",
-      data.supportNeeds.length > 0
-        ? escapeHtml(data.supportNeeds.map(formatLabel).join(", "))
-        : '<span style="color:#7a7a7a">Not provided</span>',
-    ],
-  ];
-
-  return rows
-    .map(
-      ([label, value]) => `
-        <tr>
-          <td style="width:150px;padding:10px 0;border-bottom:1px solid #ededed;color:#737373;font:12px Geist,Arial,sans-serif">${label}</td>
-          <td style="padding:10px 0;border-bottom:1px solid #ededed;color:#111;font:14px Geist,Arial,sans-serif">${value}</td>
-        </tr>
-      `,
-    )
-    .join("");
-}
-
-function buildEnterpriseSupportEmail(data: EnterpriseSupportRequest, request: Request) {
-  const submittedAt = new Date().toISOString();
-  const origin = request.headers.get("origin") ?? "https://docs.farming-labs.dev";
-  const userAgent = request.headers.get("user-agent") ?? "Unknown";
-  const subject = `Enterprise support request: ${data.company}`;
-  const messageHtml = data.message
-    ? escapeHtml(data.message).replace(/\n/g, "<br />")
-    : '<span style="color:#7a7a7a">No message provided.</span>';
-  const text = [
-    `Enterprise support request: ${data.company}`,
-    "",
-    `Name: ${formatTextValue(data.name)}`,
-    `Company: ${data.company}`,
-    `Email: ${data.email}`,
-    `Role: ${formatTextValue(data.role)}`,
-    `Team size: ${formatTextValue(data.teamSize)}`,
-    `Website: ${formatTextValue(data.websiteUrl)}`,
-    `Support needs: ${data.supportNeeds.map(formatLabel).join(", ") || "Not provided"}`,
-    "",
-    "Message:",
-    formatTextValue(data.message),
-    "",
-    `Submitted at: ${submittedAt}`,
-    `Origin: ${origin}`,
-    `User agent: ${userAgent}`,
-  ].join("\n");
-
-  const html = `
-    <div style="margin:0;background:#f7f7f7;padding:32px 18px;font-family:Geist,Arial,sans-serif;color:#111">
-      <div style="max-width:640px;margin:0 auto;background:#fff;border:1px solid #e5e5e5">
-        <div style="border-bottom:1px solid #e5e5e5;padding:22px 24px">
-          <p style="margin:0 0 8px;color:#737373;font:11px Geist Mono,ui-monospace,monospace;text-transform:uppercase;letter-spacing:.16em">Enterprise support</p>
-          <h1 style="margin:0;color:#111;font:600 22px Geist,Arial,sans-serif;letter-spacing:-.01em">New request from ${escapeHtml(data.company)}</h1>
-        </div>
-        <div style="padding:8px 24px 4px">
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
-            ${detailsRows(data)}
-          </table>
-        </div>
-        <div style="padding:20px 24px">
-          <p style="margin:0 0 8px;color:#737373;font:11px Geist Mono,ui-monospace,monospace;text-transform:uppercase;letter-spacing:.16em">Message</p>
-          <div style="border:1px solid #ededed;background:#fafafa;padding:14px 16px;color:#222;font:14px/1.7 Geist,Arial,sans-serif">${messageHtml}</div>
-        </div>
-        <div style="border-top:1px solid #e5e5e5;padding:16px 24px;color:#737373;font:12px/1.6 Geist,Arial,sans-serif">
-          Submitted ${escapeHtml(submittedAt)} from ${escapeHtml(origin)}<br />
-          ${escapeHtml(userAgent)}
-        </div>
-      </div>
-    </div>
-  `;
-
-  return { subject, html, text };
-}
-
-async function sendEnterpriseSupportEmail(data: EnterpriseSupportRequest, request: Request) {
-  const apiKey = process.env.RESEND_API_KEY?.trim();
-  const from = process.env.RESEND_FROM_EMAIL?.trim();
-
-  if (!apiKey || !from) {
-    console.warn("[enterprise support POST] Resend is not configured.");
-    return { sent: false };
-  }
-
-  const email = buildEnterpriseSupportEmail(data, request);
-  const response = await fetch(RESEND_ENDPOINT, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${apiKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      from,
-      to: ENTERPRISE_SUPPORT_TO_EMAIL,
-      reply_to: data.email,
-      subject: email.subject,
-      html: email.html,
-      text: email.text,
-    }),
-  });
-
-  if (!response.ok) {
-    const details = await response.text().catch(() => "");
-    console.warn("[enterprise support POST] Resend delivery failed.", {
-      status: response.status,
-      details: details.slice(0, 500),
-    });
-    return { sent: false };
-  }
-
-  return { sent: true };
 }
 
 export async function POST(request: Request) {
@@ -268,14 +117,13 @@ export async function POST(request: Request) {
       supportNeeds,
       message,
     };
-    const emailResult = await sendEnterpriseSupportEmail(supportRequest, request);
 
     if (!process.env.DATABASE_URL) {
       return NextResponse.json(
         {
           ok: true,
           stored: false,
-          emailed: emailResult.sent,
+          queuedEmail: false,
           warning:
             "Support request validated, but the enterprise support database is not configured yet.",
         },
@@ -296,9 +144,27 @@ export async function POST(request: Request) {
           message,
         },
       });
+      let queuedEmail = false;
+
+      try {
+        const payload = createEnterpriseSupportEmailPayload(supportRequest, request);
+        const email = buildEnterpriseSupportEmail(payload);
+
+        await prisma.enterpriseSupportEmailNotification.create({
+          data: {
+            requestId: entry.id,
+            recipient: getEnterpriseSupportRecipient(),
+            subject: email.subject,
+            payload: payload as unknown as Prisma.InputJsonValue,
+          },
+        });
+        queuedEmail = true;
+      } catch (queueError) {
+        console.warn("[enterprise support POST] Saved request but could not queue email.", queueError);
+      }
 
       return NextResponse.json(
-        { ok: true, stored: true, emailed: emailResult.sent, id: entry.id },
+        { ok: true, stored: true, queuedEmail, id: entry.id },
         { status: 201 },
       );
     } catch (error) {
@@ -315,7 +181,7 @@ export async function POST(request: Request) {
           {
             ok: true,
             stored: false,
-            emailed: emailResult.sent,
+            queuedEmail: false,
             warning:
               "Enterprise support request received, but the dedicated support schema is not synced yet.",
           },
@@ -330,7 +196,7 @@ export async function POST(request: Request) {
           {
             ok: true,
             stored: false,
-            emailed: emailResult.sent,
+            queuedEmail: false,
             warning: "Enterprise support database is currently unreachable.",
           },
           { status: 202 },

--- a/website/app/api/enterprise-support/route.ts
+++ b/website/app/api/enterprise-support/route.ts
@@ -149,18 +149,28 @@ export async function POST(request: Request) {
       try {
         const payload = createEnterpriseSupportEmailPayload(supportRequest, request);
         const email = buildEnterpriseSupportEmail(payload);
+        const recipient = getEnterpriseSupportRecipient();
 
-        await prisma.enterpriseSupportEmailNotification.create({
-          data: {
-            requestId: entry.id,
-            recipient: getEnterpriseSupportRecipient(),
-            subject: email.subject,
-            payload: payload as unknown as Prisma.InputJsonValue,
-          },
-        });
-        queuedEmail = true;
+        if (!recipient) {
+          console.warn(
+            "[enterprise support POST] Saved request but ENTERPRISE_SUPPORT_TO_EMAIL is not configured.",
+          );
+        } else {
+          await prisma.enterpriseSupportEmailNotification.create({
+            data: {
+              requestId: entry.id,
+              recipient,
+              subject: email.subject,
+              payload: payload as unknown as Prisma.InputJsonValue,
+            },
+          });
+          queuedEmail = true;
+        }
       } catch (queueError) {
-        console.warn("[enterprise support POST] Saved request but could not queue email.", queueError);
+        console.warn(
+          "[enterprise support POST] Saved request but could not queue email.",
+          queueError,
+        );
       }
 
       return NextResponse.json(

--- a/website/lib/enterprise-support-email.ts
+++ b/website/lib/enterprise-support-email.ts
@@ -1,5 +1,3 @@
-const ENTERPRISE_SUPPORT_TO_EMAIL =
-  process.env.ENTERPRISE_SUPPORT_TO_EMAIL?.trim() || "kinfetare83@gmail.com";
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 
 export type EnterpriseSupportEmailInput = {
@@ -20,7 +18,7 @@ export type EnterpriseSupportEmailPayload = EnterpriseSupportEmailInput & {
 };
 
 export function getEnterpriseSupportRecipient() {
-  return ENTERPRISE_SUPPORT_TO_EMAIL;
+  return process.env.ENTERPRISE_SUPPORT_TO_EMAIL?.trim();
 }
 
 export function createEnterpriseSupportEmailPayload(
@@ -148,12 +146,12 @@ export function buildEnterpriseSupportEmail(data: EnterpriseSupportEmailPayload)
 
 export async function sendEnterpriseSupportEmail(
   data: EnterpriseSupportEmailPayload,
-  recipient = ENTERPRISE_SUPPORT_TO_EMAIL,
+  recipient: string,
 ) {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   const from = process.env.RESEND_FROM_EMAIL?.trim();
 
-  if (!apiKey || !from) {
+  if (!apiKey || !from || !recipient) {
     return { sent: false, error: "Resend is not configured." };
   }
 

--- a/website/lib/enterprise-support-email.ts
+++ b/website/lib/enterprise-support-email.ts
@@ -1,0 +1,187 @@
+const ENTERPRISE_SUPPORT_TO_EMAIL =
+  process.env.ENTERPRISE_SUPPORT_TO_EMAIL?.trim() || "kinfetare83@gmail.com";
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export type EnterpriseSupportEmailInput = {
+  email: string;
+  name?: string;
+  company: string;
+  role?: string;
+  teamSize?: string;
+  websiteUrl?: string;
+  supportNeeds: string[];
+  message?: string;
+};
+
+export type EnterpriseSupportEmailPayload = EnterpriseSupportEmailInput & {
+  submittedAt: string;
+  origin: string;
+  userAgent: string;
+};
+
+export function getEnterpriseSupportRecipient() {
+  return ENTERPRISE_SUPPORT_TO_EMAIL;
+}
+
+export function createEnterpriseSupportEmailPayload(
+  data: EnterpriseSupportEmailInput,
+  request: Request,
+): EnterpriseSupportEmailPayload {
+  return {
+    ...data,
+    submittedAt: new Date().toISOString(),
+    origin: request.headers.get("origin") ?? "https://docs.farming-labs.dev",
+    userAgent: request.headers.get("user-agent") ?? "Unknown",
+  };
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatValue(value?: string) {
+  return value ? escapeHtml(value) : '<span style="color:#7a7a7a">Not provided</span>';
+}
+
+function formatTextValue(value?: string) {
+  return value || "Not provided";
+}
+
+function formatLabel(value: string) {
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function detailsRows(data: EnterpriseSupportEmailPayload) {
+  const rows: Array<[string, string]> = [
+    ["Name", formatValue(data.name)],
+    ["Company", escapeHtml(data.company)],
+    [
+      "Email",
+      `<a href="mailto:${escapeHtml(data.email)}" style="color:#000;text-decoration:underline">${escapeHtml(data.email)}</a>`,
+    ],
+    ["Role", formatValue(data.role)],
+    ["Team size", formatValue(data.teamSize)],
+    [
+      "Website",
+      data.websiteUrl
+        ? `<a href="${escapeHtml(data.websiteUrl)}" style="color:#000;text-decoration:underline">${escapeHtml(data.websiteUrl)}</a>`
+        : '<span style="color:#7a7a7a">Not provided</span>',
+    ],
+    [
+      "Support needs",
+      data.supportNeeds.length > 0
+        ? escapeHtml(data.supportNeeds.map(formatLabel).join(", "))
+        : '<span style="color:#7a7a7a">Not provided</span>',
+    ],
+  ];
+
+  return rows
+    .map(
+      ([label, value]) => `
+        <tr>
+          <td style="width:150px;padding:10px 0;border-bottom:1px solid #ededed;color:#737373;font:12px Geist,Arial,sans-serif">${label}</td>
+          <td style="padding:10px 0;border-bottom:1px solid #ededed;color:#111;font:14px Geist,Arial,sans-serif">${value}</td>
+        </tr>
+      `,
+    )
+    .join("");
+}
+
+export function buildEnterpriseSupportEmail(data: EnterpriseSupportEmailPayload) {
+  const subject = `Enterprise support request: ${data.company}`;
+  const messageHtml = data.message
+    ? escapeHtml(data.message).replace(/\n/g, "<br />")
+    : '<span style="color:#7a7a7a">No message provided.</span>';
+  const text = [
+    `Enterprise support request: ${data.company}`,
+    "",
+    `Name: ${formatTextValue(data.name)}`,
+    `Company: ${data.company}`,
+    `Email: ${data.email}`,
+    `Role: ${formatTextValue(data.role)}`,
+    `Team size: ${formatTextValue(data.teamSize)}`,
+    `Website: ${formatTextValue(data.websiteUrl)}`,
+    `Support needs: ${data.supportNeeds.map(formatLabel).join(", ") || "Not provided"}`,
+    "",
+    "Message:",
+    formatTextValue(data.message),
+    "",
+    `Submitted at: ${data.submittedAt}`,
+    `Origin: ${data.origin}`,
+    `User agent: ${data.userAgent}`,
+  ].join("\n");
+
+  const html = `
+    <div style="margin:0;background:#f7f7f7;padding:32px 18px;font-family:Geist,Arial,sans-serif;color:#111">
+      <div style="max-width:640px;margin:0 auto;background:#fff;border:1px solid #e5e5e5">
+        <div style="border-bottom:1px solid #e5e5e5;padding:22px 24px">
+          <p style="margin:0 0 8px;color:#737373;font:11px Geist Mono,ui-monospace,monospace;text-transform:uppercase;letter-spacing:.16em">Enterprise support</p>
+          <h1 style="margin:0;color:#111;font:600 22px Geist,Arial,sans-serif;letter-spacing:-.01em">New request from ${escapeHtml(data.company)}</h1>
+        </div>
+        <div style="padding:8px 24px 4px">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
+            ${detailsRows(data)}
+          </table>
+        </div>
+        <div style="padding:20px 24px">
+          <p style="margin:0 0 8px;color:#737373;font:11px Geist Mono,ui-monospace,monospace;text-transform:uppercase;letter-spacing:.16em">Message</p>
+          <div style="border:1px solid #ededed;background:#fafafa;padding:14px 16px;color:#222;font:14px/1.7 Geist,Arial,sans-serif">${messageHtml}</div>
+        </div>
+        <div style="border-top:1px solid #e5e5e5;padding:16px 24px;color:#737373;font:12px/1.6 Geist,Arial,sans-serif">
+          Submitted ${escapeHtml(data.submittedAt)} from ${escapeHtml(data.origin)}<br />
+          ${escapeHtml(data.userAgent)}
+        </div>
+      </div>
+    </div>
+  `;
+
+  return { subject, html, text };
+}
+
+export async function sendEnterpriseSupportEmail(
+  data: EnterpriseSupportEmailPayload,
+  recipient = ENTERPRISE_SUPPORT_TO_EMAIL,
+) {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.RESEND_FROM_EMAIL?.trim();
+
+  if (!apiKey || !from) {
+    return { sent: false, error: "Resend is not configured." };
+  }
+
+  const email = buildEnterpriseSupportEmail(data);
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: recipient,
+      reply_to: data.email,
+      subject: email.subject,
+      html: email.html,
+      text: email.text,
+    }),
+  });
+
+  if (!response.ok) {
+    const details = await response.text().catch(() => "");
+
+    return {
+      sent: false,
+      error: `Resend delivery failed with ${response.status}: ${details.slice(0, 500)}`,
+    };
+  }
+
+  return { sent: true };
+}

--- a/website/lib/enterprise-support-email.ts
+++ b/website/lib/enterprise-support-email.ts
@@ -50,6 +50,20 @@ function formatTextValue(value?: string) {
   return value || "Not provided";
 }
 
+function safeHttpUrl(value?: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value);
+
+    return ["http:", "https:"].includes(url.protocol) ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function formatLabel(value: string) {
   return value
     .split("-")
@@ -58,6 +72,7 @@ function formatLabel(value: string) {
 }
 
 function detailsRows(data: EnterpriseSupportEmailPayload) {
+  const websiteUrl = safeHttpUrl(data.websiteUrl);
   const rows: Array<[string, string]> = [
     ["Name", formatValue(data.name)],
     ["Company", escapeHtml(data.company)],
@@ -69,8 +84,8 @@ function detailsRows(data: EnterpriseSupportEmailPayload) {
     ["Team size", formatValue(data.teamSize)],
     [
       "Website",
-      data.websiteUrl
-        ? `<a href="${escapeHtml(data.websiteUrl)}" style="color:#000;text-decoration:underline">${escapeHtml(data.websiteUrl)}</a>`
+      websiteUrl
+        ? `<a href="${escapeHtml(websiteUrl)}" style="color:#000;text-decoration:underline">${escapeHtml(websiteUrl)}</a>`
         : '<span style="color:#7a7a7a">Not provided</span>',
     ],
     [
@@ -156,21 +171,30 @@ export async function sendEnterpriseSupportEmail(
   }
 
   const email = buildEnterpriseSupportEmail(data);
-  const response = await fetch(RESEND_ENDPOINT, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${apiKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      from,
-      to: recipient,
-      reply_to: data.email,
-      subject: email.subject,
-      html: email.html,
-      text: email.text,
-    }),
-  });
+  let response: Response;
+
+  try {
+    response = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: recipient,
+        reply_to: data.email,
+        subject: email.subject,
+        html: email.html,
+        text: email.text,
+      }),
+    });
+  } catch (error) {
+    return {
+      sent: false,
+      error: error instanceof Error ? error.message : "Unknown email transport error",
+    };
+  }
 
   if (!response.ok) {
     const details = await response.text().catch(() => "");

--- a/website/prisma/schema.prisma
+++ b/website/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 enum ApprovalStatus {
-  IDLE    
+  IDLE
   APPROVED
   REJECTED
 }
@@ -67,24 +67,52 @@ enum EnterpriseSupportStatus {
   CLOSED
 }
 
+enum EnterpriseSupportEmailStatus {
+  PENDING
+  SENT
+  FAILED
+  EXHAUSTED
+}
+
 model EnterpriseSupportRequest {
-  id           String                  @id @default(cuid())
-  email        String
-  name         String?
-  company      String
-  role         String?
-  teamSize     String?
-  websiteUrl   String?
-  supportNeeds String[]                @default([])
-  message      String?
-  status       EnterpriseSupportStatus @default(NEW)
-  createdAt    DateTime                @default(now())
-  updatedAt    DateTime                @updatedAt
+  id                 String                               @id @default(cuid())
+  email              String
+  name               String?
+  company            String
+  role               String?
+  teamSize           String?
+  websiteUrl         String?
+  supportNeeds       String[]                             @default([])
+  message            String?
+  status             EnterpriseSupportStatus              @default(NEW)
+  emailNotifications EnterpriseSupportEmailNotification[]
+  createdAt          DateTime                             @default(now())
+  updatedAt          DateTime                             @updatedAt
 
   @@index([createdAt])
   @@index([email])
   @@index([company])
   @@index([status])
+}
+
+model EnterpriseSupportEmailNotification {
+  id            String                       @id @default(cuid())
+  requestId     String
+  request       EnterpriseSupportRequest     @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  status        EnterpriseSupportEmailStatus @default(PENDING)
+  recipient     String
+  subject       String
+  payload       Json
+  attempts      Int                          @default(0)
+  maxAttempts   Int                          @default(5)
+  nextAttemptAt DateTime                     @default(now())
+  sentAt        DateTime?
+  lastError     String?
+  createdAt     DateTime                     @default(now())
+  updatedAt     DateTime                     @updatedAt
+
+  @@index([status, nextAttemptAt])
+  @@index([requestId])
 }
 
 model AgentScoreEntry {

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/enterprise-support/email/process",
+      "schedule": "*/10 * * * *"
+    }
+  ]
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/enterprise-support/email/process",
-      "schedule": "*/10 * * * *"
+      "schedule": "0 12 * * *"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves enterprise support email sending to a small background queue processed by Vercel Cron to cut request latency and add retries with backoff for reliability.

- **New Features**
  - Queue emails via new Prisma model EnterpriseSupportEmailNotification with status, attempts, maxAttempts, nextAttemptAt, sentAt, and lastError.
  - POST /api/enterprise-support stores the request and enqueues an email; response now includes queuedEmail.
  - New worker endpoint /api/enterprise-support/email/process with Bearer auth via `CRON_SECRET` or `ENTERPRISE_SUPPORT_EMAIL_WORKER_SECRET`, optional limit, and exponential backoff (up to 5 attempts; EXHAUSTED on max). Supports GET and POST.
  - Extracted email compose/send to website/lib/enterprise-support-email.ts using Resend and a configurable recipient.
  - Added Vercel Cron in vercel.json to run daily at 12:00 UTC.
  - Validation: websiteUrl must start with http:// or https://.

- **Migration**
  - Run Prisma migrate to add the email notification table and indexes.
  - Set `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `ENTERPRISE_SUPPORT_TO_EMAIL`; set `CRON_SECRET` or `ENTERPRISE_SUPPORT_EMAIL_WORKER_SECRET`.
  - Note: POST /api/enterprise-support now returns queuedEmail (replaces emailed) and responds with 503 if the enterprise support database is missing, unreachable, or the schema isn’t synced.

<sup>Written for commit 3b7684627fff33e8e6d4b08b9868ad5838512af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/230?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

