### PR TITLE
fix: hide stack trace for missing env

### DIFF
--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -14,6 +14,7 @@ import {
   resolveDocsConfigPath,
   resolveDocsContentDir,
 } from "./config.js";
+import { markCliErrorReported } from "./errors.js";
 import { detectFramework, type Framework } from "./utils.js";
 
 const DOCS_JSON_FILE = "docs.json";
@@ -1481,7 +1482,10 @@ async function runCloudDeployment(options: CloudCommandOptions = {}) {
     return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    spinner.fail(message);
+    if (!options.json) {
+      spinner.fail(message);
+      markCliErrorReported(error);
+    }
     throw error;
   } finally {
     spinner.stop();

--- a/packages/docs/src/cli/errors.test.ts
+++ b/packages/docs/src/cli/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCliError,
+  markCliErrorReported,
+  shouldPrintStackTrace,
+  wasCliErrorReported,
+} from "./errors.js";
+
+describe("cli error helpers", () => {
+  it("returns only the message for Error objects", () => {
+    const error = new Error("Missing Docs Cloud API key.");
+    expect(formatCliError(error)).toBe("Missing Docs Cloud API key.");
+    expect(formatCliError(error)).not.toContain("at ");
+  });
+
+  it("handles string and unknown errors", () => {
+    expect(formatCliError("  nope  ")).toBe("nope");
+    expect(formatCliError(null)).toBe("An unexpected error occurred.");
+  });
+
+  it("tracks errors that were already printed by a command", () => {
+    const error = new Error("Already printed");
+    expect(wasCliErrorReported(error)).toBe(false);
+    markCliErrorReported(error);
+    expect(wasCliErrorReported(error)).toBe(true);
+  });
+
+  it("only enables stack traces with explicit debug env values", () => {
+    expect(shouldPrintStackTrace({})).toBe(false);
+    expect(shouldPrintStackTrace({ DOCS_DEBUG: "1" })).toBe(true);
+    expect(shouldPrintStackTrace({ DEBUG: "@farming-labs/docs" })).toBe(true);
+  });
+});

--- a/packages/docs/src/cli/errors.ts
+++ b/packages/docs/src/cli/errors.ts
@@ -1,0 +1,30 @@
+const CLI_ERROR_REPORTED_KEY = "__farmingLabsDocsCliErrorReported";
+
+type ReportedCliError = {
+  [CLI_ERROR_REPORTED_KEY]?: boolean;
+};
+
+export function formatCliError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  if (typeof error === "string" && error.trim()) return error.trim();
+  return "An unexpected error occurred.";
+}
+
+export function markCliErrorReported(error: unknown): void {
+  if (error && typeof error === "object") {
+    (error as ReportedCliError)[CLI_ERROR_REPORTED_KEY] = true;
+  }
+}
+
+export function wasCliErrorReported(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    (error as ReportedCliError)[CLI_ERROR_REPORTED_KEY] === true,
+  );
+}
+
+export function shouldPrintStackTrace(env: NodeJS.ProcessEnv = process.env): boolean {
+  const debug = env.DOCS_DEBUG ?? env.DEBUG;
+  return debug === "1" || debug === "true" || debug === "@farming-labs/docs";
+}

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import pc from "picocolors";
+import { formatCliError, shouldPrintStackTrace, wasCliErrorReported } from "./errors.js";
+
+export { formatCliError } from "./errors.js";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -436,7 +439,10 @@ function printVersion() {
 }
 
 main().catch((err) => {
-  console.error(pc.red("An unexpected error occurred:"));
-  console.error(err);
+  if (shouldPrintStackTrace()) {
+    console.error(err);
+  } else if (!wasCliErrorReported(err)) {
+    console.error(pc.red(`Error: ${formatCliError(err)}`));
+  }
   process.exit(1);
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide noisy stack traces in the Docs CLI when env vars are missing, and show a clean one-line error instead. Stack traces now appear only when debugging is enabled.

- **Bug Fixes**
  - Print stack traces only with `DOCS_DEBUG=1|true` or `DEBUG=@farming-labs/docs`.
  - Format errors to a single line with a safe fallback message.
  - Prevent duplicate error output by marking errors as reported in the `cloud` command when not using `--json`.
  - Add `errors.ts` helpers and tests (`formatCliError`, `markCliErrorReported`, `wasCliErrorReported`, `shouldPrintStackTrace`).

<sup>Written for commit dfcb4805fc0c78171832edbb003ffa3c7af65883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

