### PR TITLE
feat: docs cloud dogfodding via api key & v1 release

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -292,7 +292,7 @@ describe("analytics", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://docs-app.farming-labs.dev/api/analytics/events",
+      "https://api.farming-labs.dev/v1/analytics/events",
       expect.objectContaining({
         method: "POST",
         keepalive: true,
@@ -599,7 +599,7 @@ describe("analytics", () => {
     expect(seen).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://docs-app.farming-labs.dev/api/analytics/events",
+      "https://api.farming-labs.dev/v1/analytics/events",
       expect.objectContaining({
         method: "POST",
       }),

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -7,7 +7,7 @@ interface DocsCloudAnalyticsOptions {
 }
 
 const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
-  "https://docs-app.farming-labs.dev/api/analytics/events";
+  "https://api.farming-labs.dev/v1/analytics/events";
 
 function normalizeRuntimeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -6,8 +6,7 @@ interface DocsCloudAnalyticsOptions {
   apiKey?: string;
 }
 
-const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
-  "https://api.farming-labs.dev/v1/analytics/events";
+const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT = "https://api.farming-labs.dev/v1/analytics/events";
 
 function normalizeRuntimeEnvValue(value: string | undefined): string | undefined {
   const normalized = value?.trim();

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1189,7 +1189,7 @@ describe("withDocs (app dir: src/app vs app)", () => {
 
     expect(nextConfig.env?.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID).toBe("project_user");
     expect(nextConfig.env?.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT).toBe(
-      "https://docs-app.farming-labs.dev/api/analytics/events",
+      "https://api.farming-labs.dev/v1/analytics/events",
     );
   });
 

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -166,7 +166,7 @@ export default function HiddenChangelogSourceLayout() {
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
 const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
-  "https://docs-app.farming-labs.dev/api/analytics/events";
+  "https://api.farming-labs.dev/v1/analytics/events";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -165,8 +165,7 @@ export default function HiddenChangelogSourceLayout() {
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
-const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT =
-  "https://api.farming-labs.dev/v1/analytics/events";
+const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT = "https://api.farming-labs.dev/v1/analytics/events";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";

--- a/website/.env.example
+++ b/website/.env.example
@@ -31,4 +31,5 @@
 # Create/copy this from the Docs Cloud project settings for docs.farming-labs.dev.
 # NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
 # NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=true
+# NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT=https://api.farming-labs.dev/v1/analytics/events
 # DOCS_CLOUD_API_KEY=fl_key_...

--- a/website/.env.example
+++ b/website/.env.example
@@ -26,3 +26,9 @@
 # ALGOLIA_SEARCH_API_KEY=your-search-key
 # ALGOLIA_ADMIN_API_KEY=your-admin-key
 # ALGOLIA_INDEX_NAME=farming-labs-docs
+
+# Docs Cloud dogfooding.
+# Create/copy this from the Docs Cloud project settings for docs.farming-labs.dev.
+# NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+# NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=true
+# DOCS_CLOUD_API_KEY=fl_key_...

--- a/website/.env.example
+++ b/website/.env.example
@@ -31,5 +31,7 @@
 # Create/copy this from the Docs Cloud project settings for docs.farming-labs.dev.
 # NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
 # NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=true
-# NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT=https://api.farming-labs.dev/v1/analytics/events
 # DOCS_CLOUD_API_KEY=fl_key_...
+
+# Optional: only set this when overriding the default Docs Cloud API endpoint.
+# NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT=https://cloud.example.com/v1/analytics/events

--- a/website/app/docs/cloud/analytics/page.mdx
+++ b/website/app/docs/cloud/analytics/page.mdx
@@ -55,6 +55,9 @@ runtime environment, set the analytics flag to `false`:
 NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=false
 ```
 
+Only set `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT` when the docs app should send events to a
+custom or self-hosted Docs Cloud API. The hosted Docs Cloud endpoint is the default.
+
 ## Runtime Contract
 
 The runtime analytics stream is produced by `@farming-labs/docs`. Events cover product usage such as

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -476,4 +476,19 @@ export default defineDocs({
     DocsMcpAccess,
     GuideCard,
   },
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    deploy: { enabled: true },
+    analytics: {
+      enabled: true,
+      console: false,
+      includeInputs: false,
+    },
+    publish: { mode: "draft-pr", baseBranch: "main" },
+  },
+  analytics: {
+    enabled: true,
+    console: false,
+    includeInputs: false,
+  },
 });

--- a/website/docs.json
+++ b/website/docs.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.farming-labs.dev/schema/docs.json",
+  "version": 1,
+  "docs": {
+    "mode": "framework",
+    "runtime": "nextjs",
+    "root": "."
+  },
+  "content": {
+    "docsRoot": "app/docs"
+  },
+  "site": {
+    "name": "Docs Website"
+  },
+  "cloud": {
+    "apiKey": {
+      "env": "DOCS_CLOUD_API_KEY"
+    },
+    "publish": {
+      "mode": "draft-pr",
+      "baseBranch": "main"
+    },
+    "analytics": {
+      "enabled": true,
+      "console": false,
+      "includeInputs": false
+    },
+    "deploy": {
+      "enabled": true
+    }
+  }
+}

--- a/website/public/schema/cloud.json
+++ b/website/public/schema/cloud.json
@@ -165,6 +165,19 @@
       "required": [
         "title"
       ]
+    },
+    "cloudApiKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Docs Cloud API key lookup. The secret value stays in the named environment variable.",
+      "properties": {
+        "env": {
+          "type": "string",
+          "minLength": 1,
+          "default": "DOCS_CLOUD_API_KEY",
+          "description": "Environment variable that stores the Docs Cloud API key."
+        }
+      }
     }
   },
   "properties": {
@@ -589,12 +602,15 @@
       "default": {
         "enabled": false
       },
-      "description": "Hosted Docs Cloud services layered on top of the docs project. Authentication and API keys are handled outside this file.",
+      "description": "Hosted Docs Cloud services layered on top of the docs project. API key secrets stay outside this file; this config can name the environment variable that stores them.",
       "properties": {
         "enabled": {
           "type": "boolean",
           "default": false,
           "description": "Whether this project is connected to Docs Cloud services."
+        },
+        "apiKey": {
+          "$ref": "#/$defs/cloudApiKey"
         },
         "preview": {
           "type": "object",

--- a/website/public/schema/docs.json
+++ b/website/public/schema/docs.json
@@ -165,6 +165,19 @@
       "required": [
         "title"
       ]
+    },
+    "cloudApiKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Docs Cloud API key lookup. The secret value stays in the named environment variable.",
+      "properties": {
+        "env": {
+          "type": "string",
+          "minLength": 1,
+          "default": "DOCS_CLOUD_API_KEY",
+          "description": "Environment variable that stores the Docs Cloud API key."
+        }
+      }
     }
   },
   "properties": {
@@ -589,12 +602,15 @@
       "default": {
         "enabled": false
       },
-      "description": "Hosted Docs Cloud services layered on top of the docs project. Authentication and API keys are handled outside this file.",
+      "description": "Hosted Docs Cloud services layered on top of the docs project. API key secrets stay outside this file; this config can name the environment variable that stores them.",
       "properties": {
         "enabled": {
           "type": "boolean",
           "default": false,
           "description": "Whether this project is connected to Docs Cloud services."
+        },
+        "apiKey": {
+          "$ref": "#/$defs/cloudApiKey"
         },
         "preview": {
           "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Integrates Docs Cloud into the docs site via API key for draft PR publishing, deploys, and analytics. Switches analytics to the v1 API and makes endpoint overrides optional.

- **New Features**
  - Added Docs Cloud config: new `website/docs.json`; updated `website/docs.config.tsx` with `cloud` and top-level `analytics`.
  - Switched default analytics endpoint to https://api.farming-labs.dev/v1/analytics/events in `@farming-labs/docs` and `@farming-labs/next`; updated tests.
  - Updated public schemas to support `cloud.apiKey.env`; docs and `.env.example` clarify the hosted endpoint is default and overrides are optional.

- **Migration**
  - Set DOCS_CLOUD_API_KEY. Optionally set NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID and NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=true.
  - Do not set NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT unless overriding the default. Draft PR publishing to `main` and analytics are enabled.

<sup>Written for commit 8ce1c32726b98a056a894f973d4a007f90298204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

