### PR TITLE
feat: docs cloud init cmd

### DIFF
--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -3,7 +3,12 @@ import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { materializeCloudConfig, runCloudDeploy, runCloudPreview } from "./cloud.js";
+import {
+  initCloudConfig,
+  materializeCloudConfig,
+  runCloudDeploy,
+  runCloudPreview,
+} from "./cloud.js";
 
 describe("cloud cli", () => {
   const originalEnv = { ...process.env };
@@ -102,6 +107,103 @@ describe("cloud cli", () => {
     });
     expect(docsJson.cloud.apiKey.env).toBe("DOCS_CLOUD_API_KEY");
     expect(docsJson.cloud.preview).toBeUndefined();
+  });
+
+  it("initializes Docs Cloud config, analytics, and docs.json", async () => {
+    writePackageJson();
+    mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  nav: { title: "Acme Docs" },
+});
+`,
+      "utf-8",
+    );
+
+    const result = await initCloudConfig({ rootDir: tmpDir });
+    const config = readFileSync(path.join(tmpDir, "docs.config.ts"), "utf-8");
+    const docsJson = JSON.parse(readFileSync(path.join(tmpDir, "docs.json"), "utf-8"));
+
+    expect(result).toMatchObject({
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      analyticsProjectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+      configCreated: false,
+      configUpdated: true,
+      docsJsonCreated: true,
+    });
+    expect(config).toContain("analytics: {");
+    expect(config).toContain("console: false");
+    expect(config).toContain('apiKey: { env: "DOCS_CLOUD_API_KEY" }');
+    expect(config).toContain("deploy: { enabled: true }");
+    expect(config).toContain('publish: { mode: "draft-pr", baseBranch: "main" }');
+    expect(config).not.toContain("createDocsCloudAnalytics");
+    expect(docsJson).toMatchObject({
+      cloud: {
+        apiKey: { env: "DOCS_CLOUD_API_KEY" },
+        deploy: { enabled: true },
+        analytics: {
+          enabled: true,
+          console: false,
+          includeInputs: false,
+        },
+        publish: {
+          mode: "draft-pr",
+          baseBranch: "main",
+        },
+      },
+    });
+  });
+
+  it("creates docs.config.ts during cloud init when config is missing", async () => {
+    writePackageJson({ "@sveltejs/kit": "2.0.0" });
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+
+    const result = await initCloudConfig({
+      rootDir: tmpDir,
+      apiKeyEnv: "ACME_DOCS_CLOUD_KEY",
+    });
+    const config = readFileSync(path.join(tmpDir, "docs.config.ts"), "utf-8");
+    const docsJson = JSON.parse(readFileSync(path.join(tmpDir, "docs.json"), "utf-8"));
+
+    expect(result.configCreated).toBe(true);
+    expect(config).toContain('apiKey: { env: "ACME_DOCS_CLOUD_KEY" }');
+    expect(config).toContain("analytics: {");
+    expect(docsJson.docs.runtime).toBe("sveltekit");
+    expect(docsJson.cloud.apiKey.env).toBe("ACME_DOCS_CLOUD_KEY");
+    expect(docsJson.cloud.analytics.enabled).toBe(true);
+  });
+
+  it("adds missing cloud init fields without replacing existing cloud settings", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    publish: { mode: "draft-pr", baseBranch: "develop" },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    await initCloudConfig({ rootDir: tmpDir });
+
+    const config = readFileSync(path.join(tmpDir, "docs.config.ts"), "utf-8");
+    const docsJson = JSON.parse(readFileSync(path.join(tmpDir, "docs.json"), "utf-8"));
+    expect(config).toContain('baseBranch: "develop"');
+    expect(config).toContain('apiKey: { env: "DOCS_CLOUD_API_KEY" }');
+    expect(config).toContain("deploy: { enabled: true }");
+    expect(docsJson.cloud.publish.baseBranch).toBe("develop");
+    expect(docsJson.cloud.analytics).toEqual({
+      enabled: true,
+      console: false,
+      includeInputs: false,
+    });
   });
 
   it("preserves boolean analytics.console values when static config parsing is used", async () => {

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -19,6 +19,7 @@ import { detectFramework, type Framework } from "./utils.js";
 const DOCS_JSON_FILE = "docs.json";
 const DOCS_CLOUD_SCHEMA_URL = "https://docs.farming-labs.dev/schema/docs.json";
 const DOCS_CLOUD_DEFAULT_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
+const DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
 const DEFAULT_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PREVIEW_POLL_INTERVAL_MS = 2000;
@@ -70,10 +71,22 @@ export interface CloudCommandOptions {
   configPath?: string;
   apiBaseUrl?: string;
   apiKey?: string;
+  apiKeyEnv?: string;
   json?: boolean;
   rootDir?: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
+}
+
+export interface CloudInitResult {
+  configPath: string;
+  docsJsonPath: string;
+  apiKeyEnv: string;
+  analyticsProjectIdEnv: string;
+  configCreated: boolean;
+  configUpdated: boolean;
+  docsJsonCreated: boolean;
+  docsJsonUpdated: boolean;
 }
 
 export interface MaterializeCloudConfigResult {
@@ -216,6 +229,454 @@ async function loadDocsConfigSnapshot(
     content,
     config: loaded?.config,
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findBalancedBraceEnd(content: string, braceStart: number): number {
+  let depth = 0;
+  let stringQuote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = braceStart; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (stringQuote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (char === stringQuote) {
+        stringQuote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      stringQuote = char;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char !== "}") continue;
+
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+
+  return -1;
+}
+
+interface ObjectRange {
+  braceStart: number;
+  braceEnd: number;
+  bodyStart: number;
+  bodyEnd: number;
+}
+
+interface PropertyRange {
+  start: number;
+  end: number;
+}
+
+function findConfigObjectRange(content: string): ObjectRange | undefined {
+  for (const marker of ["defineDocs(", "export default"]) {
+    const markerIndex = content.indexOf(marker);
+    if (markerIndex === -1) continue;
+
+    const braceStart = content.indexOf("{", markerIndex);
+    if (braceStart === -1) continue;
+
+    const braceEnd = findBalancedBraceEnd(content, braceStart);
+    if (braceEnd === -1) continue;
+
+    return {
+      braceStart,
+      braceEnd,
+      bodyStart: braceStart + 1,
+      bodyEnd: braceEnd,
+    };
+  }
+
+  return undefined;
+}
+
+function stripLeadingPropertyTrivia(content: string): string {
+  let current = content;
+
+  while (true) {
+    const trimmed = current.replace(/^\s+/, "");
+
+    if (trimmed.startsWith("//")) {
+      const lineEnd = trimmed.indexOf("\n");
+      current = lineEnd === -1 ? "" : trimmed.slice(lineEnd + 1);
+      continue;
+    }
+
+    if (trimmed.startsWith("/*")) {
+      const blockEnd = trimmed.indexOf("*/");
+      current = blockEnd === -1 ? trimmed : trimmed.slice(blockEnd + 2);
+      continue;
+    }
+
+    return trimmed;
+  }
+}
+
+function propertyStartsWithKey(property: string, key: string): boolean {
+  return new RegExp(`^${escapeRegExp(key)}\\s*:`).test(stripLeadingPropertyTrivia(property));
+}
+
+function findTopLevelPropertyRange(
+  content: string,
+  bodyStart: number,
+  bodyEnd: number,
+  key: string,
+): PropertyRange | undefined {
+  let start = bodyStart;
+  let stringQuote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  const maybeMatch = (end: number): PropertyRange | undefined => {
+    const property = content.slice(start, end);
+    if (!propertyStartsWithKey(property, key)) return undefined;
+    return { start, end };
+  };
+
+  for (let index = bodyStart; index <= bodyEnd; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (index === bodyEnd) {
+      return maybeMatch(index);
+    }
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (stringQuote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (char === stringQuote) {
+        stringQuote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      stringQuote = char;
+      continue;
+    }
+
+    if (char === "{") {
+      braceDepth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+
+    if (char === "[") {
+      bracketDepth += 1;
+      continue;
+    }
+
+    if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+
+    if (char === "(") {
+      parenDepth += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+      continue;
+    }
+
+    if (char !== "," || braceDepth !== 0 || bracketDepth !== 0 || parenDepth !== 0) {
+      continue;
+    }
+
+    const match = maybeMatch(index);
+    if (match) return match;
+    start = index + 1;
+  }
+
+  return undefined;
+}
+
+function findObjectPropertyRange(
+  content: string,
+  object: ObjectRange,
+  key: string,
+): ObjectRange | undefined {
+  const property = findTopLevelPropertyRange(content, object.bodyStart, object.bodyEnd, key);
+  if (!property) return undefined;
+
+  const colon = content.indexOf(":", property.start);
+  const braceStart = content.indexOf("{", colon);
+  if (colon === -1 || braceStart === -1 || braceStart > property.end) return undefined;
+
+  const braceEnd = findBalancedBraceEnd(content, braceStart);
+  if (braceEnd === -1 || braceEnd > property.end) return undefined;
+
+  return {
+    braceStart,
+    braceEnd,
+    bodyStart: braceStart + 1,
+    bodyEnd: braceEnd,
+  };
+}
+
+function lineIndentAt(content: string, index: number): string {
+  const lineStart = content.lastIndexOf("\n", index - 1) + 1;
+  return content.slice(lineStart, index).match(/^\s*/)?.[0] ?? "";
+}
+
+function insertObjectProperties(
+  content: string,
+  object: ObjectRange,
+  properties: string[],
+): string {
+  if (properties.length === 0) return content;
+
+  const body = content.slice(object.bodyStart, object.bodyEnd);
+  const closingIndent = lineIndentAt(content, object.braceEnd);
+  const beforeObjectClose = content.slice(0, object.bodyEnd).replace(/\s*$/, "");
+  const suffix = content.slice(object.bodyEnd);
+  const needsComma = body.trim().length > 0 && !beforeObjectClose.endsWith(",");
+
+  return `${beforeObjectClose}${needsComma ? "," : ""}\n${properties.join("\n")}\n${closingIndent}${suffix}`;
+}
+
+function renderAnalyticsConfigProperty(indent: string): string {
+  return `${indent}analytics: {
+${indent}  enabled: true,
+${indent}  console: false,
+${indent}  includeInputs: false,
+${indent}},`;
+}
+
+function renderCloudConfigProperty(indent: string, apiKeyEnv: string): string {
+  return `${indent}cloud: {
+${indent}  apiKey: { env: ${JSON.stringify(apiKeyEnv)} },
+${indent}  deploy: { enabled: true },
+${indent}  analytics: {
+${indent}    enabled: true,
+${indent}    console: false,
+${indent}    includeInputs: false,
+${indent}  },
+${indent}  publish: { mode: "draft-pr", baseBranch: "main" },
+${indent}},`;
+}
+
+function renderCloudInitDocsConfig(apiKeyEnv: string): string {
+  return `import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+${renderAnalyticsConfigProperty("  ")}
+${renderCloudConfigProperty("  ", apiKeyEnv)}
+});
+`;
+}
+
+function normalizeEnvName(value: string | undefined, fallback: string): string {
+  const normalized = value?.trim();
+  if (!normalized) return fallback;
+
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(normalized)) {
+    throw new Error(`Invalid environment variable name: ${normalized}`);
+  }
+
+  return normalized;
+}
+
+function ensureDocsConfigCloudInit(options: {
+  rootDir: string;
+  configPath?: string;
+  apiKeyEnv: string;
+}): { configPath: string; created: boolean; updated: boolean } {
+  const resolvedConfigPath = tryResolveDocsConfigPath(options.rootDir, options.configPath);
+  const configPath = resolvedConfigPath ?? path.join(options.rootDir, "docs.config.ts");
+
+  if (!resolvedConfigPath) {
+    fs.writeFileSync(configPath, renderCloudInitDocsConfig(options.apiKeyEnv), "utf-8");
+    return { configPath, created: true, updated: true };
+  }
+
+  const original = fs.readFileSync(configPath, "utf-8");
+  let content = original;
+  let configObject = findConfigObjectRange(content);
+  if (!configObject) {
+    throw new Error(
+      `Could not find an object export in ${path.relative(options.rootDir, configPath)}. Use defineDocs({ ... }) or export default { ... } before running cloud init.`,
+    );
+  }
+
+  const topLevelIndent = `${lineIndentAt(content, configObject.braceEnd)}  `;
+  const cloudProperty = findTopLevelPropertyRange(
+    content,
+    configObject.bodyStart,
+    configObject.bodyEnd,
+    "cloud",
+  );
+  let cloudObject = findObjectPropertyRange(content, configObject, "cloud");
+
+  if (!cloudProperty) {
+    content = insertObjectProperties(content, configObject, [
+      renderCloudConfigProperty(topLevelIndent, options.apiKeyEnv),
+    ]);
+  } else if (!cloudObject) {
+    throw new Error(
+      `Could not update cloud config in ${path.relative(options.rootDir, configPath)} because cloud is not an object literal.`,
+    );
+  }
+
+  configObject = findConfigObjectRange(content);
+  if (!configObject) {
+    throw new Error(`Could not re-read ${path.relative(options.rootDir, configPath)}.`);
+  }
+
+  cloudObject = findObjectPropertyRange(content, configObject, "cloud");
+  if (cloudObject) {
+    const cloudIndent = `${lineIndentAt(content, cloudObject.braceEnd)}  `;
+    const missingCloudProperties: string[] = [];
+
+    if (!findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "apiKey")) {
+      missingCloudProperties.push(
+        `${cloudIndent}apiKey: { env: ${JSON.stringify(options.apiKeyEnv)} },`,
+      );
+    } else {
+      const apiKeyObject = findObjectPropertyRange(content, cloudObject, "apiKey");
+      if (
+        apiKeyObject &&
+        !findTopLevelPropertyRange(content, apiKeyObject.bodyStart, apiKeyObject.bodyEnd, "env")
+      ) {
+        content = insertObjectProperties(content, apiKeyObject, [
+          `${lineIndentAt(content, apiKeyObject.braceEnd)}  env: ${JSON.stringify(options.apiKeyEnv)},`,
+        ]);
+        configObject = findConfigObjectRange(content)!;
+        cloudObject = findObjectPropertyRange(content, configObject, "cloud")!;
+      }
+    }
+
+    if (!findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "deploy")) {
+      missingCloudProperties.push(`${cloudIndent}deploy: { enabled: true },`);
+    }
+
+    if (
+      !findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "analytics")
+    ) {
+      missingCloudProperties.push(renderAnalyticsConfigProperty(cloudIndent));
+    }
+
+    if (!findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "publish")) {
+      missingCloudProperties.push(
+        `${cloudIndent}publish: { mode: "draft-pr", baseBranch: "main" },`,
+      );
+    }
+
+    content = insertObjectProperties(content, cloudObject, missingCloudProperties);
+  }
+
+  configObject = findConfigObjectRange(content);
+  if (!configObject) {
+    throw new Error(`Could not re-read ${path.relative(options.rootDir, configPath)}.`);
+  }
+
+  if (
+    !findTopLevelPropertyRange(content, configObject.bodyStart, configObject.bodyEnd, "analytics")
+  ) {
+    content = insertObjectProperties(content, configObject, [
+      renderAnalyticsConfigProperty(`${lineIndentAt(content, configObject.braceEnd)}  `),
+    ]);
+  }
+
+  if (content !== original) {
+    fs.writeFileSync(configPath, content, "utf-8");
+  }
+
+  return { configPath, created: false, updated: content !== original };
 }
 
 function readExistingDocsJson(docsJsonPath: string): ManagedDocsJson | undefined {

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -650,7 +650,9 @@ function ensureDocsConfigCloudInit(options: {
       missingCloudProperties.push(renderAnalyticsConfigProperty(cloudIndent));
     }
 
-    if (!findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "publish")) {
+    if (
+      !findTopLevelPropertyRange(content, cloudObject.bodyStart, cloudObject.bodyEnd, "publish")
+    ) {
       missingCloudProperties.push(
         `${cloudIndent}publish: { mode: "draft-pr", baseBranch: "main" },`,
       );
@@ -1346,6 +1348,70 @@ export async function syncCloudConfig(options: CloudCommandOptions = {}) {
   return result;
 }
 
+export async function initCloudConfig(options: CloudCommandOptions = {}): Promise<CloudInitResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const apiKeyEnv = normalizeEnvName(options.apiKeyEnv, DOCS_CLOUD_DEFAULT_API_KEY_ENV);
+  const configUpdate = ensureDocsConfigCloudInit({
+    rootDir,
+    configPath: options.configPath,
+    apiKeyEnv,
+  });
+  const materialized = await materializeCloudConfig({
+    ...options,
+    rootDir,
+    configPath: path.relative(rootDir, configUpdate.configPath),
+  });
+
+  return {
+    configPath: configUpdate.configPath,
+    docsJsonPath: materialized.docsJsonPath,
+    apiKeyEnv: materialized.apiKeyEnv,
+    analyticsProjectIdEnv: DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV,
+    configCreated: configUpdate.created,
+    configUpdated: configUpdate.updated,
+    docsJsonCreated: materialized.created,
+    docsJsonUpdated: materialized.updated,
+  };
+}
+
+export async function runCloudInit(options: CloudCommandOptions = {}) {
+  const result = await initCloudConfig(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+
+  const relativeConfigPath = path.relative(process.cwd(), result.configPath) || "docs.config.ts";
+  const relativeDocsJsonPath = path.relative(process.cwd(), result.docsJsonPath) || DOCS_JSON_FILE;
+  const configAction = result.configCreated
+    ? "Created"
+    : result.configUpdated
+      ? "Updated"
+      : "Checked";
+  const docsJsonAction = result.docsJsonCreated
+    ? "created"
+    : result.docsJsonUpdated
+      ? "updated"
+      : "checked";
+
+  console.log(`${pc.green("ok")} ${configAction} ${pc.cyan(relativeConfigPath)}`);
+  console.log(`${pc.green("ok")} ${docsJsonAction} ${pc.cyan(relativeDocsJsonPath)}`);
+  console.log();
+  console.log(pc.bold("Add these env vars"));
+  console.log(`${pc.cyan(result.apiKeyEnv)}=${pc.dim("paste_your_docs_cloud_api_key")}`);
+  console.log(
+    `${pc.cyan(result.analyticsProjectIdEnv)}=${pc.dim("paste_your_docs_cloud_project_id")}`,
+  );
+  console.log();
+  console.log(
+    pc.dim("Use the same env vars in production. The API key value is never written to config."),
+  );
+  console.log(pc.dim(`Then run ${pc.cyan("pnpm dlx @farming-labs/docs deploy")}.`));
+
+  return result;
+}
+
 async function runCloudDeployment(options: CloudCommandOptions = {}) {
   const rootDir = options.rootDir ?? process.cwd();
   const spinner = createSpinner("Preparing Docs Cloud deployment", options);
@@ -1433,6 +1499,7 @@ export function printCloudHelp() {
 ${pc.bold("@farming-labs/docs cloud")}
 
 ${pc.dim("Usage:")}
+  ${pc.cyan("docs cloud init")}           Add Docs Cloud config to ${pc.dim("docs.config.ts")} and ${pc.dim("docs.json")}
   ${pc.cyan("docs deploy")}               Sync ${pc.dim("docs.config.ts")} to ${pc.dim("docs.json")} and deploy hosted preview docs
   ${pc.cyan("docs cloud deploy")}         Same as ${pc.cyan("docs deploy")}
   ${pc.cyan("docs preview")}              Compatibility alias for ${pc.cyan("docs deploy")}
@@ -1441,6 +1508,7 @@ ${pc.dim("Usage:")}
 
 ${pc.dim("Options:")}
   ${pc.cyan("--config <path>")}           Use a custom docs config path
+  ${pc.cyan("--api-key-env <name>")}      Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}      Override Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}           Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--json")}                    Print machine-readable output
@@ -1452,6 +1520,7 @@ ${pc.dim("Config example:")}
   cloud: {
     apiKey: { env: "DOCS_CLOUD_API_KEY" },
     deploy: { enabled: true },
+    analytics: { enabled: true, console: false, includeInputs: false },
     publish: { mode: "draft-pr", baseBranch: "main" },
   }
 `);

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -355,7 +355,7 @@ function stripLeadingPropertyTrivia(content: string): string {
 
     if (trimmed.startsWith("/*")) {
       const blockEnd = trimmed.indexOf("*/");
-      current = blockEnd === -1 ? trimmed : trimmed.slice(blockEnd + 2);
+      current = blockEnd === -1 ? "" : trimmed.slice(blockEnd + 2);
       continue;
     }
 

--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -58,10 +58,13 @@ describe("parseFlags", () => {
       "src/lib/docs.config.ts",
       "--api-base-url",
       "https://docs-app.example.com",
+      "--api-key-env",
+      "ACME_DOCS_CLOUD_KEY",
       "--json",
     ]);
     expect(flags.config).toBe("src/lib/docs.config.ts");
     expect(flags["api-base-url"]).toBe("https://docs-app.example.com");
+    expect(flags["api-key-env"]).toBe("ACME_DOCS_CLOUD_KEY");
     expect(flags.json).toBe(true);
   });
 

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -108,6 +108,7 @@ async function main() {
           ? flags.url
           : undefined,
     apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
+    apiKeyEnv: typeof flags["api-key-env"] === "string" ? flags["api-key-env"] : undefined,
     json: typeof flags.json === "boolean" ? flags.json : undefined,
   };
 
@@ -129,6 +130,9 @@ async function main() {
   } else if (parsedCommand.command === "cloud" && subcommand === "preview") {
     const { runCloudPreview } = await import("./cloud.js");
     await runCloudPreview(cloudOptions);
+  } else if (parsedCommand.command === "cloud" && subcommand === "init") {
+    const { runCloudInit } = await import("./cloud.js");
+    await runCloudInit(cloudOptions);
   } else if (parsedCommand.command === "cloud" && subcommand === "sync") {
     const { syncCloudConfig } = await import("./cloud.js");
     await syncCloudConfig(cloudOptions);
@@ -295,7 +299,7 @@ ${pc.dim("Commands:")}
   ${pc.cyan("dev")}      Run frameworkless docs locally from ${pc.dim("docs.json")}
   ${pc.cyan("deploy")}   Sync cloud config and deploy hosted preview docs
   ${pc.cyan("preview")}  Alias for ${pc.cyan("deploy")}
-  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("deploy")}, ${pc.dim("preview")}, ${pc.dim("sync")})
+  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("init")}, ${pc.dim("deploy")}, ${pc.dim("preview")}, ${pc.dim("sync")})
   ${pc.cyan("agent")}    Agent utilities (${pc.dim("compact")} to generate sibling agent.md files)
   ${pc.cyan("agents")}   AGENTS.md utilities (${pc.dim("generate")} for static agent instructions)
   ${pc.cyan("doctor")}   Inspect and score agent or reader-facing docs quality
@@ -330,12 +334,14 @@ ${pc.dim("Options for dev:")}
   ${pc.cyan("--verbose")}           Show raw runtime logs in addition to branded CLI output
 
 ${pc.dim("Options for cloud deploy:")}
+  ${pc.cyan("cloud init")}                           Add Docs Cloud config to ${pc.dim("docs.config.ts")} and ${pc.dim("docs.json")}
   ${pc.cyan("deploy")}                               Sync ${pc.dim("docs.config.ts")} into ${pc.dim("docs.json")} and deploy hosted preview docs
   ${pc.cyan("cloud deploy")}                         Same as ${pc.cyan("deploy")}
   ${pc.cyan("preview")}                              Alias for ${pc.cyan("deploy")}
   ${pc.cyan("cloud preview")}                        Compatibility alias for ${pc.cyan("cloud deploy")}
   ${pc.cyan("cloud sync")}                           Only materialize cloud settings into ${pc.dim("docs.json")}
   ${pc.cyan("--config <path>")}                      Use a custom docs config path
+  ${pc.cyan("--api-key-env <name>")}                 Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}                 Override the Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}                      Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--json")}                              Print machine-readable output


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `docs cloud init` CLI to scaffold or update `docs.config.ts` and materialize `docs.json` with Docs Cloud settings (API key, deploy, analytics, publish). Supports `--api-key-env`, uses safe defaults, and prints the env vars to set.

- **New Features**
  - Generates `docs.config.ts` when missing using `defineDocs` from `@farming-labs/docs`.
  - Adds/updates `cloud` config: `apiKey.env` (default `DOCS_CLOUD_API_KEY` or `--api-key-env`), `deploy.enabled`, `analytics` defaults (`enabled: true`, `console: false`, `includeInputs: false`), and `publish` set to `draft-pr` on `main`.
  - Ensures top-level `analytics` config exists.
  - Creates or updates `docs.json` with matching cloud settings and detected framework runtime.
  - Structure-aware edits fill missing fields without overwriting existing settings, preserve formatting/comments, safely handle unterminated comment blocks, and surface `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`.

- **Migration**
  - Set `DOCS_CLOUD_API_KEY` (or your `--api-key-env`) and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` in your environment.
  - Run `docs cloud init` from the project root and commit the changes.

<sup>Written for commit 625160bf1d3315f1f88d799b5c1c94afa3b6d611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

