### PR TITLE
chore: adding docs link for error crash

### DIFF
--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -631,7 +631,7 @@ void missing;
         apiBaseUrl: "https://cloud.example.com",
         json: true,
       }),
-    ).rejects.toThrow("Missing Docs Cloud API key");
+    ).rejects.toThrow("https://docs.farming-labs.dev/docs/cloud/deploy#missing-api-key");
   });
 
   it("fails clearly when preview deployment is disabled in cloud config", async () => {

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -20,6 +20,8 @@ const DOCS_JSON_FILE = "docs.json";
 const DOCS_CLOUD_SCHEMA_URL = "https://docs.farming-labs.dev/schema/docs.json";
 const DOCS_CLOUD_DEFAULT_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
+const DOCS_CLOUD_MISSING_API_KEY_DOCS_URL =
+  "https://docs.farming-labs.dev/docs/cloud/deploy#missing-api-key";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
 const DEFAULT_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PREVIEW_POLL_INTERVAL_MS = 2000;
@@ -1005,7 +1007,7 @@ function resolveApiKey(options: CloudCommandOptions, rootDir: string, envName: s
   if (token) return token;
 
   throw new Error(
-    `Missing Docs Cloud API key. Set ${envName} in your shell or .env.local, or configure cloud.apiKey.env in docs.config.ts.`,
+    `Missing Docs Cloud API key. Set ${envName} in your shell or .env.local, or configure cloud.apiKey.env in docs.config.ts. See ${DOCS_CLOUD_MISSING_API_KEY_DOCS_URL}.`,
   );
 }
 

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -152,7 +152,7 @@ Cloud project owns the branch policy.
 
 ## Troubleshooting
 
-**Missing API key**
+### Missing API key
 
 Set the environment variable named by `cloud.apiKey.env`:
 
@@ -162,12 +162,12 @@ export DOCS_CLOUD_API_KEY=fl_key_...
 
 or add it to `.env.local`.
 
-**Deploy disabled**
+### Deploy disabled
 
 If `cloud.deploy.enabled` is `false`, `docs deploy` stops before requesting a hosted preview. Set it
 back to `true` or remove the override.
 
-**Wrong Cloud host**
+### Wrong Cloud host
 
 For staging or self-hosted testing, pass:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a help link to the “Missing Docs Cloud API key” error so developers can jump straight to troubleshooting. Updated docs to expose the `#missing-api-key` anchor and aligned tests.

- **New Features**
  - The missing API key error now includes a docs URL: https://docs.farming-labs.dev/docs/cloud/deploy#missing-api-key (via `DOCS_CLOUD_MISSING_API_KEY_DOCS_URL` in `packages/docs/src/cli/cloud.ts`).
  - Updated `packages/docs/src/cli/cloud.test.ts` to expect the new error message with the link.
  - Changed troubleshooting headings to H3 in `website/app/docs/cloud/deploy/page.mdx` to generate stable anchors.

<sup>Written for commit f450370ca0fe5b9ee2063d8512e01ed9b1118b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

