### PR TITLE
feat: cloud onboarding on cli init

### DIFF
--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -26,11 +26,13 @@ describe("parseFlags", () => {
       "darksharp",
       "--entry",
       "docs",
+      "--cloud",
     ]);
     expect(flags.template).toBe("astro");
     expect(flags.name).toBe("my-app");
     expect(flags.theme).toBe("darksharp");
     expect(flags.entry).toBe("docs");
+    expect(flags.cloud).toBe(true);
   });
 
   it("parses api reference flags", () => {
@@ -38,6 +40,10 @@ describe("parseFlags", () => {
     expect(flags["api-reference"]).toBe(true);
     expect(flags["api-route-root"]).toBe("internal-api");
     expect(flags.other).toBe(false);
+  });
+
+  it("parses --no-cloud", () => {
+    expect(parseFlags(["init", "--no-cloud"]).cloud).toBe(false);
   });
 
   it("parses mcp flags", () => {
@@ -81,8 +87,9 @@ describe("parseFlags", () => {
   });
 
   it("parses boolean values in --key=value form", () => {
-    const flags = parseFlags(["--api-reference=false", "--theme=colorful"]);
+    const flags = parseFlags(["--api-reference=false", "--cloud=true", "--theme=colorful"]);
     expect(flags["api-reference"]).toBe(false);
+    expect(flags.cloud).toBe(true);
     expect(flags.theme).toBe("colorful");
   });
 

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -33,6 +33,7 @@ export function parseFlags(argv: string[]): Record<string, string | boolean | un
   const flags: Record<string, string | boolean | undefined> = {};
   const booleanFlags = new Set([
     "api-reference",
+    "cloud",
     "typesense",
     "algolia",
     "verbose",
@@ -74,6 +75,7 @@ async function main() {
     entry: typeof flags.entry === "string" ? flags.entry : undefined,
     apiReference: typeof flags["api-reference"] === "boolean" ? flags["api-reference"] : undefined,
     apiRouteRoot: typeof flags["api-route-root"] === "string" ? flags["api-route-root"] : undefined,
+    cloud: typeof flags.cloud === "boolean" ? flags.cloud : undefined,
   };
   const mcpOptions = {
     configPath: typeof flags.config === "string" ? flags.config : undefined,
@@ -326,6 +328,8 @@ ${pc.dim("Options for init:")}
   ${pc.cyan("--api-reference")}    Scaffold API reference support during ${pc.cyan("init")}
   ${pc.cyan("--no-api-reference")} Skip API reference scaffold during ${pc.cyan("init")}
   ${pc.cyan("--api-route-root <path>")}  Override the API route root scanned by ${pc.cyan("apiReference.routeRoot")} (e.g. ${pc.dim("api")}, ${pc.dim("internal-api")})
+  ${pc.cyan("--cloud")}            Add Docs Cloud infrastructure support during ${pc.cyan("init")}
+  ${pc.cyan("--no-cloud")}         Skip the Docs Cloud infrastructure prompt during ${pc.cyan("init")}
 
 ${pc.dim("Options for mcp:")}
   ${pc.cyan("--config <path>")}     Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}

--- a/packages/docs/src/cli/init.test.ts
+++ b/packages/docs/src/cli/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { VALID_TEMPLATES, init } from "./init.js";
+import { VALID_TEMPLATES, getDocsCloudConfigPathForFramework, init } from "./init.js";
 
 const cancelSymbol = Symbol("clack:cancel");
 
@@ -25,6 +25,10 @@ vi.mock("./utils.js", async () => {
     exec: vi.fn(),
   };
 });
+
+vi.mock("./cloud.js", () => ({
+  initCloudConfig: vi.fn(),
+}));
 
 // Mock fs so fresh template flow doesn't touch the real filesystem.
 vi.mock("node:fs", () => {
@@ -55,13 +59,19 @@ describe("init", () => {
     beforeEach(async () => {
       const prompts = await import("@clack/prompts");
       const utils = await import("./utils.js");
+      const cloud = await import("./cloud.js");
       vi.mocked(prompts.select).mockReset();
       vi.mocked(prompts.multiselect).mockReset();
       vi.mocked(prompts.text).mockReset();
       vi.mocked(prompts.confirm).mockReset();
+      vi.mocked(prompts.log.info).mockReset();
+      vi.mocked(prompts.log.success).mockReset();
+      vi.mocked(prompts.log.warn).mockReset();
+      vi.mocked(prompts.log.error).mockReset();
       vi.mocked(prompts.isCancel).mockImplementation((value: unknown) => value === cancelSymbol);
       vi.mocked(utils.detectFramework).mockReset();
       vi.mocked(utils.detectPackageManagerFromLockfile).mockReset();
+      vi.mocked(cloud.initCloudConfig).mockReset();
       exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
         throw new Error("process.exit");
       }) as () => never);
@@ -246,6 +256,94 @@ describe("init", () => {
           defaultValue: "api",
         }),
       );
+    });
+
+    it("asks whether to add Docs Cloud infrastructure support after installing deps", async () => {
+      const prompts = await import("@clack/prompts");
+      const utils = await import("./utils.js");
+
+      vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
+      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+
+      vi.mocked(prompts.select)
+        .mockResolvedValueOnce("existing" as never)
+        .mockResolvedValueOnce("fumadocs" as never)
+        .mockResolvedValueOnce("pnpm" as never);
+      vi.mocked(prompts.confirm)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(cancelSymbol as never);
+      vi.mocked(prompts.text)
+        .mockResolvedValueOnce("docs" as never)
+        .mockResolvedValueOnce("app/globals.css" as never);
+
+      await expect(init({})).rejects.toThrow("process.exit");
+
+      expect(prompts.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Docs Cloud infrastructure support"),
+          initialValue: false,
+        }),
+      );
+    });
+
+    it("configures Docs Cloud support when enabled during init", async () => {
+      const prompts = await import("@clack/prompts");
+      const utils = await import("./utils.js");
+      const cloud = await import("./cloud.js");
+
+      vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
+      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(cloud.initCloudConfig).mockResolvedValueOnce({
+        configPath: `${process.cwd()}/docs.config.ts`,
+        docsJsonPath: `${process.cwd()}/docs.json`,
+        apiKeyEnv: "DOCS_CLOUD_API_KEY",
+        analyticsProjectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+        configCreated: false,
+        configUpdated: true,
+        docsJsonCreated: true,
+        docsJsonUpdated: true,
+      });
+
+      vi.mocked(prompts.select)
+        .mockResolvedValueOnce("existing" as never)
+        .mockResolvedValueOnce("fumadocs" as never)
+        .mockResolvedValueOnce("pnpm" as never);
+      vi.mocked(prompts.confirm)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(false as never)
+        .mockResolvedValueOnce(true as never)
+        .mockResolvedValueOnce(false as never);
+      vi.mocked(prompts.text)
+        .mockResolvedValueOnce("docs" as never)
+        .mockResolvedValueOnce("app/globals.css" as never);
+
+      await expect(init({})).rejects.toThrow("process.exit");
+
+      expect(cloud.initCloudConfig).toHaveBeenCalledWith({
+        rootDir: process.cwd(),
+        configPath: undefined,
+      });
+      expect(prompts.log.success).toHaveBeenCalledWith(
+        expect.stringContaining("Docs Cloud infrastructure support configured"),
+      );
+    });
+  });
+
+  describe("getDocsCloudConfigPathForFramework", () => {
+    it("uses src/lib docs config paths for frameworks that scaffold there", () => {
+      expect(getDocsCloudConfigPathForFramework("sveltekit")).toBe("src/lib/docs.config.ts");
+      expect(getDocsCloudConfigPathForFramework("astro")).toBe("src/lib/docs.config.ts");
+    });
+
+    it("lets root-config frameworks auto-resolve docs.config extensions", () => {
+      expect(getDocsCloudConfigPathForFramework("nextjs")).toBeUndefined();
+      expect(getDocsCloudConfigPathForFramework("tanstack-start")).toBeUndefined();
+      expect(getDocsCloudConfigPathForFramework("nuxt")).toBeUndefined();
     });
   });
 });

--- a/packages/docs/src/cli/init.ts
+++ b/packages/docs/src/cli/init.ts
@@ -267,7 +267,7 @@ export function getDocsCloudConfigPathForFramework(framework: Framework): string
 
 function docsCloudDeployCommand(pm: PackageManager): string {
   if (pm === "pnpm") return "pnpm dlx @farming-labs/docs deploy";
-  if (pm === "yarn") return "yarn dlx @farming-labs/docs deploy";
+  if (pm === "yarn") return "npx @farming-labs/docs deploy";
   if (pm === "bun") return "bunx @farming-labs/docs deploy";
   return "npx @farming-labs/docs deploy";
 }

--- a/packages/docs/src/cli/init.ts
+++ b/packages/docs/src/cli/init.ts
@@ -29,6 +29,7 @@ export interface InitOptions {
   entry?: string;
   apiReference?: boolean;
   apiRouteRoot?: string;
+  cloud?: boolean;
 }
 
 import {
@@ -108,6 +109,8 @@ import {
   injectNuxtCssImport,
   type TemplateConfig,
 } from "./templates.js";
+
+const DOCS_CLOUD_DASHBOARD_URL = "https://docs-app.farming-labs.dev";
 
 const COMMON_LOCALE_OPTIONS = [
   { value: "en", label: "English", hint: "en" },
@@ -247,6 +250,92 @@ function detectApiRouteRoot(
         entry.isFile(),
     ) ?? defaultRoot
   );
+}
+
+function frameworkForTemplate(template: TemplateName): Framework {
+  if (template === "next") return "nextjs";
+  if (template === "tanstack-start") return "tanstack-start";
+  if (template === "sveltekit") return "sveltekit";
+  if (template === "astro") return "astro";
+  return "nuxt";
+}
+
+export function getDocsCloudConfigPathForFramework(framework: Framework): string | undefined {
+  if (framework === "sveltekit" || framework === "astro") return "src/lib/docs.config.ts";
+  return undefined;
+}
+
+function docsCloudDeployCommand(pm: PackageManager): string {
+  if (pm === "pnpm") return "pnpm dlx @farming-labs/docs deploy";
+  if (pm === "yarn") return "yarn dlx @farming-labs/docs deploy";
+  if (pm === "bun") return "bunx @farming-labs/docs deploy";
+  return "npx @farming-labs/docs deploy";
+}
+
+function printDocsCloudOnboardingInstructions(
+  result: {
+    configPath: string;
+    docsJsonPath: string;
+    apiKeyEnv: string;
+    analyticsProjectIdEnv: string;
+  },
+  rootDir: string,
+  pm: PackageManager,
+) {
+  const relativeConfigPath =
+    path.relative(rootDir, result.configPath) || path.basename(result.configPath);
+  const relativeDocsJsonPath =
+    path.relative(rootDir, result.docsJsonPath) || path.basename(result.docsJsonPath);
+
+  p.log.success(
+    `Docs Cloud infrastructure support configured:\n` +
+      `  ${pc.green("+")} ${relativeConfigPath}\n` +
+      `  ${pc.green("+")} ${relativeDocsJsonPath}`,
+  );
+
+  console.log();
+  console.log(pc.bold("Finish Docs Cloud authentication"));
+  console.log(`1. Sign in to ${pc.cyan(DOCS_CLOUD_DASHBOARD_URL)}.`);
+  console.log("2. Open your Docs Cloud project settings and create a project API key.");
+  console.log(`3. Add the key to ${pc.cyan(".env.local")} or your shell:`);
+  console.log(`   ${pc.cyan(result.apiKeyEnv)}=${pc.dim("fl_key_...")}`);
+  console.log(`   ${pc.cyan(result.analyticsProjectIdEnv)}=${pc.dim("docs_cloud_project_id")}`);
+  console.log("4. Keep local env files out of git and use the same env names in production.");
+  console.log(`5. Deploy when ready with ${pc.cyan(docsCloudDeployCommand(pm))}.`);
+  console.log();
+}
+
+async function configureDocsCloudOnboarding(options: {
+  rootDir: string;
+  framework: Framework;
+  packageManager: PackageManager;
+  enabled?: boolean;
+}) {
+  let enabled = options.enabled;
+
+  if (typeof enabled !== "boolean") {
+    const cloudAnswer = await p.confirm({
+      message: `Do you want Docs Cloud infrastructure support? ${pc.dim("Adds cloud config and docs.json")}`,
+      initialValue: false,
+    });
+
+    if (p.isCancel(cloudAnswer)) {
+      p.outro(pc.red("Init cancelled."));
+      process.exit(0);
+    }
+
+    enabled = cloudAnswer;
+  }
+
+  if (!enabled) return;
+
+  const { initCloudConfig } = await import("./cloud.js");
+  const result = await initCloudConfig({
+    rootDir: options.rootDir,
+    configPath: getDocsCloudConfigPathForFramework(options.framework),
+  });
+
+  printDocsCloudOnboardingInstructions(result, options.rootDir, options.packageManager);
 }
 
 export async function init(options: InitOptions = {}) {
@@ -406,11 +495,26 @@ export async function init(options: InitOptions = {}) {
             ? "bun install"
             : "pnpm install";
 
+    let installSucceeded = true;
     try {
       exec(installCmd, targetDir);
     } catch {
+      installSucceeded = false;
       p.log.warn(
         `${pmFresh} install failed. Run ${pc.cyan(installCmd)} manually inside the project.`,
+      );
+    }
+
+    if (installSucceeded) {
+      await configureDocsCloudOnboarding({
+        rootDir: targetDir,
+        framework: frameworkForTemplate(template),
+        packageManager: pmFresh,
+        enabled: options.cloud,
+      });
+    } else if (options.cloud) {
+      p.log.warn(
+        `Skipping Docs Cloud onboarding until dependencies are installed. Then run ${pc.cyan("docs cloud init")}.`,
       );
     }
 
@@ -1096,6 +1200,13 @@ export async function init(options: InitOptions = {}) {
   }
 
   s2.stop("Dependencies installed");
+
+  await configureDocsCloudOnboarding({
+    rootDir: cwd,
+    framework,
+    packageManager: pm,
+    enabled: options.cloud,
+  });
 
   // -----------------------------------------------------------------------
   // Step 10: Start dev server

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, preview, deploy, cloud preview, cloud deploy, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
+description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits, compact agent docs, validate code blocks, generate AGENTS.md, generate sitemaps, generate robots.txt, sync external search indexes, and run MCP for docs. Use when running init, preview, deploy, cloud preview, cloud deploy, cloud sync, upgrade, downgrade, doctor, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, or flags like --template, --name, --theme, --entry, --api-reference, --api-route-root, --cloud, --framework, --latest, --beta, --version, --config, --url, --page, --all, --api-key, or --dry-run. Covers init flow, Create your own theme, optional defaults, npm/pnpm/yarn/bun, and framework detection.
 ---
 
 # @farming-labs/docs — CLI
@@ -31,8 +31,8 @@ yarn dlx @farming-labs/docs@latest init
 bunx @farming-labs/docs@latest init
 ```
 
-- **Existing project** — Add docs to the current directory. CLI then detects framework (or prompts), asks for theme (including **Create your own theme**, which prompts for theme name and scaffolds `themes/<name>.ts` and `themes/<name>.css`), entry path (default `docs`), optional i18n scaffolding, path aliases, and global CSS. TanStack Start follows the same flow, but the CLI currently skips the built-in i18n scaffold there so the generated routes stay minimal and working. **Prompts that show a placeholder use it as the default** — press **Enter** to accept (e.g. entry path `docs`, theme name `my-theme`, project name `my-docs`).
-- **Fresh project** — Bootstrap a new app. CLI asks for framework (Next.js, Nuxt, SvelteKit, Astro, TanStack Start), then project name (default `my-docs`; press Enter to accept), creates the folder, clones the template with degit, and runs install using the package manager you chose. You then `cd <name>` and run the matching dev command for that package manager.
+- **Existing project** — Add docs to the current directory. CLI then detects framework (or prompts), asks for theme (including **Create your own theme**, which prompts for theme name and scaffolds `themes/<name>.ts` and `themes/<name>.css`), entry path (default `docs`), optional i18n scaffolding, path aliases, global CSS, and optional Docs Cloud infrastructure support. TanStack Start follows the same flow, but the CLI currently skips the built-in i18n scaffold there so the generated routes stay minimal and working. **Prompts that show a placeholder use it as the default** — press **Enter** to accept (e.g. entry path `docs`, theme name `my-theme`, project name `my-docs`).
+- **Fresh project** — Bootstrap a new app. CLI asks for framework (Next.js, Nuxt, SvelteKit, Astro, TanStack Start), then project name (default `my-docs`; press Enter to accept), creates the folder, clones the template with degit, runs install using the package manager you chose, and can optionally add Docs Cloud infrastructure support. You then `cd <name>` and run the matching dev command for that package manager.
 
 If you use **`--template`** with **`--name`**, the CLI skips the existing-vs-fresh prompt and goes straight to bootstrap (same as choosing Fresh and then framework + name).
 
@@ -61,6 +61,8 @@ Replace `my-docs` with the desired folder name. Same pattern with `pnpm dlx`, `y
 | `--api-reference` | Enable API reference scaffold during `init`. |
 | `--no-api-reference` | Explicitly skip the API reference scaffold. |
 | `--api-route-root <path>` | Override the detected API route root written to `apiReference.routeRoot` (e.g. `api`, `internal-api`). |
+| `--cloud` | Add Docs Cloud infrastructure support during `init` without prompting. |
+| `--no-cloud` | Skip the Docs Cloud infrastructure prompt during `init`. |
 
 Example (non-interactive bootstrap with theme):
 
@@ -73,6 +75,17 @@ Example (existing project with API reference):
 ```bash
 npx @farming-labs/docs@latest init --theme greentree --entry docs --api-reference --api-route-root internal-api
 ```
+
+If Docs Cloud support is enabled during `init`, the CLI updates the docs config, writes the safe
+`docs.json` contract, and prints the next steps: sign in to `https://docs-app.farming-labs.dev`,
+create a project API key, and add it to `.env.local` or the shell:
+
+```bash
+DOCS_CLOUD_API_KEY=fl_key_...
+NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+```
+
+The raw key is never written to `docs.config.ts` or `docs.json`.
 
 ---
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -115,6 +115,7 @@ Run that from your app root. The CLI will:
 3. ask where docs should live, usually `docs`
 4. ask about aliases, global CSS, and optional i18n when supported
 5. generate the docs files and install the correct `@farming-labs/*` packages
+6. optionally add Docs Cloud infrastructure support and print the auth plus `.env.local` steps
 
 ### Upgrade an existing docs project
 
@@ -739,6 +740,8 @@ Use these to skip the matching prompts during `init`:
 | `--api-reference` | Enable API reference scaffold during `init` |
 | `--no-api-reference` | Explicitly skip API reference scaffold |
 | `--api-route-root <path>` | Set the detected API route root written to `apiReference.routeRoot` |
+| `--cloud` | Add Docs Cloud infrastructure support during `init` |
+| `--no-cloud` | Skip the Docs Cloud infrastructure prompt |
 
 Example:
 
@@ -752,6 +755,26 @@ When API reference is enabled through `init`:
 
 - **Next.js** writes the `apiReference` block and `app/api-reference/[[...slug]]/route.ts` (or `src/app/...`).
 - **TanStack Start, SvelteKit, Astro, and Nuxt** write the `apiReference` block and also scaffold the minimal `/{path}` handler files so the reference works immediately.
+
+### Optional Docs Cloud infrastructure
+
+During `init`, the CLI asks whether you want Docs Cloud infrastructure support. If you answer yes,
+or pass `--cloud`, it adds the `cloud` block to your docs config, writes the safe `docs.json`
+contract, and prints the authentication steps.
+
+The CLI does not write secret values. Sign in to `https://docs-app.farming-labs.dev`, create a
+project API key from your Docs Cloud project settings, then add it to `.env.local` or your shell:
+
+```bash title=".env.local"
+DOCS_CLOUD_API_KEY=fl_key_...
+NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+```
+
+Keep local env files out of git and set the same env names in production or CI. When ready, run:
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs deploy
+```
 
 ### Optional i18n scaffold
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional Docs Cloud onboarding to `@farming-labs/docs` CLI init for both fresh and existing projects. Enable it via a prompt or `--cloud`; the CLI sets up config, writes a safe contract, and prints clear next steps.

- **New Features**
  - Adds `--cloud` and `--no-cloud` flags (also works with `--key=value`).
  - After dependencies install, runs cloud setup: calls `initCloudConfig`, updates `docs.config` (framework-aware path), writes safe `docs.json`, logs created paths, and prints next steps (dashboard URL, envs `DOCS_CLOUD_API_KEY` and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`, and a package-manager-aware deploy command). Secrets are never written to files.
  - If install fails, skips onboarding; when `--cloud` is passed, suggests running `docs cloud init` later.
  - Updated CLI help, tests, `skills` docs, and website docs to cover the flow and flags.

<sup>Written for commit af17b73f08a47a0397551dbcf9b8ba5273e7fd5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

