### PR TITLE
fix: deprecate wraper api

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createDocsCloudAnalytics } from "./cloud-analytics.js";
 import {
   DOCS_AGENT_TRACE_EVENT_TYPES,
   emitDocsAgentTraceEvent,
@@ -268,17 +267,19 @@ describe("analytics", () => {
   });
 
   it("posts Docs Cloud analytics events to the configured ingestion endpoint", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_123";
+
     const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
       async () => new Response(null, { status: 202 }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
-      createDocsCloudAnalytics({
-        projectId: "project_123",
+      {
+        enabled: true,
         console: false,
         includeInputs: true,
-      }),
+      },
       {
         type: "page_view",
         source: "client",
@@ -314,6 +315,7 @@ describe("analytics", () => {
   });
 
   it("posts Docs Cloud analytics events to the public endpoint env when provided", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_endpoint";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
       "https://docs-cloud.example.com/api/analytics/events";
 
@@ -323,10 +325,10 @@ describe("analytics", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
-      createDocsCloudAnalytics({
-        projectId: "project_endpoint",
+      {
+        enabled: true,
         console: false,
-      }),
+      },
       {
         type: "page_view",
         source: "client",
@@ -341,7 +343,7 @@ describe("analytics", () => {
     );
   });
 
-  it("falls back to public env when explicit Docs Cloud options were stripped in the client", async () => {
+  it("posts Docs Cloud analytics from plain config when public env is present", async () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
       "https://docs-cloud.example.com/api/analytics/events";
@@ -352,10 +354,10 @@ describe("analytics", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
-      createDocsCloudAnalytics({
+      {
+        enabled: true,
         console: false,
-        projectId: undefined,
-      }),
+      },
       {
         type: "page_view",
         source: "client",
@@ -378,9 +380,10 @@ describe("analytics", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await emitDocsAnalyticsEvent(
-      createDocsCloudAnalytics({
+      {
+        enabled: true,
         console: false,
-      }),
+      },
       {
         type: "page_view",
         source: "client",

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -119,6 +119,14 @@ export function createDocsAgentTraceContext(name = "agent.run"): DocsAgentTraceC
 export function resolveDocsAnalyticsConfig(
   analytics?: boolean | DocsAnalyticsConfig,
 ): ResolvedDocsAnalyticsConfig {
+  if (analytics === false) {
+    return {
+      enabled: false,
+      console: false,
+      includeInputs: false,
+    };
+  }
+
   const cloudOptions = resolveDocsCloudAnalyticsOptions(analytics);
   const cloudOnEvent = cloudOptions
     ? async (event: DocsAnalyticsEvent) => {

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -1,21 +1,13 @@
 import type { DocsAnalyticsConfig, DocsAnalyticsEvent } from "./types.js";
 
-export interface DocsCloudAnalyticsOptions {
-  enabled?: boolean;
-  console?: DocsAnalyticsConfig["console"];
+interface DocsCloudAnalyticsOptions {
   endpoint?: string;
-  includeInputs?: boolean;
   projectId?: string;
   apiKey?: string;
 }
 
-const DOCS_CLOUD_ANALYTICS_OPTIONS = Symbol.for("@farming-labs/docs/cloud-analytics");
 const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
   "https://docs-app.farming-labs.dev/api/analytics/events";
-
-type DocsAnalyticsConfigWithCloud = DocsAnalyticsConfig & {
-  [DOCS_CLOUD_ANALYTICS_OPTIONS]?: DocsCloudAnalyticsOptions;
-};
 
 function normalizeRuntimeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();
@@ -60,6 +52,13 @@ function isFalsyEnv(value: string | undefined): boolean {
 export function resolveDocsCloudAnalyticsOptions(
   analytics?: boolean | DocsAnalyticsConfig,
 ): DocsCloudAnalyticsOptions | null {
+  if (
+    analytics === false ||
+    (analytics && typeof analytics === "object" && analytics.enabled === false)
+  ) {
+    return null;
+  }
+
   const projectId =
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
   const apiKey =
@@ -77,26 +76,7 @@ export function resolveDocsCloudAnalyticsOptions(
     return null;
   }
 
-  if (analytics && typeof analytics === "object") {
-    const explicit = (analytics as DocsAnalyticsConfigWithCloud)[DOCS_CLOUD_ANALYTICS_OPTIONS];
-
-    if (explicit) {
-      const resolvedProjectId = normalizeRuntimeEnvValue(explicit.projectId) ?? projectId;
-
-      if (!resolvedProjectId || explicit.enabled === false) {
-        return null;
-      }
-
-      return {
-        ...explicit,
-        apiKey: normalizeRuntimeEnvValue(explicit.apiKey) ?? apiKey,
-        endpoint: normalizeRuntimeEnvValue(explicit.endpoint) ?? endpoint,
-        projectId: resolvedProjectId,
-      };
-    }
-  }
-
-  if (!projectId || isFalsyEnv(enabled)) {
+  if (!projectId) {
     return null;
   }
 
@@ -141,17 +121,4 @@ export async function sendDocsCloudAnalyticsEvent(
   } catch {
     // Analytics should never break the docs runtime.
   }
-}
-
-export function createDocsCloudAnalytics(
-  options: DocsCloudAnalyticsOptions = {},
-): DocsAnalyticsConfig {
-  const analytics: DocsAnalyticsConfigWithCloud = {
-    enabled: options.enabled,
-    console: options.console,
-    includeInputs: options.includeInputs,
-  };
-
-  analytics[DOCS_CLOUD_ANALYTICS_OPTIONS] = options;
-  return analytics;
 }

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -10,7 +10,6 @@
 import type { DocsConfig } from "./types.js";
 
 export { defineDocs } from "./define-docs.js";
-export { createDocsCloudAnalytics } from "./cloud-analytics.js";
 export {
   DOCS_AGENT_TRACE_EVENT_TYPES,
   createDocsAgentTraceContext,
@@ -320,7 +319,6 @@ export type {
   ResolvedDocsAnalyticsConfig,
   ResolvedDocsObservabilityConfig,
 } from "./analytics.js";
-export type { DocsCloudAnalyticsOptions } from "./cloud-analytics.js";
 export type { ChangelogEntrySummary, ResolvedChangelogConfig } from "./changelog.js";
 export type { ResolvedDocsI18n, DocsPathMatch } from "./i18n.js";
 export type { DocsPageStructuredDataInput, DocsStructuredDataBreadcrumb } from "./metadata.js";

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -1,4 +1,3 @@
-export { createDocsCloudAnalytics } from "./cloud-analytics.js";
 export { remarkCodeGroup } from "./code-group-mdx.js";
 export {
   DOCS_AGENT_TRACE_EVENT_TYPES,
@@ -150,4 +149,3 @@ export type {
   ResolvedDocsAnalyticsConfig,
   ResolvedDocsObservabilityConfig,
 } from "./analytics.js";
-export type { DocsCloudAnalyticsOptions } from "./cloud-analytics.js";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Docs Cloud analytics wrapper and moved to env-first configuration. This simplifies setup and makes analytics: false a reliable opt-out.

- **Refactors**
  - Removed `createDocsCloudAnalytics` and related exports.
  - `resolveDocsAnalyticsConfig` now returns a disabled config when `analytics === false`.
  - Cloud options resolve only from env (project ID, endpoint, API key); public envs work on the client.
  - Tests updated to use plain config objects.

- **Migration**
  - Replace `createDocsCloudAnalytics({...})` with a plain config, e.g. `{ enabled: true, console: false, includeInputs: true }`.
  - Set project ID via `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` (client) or `DOCS_CLOUD_PROJECT_ID` (server); optionally set `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT`/`DOCS_CLOUD_ANALYTICS_ENDPOINT` and `DOCS_CLOUD_API_KEY`.
  - Remove imports/usages of `createDocsCloudAnalytics` and `DocsCloudAnalyticsOptions`.

<sup>Written for commit ed07a0e36ef1565f51e1d7488eeb38ea440ecdc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

