### PR TITLE
fix: analytics harness & identity detections

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -343,6 +343,71 @@ describe("analytics", () => {
     );
   });
 
+  it("adds agent traffic hints to Docs Cloud agent and MCP events", async () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_agents";
+
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(null, { status: 202 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
+        type: "agent_read",
+        source: "server",
+        path: "/docs/install.md",
+        properties: {
+          delivery: "markdown_route",
+        },
+      },
+    );
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
+        type: "mcp_tool",
+        source: "mcp",
+        path: "/docs/install",
+        properties: {
+          tool: "read_page",
+        },
+      },
+    );
+
+    const requestBodies = fetchMock.mock.calls.map((call) => JSON.parse(String(call[1]?.body)));
+    expect(requestBodies[0]).toMatchObject({
+      event: {
+        type: "agent_read",
+        source: "server",
+        properties: {
+          delivery: "markdown_route",
+          trafficType: "agent",
+          agentName: "Docs agent",
+          botProvider: "Docs agent",
+        },
+      },
+    });
+    expect(requestBodies[1]).toMatchObject({
+      event: {
+        type: "mcp_tool",
+        source: "mcp",
+        properties: {
+          tool: "read_page",
+          trafficType: "agent",
+          agentName: "MCP client",
+          botProvider: "MCP client",
+        },
+      },
+    });
+  });
+
   it("posts Docs Cloud analytics from plain config when public env is present", async () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =

--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -373,6 +373,52 @@ describe("analytics", () => {
         console: false,
       },
       {
+        type: "markdown_request",
+        source: "server",
+        path: "/docs/install.md",
+        properties: {
+          delivery: "md_route",
+          userAgent: "Mozilla/5.0",
+        },
+      },
+    );
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
+        type: "skill_request",
+        source: "server",
+        path: "/skill.md",
+        properties: {
+          userAgent: "CodexTestBot/1.0",
+        },
+      },
+    );
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
+        type: "llms_request",
+        source: "server",
+        path: "/llms.txt",
+        properties: {
+          trafficType: "agent",
+        },
+      },
+    );
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
         type: "agent_read",
         source: "server",
         path: "/docs/install.md",
@@ -394,6 +440,8 @@ describe("analytics", () => {
         path: "/docs/install",
         properties: {
           tool: "read_page",
+          agentName: " ",
+          botProvider: " ",
         },
       },
     );
@@ -414,6 +462,40 @@ describe("analytics", () => {
     });
     expect(requestBodies[1]).toMatchObject({
       event: {
+        type: "markdown_request",
+        source: "server",
+        properties: {
+          delivery: "md_route",
+          userAgent: "Mozilla/5.0",
+        },
+      },
+    });
+    expect(requestBodies[1].event.properties).not.toHaveProperty("trafficType");
+    expect(requestBodies[2]).toMatchObject({
+      event: {
+        type: "skill_request",
+        source: "server",
+        properties: {
+          userAgent: "CodexTestBot/1.0",
+          trafficType: "agent",
+          agentName: "Codex",
+          botProvider: "Codex",
+        },
+      },
+    });
+    expect(requestBodies[3]).toMatchObject({
+      event: {
+        type: "llms_request",
+        source: "server",
+        properties: {
+          trafficType: "agent",
+          agentName: "Docs reader",
+          botProvider: "Docs reader",
+        },
+      },
+    });
+    expect(requestBodies[4]).toMatchObject({
+      event: {
         type: "agent_read",
         source: "server",
         properties: {
@@ -422,8 +504,8 @@ describe("analytics", () => {
         },
       },
     });
-    expect(requestBodies[1].event.properties).not.toHaveProperty("trafficType");
-    expect(requestBodies[2]).toMatchObject({
+    expect(requestBodies[4].event.properties).not.toHaveProperty("trafficType");
+    expect(requestBodies[5]).toMatchObject({
       event: {
         type: "mcp_tool",
         source: "mcp",

--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -343,7 +343,7 @@ describe("analytics", () => {
     );
   });
 
-  it("adds agent traffic hints to Docs Cloud agent and MCP events", async () => {
+  it("adds agent traffic hints to Docs Cloud events from caller identity", async () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_agents";
 
     const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
@@ -362,6 +362,23 @@ describe("analytics", () => {
         path: "/docs/install.md",
         properties: {
           delivery: "markdown_route",
+          userAgent: "ChatGPT-User/1.0",
+        },
+      },
+    );
+
+    await emitDocsAnalyticsEvent(
+      {
+        enabled: true,
+        console: false,
+      },
+      {
+        type: "agent_read",
+        source: "server",
+        path: "/docs/install.md",
+        properties: {
+          delivery: "markdown_route",
+          userAgent: "Mozilla/5.0",
         },
       },
     );
@@ -388,13 +405,25 @@ describe("analytics", () => {
         source: "server",
         properties: {
           delivery: "markdown_route",
+          userAgent: "ChatGPT-User/1.0",
           trafficType: "agent",
-          agentName: "Docs agent",
-          botProvider: "Docs agent",
+          agentName: "ChatGPT",
+          botProvider: "ChatGPT",
         },
       },
     });
     expect(requestBodies[1]).toMatchObject({
+      event: {
+        type: "agent_read",
+        source: "server",
+        properties: {
+          delivery: "markdown_route",
+          userAgent: "Mozilla/5.0",
+        },
+      },
+    });
+    expect(requestBodies[1].event.properties).not.toHaveProperty("trafficType");
+    expect(requestBodies[2]).toMatchObject({
       event: {
         type: "mcp_tool",
         source: "mcp",

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -119,7 +119,7 @@ export function createDocsAgentTraceContext(name = "agent.run"): DocsAgentTraceC
 export function getDocsRequestAnalyticsProperties(request: Request): Record<string, unknown> {
   const userAgent = request.headers.get("user-agent")?.trim();
 
-  return (userAgent ? { userAgent } : {});
+  return userAgent ? { userAgent } : {};
 }
 
 export function resolveDocsAnalyticsConfig(

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -116,6 +116,14 @@ export function createDocsAgentTraceContext(name = "agent.run"): DocsAgentTraceC
   };
 }
 
+export function getDocsRequestAnalyticsProperties(request: Request): Record<string, unknown> {
+  const userAgent = request.headers.get("user-agent")?.trim();
+
+  return {
+    ...(userAgent ? { userAgent } : {}),
+  };
+}
+
 export function resolveDocsAnalyticsConfig(
   analytics?: boolean | DocsAnalyticsConfig,
 ): ResolvedDocsAnalyticsConfig {

--- a/packages/docs/src/analytics.ts
+++ b/packages/docs/src/analytics.ts
@@ -119,9 +119,7 @@ export function createDocsAgentTraceContext(name = "agent.run"): DocsAgentTraceC
 export function getDocsRequestAnalyticsProperties(request: Request): Record<string, unknown> {
   const userAgent = request.headers.get("user-agent")?.trim();
 
-  return {
-    ...(userAgent ? { userAgent } : {}),
-  };
+  return (userAgent ? { userAgent } : {});
 }
 
 export function resolveDocsAnalyticsConfig(

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -87,6 +87,77 @@ export function resolveDocsCloudAnalyticsOptions(
   };
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeAnalyticsLabel(value: string | undefined) {
+  return value?.trim().toLowerCase().replace(/[-\s]+/g, "_") ?? "";
+}
+
+function isAgentAnalyticsEvent(event: DocsAnalyticsEvent) {
+  const type = normalizeAnalyticsLabel(event.type);
+  const source = normalizeAnalyticsLabel(event.source);
+
+  return (
+    source === "mcp" ||
+    type.startsWith("mcp_") ||
+    type.startsWith("agent_") ||
+    ["agents_request", "llms_request", "markdown_request", "skill_request"].includes(type)
+  );
+}
+
+function inferAgentProvider(event: DocsAnalyticsEvent) {
+  const type = normalizeAnalyticsLabel(event.type);
+  const source = normalizeAnalyticsLabel(event.source);
+
+  if (source === "mcp" || type.startsWith("mcp_")) {
+    return "MCP client";
+  }
+
+  if (type.startsWith("agent_") || type === "agents_request") {
+    return "Docs agent";
+  }
+
+  if (["llms_request", "markdown_request", "skill_request"].includes(type)) {
+    return "Docs reader";
+  }
+
+  return undefined;
+}
+
+function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEvent {
+  if (!isAgentAnalyticsEvent(event)) {
+    return event;
+  }
+
+  const properties = asRecord(event.properties);
+  const agentProvider =
+    asString(properties.agentName) ??
+    asString(properties.agent) ??
+    asString(properties.botProvider) ??
+    asString(properties.provider) ??
+    asString(properties.crawler) ??
+    asString(asRecord(properties.bot).provider) ??
+    inferAgentProvider(event);
+
+  return {
+    ...event,
+    properties: {
+      ...properties,
+      trafficType: "agent",
+      ...(agentProvider && !properties.agentName ? { agentName: agentProvider } : {}),
+      ...(agentProvider && !properties.botProvider ? { botProvider: agentProvider } : {}),
+    },
+  };
+}
+
 export async function sendDocsCloudAnalyticsEvent(
   options: DocsCloudAnalyticsOptions,
   event: DocsAnalyticsEvent,
@@ -102,6 +173,7 @@ export async function sendDocsCloudAnalyticsEvent(
   }
 
   try {
+    const normalizedEvent = withDocsCloudAnalyticsHints(event);
     await fetch(endpoint, {
       method: "POST",
       headers: {
@@ -114,7 +186,7 @@ export async function sendDocsCloudAnalyticsEvent(
       },
       body: JSON.stringify({
         projectId,
-        event,
+        event: normalizedEvent,
       }),
       keepalive: true,
     });

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -98,7 +98,12 @@ function asString(value: unknown): string | undefined {
 }
 
 function normalizeAnalyticsLabel(value: string | undefined) {
-  return value?.trim().toLowerCase().replace(/[-\s]+/g, "_") ?? "";
+  return (
+    value
+      ?.trim()
+      .toLowerCase()
+      .replace(/[-\s]+/g, "_") ?? ""
+  );
 }
 
 function isAgentAnalyticsEvent(event: DocsAnalyticsEvent) {

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -106,16 +106,11 @@ function normalizeAnalyticsLabel(value: string | undefined) {
   );
 }
 
-function isAgentAnalyticsEvent(event: DocsAnalyticsEvent) {
+function isProtocolAgentEvent(event: DocsAnalyticsEvent) {
   const type = normalizeAnalyticsLabel(event.type);
   const source = normalizeAnalyticsLabel(event.source);
 
-  return (
-    source === "mcp" ||
-    type.startsWith("mcp_") ||
-    type.startsWith("agent_") ||
-    ["agents_request", "llms_request", "markdown_request", "skill_request"].includes(type)
-  );
+  return source === "mcp" || type.startsWith("mcp_");
 }
 
 function inferAgentProvider(event: DocsAnalyticsEvent) {
@@ -137,12 +132,53 @@ function inferAgentProvider(event: DocsAnalyticsEvent) {
   return undefined;
 }
 
-function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEvent {
-  if (!isAgentAnalyticsEvent(event)) {
-    return event;
+function detectAgentProviderFromUserAgent(userAgent: string | undefined) {
+  const value = userAgent?.toLowerCase() ?? "";
+
+  if (!value) {
+    return undefined;
   }
 
+  const providers: Array<[RegExp, string]> = [
+    [/cursor/i, "Cursor"],
+    [/codex/i, "Codex"],
+    [/chatgpt-user|chatgpt/i, "ChatGPT"],
+    [/gptbot/i, "GPTBot"],
+    [/oai-searchbot|openai-search/i, "ChatGPT Search"],
+    [/openai/i, "ChatGPT"],
+    [/github-copilot|githubcopilot|copilot/i, "GitHub Copilot"],
+    [/claudebot|claude-user|anthropic/i, "Claude"],
+    [/perplexitybot|perplexity-user/i, "Perplexity"],
+    [/google-extended|googlebot|apis-google/i, "Google"],
+    [/bingbot|msnbot/i, "Bing"],
+    [/duckduckbot/i, "DuckDuckGo"],
+    [/applebot/i, "Apple"],
+    [/bytespider|bytedance/i, "ByteDance"],
+    [/ccbot|common crawl/i, "Common Crawl"],
+    [/ahrefsbot/i, "Ahrefs"],
+    [/semrushbot/i, "Semrush"],
+  ];
+
+  for (const [pattern, provider] of providers) {
+    if (pattern.test(value)) {
+      return provider;
+    }
+  }
+
+  if (/bot|crawler|spider|slurp|facebookexternalhit|ia_archiver/.test(value)) {
+    return "Other bot";
+  }
+
+  return undefined;
+}
+
+function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEvent {
   const properties = asRecord(event.properties);
+  const userAgent = asString(properties.userAgent) ?? asString(properties.user_agent);
+  const detectedAgent = detectAgentProviderFromUserAgent(userAgent);
+  const protocolAgent = isProtocolAgentEvent(event);
+  const incomingTrafficType = asString(properties.trafficType)?.toLowerCase();
+  const explicitAgent = incomingTrafficType === "agent" || incomingTrafficType === "bot";
   const agentProvider =
     asString(properties.agentName) ??
     asString(properties.agent) ??
@@ -150,7 +186,12 @@ function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEv
     asString(properties.provider) ??
     asString(properties.crawler) ??
     asString(asRecord(properties.bot).provider) ??
-    inferAgentProvider(event);
+    detectedAgent ??
+    (protocolAgent || explicitAgent ? inferAgentProvider(event) : undefined);
+
+  if (!explicitAgent && !protocolAgent && !detectedAgent && !agentProvider) {
+    return event;
+  }
 
   return {
     ...event,

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -179,6 +179,7 @@ function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEv
   const protocolAgent = isProtocolAgentEvent(event);
   const incomingTrafficType = asString(properties.trafficType)?.toLowerCase();
   const explicitAgent = incomingTrafficType === "agent" || incomingTrafficType === "bot";
+  // Agent-readable routes can still be opened by humans, so event type alone is not identity.
   const agentProvider =
     asString(properties.agentName) ??
     asString(properties.agent) ??
@@ -198,8 +199,8 @@ function withDocsCloudAnalyticsHints(event: DocsAnalyticsEvent): DocsAnalyticsEv
     properties: {
       ...properties,
       trafficType: "agent",
-      ...(agentProvider && !properties.agentName ? { agentName: agentProvider } : {}),
-      ...(agentProvider && !properties.botProvider ? { botProvider: agentProvider } : {}),
+      ...(agentProvider && !asString(properties.agentName) ? { agentName: agentProvider } : {}),
+      ...(agentProvider && !asString(properties.botProvider) ? { botProvider: agentProvider } : {}),
     },
   };
 }

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -17,6 +17,7 @@ export {
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
   emitDocsObservabilityEvent,
+  getDocsRequestAnalyticsProperties,
   resolveDocsAnalyticsConfig,
   resolveDocsObservabilityConfig,
 } from "./analytics.js";

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -6,6 +6,7 @@ export {
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
   emitDocsObservabilityEvent,
+  getDocsRequestAnalyticsProperties,
   resolveDocsAnalyticsConfig,
   resolveDocsObservabilityConfig,
 } from "./analytics.js";

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1276,6 +1276,11 @@ Install the package.
       "accept_header",
       "user_agent",
     ]);
+    expect(agentReads.find((event) => event.properties?.delivery === "user_agent")).toMatchObject({
+      properties: expect.objectContaining({
+        userAgent: "ClaudeBot/1.0",
+      }),
+    });
     expect(agentReads).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2244,9 +2244,7 @@ function safeUrlOrigin(value: string): string {
 function getRequestAnalyticsProperties(request: Request): Record<string, unknown> {
   const userAgent = request.headers.get("user-agent")?.trim();
 
-  return {
-    ...(userAgent ? { userAgent } : {}),
-  };
+  return (userAgent ? { userAgent } : {});
 }
 
 async function handleAskAI(

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2244,7 +2244,7 @@ function safeUrlOrigin(value: string): string {
 function getRequestAnalyticsProperties(request: Request): Record<string, unknown> {
   const userAgent = request.headers.get("user-agent")?.trim();
 
-  return (userAgent ? { userAgent } : {});
+  return userAgent ? { userAgent } : {};
 }
 
 async function handleAskAI(

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2241,6 +2241,14 @@ function safeUrlOrigin(value: string): string {
   }
 }
 
+function getRequestAnalyticsProperties(request: Request): Record<string, unknown> {
+  const userAgent = request.headers.get("user-agent")?.trim();
+
+  return {
+    ...(userAgent ? { userAgent } : {}),
+  };
+}
+
 async function handleAskAI(
   request: Request,
   indexes: DocsSearchSourcePage[],
@@ -2251,6 +2259,7 @@ async function handleAskAI(
   analyticsContext: { locale?: string } = {},
 ): Promise<Response> {
   const url = new URL(request.url);
+  const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
   const requestStartedAt = Date.now();
   const trace = createDocsAgentTraceContext("ask-ai");
   const runSpanId = createDocsAgentTraceId("span");
@@ -2330,6 +2339,7 @@ async function handleAskAI(
       path: url.pathname,
       locale: analyticsContext.locale,
       properties: {
+        ...requestAnalyticsProperties,
         reason: "invalid_json",
         durationMs: Math.max(0, Date.now() - requestStartedAt),
       },
@@ -2350,6 +2360,7 @@ async function handleAskAI(
       path: url.pathname,
       locale: analyticsContext.locale,
       properties: {
+        ...requestAnalyticsProperties,
         reason: "missing_messages",
         durationMs: Math.max(0, Date.now() - requestStartedAt),
       },
@@ -2370,6 +2381,7 @@ async function handleAskAI(
       path: url.pathname,
       locale: analyticsContext.locale,
       properties: {
+        ...requestAnalyticsProperties,
         reason: "missing_user_message",
         messageCount: messages.length,
         durationMs: Math.max(0, Date.now() - requestStartedAt),
@@ -2504,6 +2516,7 @@ async function handleAskAI(
       locale: analyticsContext.locale,
       input: { question: query },
       properties: {
+        ...requestAnalyticsProperties,
         reason: "missing_api_key",
         messageCount: messages.length,
         questionLength: query.length,
@@ -2535,6 +2548,7 @@ async function handleAskAI(
     locale: analyticsContext.locale,
     input: { question: query },
     properties: {
+      ...requestAnalyticsProperties,
       messageCount: messages.length,
       questionLength: query.length,
       retrievedCount: scored.length,
@@ -2604,6 +2618,7 @@ async function handleAskAI(
       locale: analyticsContext.locale,
       input: { question: query },
       properties: {
+        ...requestAnalyticsProperties,
         reason: "llm_fetch_error",
         messageCount: messages.length,
         questionLength: query.length,
@@ -2650,6 +2665,7 @@ async function handleAskAI(
       locale: analyticsContext.locale,
       input: { question: query },
       properties: {
+        ...requestAnalyticsProperties,
         reason: "llm_error",
         status: llmResponse.status,
         messageCount: messages.length,
@@ -2681,6 +2697,7 @@ async function handleAskAI(
     locale: analyticsContext.locale,
     input: { question: query },
     properties: {
+      ...requestAnalyticsProperties,
       messageCount: messages.length,
       questionLength: query.length,
       retrievedCount: scored.length,
@@ -3235,6 +3252,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     async GET(request: Request) {
       const ctx = resolveContextFromRequest(request);
       const url = new URL(request.url);
+      const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
       if (resolveAgentSpecRequest(url)) {
         await emitDocsAnalyticsEvent(analytics, {
           type: "agent_spec_request",
@@ -3243,6 +3261,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             method: "GET",
           },
         });
@@ -3316,6 +3335,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             method: "GET",
           },
         });
@@ -3336,6 +3356,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             method: "GET",
           },
         });
@@ -3370,6 +3391,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             method: "GET",
           },
         });
@@ -3451,6 +3473,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             path: url.pathname,
             locale: ctx.locale,
             properties: {
+              ...requestAnalyticsProperties,
               requestedPath: markdownRequest.requestedPath,
               delivery: markdownRequest.delivery,
               found: false,
@@ -3463,6 +3486,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             path: url.pathname,
             locale: ctx.locale,
             properties: {
+              ...requestAnalyticsProperties,
               requestedPath: markdownRequest.requestedPath,
               delivery: markdownRequest.delivery,
               found: false,
@@ -3505,6 +3529,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             requestedPath: markdownRequest.requestedPath,
             delivery: markdownRequest.delivery,
             found: true,
@@ -3518,6 +3543,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             requestedPath: markdownRequest.requestedPath,
             delivery: markdownRequest.delivery,
             found: true,
@@ -3583,6 +3609,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           path: url.pathname,
           locale: ctx.locale,
           properties: {
+            ...requestAnalyticsProperties,
             format: llmsRequest.format,
             section: llmsRequest.section?.route,
             contentLength: selected.content.length,
@@ -3620,6 +3647,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         locale: ctx.locale,
         input: { query },
         properties: {
+          ...requestAnalyticsProperties,
           queryLength: query.length,
           resultCount: results.length,
           pathname: url.searchParams.get("pathname") ?? undefined,
@@ -3639,6 +3667,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
      */
     async POST(request: Request): Promise<Response> {
       const url = new URL(request.url);
+      const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
       const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
 
       if (agentFeedbackRequest) {
@@ -3662,6 +3691,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             url: request.url,
             path: url.pathname,
             properties: {
+              ...requestAnalyticsProperties,
               reason: "invalid_body",
             },
           });
@@ -3679,6 +3709,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             url: request.url,
             path: url.pathname,
             properties: {
+              ...requestAnalyticsProperties,
               reason: "invalid_payload",
               error: payloadError,
             },
@@ -3693,6 +3724,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             url: request.url,
             path: url.pathname,
             properties: {
+              ...requestAnalyticsProperties,
               handled: false,
               payloadKeys: Object.keys(parsed.data.payload),
               hasContext: Boolean(parsed.data.context),
@@ -3708,6 +3740,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           url: request.url,
           path: url.pathname,
           properties: {
+            ...requestAnalyticsProperties,
             handled: true,
             payloadKeys: Object.keys(parsed.data.payload),
             hasContext: Boolean(parsed.data.context),
@@ -3723,6 +3756,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           url: request.url,
           path: url.pathname,
           properties: {
+            ...requestAnalyticsProperties,
             reason: "disabled",
           },
         });


### PR DESCRIPTION
- **fix: analytics harness tests and prefix catch**
- **chore: format**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Docs Cloud analytics to reliably tag agent/bot traffic and infer provider names from user-agent and protocol hints. Passes `userAgent` through `packages/docs` and `packages/fumadocs` so events are normalized server-side without extra work.

- New Features
  - Server-side hints: infer provider from user-agent (ChatGPT, Claude, Perplexity, Cursor, Copilot, GPTBot, common crawlers), protocol/source (`mcp` or `mcp_*`), and agent-facing types (`agent_*`, `agents_request`, `llms_request`, `markdown_request`, `skill_request`).
  - Set `trafficType="agent"` and fill `agentName`/`botProvider` only when not provided; use "MCP client", "Docs agent", or "Docs reader" as needed.
  - Add `getDocsRequestAnalyticsProperties(request)` in `packages/docs` (exported from `index` and `server`); include `userAgent` across `packages/fumadocs` endpoints (spec, markdown, llms, search, feedback) and Ask AI.

- Bug Fixes
  - Fix analytics harness for header-based detection and expand tests to assert UA capture, provider tagging (e.g., `ClaudeBot/1.0`), and avoid false positives for normal browsers (`Mozilla/5.0`).

<sup>Written for commit 0240048eee35622ee2f6b71352335afc70aace1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

