### PR TITLE
fix: analytics harness

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -56,9 +56,11 @@ describe("analytics", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY;
     delete process.env.DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT;
     delete process.env.DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_ANALYTICS_KEY;
   });
@@ -311,7 +313,65 @@ describe("analytics", () => {
     });
   });
 
-  it("no-ops Docs Cloud analytics events when endpoint or project id is missing", async () => {
+  it("posts Docs Cloud analytics events to the public endpoint env when provided", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
+      "https://docs-cloud.example.com/api/analytics/events";
+
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsAnalyticsEvent(
+      createDocsCloudAnalytics({
+        projectId: "project_endpoint",
+        console: false,
+      }),
+      {
+        type: "page_view",
+        source: "client",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs-cloud.example.com/api/analytics/events",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("falls back to public env when explicit Docs Cloud options were stripped in the client", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
+      "https://docs-cloud.example.com/api/analytics/events";
+
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsAnalyticsEvent(
+      createDocsCloudAnalytics({
+        console: false,
+        projectId: undefined,
+      }),
+      {
+        type: "page_view",
+        source: "client",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs-cloud.example.com/api/analytics/events",
+      expect.objectContaining({
+        body: expect.stringContaining('"projectId":"project_public"'),
+      }),
+    );
+  });
+
+  it("no-ops Docs Cloud analytics events when project id is missing", async () => {
     const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
       async () => new Response(null, { status: 202 }),
     );

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -3,13 +3,15 @@ import type { DocsAnalyticsConfig, DocsAnalyticsEvent } from "./types.js";
 export interface DocsCloudAnalyticsOptions {
   enabled?: boolean;
   console?: DocsAnalyticsConfig["console"];
+  endpoint?: string;
   includeInputs?: boolean;
   projectId?: string;
   apiKey?: string;
 }
 
 const DOCS_CLOUD_ANALYTICS_OPTIONS = Symbol.for("@farming-labs/docs/cloud-analytics");
-const DOCS_CLOUD_ANALYTICS_ENDPOINT = "https://docs-app.farming-labs.dev/api/analytics/events";
+const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
+  "https://docs-app.farming-labs.dev/api/analytics/events";
 
 type DocsAnalyticsConfigWithCloud = DocsAnalyticsConfig & {
   [DOCS_CLOUD_ANALYTICS_OPTIONS]?: DocsCloudAnalyticsOptions;
@@ -38,6 +40,10 @@ function readRuntimeEnv(name: string): string | undefined {
       return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED);
     case "DOCS_CLOUD_ANALYTICS_ENABLED":
       return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);
+    case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT":
+      return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT);
+    case "DOCS_CLOUD_ANALYTICS_ENDPOINT":
+      return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT);
     default:
       return undefined;
   }
@@ -54,13 +60,6 @@ function isFalsyEnv(value: string | undefined): boolean {
 export function resolveDocsCloudAnalyticsOptions(
   analytics?: boolean | DocsAnalyticsConfig,
 ): DocsCloudAnalyticsOptions | null {
-  if (analytics && typeof analytics === "object") {
-    const explicit = (analytics as DocsAnalyticsConfigWithCloud)[DOCS_CLOUD_ANALYTICS_OPTIONS];
-    if (explicit) {
-      return explicit;
-    }
-  }
-
   const projectId =
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
   const apiKey =
@@ -69,12 +68,40 @@ export function resolveDocsCloudAnalyticsOptions(
   const enabled =
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED") ??
     readRuntimeEnv("DOCS_CLOUD_ANALYTICS_ENABLED");
+  const endpoint =
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT") ??
+    readRuntimeEnv("DOCS_CLOUD_ANALYTICS_ENDPOINT") ??
+    DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+
+  if (isFalsyEnv(enabled)) {
+    return null;
+  }
+
+  if (analytics && typeof analytics === "object") {
+    const explicit = (analytics as DocsAnalyticsConfigWithCloud)[DOCS_CLOUD_ANALYTICS_OPTIONS];
+
+    if (explicit) {
+      const resolvedProjectId = normalizeRuntimeEnvValue(explicit.projectId) ?? projectId;
+
+      if (!resolvedProjectId || explicit.enabled === false) {
+        return null;
+      }
+
+      return {
+        ...explicit,
+        apiKey: normalizeRuntimeEnvValue(explicit.apiKey) ?? apiKey,
+        endpoint: normalizeRuntimeEnvValue(explicit.endpoint) ?? endpoint,
+        projectId: resolvedProjectId,
+      };
+    }
+  }
 
   if (!projectId || isFalsyEnv(enabled)) {
     return null;
   }
 
   return {
+    endpoint,
     projectId,
     apiKey,
   };
@@ -88,7 +115,7 @@ export async function sendDocsCloudAnalyticsEvent(
     return;
   }
 
-  const endpoint = DOCS_CLOUD_ANALYTICS_ENDPOINT;
+  const endpoint = options.endpoint?.trim() || DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;
   const projectId = options.projectId?.trim();
   if (!endpoint || !projectId) {
     return;

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -15,17 +15,32 @@ type DocsAnalyticsConfigWithCloud = DocsAnalyticsConfig & {
   [DOCS_CLOUD_ANALYTICS_OPTIONS]?: DocsCloudAnalyticsOptions;
 };
 
+function normalizeRuntimeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
 function readRuntimeEnv(name: string): string | undefined {
-  if (
-    typeof process !== "undefined" &&
-    process.env &&
-    typeof process.env[name] === "string" &&
-    process.env[name]!.trim().length > 0
-  ) {
-    return process.env[name]!.trim();
+  if (typeof process === "undefined" || !process.env) {
+    return undefined;
   }
 
-  return undefined;
+  switch (name) {
+    case "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID":
+      return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID);
+    case "DOCS_CLOUD_PROJECT_ID":
+      return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_PROJECT_ID);
+    case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY":
+      return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY);
+    case "DOCS_CLOUD_ANALYTICS_KEY":
+      return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_KEY);
+    case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED":
+      return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED);
+    case "DOCS_CLOUD_ANALYTICS_ENABLED":
+      return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);
+    default:
+      return undefined;
+  }
 }
 
 function isFalsyEnv(value: string | undefined): boolean {

--- a/packages/fumadocs/src/client-analytics.test.ts
+++ b/packages/fumadocs/src/client-analytics.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DocsAnalyticsEvent, DocsAnalyticsEventType } from "@farming-labs/docs";
-import { emitClientAnalyticsEvent } from "./client-analytics.js";
+import { emitClientAnalyticsEvent, getDocsClientAnalyticsIdentity } from "./client-analytics.js";
 
 const CLIENT_ANALYTICS_EVENTS = [
   "page_view",
@@ -28,6 +28,8 @@ const CLIENT_ANALYTICS_EVENTS = [
 interface TestWindow extends Partial<Window> {
   __fdAnalytics__?: (event: DocsAnalyticsEvent) => void | Promise<void>;
   __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
+  __fdAnalyticsSessionId__?: string;
+  __fdAnalyticsVisitorId__?: string;
 }
 
 function installClientGlobals(onEvent?: (event: DocsAnalyticsEvent) => void) {
@@ -100,6 +102,57 @@ describe("client analytics", () => {
       type: "page_view",
       source: "client",
       path: "/docs/installation",
+    });
+  });
+
+  it("adds stable anonymous visitor and session ids to client events", () => {
+    const events: DocsAnalyticsEvent[] = [];
+    installClientGlobals((event) => events.push(event));
+
+    emitClientAnalyticsEvent({ type: "page_view" });
+    emitClientAnalyticsEvent({ type: "search_open" });
+
+    const firstProperties = events[0]?.properties;
+    const secondProperties = events[1]?.properties;
+
+    expect(firstProperties?.visitorId).toEqual(expect.stringMatching(/^visitor_/));
+    expect(firstProperties?.sessionId).toEqual(expect.stringMatching(/^session_/));
+    expect(firstProperties?.anonymousId).toBe(firstProperties?.visitorId);
+    expect(firstProperties?.visitor).toMatchObject({ id: firstProperties?.visitorId });
+    expect(firstProperties?.session).toMatchObject({ id: firstProperties?.sessionId });
+    expect(secondProperties?.visitorId).toBe(firstProperties?.visitorId);
+    expect(secondProperties?.sessionId).toBe(firstProperties?.sessionId);
+  });
+
+  it("keeps caller-provided visitor identity when supplied", () => {
+    const events: DocsAnalyticsEvent[] = [];
+    installClientGlobals((event) => events.push(event));
+
+    emitClientAnalyticsEvent({
+      type: "feedback_select",
+      properties: {
+        userId: "user_123",
+        visitorId: "visitor_custom",
+        sessionId: "session_custom",
+      },
+    });
+
+    expect(events[0]?.properties).toMatchObject({
+      userId: "user_123",
+      visitorId: "visitor_custom",
+      sessionId: "session_custom",
+    });
+  });
+
+  it("exposes the current browser analytics identity", () => {
+    installClientGlobals();
+
+    const identity = getDocsClientAnalyticsIdentity();
+
+    expect(identity).toMatchObject({
+      anonymousId: expect.stringMatching(/^visitor_/),
+      visitorId: expect.stringMatching(/^visitor_/),
+      sessionId: expect.stringMatching(/^session_/),
     });
   });
 

--- a/packages/fumadocs/src/client-analytics.test.ts
+++ b/packages/fumadocs/src/client-analytics.test.ts
@@ -139,8 +139,15 @@ describe("client analytics", () => {
 
     expect(events[0]?.properties).toMatchObject({
       userId: "user_123",
+      anonymousId: "visitor_custom",
       visitorId: "visitor_custom",
       sessionId: "session_custom",
+      visitor: {
+        id: "visitor_custom",
+      },
+      session: {
+        id: "session_custom",
+      },
     });
   });
 

--- a/packages/fumadocs/src/client-analytics.ts
+++ b/packages/fumadocs/src/client-analytics.ts
@@ -5,18 +5,116 @@ import type { DocsAnalyticsEvent, DocsAnalyticsEventInput } from "@farming-labs/
 interface DocsAnalyticsWindow extends Window {
   __fdAnalytics__?: (event: DocsAnalyticsEvent) => void | Promise<void>;
   __fdAnalyticsQueue__?: DocsAnalyticsEvent[];
+  __fdAnalyticsSessionId__?: string;
+  __fdAnalyticsVisitorId__?: string;
+}
+
+const VISITOR_ID_STORAGE_KEY = "fd:analytics:visitor-id";
+const SESSION_ID_STORAGE_KEY = "fd:analytics:session-id";
+
+function createAnalyticsId(prefix: "session" | "visitor") {
+  const random =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
+
+  return `${prefix}_${random}`;
+}
+
+function readStorage(storage: Storage | undefined, key: string) {
+  try {
+    const value = storage?.getItem(key)?.trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStorage(storage: Storage | undefined, key: string, value: string) {
+  try {
+    storage?.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down embeds.
+  }
+}
+
+function getBrowserStorage(target: DocsAnalyticsWindow, key: "localStorage" | "sessionStorage") {
+  try {
+    return target[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function getOrCreateClientId({
+  cachedValue,
+  create,
+  storage,
+  storageKey,
+}: {
+  cachedValue: string | undefined;
+  create: () => string;
+  storage: Storage | undefined;
+  storageKey: string;
+}) {
+  const stored = readStorage(storage, storageKey);
+  const value = stored ?? cachedValue ?? create();
+
+  if (!stored) {
+    writeStorage(storage, storageKey, value);
+  }
+
+  return value;
+}
+
+export function getDocsClientAnalyticsIdentity() {
+  if (typeof window === "undefined") return null;
+
+  const target = window as DocsAnalyticsWindow;
+  const visitorId = getOrCreateClientId({
+    cachedValue: target.__fdAnalyticsVisitorId__,
+    create: () => createAnalyticsId("visitor"),
+    storage: getBrowserStorage(target, "localStorage"),
+    storageKey: VISITOR_ID_STORAGE_KEY,
+  });
+  const sessionId = getOrCreateClientId({
+    cachedValue: target.__fdAnalyticsSessionId__,
+    create: () => createAnalyticsId("session"),
+    storage: getBrowserStorage(target, "sessionStorage"),
+    storageKey: SESSION_ID_STORAGE_KEY,
+  });
+
+  target.__fdAnalyticsVisitorId__ = visitorId;
+  target.__fdAnalyticsSessionId__ = sessionId;
+
+  return {
+    anonymousId: visitorId,
+    visitorId,
+    sessionId,
+    visitor: {
+      id: visitorId,
+    },
+    session: {
+      id: sessionId,
+    },
+  };
 }
 
 export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
   if (typeof window === "undefined") return;
 
+  const identity = getDocsClientAnalyticsIdentity();
   const normalized: DocsAnalyticsEvent = {
     ...event,
     source: "client",
-    path: window.location.pathname,
-    url: window.location.href,
-    referrer: document.referrer || undefined,
+    path: event.path ?? window.location.pathname,
+    url: event.url ?? window.location.href,
+    referrer: event.referrer ?? (document.referrer || undefined),
     timestamp: new Date().toISOString(),
+    properties: {
+      ...(identity ?? {}),
+      ...(event.properties ?? {}),
+    },
   };
 
   const target = window as DocsAnalyticsWindow;

--- a/packages/fumadocs/src/client-analytics.ts
+++ b/packages/fumadocs/src/client-analytics.ts
@@ -100,6 +100,57 @@ export function getDocsClientAnalyticsIdentity() {
   };
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeClientAnalyticsProperties(
+  identity: ReturnType<typeof getDocsClientAnalyticsIdentity>,
+  properties: DocsAnalyticsEventInput["properties"],
+) {
+  const provided = properties ?? {};
+  const visitorId =
+    asString(provided.visitorId) ??
+    asString(asRecord(provided.visitor).id) ??
+    asString(provided.anonymousId) ??
+    identity?.visitorId;
+  const sessionId =
+    asString(provided.sessionId) ?? asString(asRecord(provided.session).id) ?? identity?.sessionId;
+  const merged = {
+    ...(identity ?? {}),
+    ...provided,
+  };
+
+  return {
+    ...merged,
+    ...(visitorId
+      ? {
+          anonymousId: asString(provided.anonymousId) ?? visitorId,
+          visitorId,
+          visitor: {
+            ...asRecord(merged.visitor),
+            id: visitorId,
+          },
+        }
+      : {}),
+    ...(sessionId
+      ? {
+          sessionId,
+          session: {
+            ...asRecord(merged.session),
+            id: sessionId,
+          },
+        }
+      : {}),
+  };
+}
+
 export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
   if (typeof window === "undefined") return;
 
@@ -111,10 +162,7 @@ export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
     url: event.url ?? window.location.href,
     referrer: event.referrer ?? (document.referrer || undefined),
     timestamp: new Date().toISOString(),
-    properties: {
-      ...identity,
-      ...event.properties,
-    },
+    properties: normalizeClientAnalyticsProperties(identity, event.properties),
   };
 
   const target = window as DocsAnalyticsWindow;

--- a/packages/fumadocs/src/client-analytics.ts
+++ b/packages/fumadocs/src/client-analytics.ts
@@ -112,8 +112,8 @@ export function emitClientAnalyticsEvent(event: DocsAnalyticsEventInput) {
     referrer: event.referrer ?? (document.referrer || undefined),
     timestamp: new Date().toISOString(),
     properties: {
-      ...(identity ?? {}),
-      ...(event.properties ?? {}),
+      ...identity,
+      ...event.properties,
     },
   };
 

--- a/packages/fumadocs/src/docs-client-hooks.test.ts
+++ b/packages/fumadocs/src/docs-client-hooks.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isDocsClientAnalyticsEnabled } from "./docs-client-hooks.js";
+
+describe("DocsClientHooks analytics resolution", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    delete process.env.DOCS_CLOUD_PROJECT_ID;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.DOCS_CLOUD_ANALYTICS_ENABLED;
+  });
+
+  it("enables the client analytics hook from the Docs Cloud project id env", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+
+    expect(isDocsClientAnalyticsEnabled()).toBe(true);
+  });
+
+  it("keeps the client analytics hook disabled when Cloud analytics is opted out", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "false";
+
+    expect(isDocsClientAnalyticsEnabled()).toBe(false);
+  });
+
+  it("respects an explicit analytics false config even when a Cloud project id exists", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+
+    expect(isDocsClientAnalyticsEnabled({ enabled: false })).toBe(false);
+  });
+});

--- a/packages/fumadocs/src/docs-client-hooks.tsx
+++ b/packages/fumadocs/src/docs-client-hooks.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { emitDocsAnalyticsEvent } from "@farming-labs/docs";
+import { emitDocsAnalyticsEvent, resolveDocsAnalyticsConfig } from "@farming-labs/docs";
 import { emitClientAnalyticsEvent } from "./client-analytics.js";
 import type {
   CodeBlockCopyData,
@@ -48,10 +48,14 @@ function useWindowHook<K extends keyof DocsWindowHooks>(key: K, handler: DocsWin
   }, [handler, key]);
 }
 
+export function isDocsClientAnalyticsEnabled(analytics?: boolean | DocsAnalyticsConfig) {
+  return resolveDocsAnalyticsConfig(analytics).enabled;
+}
+
 function useAnalyticsHook(analytics?: boolean | DocsAnalyticsConfig) {
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (!analytics) return;
+    if (!isDocsClientAnalyticsEnabled(analytics)) return;
 
     const target = window as DocsWindowHooks;
     const handler = (event: DocsAnalyticsEvent) => {
@@ -79,7 +83,7 @@ function useAnalyticsHook(analytics?: boolean | DocsAnalyticsConfig) {
 function useCodeCopyAnalytics(analytics?: boolean | DocsAnalyticsConfig) {
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (!analytics) return;
+    if (!isDocsClientAnalyticsEnabled(analytics)) return;
 
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;

--- a/packages/fumadocs/tsdown.config.ts
+++ b/packages/fumadocs/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/mdx.ts",
     "src/search.ts",
     "src/docs-api.ts",
+    "src/docs-client-hooks.tsx",
     "src/ai-search-dialog.tsx",
     "src/code-block-copy-wrapper.tsx",
     "src/docs-ai-features.tsx",

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1166,6 +1166,15 @@ describe("withDocs (app dir: src/app vs app)", () => {
     });
   });
 
+  it("does not serialize Docs Cloud analytics env when analytics is not configured", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+
+    expect(nextConfig.env).toBeUndefined();
+  });
+
   it("does not override user-provided public Docs Cloud analytics env", () => {
     process.env.DOCS_CLOUD_PROJECT_ID = "project_server_only";
 

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1384,7 +1384,51 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     writeFileSync(join(workspaceRoot, "packages", "docs", "src", "index.ts"), "export {};\n");
     writeFileSync(join(workspaceRoot, "packages", "fumadocs", "src", "index.ts"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "fumadocs", "src", "search.ts"), "export {};\n");
     writeFileSync(join(workspaceRoot, "packages", "next", "src", "config.ts"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "next", "src", "api.ts"), "export {};\n");
+    writeFileSync(join(appRoot, "docs.config.ts"), DOCS_CONFIG, "utf-8");
+    process.chdir(appRoot);
+
+    const nextConfig = withDocs({});
+    const turbopack = nextConfig.turbopack as
+      | { root?: string; resolveAlias?: Record<string, string> }
+      | undefined;
+
+    expect(turbopack?.root).toBe(realpathSync(workspaceRoot));
+    expect(turbopack?.resolveAlias?.["@farming-labs/docs"]).toBe(
+      "../../packages/docs/src/index.ts",
+    );
+    expect(turbopack?.resolveAlias?.["@farming-labs/next/api"]).toBe(
+      "../../packages/next/src/api.ts",
+    );
+    expect(turbopack?.resolveAlias?.["@farming-labs/theme/search"]).toBe(
+      "../../packages/fumadocs/src/search.ts",
+    );
+  });
+
+  it("prefers built workspace turbopack aliases when dist entrypoints exist", () => {
+    const workspaceRoot = join(tmpDir, "repo");
+    const appRoot = join(workspaceRoot, "examples", "next");
+
+    mkdirSync(join(workspaceRoot, "packages", "docs", "src"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "packages", "docs", "dist"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "packages", "fumadocs", "src"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "packages", "fumadocs", "dist"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "packages", "next", "src"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "packages", "next", "dist"), { recursive: true });
+    mkdirSync(join(appRoot, "app"), { recursive: true });
+
+    writeFileSync(join(workspaceRoot, "packages", "docs", "src", "index.ts"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "docs", "dist", "index.mjs"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "fumadocs", "src", "index.ts"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "fumadocs", "src", "search.ts"), "export {};\n");
+    writeFileSync(
+      join(workspaceRoot, "packages", "fumadocs", "dist", "search.mjs"),
+      "export {};\n",
+    );
+    writeFileSync(join(workspaceRoot, "packages", "next", "src", "config.ts"), "export {};\n");
+    writeFileSync(join(workspaceRoot, "packages", "next", "dist", "api.mjs"), "export {};\n");
     writeFileSync(join(appRoot, "docs.config.ts"), DOCS_CONFIG, "utf-8");
     process.chdir(appRoot);
 

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -224,6 +224,13 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    delete process.env.DOCS_CLOUD_PROJECT_ID;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+    delete process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.DOCS_CLOUD_ANALYTICS_ENABLED;
+
     try {
       rmSync(tmpDir, { recursive: true, force: true });
     } catch {
@@ -1140,6 +1147,43 @@ describe("withDocs (app dir: src/app vs app)", () => {
     expect(existsSync(join(tmpDir, "app/docs/docs-theme.css"))).toBe(false);
   });
 
+  it("serializes public Docs Cloud analytics env into the client bundle", () => {
+    process.env.DOCS_CLOUD_PROJECT_ID = "project_server_only";
+    process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT =
+      "https://docs-cloud.example.com/api/analytics/events";
+    process.env.DOCS_CLOUD_ANALYTICS_ENABLED = "false";
+
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({});
+
+    expect(nextConfig.env).toMatchObject({
+      NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_server_only",
+      NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT:
+        "https://docs-cloud.example.com/api/analytics/events",
+      NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED: "false",
+    });
+  });
+
+  it("does not override user-provided public Docs Cloud analytics env", () => {
+    process.env.DOCS_CLOUD_PROJECT_ID = "project_server_only";
+
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    const nextConfig = withDocs({
+      env: {
+        NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_user",
+      },
+    });
+
+    expect(nextConfig.env?.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID).toBe("project_user");
+    expect(nextConfig.env?.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT).toBe(
+      "https://docs-app.farming-labs.dev/api/analytics/events",
+    );
+  });
+
   it("generates a docs API route that forwards search and ai config", () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
@@ -1350,10 +1394,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
       | undefined;
 
     expect(turbopack?.root).toBe(realpathSync(workspaceRoot));
-    expect(turbopack?.resolveAlias?.["@farming-labs/docs"]).toBe("./packages/docs/src/index.ts");
-    expect(turbopack?.resolveAlias?.["@farming-labs/next/api"]).toBe("./packages/next/src/api.ts");
+    expect(turbopack?.resolveAlias?.["@farming-labs/docs"]).toBe(
+      "../../packages/docs/dist/index.mjs",
+    );
+    expect(turbopack?.resolveAlias?.["@farming-labs/next/api"]).toBe(
+      "../../packages/next/dist/api.mjs",
+    );
     expect(turbopack?.resolveAlias?.["@farming-labs/theme/search"]).toBe(
-      "./packages/fumadocs/src/search.ts",
+      "../../packages/fumadocs/dist/search.mjs",
     );
   });
 });

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -2221,7 +2221,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
   if (Object.keys(publicDocsCloudAnalyticsEnv).length > 0) {
     nextConfig.env = {
       ...publicDocsCloudAnalyticsEnv,
-      ...(nextConfig.env ?? {}),
+      ...nextConfig.env,
     };
   }
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -316,93 +316,100 @@ function createPublicDocsCloudAnalyticsEnv() {
 function createDocsWorkspaceAliases(root: string, workspaceRoot: string): Record<string, string> {
   const workspaceAlias = (...parts: string[]) =>
     toTurbopackAliasPath(root, join(workspaceRoot, ...parts));
+  const workspaceEntrypoint = (distParts: string[], sourceParts: string[]) => {
+    const distPath = join(workspaceRoot, ...distParts);
+    const sourcePath = join(workspaceRoot, ...sourceParts);
+
+    return workspaceAlias(
+      ...(existsSync(distPath) || !existsSync(sourcePath) ? distParts : sourceParts),
+    );
+  };
 
   return {
-    "@farming-labs/docs": workspaceAlias("packages", "docs", "dist", "index.mjs"),
-    "@farming-labs/docs/server": workspaceAlias("packages", "docs", "dist", "server.mjs"),
-    "@farming-labs/next": workspaceAlias("packages", "next", "dist", "index.mjs"),
-    "@farming-labs/next/api": workspaceAlias("packages", "next", "dist", "api.mjs"),
-    "@farming-labs/next/changelog": workspaceAlias("packages", "next", "dist", "changelog.mjs"),
-    "@farming-labs/next/client-callbacks": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "client-callbacks.mjs",
+    "@farming-labs/docs": workspaceEntrypoint(
+      ["packages", "docs", "dist", "index.mjs"],
+      ["packages", "docs", "src", "index.ts"],
     ),
-    "@farming-labs/next/layout": workspaceAlias("packages", "next", "dist", "layout.mjs"),
-    "@farming-labs/next/mdx-plugins/rehype-code": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "rehype-code.mjs",
+    "@farming-labs/docs/server": workspaceEntrypoint(
+      ["packages", "docs", "dist", "server.mjs"],
+      ["packages", "docs", "src", "server.ts"],
     ),
-    "@farming-labs/next/mdx-plugins/rehype-toc": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "rehype-toc.mjs",
+    "@farming-labs/next": workspaceEntrypoint(
+      ["packages", "next", "dist", "index.mjs"],
+      ["packages", "next", "src", "index.ts"],
     ),
-    "@farming-labs/next/mdx-plugins/remark-code-group": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "remark-code-group.mjs",
+    "@farming-labs/next/api": workspaceEntrypoint(
+      ["packages", "next", "dist", "api.mjs"],
+      ["packages", "next", "src", "api.ts"],
     ),
-    "@farming-labs/next/mdx-plugins/remark-heading": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "remark-heading.mjs",
+    "@farming-labs/next/changelog": workspaceEntrypoint(
+      ["packages", "next", "dist", "changelog.mjs"],
+      ["packages", "next", "src", "changelog.tsx"],
     ),
-    "@farming-labs/next/mdx-plugins/remark-og": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "remark-og.mjs",
+    "@farming-labs/next/client-callbacks": workspaceEntrypoint(
+      ["packages", "next", "dist", "client-callbacks.mjs"],
+      ["packages", "next", "src", "client-callbacks.tsx"],
     ),
-    "@farming-labs/next/mdx-plugins/remark-markdown-alternate": workspaceAlias(
-      "packages",
-      "next",
-      "dist",
-      "mdx-plugins",
-      "remark-markdown-alternate.mjs",
+    "@farming-labs/next/layout": workspaceEntrypoint(
+      ["packages", "next", "dist", "layout.mjs"],
+      ["packages", "next", "src", "layout.tsx"],
     ),
-    "@farming-labs/theme": workspaceAlias("packages", "fumadocs", "dist", "index.mjs"),
-    "@farming-labs/theme/api": workspaceAlias("packages", "fumadocs", "dist", "docs-api.mjs"),
-    "@farming-labs/theme/client-hooks": workspaceAlias(
-      "packages",
-      "fumadocs",
-      "dist",
-      "docs-client-hooks.mjs",
+    "@farming-labs/next/mdx-plugins/rehype-code": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "rehype-code.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "rehype-code.ts"],
     ),
-    "@farming-labs/theme/concrete": workspaceAlias(
-      "packages",
-      "fumadocs",
-      "dist",
-      "concrete",
-      "index.mjs",
+    "@farming-labs/next/mdx-plugins/rehype-toc": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "rehype-toc.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "rehype-toc.ts"],
     ),
-    "@farming-labs/theme/hardline": workspaceAlias(
-      "packages",
-      "fumadocs",
-      "dist",
-      "hardline",
-      "index.mjs",
+    "@farming-labs/next/mdx-plugins/remark-code-group": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "remark-code-group.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "remark-code-group.ts"],
     ),
-    "@farming-labs/theme/ledger": workspaceAlias(
-      "packages",
-      "fumadocs",
-      "dist",
-      "ledger",
-      "index.mjs",
+    "@farming-labs/next/mdx-plugins/remark-heading": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "remark-heading.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "remark-heading.ts"],
     ),
-    "@farming-labs/theme/mdx": workspaceAlias("packages", "fumadocs", "dist", "mdx.mjs"),
-    "@farming-labs/theme/search": workspaceAlias("packages", "fumadocs", "dist", "search.mjs"),
+    "@farming-labs/next/mdx-plugins/remark-og": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "remark-og.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "remark-og.ts"],
+    ),
+    "@farming-labs/next/mdx-plugins/remark-markdown-alternate": workspaceEntrypoint(
+      ["packages", "next", "dist", "mdx-plugins", "remark-markdown-alternate.mjs"],
+      ["packages", "next", "src", "mdx-plugins", "remark-markdown-alternate.ts"],
+    ),
+    "@farming-labs/theme": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "index.mjs"],
+      ["packages", "fumadocs", "src", "index.ts"],
+    ),
+    "@farming-labs/theme/api": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "docs-api.mjs"],
+      ["packages", "fumadocs", "src", "docs-api.ts"],
+    ),
+    "@farming-labs/theme/client-hooks": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "docs-client-hooks.mjs"],
+      ["packages", "fumadocs", "src", "docs-client-hooks.tsx"],
+    ),
+    "@farming-labs/theme/concrete": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "concrete", "index.mjs"],
+      ["packages", "fumadocs", "src", "concrete", "index.ts"],
+    ),
+    "@farming-labs/theme/hardline": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "hardline", "index.mjs"],
+      ["packages", "fumadocs", "src", "hardline", "index.ts"],
+    ),
+    "@farming-labs/theme/ledger": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "ledger", "index.mjs"],
+      ["packages", "fumadocs", "src", "ledger", "index.ts"],
+    ),
+    "@farming-labs/theme/mdx": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "mdx.mjs"],
+      ["packages", "fumadocs", "src", "mdx.ts"],
+    ),
+    "@farming-labs/theme/search": workspaceEntrypoint(
+      ["packages", "fumadocs", "dist", "search.mjs"],
+      ["packages", "fumadocs", "src", "search.ts"],
+    ),
   };
 }
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -165,6 +165,8 @@ export default function HiddenChangelogSourceLayout() {
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
+const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
+  "https://docs-app.farming-labs.dev/api/analytics/events";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
@@ -276,6 +278,39 @@ function findDocsWorkspaceRoot(start: string): string | undefined {
     if (parent === current) return undefined;
     current = parent;
   }
+}
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function createPublicDocsCloudAnalyticsEnv() {
+  const projectId =
+    normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID) ??
+    normalizeEnvValue(process.env.DOCS_CLOUD_PROJECT_ID);
+  const endpoint =
+    normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
+    normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
+    DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+  const enabled =
+    normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED) ??
+    normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);
+  const env: Record<string, string> = {};
+
+  if (projectId) {
+    env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = projectId;
+  }
+
+  if (endpoint) {
+    env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT = endpoint;
+  }
+
+  if (enabled) {
+    env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = enabled;
+  }
+
+  return env;
 }
 
 function createDocsWorkspaceAliases(root: string, workspaceRoot: string): Record<string, string> {
@@ -2180,6 +2215,14 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     }
   } else {
     nextConfig.pageExtensions = defaultExts;
+  }
+
+  const publicDocsCloudAnalyticsEnv = createPublicDocsCloudAnalyticsEnv();
+  if (Object.keys(publicDocsCloudAnalyticsEnv).length > 0) {
+    nextConfig.env = {
+      ...publicDocsCloudAnalyticsEnv,
+      ...(nextConfig.env ?? {}),
+    };
   }
 
   const existingTurbopack = (nextConfig.turbopack as Record<string, unknown> | undefined) ?? {};

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -289,10 +289,11 @@ function createPublicDocsCloudAnalyticsEnv() {
   const projectId =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID) ??
     normalizeEnvValue(process.env.DOCS_CLOUD_PROJECT_ID);
-  const endpoint =
+  const configuredEndpoint =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
-    normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
-    DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+    normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT);
+  const endpoint =
+    configuredEndpoint ?? (projectId ? DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT : undefined);
   const enabled =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED) ??
     normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -278,32 +278,96 @@ function findDocsWorkspaceRoot(start: string): string | undefined {
   }
 }
 
-function createDocsWorkspaceAliases(): Record<string, string> {
+function createDocsWorkspaceAliases(root: string, workspaceRoot: string): Record<string, string> {
+  const workspaceAlias = (...parts: string[]) =>
+    toTurbopackAliasPath(root, join(workspaceRoot, ...parts));
+
   return {
-    "@farming-labs/docs": "./packages/docs/src/index.ts",
-    "@farming-labs/docs/server": "./packages/docs/src/server.ts",
-    "@farming-labs/next": "./packages/next/src/index.ts",
-    "@farming-labs/next/api": "./packages/next/src/api.ts",
-    "@farming-labs/next/changelog": "./packages/next/src/changelog.tsx",
-    "@farming-labs/next/client-callbacks": "./packages/next/src/client-callbacks.tsx",
-    "@farming-labs/next/layout": "./packages/next/src/layout.tsx",
-    "@farming-labs/next/mdx-plugins/rehype-code": "./packages/next/src/mdx-plugins/rehype-code.ts",
-    "@farming-labs/next/mdx-plugins/rehype-toc": "./packages/next/src/mdx-plugins/rehype-toc.ts",
-    "@farming-labs/next/mdx-plugins/remark-code-group":
-      "./packages/next/src/mdx-plugins/remark-code-group.ts",
-    "@farming-labs/next/mdx-plugins/remark-heading":
-      "./packages/next/src/mdx-plugins/remark-heading.ts",
-    "@farming-labs/next/mdx-plugins/remark-og": "./packages/next/src/mdx-plugins/remark-og.ts",
-    "@farming-labs/next/mdx-plugins/remark-markdown-alternate":
-      "./packages/next/src/mdx-plugins/remark-markdown-alternate.ts",
-    "@farming-labs/theme": "./packages/fumadocs/src/index.ts",
-    "@farming-labs/theme/api": "./packages/fumadocs/src/docs-api.ts",
-    "@farming-labs/theme/client-hooks": "./packages/fumadocs/src/docs-client-hooks.tsx",
-    "@farming-labs/theme/concrete": "./packages/fumadocs/src/concrete/index.ts",
-    "@farming-labs/theme/hardline": "./packages/fumadocs/src/hardline/index.ts",
-    "@farming-labs/theme/ledger": "./packages/fumadocs/src/ledger/index.ts",
-    "@farming-labs/theme/mdx": "./packages/fumadocs/src/mdx.ts",
-    "@farming-labs/theme/search": "./packages/fumadocs/src/search.ts",
+    "@farming-labs/docs": workspaceAlias("packages", "docs", "dist", "index.mjs"),
+    "@farming-labs/docs/server": workspaceAlias("packages", "docs", "dist", "server.mjs"),
+    "@farming-labs/next": workspaceAlias("packages", "next", "dist", "index.mjs"),
+    "@farming-labs/next/api": workspaceAlias("packages", "next", "dist", "api.mjs"),
+    "@farming-labs/next/changelog": workspaceAlias("packages", "next", "dist", "changelog.mjs"),
+    "@farming-labs/next/client-callbacks": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "client-callbacks.mjs",
+    ),
+    "@farming-labs/next/layout": workspaceAlias("packages", "next", "dist", "layout.mjs"),
+    "@farming-labs/next/mdx-plugins/rehype-code": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "rehype-code.mjs",
+    ),
+    "@farming-labs/next/mdx-plugins/rehype-toc": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "rehype-toc.mjs",
+    ),
+    "@farming-labs/next/mdx-plugins/remark-code-group": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "remark-code-group.mjs",
+    ),
+    "@farming-labs/next/mdx-plugins/remark-heading": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "remark-heading.mjs",
+    ),
+    "@farming-labs/next/mdx-plugins/remark-og": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "remark-og.mjs",
+    ),
+    "@farming-labs/next/mdx-plugins/remark-markdown-alternate": workspaceAlias(
+      "packages",
+      "next",
+      "dist",
+      "mdx-plugins",
+      "remark-markdown-alternate.mjs",
+    ),
+    "@farming-labs/theme": workspaceAlias("packages", "fumadocs", "dist", "index.mjs"),
+    "@farming-labs/theme/api": workspaceAlias("packages", "fumadocs", "dist", "docs-api.mjs"),
+    "@farming-labs/theme/client-hooks": workspaceAlias(
+      "packages",
+      "fumadocs",
+      "dist",
+      "docs-client-hooks.mjs",
+    ),
+    "@farming-labs/theme/concrete": workspaceAlias(
+      "packages",
+      "fumadocs",
+      "dist",
+      "concrete",
+      "index.mjs",
+    ),
+    "@farming-labs/theme/hardline": workspaceAlias(
+      "packages",
+      "fumadocs",
+      "dist",
+      "hardline",
+      "index.mjs",
+    ),
+    "@farming-labs/theme/ledger": workspaceAlias(
+      "packages",
+      "fumadocs",
+      "dist",
+      "ledger",
+      "index.mjs",
+    ),
+    "@farming-labs/theme/mdx": workspaceAlias("packages", "fumadocs", "dist", "mdx.mjs"),
+    "@farming-labs/theme/search": workspaceAlias("packages", "fumadocs", "dist", "search.mjs"),
   };
 }
 
@@ -2126,7 +2190,7 @@ export function withDocs(nextConfig: NextConfig = {}): NextConfig {
     ...existingTurbopack,
     ...(workspaceRoot && !existingTurbopack.root ? { root: workspaceRoot } : {}),
     resolveAlias: {
-      ...(workspaceRoot ? createDocsWorkspaceAliases() : {}),
+      ...(workspaceRoot ? createDocsWorkspaceAliases(root, workspaceRoot) : {}),
       ...existingResolveAlias,
       [INTERNAL_DOCS_CONFIG_ALIAS]: docsConfigRelativeAlias,
       "fumadocs-openapi": toTurbopackAliasPath(root, FUMADOCS_OPENAPI_PACKAGE_ALIAS),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a browser analytics harness that persists anonymous visitor and session IDs, attaches them to client events, exposes the current identity, and only enables the client hook when analytics is on. Adds a configurable Docs Cloud analytics endpoint with a safe default and forwards Docs Cloud env to the client via `withDocs`; Turbopack now prefers built `dist` entrypoints.

- **New Features**
  - Supports `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT`/`DOCS_CLOUD_ANALYTICS_ENDPOINT` with a default; events post to the configured endpoint and the client falls back to public env when explicit options are stripped.
  - `getDocsClientAnalyticsIdentity` returns the current anonymous visitor/session; caller-provided IDs are preserved on events.
  - `withDocs` serializes `DOCS_CLOUD_*` to `NEXT_PUBLIC_*` only when analytics is configured and does not override user-provided env; exported `isDocsClientAnalyticsEnabled`.

- **Refactors**
  - Hardened Docs Cloud env resolution with an allowlist and trimmed values; analytics no-ops when disabled or missing project id.
  - Turbopack workspace aliases prefer `dist/*.mjs` and fall back to `src` for `@farming-labs/docs`, `@farming-labs/theme`, and `@farming-labs/next`; added `docs-client-hooks` to build outputs and alias coverage.

<sup>Written for commit 58928f23a4c3fedf19591dfe849e354ccb20a831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

