### PR TITLE
feat: docs cloud via docs-cloud provider along with stream specs

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1645,6 +1645,23 @@ export interface AIConfig {
   triggerComponent?: unknown;
 
   /**
+   * Server-side answer provider used by Ask AI.
+   *
+   * - `"docs-cloud"` — send questions to the configured Docs Cloud project
+   *   using `cloud.apiKey.env` and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`.
+   * - Omit this option to use the built-in OpenAI-compatible RAG handler.
+   *
+   * @example
+   * ```ts
+   * ai: {
+   *   enabled: true,
+   *   provider: "docs-cloud",
+   * }
+   * ```
+   */
+  provider?: "docs-cloud" | (string & {});
+
+  /**
    * The LLM model configuration.
    *
    * **Simple** — pass a plain string for a single model:

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1665,6 +1665,17 @@ export interface AIConfig {
   provider?: "docs-cloud" | (string & {});
 
   /**
+   * Whether Ask AI should request streaming responses when the selected
+   * provider supports them.
+   *
+   * Docs Cloud streams token deltas by default for `provider: "docs-cloud"`.
+   * Set this to `false` to request a single JSON answer instead.
+   *
+   * @default true
+   */
+  stream?: boolean;
+
+  /**
    * The LLM model configuration.
    *
    * **Simple** — pass a plain string for a single model:

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1648,7 +1648,10 @@ export interface AIConfig {
    * Server-side answer provider used by Ask AI.
    *
    * - `"docs-cloud"` — send questions to the configured Docs Cloud project
-   *   using `cloud.apiKey.env` and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`.
+   *   using `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` and a browser-safe
+   *   Docs Cloud API key env such as `NEXT_PUBLIC_DOCS_CLOUD_API_KEY`.
+   *   If only a server-side key is configured, framework integrations may
+   *   proxy through the local docs API route.
    * - Omit this option to use the built-in OpenAI-compatible RAG handler.
    *
    * @example

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -210,14 +210,10 @@ function createSmoothAIStreamRenderer(onRender: (content: string) => void) {
   const nextRevealCount = (gap: number, elapsedMs: number): number => {
     if (gap <= 0) return 0;
 
-    const charsPerSecond =
-      finishing || gap > 1600
-        ? 7800
-        : gap > 700
-          ? 4800
-          : gap > 180
-            ? 2600
-            : 1500;
+    let charsPerSecond = 900;
+    if (gap > 2400) charsPerSecond = finishing ? 3600 : 3000;
+    else if (gap > 1000) charsPerSecond = finishing ? 2400 : 2000;
+    else if (gap > 220) charsPerSecond = finishing ? 1600 : 1300;
 
     return Math.max(1, Math.min(gap, Math.ceil((charsPerSecond * elapsedMs) / 1000)));
   };
@@ -1043,8 +1039,8 @@ function AIChat({
     selectedModel || (Array.isArray(models) && models.length > 0 ? models[0]!.id : undefined);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+    messagesEndRef.current?.scrollIntoView({ behavior: isStreaming ? "auto" : "smooth" });
+  }, [isStreaming, messages]);
   useEffect(() => {
     aiInputRef.current?.focus();
   }, []);
@@ -1077,6 +1073,7 @@ function AIChat({
         });
       }
 
+      let streamRenderer: ReturnType<typeof createSmoothAIStreamRenderer> | undefined;
       try {
         const res = await fetch(api, {
           method: "POST",
@@ -1112,24 +1109,30 @@ function AIChat({
           return;
         }
 
-        const assistantContent = await readAIResponseContent(res, (content) => {
+        streamRenderer = createSmoothAIStreamRenderer((content) => {
           setMessages([...newMessages, { ...assistantMessage, content }]);
         });
-        if (assistantContent)
-          setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
+        const assistantContent = await readAIResponseContent(res, (content) => {
+          streamRenderer?.push(content);
+        });
+        const renderedContent = await streamRenderer.finish();
+        const finalContent = renderedContent || assistantContent;
+        if (finalContent)
+          setMessages([...newMessages, { ...assistantMessage, content: finalContent }]);
         if (analytics) {
           emitClientAnalyticsEvent({
             type: "ai_response",
             properties: {
               surface,
               questionLength: question.length,
-              responseLength: assistantContent.length,
+              responseLength: finalContent.length,
               durationMs: Math.max(0, Date.now() - startedAt),
               model: effectiveModelId,
             },
           });
         }
       } catch {
+        streamRenderer?.cancel();
         setMessages([
           ...newMessages,
           {
@@ -1974,9 +1977,12 @@ function FullModalAIChat({
   // Auto-scroll on new messages
   useEffect(() => {
     if (listRef.current) {
-      listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+      listRef.current.scrollTo({
+        top: listRef.current.scrollHeight,
+        behavior: isStreaming ? "auto" : "smooth",
+      });
     }
-  }, [messages]);
+  }, [isStreaming, messages]);
 
   const submitQuestion = useCallback(
     async (question: string) => {
@@ -2006,6 +2012,7 @@ function FullModalAIChat({
         });
       }
 
+      let streamRenderer: ReturnType<typeof createSmoothAIStreamRenderer> | undefined;
       try {
         const res = await fetch(api, {
           method: "POST",
@@ -2041,24 +2048,30 @@ function FullModalAIChat({
           return;
         }
 
-        const assistantContent = await readAIResponseContent(res, (content) => {
+        streamRenderer = createSmoothAIStreamRenderer((content) => {
           setMessages([...newMessages, { ...assistantMessage, content }]);
         });
-        if (assistantContent)
-          setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
+        const assistantContent = await readAIResponseContent(res, (content) => {
+          streamRenderer?.push(content);
+        });
+        const renderedContent = await streamRenderer.finish();
+        const finalContent = renderedContent || assistantContent;
+        if (finalContent)
+          setMessages([...newMessages, { ...assistantMessage, content: finalContent }]);
         if (analytics) {
           emitClientAnalyticsEvent({
             type: "ai_response",
             properties: {
               surface: "full-modal",
               questionLength: question.length,
-              responseLength: assistantContent.length,
+              responseLength: finalContent.length,
               durationMs: Math.max(0, Date.now() - startedAt),
               model: effectiveModelId,
             },
           });
         }
       } catch {
+        streamRenderer?.cancel();
         setMessages([
           ...newMessages,
           {

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -52,6 +52,7 @@ interface ChatMessage {
 type AIModelOption = { id: string; label: string };
 type AIRequestMode = "openai-chat" | "docs-cloud";
 type AIRequestHeaders = Record<string, string>;
+type AIRequestStream = boolean;
 
 interface DocsWindowHooks extends Window {
   __fdOnAIActions__?: (data: DocsAskAIActionData) => void | Promise<void>;
@@ -69,9 +70,12 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function buildAIRequestHeaders(requestHeaders?: AIRequestHeaders): HeadersInit {
+function buildAIRequestHeaders(
+  requestHeaders?: AIRequestHeaders,
+  requestStream: AIRequestStream = true,
+): HeadersInit {
   return {
-    Accept: "text/event-stream, application/json",
+    Accept: requestStream ? "text/event-stream, application/json" : "application/json",
     "Content-Type": "application/json",
     ...requestHeaders,
   };
@@ -79,6 +83,7 @@ function buildAIRequestHeaders(requestHeaders?: AIRequestHeaders): HeadersInit {
 
 function buildAIRequestBody(options: {
   requestMode?: AIRequestMode;
+  requestStream?: AIRequestStream;
   question: string;
   messages: ChatMessage[];
   model?: string;
@@ -95,12 +100,14 @@ function buildAIRequestBody(options: {
       answerMode: "auto",
       answerStyle: "public",
       modelPreference: options.model,
+      stream: options.requestStream !== false,
     });
   }
 
   return JSON.stringify({
     messages,
     model: options.model,
+    stream: options.requestStream !== false,
   });
 }
 
@@ -170,6 +177,104 @@ async function readAIResponseContent(
   }
 
   return assistantContent;
+}
+
+function createSmoothAIStreamRenderer(onRender: (content: string) => void) {
+  let targetContent = "";
+  let visibleContent = "";
+  let frameId: number | null = null;
+  let lastFrameAt = 0;
+  let finishing = false;
+  let cancelled = false;
+  let resolveFinish: ((content: string) => void) | undefined;
+
+  const scheduleFrame = () => {
+    if (frameId !== null || cancelled) return;
+
+    if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+      frameId = window.requestAnimationFrame(renderFrame);
+      return;
+    }
+
+    frameId = setTimeout(() => renderFrame(Date.now()), 16) as unknown as number;
+  };
+
+  const completeIfReady = () => {
+    if (!finishing || visibleContent !== targetContent || !resolveFinish) return;
+
+    const resolve = resolveFinish;
+    resolveFinish = undefined;
+    resolve(visibleContent);
+  };
+
+  const nextRevealCount = (gap: number, elapsedMs: number): number => {
+    if (gap <= 0) return 0;
+
+    const charsPerSecond =
+      finishing || gap > 1600
+        ? 7800
+        : gap > 700
+          ? 4800
+          : gap > 180
+            ? 2600
+            : 1500;
+
+    return Math.max(1, Math.min(gap, Math.ceil((charsPerSecond * elapsedMs) / 1000)));
+  };
+
+  function renderFrame(timestamp: number) {
+    frameId = null;
+    if (cancelled) return;
+
+    const elapsedMs = lastFrameAt ? Math.min(48, Math.max(8, timestamp - lastFrameAt)) : 16;
+    lastFrameAt = timestamp;
+
+    const gap = targetContent.length - visibleContent.length;
+    if (gap > 0) {
+      const nextLength = visibleContent.length + nextRevealCount(gap, elapsedMs);
+      visibleContent = targetContent.slice(0, nextLength);
+      onRender(visibleContent);
+    }
+
+    if (visibleContent.length < targetContent.length) {
+      scheduleFrame();
+      return;
+    }
+
+    completeIfReady();
+  }
+
+  return {
+    push(content: string) {
+      if (cancelled) return;
+
+      targetContent = content;
+      scheduleFrame();
+    },
+    finish(): Promise<string> {
+      finishing = true;
+
+      if (visibleContent === targetContent) {
+        return Promise.resolve(visibleContent);
+      }
+
+      return new Promise((resolve) => {
+        resolveFinish = resolve;
+        scheduleFrame();
+      });
+    },
+    cancel() {
+      cancelled = true;
+      if (frameId !== null) {
+        if (typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+          window.cancelAnimationFrame(frameId);
+        } else {
+          clearTimeout(frameId);
+        }
+      }
+      frameId = null;
+    },
+  };
 }
 
 function getLastUserQuestion(messages: ChatMessage[], assistantIndex: number): string {
@@ -888,6 +993,7 @@ function AIChat({
   api,
   requestMode,
   requestHeaders,
+  requestStream = true,
   messages,
   setMessages,
   aiInput,
@@ -907,6 +1013,7 @@ function AIChat({
   api: string;
   requestMode?: AIRequestMode;
   requestHeaders?: AIRequestHeaders;
+  requestStream?: AIRequestStream;
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   aiInput: string;
@@ -973,9 +1080,10 @@ function AIChat({
       try {
         const res = await fetch(api, {
           method: "POST",
-          headers: buildAIRequestHeaders(requestHeaders),
+          headers: buildAIRequestHeaders(requestHeaders, requestStream),
           body: buildAIRequestBody({
             requestMode,
+            requestStream,
             question,
             messages: newMessages,
             model: effectiveModelId,
@@ -1048,6 +1156,7 @@ function AIChat({
       api,
       requestMode,
       requestHeaders,
+      requestStream,
       isStreaming,
       setMessages,
       setAiInput,
@@ -1236,6 +1345,7 @@ export function DocsSearchDialog({
   api = "/api/docs",
   requestMode,
   requestHeaders,
+  requestStream,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -1250,6 +1360,7 @@ export function DocsSearchDialog({
   api?: string;
   requestMode?: AIRequestMode;
   requestHeaders?: AIRequestHeaders;
+  requestStream?: AIRequestStream;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: LoaderVariant;
@@ -1505,6 +1616,7 @@ export function DocsSearchDialog({
             api={api}
             requestMode={requestMode}
             requestHeaders={requestHeaders}
+            requestStream={requestStream}
             messages={messages}
             setMessages={setMessages}
             aiInput={aiInput}
@@ -1587,6 +1699,7 @@ export function FloatingAIChat({
   api = "/api/docs",
   requestMode,
   requestHeaders,
+  requestStream,
   position = "bottom-right",
   floatingStyle = "panel",
   triggerComponentHtml,
@@ -1602,6 +1715,7 @@ export function FloatingAIChat({
   api?: string;
   requestMode?: AIRequestMode;
   requestHeaders?: AIRequestHeaders;
+  requestStream?: AIRequestStream;
   position?: FloatingPosition;
   floatingStyle?: FloatingStyle;
   triggerComponentHtml?: string;
@@ -1669,6 +1783,7 @@ export function FloatingAIChat({
         api={api}
         requestMode={requestMode}
         requestHeaders={requestHeaders}
+        requestStream={requestStream}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         closeAI={closeFloatingAI}
@@ -1722,6 +1837,7 @@ export function FloatingAIChat({
             api={api}
             requestMode={requestMode}
             requestHeaders={requestHeaders}
+            requestStream={requestStream}
             messages={messages}
             setMessages={setMessages}
             aiInput={aiInput}
@@ -1793,6 +1909,7 @@ function FullModalAIChat({
   api,
   requestMode,
   requestHeaders,
+  requestStream,
   isOpen,
   setIsOpen,
   closeAI,
@@ -1816,6 +1933,7 @@ function FullModalAIChat({
   api: string;
   requestMode?: AIRequestMode;
   requestHeaders?: AIRequestHeaders;
+  requestStream?: AIRequestStream;
   isOpen: boolean;
   setIsOpen: (v: boolean) => void;
   closeAI: (trigger: "button" | "escape" | "overlay") => void;
@@ -1891,9 +2009,10 @@ function FullModalAIChat({
       try {
         const res = await fetch(api, {
           method: "POST",
-          headers: buildAIRequestHeaders(requestHeaders),
+          headers: buildAIRequestHeaders(requestHeaders, requestStream),
           body: buildAIRequestBody({
             requestMode,
+            requestStream,
             question,
             messages: newMessages,
             model: effectiveModelId,
@@ -1966,6 +2085,7 @@ function FullModalAIChat({
       api,
       requestMode,
       requestHeaders,
+      requestStream,
       isStreaming,
       setMessages,
       setAiInput,
@@ -2252,6 +2372,7 @@ export function AIModalDialog({
   api = "/api/docs",
   requestMode,
   requestHeaders,
+  requestStream,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -2266,6 +2387,7 @@ export function AIModalDialog({
   api?: string;
   requestMode?: AIRequestMode;
   requestHeaders?: AIRequestHeaders;
+  requestStream?: AIRequestStream;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: LoaderVariant;
@@ -2346,6 +2468,7 @@ export function AIModalDialog({
           api={api}
           requestMode={requestMode}
           requestHeaders={requestHeaders}
+          requestStream={requestStream}
           messages={messages}
           setMessages={setMessages}
           aiInput={aiInput}

--- a/packages/fumadocs/src/ai-search-dialog.tsx
+++ b/packages/fumadocs/src/ai-search-dialog.tsx
@@ -50,6 +50,8 @@ interface ChatMessage {
 }
 
 type AIModelOption = { id: string; label: string };
+type AIRequestMode = "openai-chat" | "docs-cloud";
+type AIRequestHeaders = Record<string, string>;
 
 interface DocsWindowHooks extends Window {
   __fdOnAIActions__?: (data: DocsAskAIActionData) => void | Promise<void>;
@@ -61,6 +63,113 @@ let aiMessageId = 0;
 function createAIMessageId(): string {
   aiMessageId += 1;
   return `ai_${Date.now().toString(36)}_${aiMessageId.toString(36)}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function buildAIRequestHeaders(requestHeaders?: AIRequestHeaders): HeadersInit {
+  return {
+    Accept: "text/event-stream, application/json",
+    "Content-Type": "application/json",
+    ...requestHeaders,
+  };
+}
+
+function buildAIRequestBody(options: {
+  requestMode?: AIRequestMode;
+  question: string;
+  messages: ChatMessage[];
+  model?: string;
+}): string {
+  const messages = options.messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+
+  if (options.requestMode === "docs-cloud") {
+    return JSON.stringify({
+      question: options.question,
+      messages,
+      answerMode: "auto",
+      answerStyle: "public",
+      modelPreference: options.model,
+    });
+  }
+
+  return JSON.stringify({
+    messages,
+    model: options.model,
+  });
+}
+
+function getOpenAICompatibleDeltaContent(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+
+  const firstChoice = Array.isArray(value.choices) ? value.choices[0] : undefined;
+  if (!isPlainObject(firstChoice)) return undefined;
+  const delta = firstChoice.delta;
+  if (!isPlainObject(delta)) return undefined;
+
+  return typeof delta.content === "string" ? delta.content : undefined;
+}
+
+function getDocsCloudAnswerContent(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!isPlainObject(value)) return undefined;
+
+  for (const key of ["answer", "content", "text", "delta"]) {
+    const content = value[key];
+    if (typeof content === "string") return content;
+  }
+
+  return undefined;
+}
+
+async function readAIResponseContent(
+  response: Response,
+  onContent: (content: string) => void,
+): Promise<string> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  if (contentType.includes("application/json")) {
+    const payload = await response.json().catch(() => null);
+    const answer = getDocsCloudAnswerContent(payload) ?? "";
+    if (answer) onContent(answer);
+    return answer;
+  }
+
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let assistantContent = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const data = line.slice(6).trim();
+      if (!data || data === "[DONE]") continue;
+      try {
+        const json = JSON.parse(data);
+        const content = getOpenAICompatibleDeltaContent(json) ?? getDocsCloudAnswerContent(json);
+        if (content) {
+          assistantContent += content;
+          onContent(assistantContent);
+        }
+      } catch {}
+    }
+  }
+
+  return assistantContent;
 }
 
 function getLastUserQuestion(messages: ChatMessage[], assistantIndex: number): string {
@@ -777,6 +886,8 @@ function AIFeedbackControls({
 
 function AIChat({
   api,
+  requestMode,
+  requestHeaders,
   messages,
   setMessages,
   aiInput,
@@ -794,6 +905,8 @@ function AIChat({
   surface = "chat",
 }: {
   api: string;
+  requestMode?: AIRequestMode;
+  requestHeaders?: AIRequestHeaders;
   messages: ChatMessage[];
   setMessages: Dispatch<SetStateAction<ChatMessage[]>>;
   aiInput: string;
@@ -860,9 +973,11 @@ function AIChat({
       try {
         const res = await fetch(api, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          headers: buildAIRequestHeaders(requestHeaders),
+          body: buildAIRequestBody({
+            requestMode,
+            question,
+            messages: newMessages,
             model: effectiveModelId,
           }),
         });
@@ -889,32 +1004,9 @@ function AIChat({
           return;
         }
 
-        const reader = res.body!.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let assistantContent = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              const data = line.slice(6).trim();
-              if (data === "[DONE]") continue;
-              try {
-                const json = JSON.parse(data);
-                const content = json.choices?.[0]?.delta?.content;
-                if (content) {
-                  assistantContent += content;
-                  setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
-                }
-              } catch {}
-            }
-          }
-        }
+        const assistantContent = await readAIResponseContent(res, (content) => {
+          setMessages([...newMessages, { ...assistantMessage, content }]);
+        });
         if (assistantContent)
           setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
         if (analytics) {
@@ -954,6 +1046,8 @@ function AIChat({
     [
       messages,
       api,
+      requestMode,
+      requestHeaders,
       isStreaming,
       setMessages,
       setAiInput,
@@ -1140,6 +1234,8 @@ export function DocsSearchDialog({
   open,
   onOpenChange,
   api = "/api/docs",
+  requestMode,
+  requestHeaders,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -1152,6 +1248,8 @@ export function DocsSearchDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   api?: string;
+  requestMode?: AIRequestMode;
+  requestHeaders?: AIRequestHeaders;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: LoaderVariant;
@@ -1405,6 +1503,8 @@ export function DocsSearchDialog({
         {tab === "ai" && (
           <AIChat
             api={api}
+            requestMode={requestMode}
+            requestHeaders={requestHeaders}
             messages={messages}
             setMessages={setMessages}
             aiInput={aiInput}
@@ -1485,6 +1585,8 @@ function getAnimation(style: FloatingStyle): string {
 
 export function FloatingAIChat({
   api = "/api/docs",
+  requestMode,
+  requestHeaders,
   position = "bottom-right",
   floatingStyle = "panel",
   triggerComponentHtml,
@@ -1498,6 +1600,8 @@ export function FloatingAIChat({
   feedbackEnabled = true,
 }: {
   api?: string;
+  requestMode?: AIRequestMode;
+  requestHeaders?: AIRequestHeaders;
   position?: FloatingPosition;
   floatingStyle?: FloatingStyle;
   triggerComponentHtml?: string;
@@ -1563,6 +1667,8 @@ export function FloatingAIChat({
     return (
       <FullModalAIChat
         api={api}
+        requestMode={requestMode}
+        requestHeaders={requestHeaders}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         closeAI={closeFloatingAI}
@@ -1614,6 +1720,8 @@ export function FloatingAIChat({
 
           <AIChat
             api={api}
+            requestMode={requestMode}
+            requestHeaders={requestHeaders}
             messages={messages}
             setMessages={setMessages}
             aiInput={aiInput}
@@ -1683,6 +1791,8 @@ export function FloatingAIChat({
 
 function FullModalAIChat({
   api,
+  requestMode,
+  requestHeaders,
   isOpen,
   setIsOpen,
   closeAI,
@@ -1704,6 +1814,8 @@ function FullModalAIChat({
   feedbackEnabled = true,
 }: {
   api: string;
+  requestMode?: AIRequestMode;
+  requestHeaders?: AIRequestHeaders;
   isOpen: boolean;
   setIsOpen: (v: boolean) => void;
   closeAI: (trigger: "button" | "escape" | "overlay") => void;
@@ -1779,9 +1891,11 @@ function FullModalAIChat({
       try {
         const res = await fetch(api, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          headers: buildAIRequestHeaders(requestHeaders),
+          body: buildAIRequestBody({
+            requestMode,
+            question,
+            messages: newMessages,
             model: effectiveModelId,
           }),
         });
@@ -1808,32 +1922,9 @@ function FullModalAIChat({
           return;
         }
 
-        const reader = res.body!.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let assistantContent = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              const data = line.slice(6).trim();
-              if (data === "[DONE]") continue;
-              try {
-                const json = JSON.parse(data);
-                const content = json.choices?.[0]?.delta?.content;
-                if (content) {
-                  assistantContent += content;
-                  setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
-                }
-              } catch {}
-            }
-          }
-        }
+        const assistantContent = await readAIResponseContent(res, (content) => {
+          setMessages([...newMessages, { ...assistantMessage, content }]);
+        });
         if (assistantContent)
           setMessages([...newMessages, { ...assistantMessage, content: assistantContent }]);
         if (analytics) {
@@ -1873,6 +1964,8 @@ function FullModalAIChat({
     [
       messages,
       api,
+      requestMode,
+      requestHeaders,
       isStreaming,
       setMessages,
       setAiInput,
@@ -2157,6 +2250,8 @@ export function AIModalDialog({
   open,
   onOpenChange,
   api = "/api/docs",
+  requestMode,
+  requestHeaders,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -2169,6 +2264,8 @@ export function AIModalDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   api?: string;
+  requestMode?: AIRequestMode;
+  requestHeaders?: AIRequestHeaders;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: LoaderVariant;
@@ -2247,6 +2344,8 @@ export function AIModalDialog({
 
         <AIChat
           api={api}
+          requestMode={requestMode}
+          requestHeaders={requestHeaders}
           messages={messages}
           setMessages={setMessages}
           aiInput={aiInput}

--- a/packages/fumadocs/src/docs-ai-features.tsx
+++ b/packages/fumadocs/src/docs-ai-features.tsx
@@ -26,6 +26,7 @@ interface DocsAIFeaturesProps {
   api?: string;
   requestMode?: "openai-chat" | "docs-cloud";
   requestHeaders?: Record<string, string>;
+  requestStream?: boolean;
   locale?: string;
   position?: "bottom-right" | "bottom-left" | "bottom-center";
   floatingStyle?: "panel" | "modal" | "popover" | "full-modal";
@@ -45,6 +46,7 @@ export function DocsAIFeatures({
   api = "/api/docs",
   requestMode,
   requestHeaders,
+  requestStream,
   locale,
   position = "bottom-right",
   floatingStyle = "panel",
@@ -68,6 +70,7 @@ export function DocsAIFeatures({
         api={localizedApi}
         requestMode={requestMode}
         requestHeaders={requestHeaders}
+        requestStream={requestStream}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant}
@@ -86,6 +89,7 @@ export function DocsAIFeatures({
         api={localizedApi}
         requestMode={requestMode}
         requestHeaders={requestHeaders}
+        requestStream={requestStream}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant}
@@ -103,6 +107,7 @@ export function DocsAIFeatures({
       api={localizedApi}
       requestMode={requestMode}
       requestHeaders={requestHeaders}
+      requestStream={requestStream}
       position={position}
       floatingStyle={floatingStyle}
       triggerComponentHtml={triggerComponentHtml}
@@ -122,6 +127,7 @@ function SearchModeAI({
   api,
   requestMode,
   requestHeaders,
+  requestStream,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -134,6 +140,7 @@ function SearchModeAI({
   api: string;
   requestMode?: "openai-chat" | "docs-cloud";
   requestHeaders?: Record<string, string>;
+  requestStream?: boolean;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: string;
@@ -200,6 +207,7 @@ function SearchModeAI({
       api={api}
       requestMode={requestMode}
       requestHeaders={requestHeaders}
+      requestStream={requestStream}
       suggestedQuestions={suggestedQuestions}
       aiLabel={aiLabel}
       loaderVariant={loaderVariant as any}
@@ -216,6 +224,7 @@ function SidebarIconModeAI({
   api,
   requestMode,
   requestHeaders,
+  requestStream,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -228,6 +237,7 @@ function SidebarIconModeAI({
   api: string;
   requestMode?: "openai-chat" | "docs-cloud";
   requestHeaders?: Record<string, string>;
+  requestStream?: boolean;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: string;
@@ -294,6 +304,7 @@ function SidebarIconModeAI({
         api={api}
         requestMode={requestMode}
         requestHeaders={requestHeaders}
+        requestStream={requestStream}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant as any}
@@ -309,6 +320,7 @@ function SidebarIconModeAI({
         api={api}
         requestMode={requestMode}
         requestHeaders={requestHeaders}
+        requestStream={requestStream}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant as any}

--- a/packages/fumadocs/src/docs-ai-features.tsx
+++ b/packages/fumadocs/src/docs-ai-features.tsx
@@ -24,6 +24,8 @@ import { emitClientAnalyticsEvent } from "./client-analytics.js";
 interface DocsAIFeaturesProps {
   mode: "search" | "floating" | "sidebar-icon";
   api?: string;
+  requestMode?: "openai-chat" | "docs-cloud";
+  requestHeaders?: Record<string, string>;
   locale?: string;
   position?: "bottom-right" | "bottom-left" | "bottom-center";
   floatingStyle?: "panel" | "modal" | "popover" | "full-modal";
@@ -41,6 +43,8 @@ interface DocsAIFeaturesProps {
 export function DocsAIFeatures({
   mode,
   api = "/api/docs",
+  requestMode,
+  requestHeaders,
   locale,
   position = "bottom-right",
   floatingStyle = "panel",
@@ -62,6 +66,8 @@ export function DocsAIFeatures({
     return (
       <SearchModeAI
         api={localizedApi}
+        requestMode={requestMode}
+        requestHeaders={requestHeaders}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant}
@@ -78,6 +84,8 @@ export function DocsAIFeatures({
     return (
       <SidebarIconModeAI
         api={localizedApi}
+        requestMode={requestMode}
+        requestHeaders={requestHeaders}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant}
@@ -93,6 +101,8 @@ export function DocsAIFeatures({
   return (
     <FloatingAIChat
       api={localizedApi}
+      requestMode={requestMode}
+      requestHeaders={requestHeaders}
       position={position}
       floatingStyle={floatingStyle}
       triggerComponentHtml={triggerComponentHtml}
@@ -110,6 +120,8 @@ export function DocsAIFeatures({
 
 function SearchModeAI({
   api,
+  requestMode,
+  requestHeaders,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -120,6 +132,8 @@ function SearchModeAI({
   feedbackEnabled,
 }: {
   api: string;
+  requestMode?: "openai-chat" | "docs-cloud";
+  requestHeaders?: Record<string, string>;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: string;
@@ -184,6 +198,8 @@ function SearchModeAI({
       open={open}
       onOpenChange={setOpen}
       api={api}
+      requestMode={requestMode}
+      requestHeaders={requestHeaders}
       suggestedQuestions={suggestedQuestions}
       aiLabel={aiLabel}
       loaderVariant={loaderVariant as any}
@@ -198,6 +214,8 @@ function SearchModeAI({
 
 function SidebarIconModeAI({
   api,
+  requestMode,
+  requestHeaders,
   suggestedQuestions,
   aiLabel,
   loaderVariant,
@@ -208,6 +226,8 @@ function SidebarIconModeAI({
   feedbackEnabled,
 }: {
   api: string;
+  requestMode?: "openai-chat" | "docs-cloud";
+  requestHeaders?: Record<string, string>;
   suggestedQuestions?: string[];
   aiLabel?: string;
   loaderVariant?: string;
@@ -272,6 +292,8 @@ function SidebarIconModeAI({
         open={searchOpen}
         onOpenChange={setSearchOpen}
         api={api}
+        requestMode={requestMode}
+        requestHeaders={requestHeaders}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant as any}
@@ -285,6 +307,8 @@ function SidebarIconModeAI({
         open={aiOpen}
         onOpenChange={setAiOpen}
         api={api}
+        requestMode={requestMode}
+        requestHeaders={requestHeaders}
         suggestedQuestions={suggestedQuestions}
         aiLabel={aiLabel}
         loaderVariant={loaderVariant as any}

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1682,6 +1682,108 @@ Install the framework with pnpm.
     }
   });
 
+  it("reads Docs Cloud API key env from docs.config for Ask AI", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-docs-cloud-config-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Configuration"
+---
+
+# Configuration
+
+Configure the framework with docs.config.ts.
+`,
+    );
+    writeFileSync(
+      join(rootDir, "docs.config.ts"),
+      `import { defineDocs } from "@farming-labs/docs";
+
+export default defineDocs({
+  entry: "docs",
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "CONFIG_DOCS_CLOUD_KEY" },
+  },
+});
+`,
+    );
+
+    const originalFetch = globalThis.fetch;
+    const originalProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalServerProjectId = process.env.DOCS_CLOUD_PROJECT_ID;
+    const originalDefaultApiKey = process.env.DOCS_CLOUD_API_KEY;
+    const originalApiKey = process.env.CONFIG_DOCS_CLOUD_KEY;
+    const originalApiUrl = process.env.DOCS_CLOUD_API_URL;
+    const originalPublicApiUrl = process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
+
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_config";
+    delete process.env.DOCS_CLOUD_PROJECT_ID;
+    delete process.env.DOCS_CLOUD_API_KEY;
+    delete process.env.DOCS_CLOUD_API_URL;
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
+    process.env.CONFIG_DOCS_CLOUD_KEY = "config-cloud-key";
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ answer: "The config key reached Docs Cloud." }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        rootDir,
+        analytics: false,
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How do I configure it?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("The config key reached Docs Cloud.");
+
+      const [cloudUrl, cloudInit] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+      expect(cloudUrl).toBe(
+        "https://docs-app.farming-labs.dev/v1/projects/project_config/knowledge/ask",
+      );
+      expect(cloudInit?.headers).toMatchObject({
+        Authorization: "Bearer config-cloud-key",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalServerProjectId === undefined) delete process.env.DOCS_CLOUD_PROJECT_ID;
+      else process.env.DOCS_CLOUD_PROJECT_ID = originalServerProjectId;
+      if (originalDefaultApiKey === undefined) delete process.env.DOCS_CLOUD_API_KEY;
+      else process.env.DOCS_CLOUD_API_KEY = originalDefaultApiKey;
+      if (originalApiKey === undefined) delete process.env.CONFIG_DOCS_CLOUD_KEY;
+      else process.env.CONFIG_DOCS_CLOUD_KEY = originalApiKey;
+      if (originalApiUrl === undefined) delete process.env.DOCS_CLOUD_API_URL;
+      else process.env.DOCS_CLOUD_API_URL = originalApiUrl;
+      if (originalPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_URL = originalPublicApiUrl;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("infers package guidance from Ask AI context so examples avoid placeholder imports", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-package-prompt-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1594,6 +1594,94 @@ Install the framework with pnpm.
     }
   });
 
+  it("uses Docs Cloud provider config for Ask AI while keeping the chat SSE contract", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-docs-cloud-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Installation"
+---
+
+# Installation
+
+Install the framework with pnpm.
+`,
+    );
+
+    const originalFetch = globalThis.fetch;
+    const originalProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalServerProjectId = process.env.DOCS_CLOUD_PROJECT_ID;
+    const originalApiKey = process.env.CUSTOM_DOCS_CLOUD_KEY;
+
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    delete process.env.DOCS_CLOUD_PROJECT_ID;
+    process.env.CUSTOM_DOCS_CLOUD_KEY = "cloud-key";
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ answer: "Use Docs Cloud for hosted Ask AI." }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    ) as typeof fetch;
+
+    try {
+      const { POST } = createDocsAPI({
+        rootDir,
+        entry: "docs",
+        ai: {
+          enabled: true,
+          provider: "docs-cloud",
+        },
+        cloud: {
+          apiKey: { env: "CUSTOM_DOCS_CLOUD_KEY" },
+        },
+        analytics: false,
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "How do I install it?" }],
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream");
+      expect(await response.text()).toContain("Use Docs Cloud for hosted Ask AI.");
+
+      const [cloudUrl, cloudInit] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+      expect(cloudUrl).toBe(
+        "https://docs-app.farming-labs.dev/v1/projects/project_cloud/knowledge/ask",
+      );
+      expect(cloudInit?.headers).toMatchObject({
+        Authorization: "Bearer cloud-key",
+      });
+      expect(JSON.parse(String(cloudInit?.body))).toMatchObject({
+        question: "How do I install it?",
+        answerMode: "auto",
+        answerStyle: "public",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalServerProjectId === undefined) delete process.env.DOCS_CLOUD_PROJECT_ID;
+      else process.env.DOCS_CLOUD_PROJECT_ID = originalServerProjectId;
+      if (originalApiKey === undefined) delete process.env.CUSTOM_DOCS_CLOUD_KEY;
+      else process.env.CUSTOM_DOCS_CLOUD_KEY = originalApiKey;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("infers package guidance from Ask AI context so examples avoid placeholder imports", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-api-ai-package-prompt-"));
     tempDirs.push(rootDir);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -890,6 +890,34 @@ function readAIConfig(root: string): AIOptions {
   return {};
 }
 
+function readCloudConfig(root: string): DocsConfig["cloud"] | undefined {
+  for (const ext of FILE_EXTS) {
+    const configPath = path.join(root, `docs.config.${ext}`);
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      const sanitized = stripCommentsAndStrings(content);
+      const configObject = extractRootConfigObject(content, sanitized);
+      const scopedContent = configObject?.content ?? content;
+      const scopedSanitized = configObject?.sanitized ?? sanitized;
+      const cloudBlock = extractObjectLiteral(scopedContent, scopedSanitized, "cloud");
+
+      if (!cloudBlock) continue;
+
+      const cloudBlockSanitized = stripCommentsAndStrings(cloudBlock);
+      const apiKeyBlock = extractObjectLiteral(cloudBlock, cloudBlockSanitized, "apiKey");
+      const apiKeyEnv = apiKeyBlock ? readStringFromBlock(apiKeyBlock, "env") : undefined;
+
+      return apiKeyEnv ? { apiKey: { env: apiKeyEnv } } : {};
+    } catch {
+      // fall through
+    }
+  }
+
+  return undefined;
+}
+
 function readMcpConfig(root: string): boolean | DocsMcpConfig | undefined {
   for (const ext of FILE_EXTS) {
     const configPath = path.join(root, `docs.config.${ext}`);
@@ -3494,7 +3522,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
   // Read AI config from docs.config if not explicitly provided
   const aiConfig: AIOptions = options?.ai ?? readAIConfig(root);
-  const cloudConfig = options?.cloud;
+  const cloudConfig = options?.cloud ?? readCloudConfig(root);
   const searchConfig = options?.search;
 
   // Read llms.txt config

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -110,6 +110,7 @@ interface AIModelConfig {
 
 interface AIOptions {
   enabled?: boolean;
+  provider?: string;
   model?: string | AIModelConfig;
   providers?: Record<string, AIProviderConfig>;
   systemPrompt?: string;
@@ -139,6 +140,8 @@ interface DocsAPIOptions {
   language?: string;
   /** AI chat configuration */
   ai?: AIOptions;
+  /** Hosted Docs Cloud configuration. */
+  cloud?: DocsConfig["cloud"];
   /** i18n config (optional) */
   i18n?: DocsI18nConfig;
   /** Search configuration */
@@ -179,6 +182,8 @@ interface DocsMCPAPIOptions {
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
+const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
+const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE = "/.well-known/agent.json";
@@ -850,6 +855,7 @@ function readAIConfig(root: string): AIOptions {
         const enabledMatch = content.match(/ai\s*:\s*\{[^}]*enabled\s*:\s*(true|false)/s);
         if (enabledMatch && enabledMatch[1] === "false") return {};
 
+        const providerMatch = content.match(/ai\s*:\s*\{[^}]*provider\s*:\s*["']([^"']+)["']/s);
         const modelMatch = content.match(/ai\s*:\s*\{[^}]*model\s*:\s*["']([^"']+)["']/s);
         const baseUrlMatch = content.match(/ai\s*:\s*\{[^}]*baseUrl\s*:\s*["']([^"']+)["']/s);
         // Match `apiKey: process.env.SOME_VAR` and resolve it at runtime
@@ -866,6 +872,7 @@ function readAIConfig(root: string): AIOptions {
 
         return {
           enabled: true,
+          provider: providerMatch?.[1],
           model: modelMatch?.[1],
           baseUrl: baseUrlMatch?.[1],
           apiKey: apiKeyMatch?.[1] ? process.env[apiKeyMatch[1]] : undefined,
@@ -2233,6 +2240,170 @@ function resolveModelAndProvider(
   return { model: modelId, baseUrl, apiKey };
 }
 
+function readRuntimeEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function resolveDocsCloudApiBaseUrl(): string {
+  return (
+    readRuntimeEnv("DOCS_CLOUD_API_URL") ??
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_URL") ??
+    DEFAULT_DOCS_CLOUD_API_BASE_URL
+  ).replace(/\/+$/, "");
+}
+
+function resolveDocsCloudProjectId(): string | undefined {
+  return (
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID")
+  );
+}
+
+function resolveDocsCloudApiKey(cloudConfig?: DocsConfig["cloud"]): {
+  envName: string;
+  apiKey: string | undefined;
+} {
+  const envName = cloudConfig?.apiKey?.env?.trim() || DEFAULT_DOCS_CLOUD_API_KEY_ENV;
+  return { envName, apiKey: readRuntimeEnv(envName) };
+}
+
+function createOpenAICompatibleSseChunk(content: string): string {
+  return `data: ${JSON.stringify({
+    choices: [
+      {
+        delta: { content },
+      },
+    ],
+  })}\n\n`;
+}
+
+function createOpenAICompatibleSseResponse(content: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (content) {
+        controller.enqueue(encoder.encode(createOpenAICompatibleSseChunk(content)));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function getOpenAICompatibleDeltaContent(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+
+  const firstChoice = Array.isArray(value.choices) ? value.choices[0] : undefined;
+  if (!isPlainObject(firstChoice)) return undefined;
+  const delta = firstChoice.delta;
+  if (!isPlainObject(delta)) return undefined;
+
+  return typeof delta.content === "string" ? delta.content : undefined;
+}
+
+function getDocsCloudStreamContent(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!isPlainObject(value)) return undefined;
+
+  for (const key of ["content", "text", "answer", "delta"]) {
+    const content = value[key];
+    if (typeof content === "string") return content;
+  }
+
+  return undefined;
+}
+
+function createDocsCloudSseProxyResponse(body: ReadableStream<Uint8Array> | null): Response {
+  if (!body) return createOpenAICompatibleSseResponse("");
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = body.getReader();
+      let buffer = "";
+      let doneSent = false;
+
+      const enqueue = (chunk: string) => {
+        controller.enqueue(encoder.encode(chunk));
+      };
+
+      const flushEvent = (event: string) => {
+        const data = event
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice("data:".length).trim())
+          .filter(Boolean)
+          .join("\n")
+          .trim();
+
+        if (!data) return;
+        if (data === "[DONE]") {
+          doneSent = true;
+          enqueue("data: [DONE]\n\n");
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(data) as unknown;
+          if (getOpenAICompatibleDeltaContent(parsed) !== undefined) {
+            enqueue(`data: ${data}\n\n`);
+            return;
+          }
+
+          const content = getDocsCloudStreamContent(parsed);
+          if (content) enqueue(createOpenAICompatibleSseChunk(content));
+        } catch {
+          enqueue(createOpenAICompatibleSseChunk(data));
+        }
+      };
+
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const events = buffer.split(/\r?\n\r?\n/);
+          buffer = events.pop() ?? "";
+          for (const event of events) flushEvent(event);
+        }
+
+        buffer += decoder.decode();
+        if (buffer.trim()) flushEvent(buffer);
+        if (!doneSent) enqueue("data: [DONE]\n\n");
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function getDocsCloudAnswerFromPayload(payload: unknown): string {
+  if (!isPlainObject(payload)) return "";
+  const answer = payload.answer;
+  if (typeof answer === "string") return answer;
+  const text = payload.text;
+  return typeof text === "string" ? text : "";
+}
+
 function safeUrlOrigin(value: string): string {
   try {
     return new URL(value).origin;
@@ -2251,6 +2422,7 @@ async function handleAskAI(
   request: Request,
   indexes: DocsSearchSourcePage[],
   aiConfig: AIOptions,
+  cloudConfig: DocsConfig["cloud"] | undefined,
   search: boolean | DocsSearchConfig | undefined,
   analytics?: boolean | DocsAnalyticsConfig,
   observability?: boolean | DocsObservabilityConfig,
@@ -2409,6 +2581,318 @@ async function handleAskAI(
           : undefined,
     },
   });
+
+  if (aiConfig.provider === "docs-cloud") {
+    const requestedModel =
+      typeof body.model === "string" && body.model.trim().length > 0
+        ? body.model.trim()
+        : undefined;
+    const model = requestedModel ?? "docs-cloud";
+    const projectId = resolveDocsCloudProjectId();
+    const { envName, apiKey } = resolveDocsCloudApiKey(cloudConfig);
+    const cloudApiBaseUrl = resolveDocsCloudApiBaseUrl();
+    const cloudAskUrl = projectId
+      ? `${cloudApiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`
+      : undefined;
+
+    if (!projectId || !apiKey || !cloudAskUrl) {
+      const reason = !projectId ? "missing_docs_cloud_project_id" : "missing_docs_cloud_api_key";
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: request.url,
+        path: url.pathname,
+        locale: analyticsContext.locale,
+        input: { question: query },
+        properties: {
+          ...requestAnalyticsProperties,
+          reason,
+          provider: "docs-cloud",
+          messageCount: messages.length,
+          questionLength: query.length,
+          model,
+          envName: !apiKey ? envName : undefined,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
+      await emitRunError(reason, {
+        status: 500,
+        provider: "docs-cloud",
+        messageCount: messages.length,
+        questionLength: query.length,
+        model,
+        envName: !apiKey ? envName : undefined,
+      });
+
+      return Response.json(
+        {
+          error: !projectId
+            ? "AI provider docs-cloud requires NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID or DOCS_CLOUD_PROJECT_ID."
+            : `AI provider docs-cloud requires ${envName} to be set on the server.`,
+        },
+        { status: 500 },
+      );
+    }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_request",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      input: { question: query },
+      properties: {
+        ...requestAnalyticsProperties,
+        provider: "docs-cloud",
+        messageCount: messages.length,
+        questionLength: query.length,
+        model,
+      },
+    });
+
+    const modelStartedAt = Date.now();
+    const modelStartedAtIso = new Date().toISOString();
+    const modelSpanId = createDocsAgentTraceId("span");
+    const providerOrigin = safeUrlOrigin(cloudApiBaseUrl);
+    await emitTrace({
+      type: "model.call",
+      name: model,
+      spanId: modelSpanId,
+      parentSpanId: runSpanId,
+      startedAt: modelStartedAtIso,
+      status: "started",
+      inputPreview: {
+        messageCount: messages.length,
+        stream: true,
+        providerOrigin,
+      },
+      metadata: {
+        model,
+        provider: "docs-cloud",
+      },
+    });
+
+    let cloudResponse: Response;
+    try {
+      cloudResponse = await fetch(cloudAskUrl, {
+        method: "POST",
+        headers: {
+          Accept: "text/event-stream, application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          question: query,
+          answerMode: "auto",
+          answerStyle: "public",
+          modelPreference: requestedModel,
+        }),
+      });
+    } catch (error) {
+      const elapsed = Math.max(0, Date.now() - modelStartedAt);
+      const message = error instanceof Error ? error.message : "Unknown error";
+      await emitTrace({
+        type: "model.error",
+        name: model,
+        parentSpanId: modelSpanId,
+        startedAt: modelStartedAtIso,
+        endedAt: new Date().toISOString(),
+        durationMs: elapsed,
+        status: "error",
+        outputPreview: {
+          message,
+        },
+        metadata: {
+          model,
+          provider: "docs-cloud",
+          providerOrigin,
+        },
+      });
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: request.url,
+        path: url.pathname,
+        locale: analyticsContext.locale,
+        input: { question: query },
+        properties: {
+          ...requestAnalyticsProperties,
+          reason: "docs_cloud_fetch_error",
+          provider: "docs-cloud",
+          messageCount: messages.length,
+          questionLength: query.length,
+          model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
+      await emitRunError("docs_cloud_fetch_error", {
+        status: 502,
+        provider: "docs-cloud",
+        messageCount: messages.length,
+        questionLength: query.length,
+        model,
+      });
+      return Response.json({ error: "Docs Cloud Ask AI request failed." }, { status: 502 });
+    }
+
+    if (!cloudResponse.ok) {
+      const errText = await cloudResponse.text().catch(() => "Unknown error");
+      const elapsed = Math.max(0, Date.now() - modelStartedAt);
+      await emitTrace({
+        type: "model.error",
+        name: model,
+        parentSpanId: modelSpanId,
+        startedAt: modelStartedAtIso,
+        endedAt: new Date().toISOString(),
+        durationMs: elapsed,
+        status: "error",
+        outputPreview: {
+          status: cloudResponse.status,
+          errorChars: errText.length,
+        },
+        metadata: {
+          model,
+          provider: "docs-cloud",
+          providerOrigin,
+        },
+      });
+      await emitDocsAnalyticsEvent(analytics, {
+        type: "api_ai_error",
+        source: "server",
+        url: request.url,
+        path: url.pathname,
+        locale: analyticsContext.locale,
+        input: { question: query },
+        properties: {
+          ...requestAnalyticsProperties,
+          reason: "docs_cloud_error",
+          provider: "docs-cloud",
+          status: cloudResponse.status,
+          messageCount: messages.length,
+          questionLength: query.length,
+          model,
+          durationMs: Math.max(0, Date.now() - requestStartedAt),
+        },
+      });
+      await emitRunError("docs_cloud_error", {
+        status: 502,
+        modelStatus: cloudResponse.status,
+        provider: "docs-cloud",
+        messageCount: messages.length,
+        questionLength: query.length,
+        model,
+      });
+      return Response.json(
+        { error: `Docs Cloud Ask AI error (${cloudResponse.status}).` },
+        { status: 502 },
+      );
+    }
+
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_response",
+      source: "server",
+      url: request.url,
+      path: url.pathname,
+      locale: analyticsContext.locale,
+      input: { question: query },
+      properties: {
+        ...requestAnalyticsProperties,
+        provider: "docs-cloud",
+        messageCount: messages.length,
+        questionLength: query.length,
+        model,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+    const responseEndedAt = new Date().toISOString();
+    const modelDurationMs = Math.max(0, Date.now() - modelStartedAt);
+    const contentType = cloudResponse.headers.get("content-type") ?? undefined;
+    await emitTrace({
+      type: "model.response",
+      name: model,
+      parentSpanId: modelSpanId,
+      startedAt: modelStartedAtIso,
+      endedAt: responseEndedAt,
+      durationMs: modelDurationMs,
+      status: "success",
+      outputPreview: {
+        status: cloudResponse.status,
+        stream: true,
+        contentType,
+      },
+      metadata: {
+        model,
+        provider: "docs-cloud",
+        providerOrigin,
+      },
+    });
+    await emitTrace({
+      type: "model.stream",
+      name: model,
+      parentSpanId: modelSpanId,
+      startedAt: modelStartedAtIso,
+      endedAt: responseEndedAt,
+      durationMs: modelDurationMs,
+      status: "success",
+      outputPreview: {
+        stream: true,
+      },
+      metadata: {
+        model,
+        provider: "docs-cloud",
+      },
+    });
+
+    const runDurationMs = Math.max(0, Date.now() - requestStartedAt);
+    await emitTrace({
+      type: "agent.final",
+      name: "ask-ai",
+      parentSpanId: runSpanId,
+      startedAt: trace.startedAt,
+      endedAt: new Date().toISOString(),
+      durationMs: runDurationMs,
+      status: "success",
+      outputPreview: {
+        stream: true,
+        provider: "docs-cloud",
+      },
+      metadata: {
+        model,
+        provider: "docs-cloud",
+      },
+    });
+    await emitTrace({
+      type: "run.end",
+      name: "ask-ai",
+      spanId: runSpanId,
+      startedAt: trace.startedAt,
+      endedAt: new Date().toISOString(),
+      durationMs: runDurationMs,
+      status: "success",
+      outputPreview: {
+        stream: true,
+        provider: "docs-cloud",
+      },
+      metadata: {
+        model,
+        provider: "docs-cloud",
+      },
+    });
+
+    if (contentType?.includes("text/event-stream")) {
+      return createDocsCloudSseProxyResponse(cloudResponse.body);
+    }
+
+    const cloudBody = await cloudResponse.text();
+    let answer = cloudBody;
+    try {
+      answer = getDocsCloudAnswerFromPayload(JSON.parse(cloudBody) as unknown);
+    } catch {
+      // Treat non-JSON Docs Cloud responses as the answer text.
+    }
+
+    return createOpenAICompatibleSseResponse(answer);
+  }
 
   const retrievalStartedAt = Date.now();
   const retrievalStartedAtIso = new Date().toISOString();
@@ -3010,6 +3494,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
   // Read AI config from docs.config if not explicitly provided
   const aiConfig: AIOptions = options?.ai ?? readAIConfig(root);
+  const cloudConfig = options?.cloud;
   const searchConfig = options?.search;
 
   // Read llms.txt config
@@ -3772,6 +4257,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         request,
         getIndexes(ctx),
         aiConfig,
+        cloudConfig,
         resolveAskAISearchRequestConfig({
           search: searchConfig,
           useMcp: aiConfig.useMcp,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -124,6 +124,7 @@ interface AIOptions {
   apiKey?: string;
   maxResults?: number;
   useMcp?: boolean | DocsAskAIMcpConfig;
+  stream?: boolean;
 }
 
 interface DocsAPIOptions {
@@ -862,6 +863,7 @@ function readAIConfig(root: string): AIOptions {
         const apiKeyMatch = content.match(/ai\s*:\s*\{[^}]*apiKey\s*:\s*process\.env\.(\w+)/s);
         const maxResultsMatch = content.match(/ai\s*:\s*\{[^}]*maxResults\s*:\s*(\d+)/s);
         const useMcpMatch = content.match(/ai\s*:\s*\{[^}]*useMcp\s*:\s*(true|false)/s);
+        const streamMatch = content.match(/ai\s*:\s*\{[^}]*stream\s*:\s*(true|false)/s);
         const systemPromptMatch = content.match(
           /ai\s*:\s*\{[^}]*systemPrompt\s*:\s*["'`]([^"'`]+)["'`]/s,
         );
@@ -878,6 +880,7 @@ function readAIConfig(root: string): AIOptions {
           apiKey: apiKeyMatch?.[1] ? process.env[apiKeyMatch[1]] : undefined,
           maxResults: maxResultsMatch ? parseInt(maxResultsMatch[1], 10) : undefined,
           useMcp: useMcpMatch ? useMcpMatch[1] === "true" : undefined,
+          stream: streamMatch ? streamMatch[1] === "true" : undefined,
           systemPrompt: systemPromptMatch?.[1],
           packageName: packageNameMatch?.[1],
           docsUrl: docsUrlMatch?.[1],
@@ -2526,7 +2529,7 @@ async function handleAskAI(
   });
 
   // ── Parse request ──────────────────────────────────────────────
-  let body: { messages?: ChatMessage[]; model?: string };
+  let body: { messages?: ChatMessage[]; model?: string; stream?: boolean };
   try {
     body = await request.json();
   } catch {
@@ -2550,6 +2553,9 @@ async function handleAskAI(
   }
 
   const messages = body.messages;
+  const shouldStreamResponse =
+    body.stream !== false &&
+    (request.headers.get("accept")?.toLowerCase().includes("text/event-stream") ?? true);
   if (!Array.isArray(messages) || messages.length === 0) {
     await emitDocsAnalyticsEvent(analytics, {
       type: "api_ai_error",
@@ -2691,7 +2697,7 @@ async function handleAskAI(
       status: "started",
       inputPreview: {
         messageCount: messages.length,
-        stream: true,
+        stream: shouldStreamResponse,
         providerOrigin,
       },
       metadata: {
@@ -2705,7 +2711,9 @@ async function handleAskAI(
       cloudResponse = await fetch(cloudAskUrl, {
         method: "POST",
         headers: {
-          Accept: "text/event-stream, application/json",
+          Accept: shouldStreamResponse
+            ? "text/event-stream, application/json"
+            : "application/json",
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },
@@ -2714,6 +2722,7 @@ async function handleAskAI(
           answerMode: "auto",
           answerStyle: "public",
           modelPreference: requestedModel,
+          stream: shouldStreamResponse,
         }),
       });
     } catch (error) {
@@ -2845,7 +2854,7 @@ async function handleAskAI(
       status: "success",
       outputPreview: {
         status: cloudResponse.status,
-        stream: true,
+        stream: shouldStreamResponse,
         contentType,
       },
       metadata: {
@@ -2863,7 +2872,7 @@ async function handleAskAI(
       durationMs: modelDurationMs,
       status: "success",
       outputPreview: {
-        stream: true,
+        stream: shouldStreamResponse,
       },
       metadata: {
         model,
@@ -2881,7 +2890,7 @@ async function handleAskAI(
       durationMs: runDurationMs,
       status: "success",
       outputPreview: {
-        stream: true,
+        stream: shouldStreamResponse,
         provider: "docs-cloud",
       },
       metadata: {
@@ -2898,7 +2907,7 @@ async function handleAskAI(
       durationMs: runDurationMs,
       status: "success",
       outputPreview: {
-        stream: true,
+        stream: shouldStreamResponse,
         provider: "docs-cloud",
       },
       metadata: {
@@ -2907,19 +2916,23 @@ async function handleAskAI(
       },
     });
 
-    if (contentType?.includes("text/event-stream")) {
+    if (shouldStreamResponse && contentType?.includes("text/event-stream")) {
       return createDocsCloudSseProxyResponse(cloudResponse.body);
     }
 
     const cloudBody = await cloudResponse.text();
     let answer = cloudBody;
+    let cloudPayload: unknown;
     try {
-      answer = getDocsCloudAnswerFromPayload(JSON.parse(cloudBody) as unknown);
+      cloudPayload = JSON.parse(cloudBody) as unknown;
+      answer = getDocsCloudAnswerFromPayload(cloudPayload);
     } catch {
       // Treat non-JSON Docs Cloud responses as the answer text.
     }
 
-    return createOpenAICompatibleSseResponse(answer);
+    return shouldStreamResponse
+      ? createOpenAICompatibleSseResponse(answer)
+      : Response.json(isPlainObject(cloudPayload) ? cloudPayload : { answer });
   }
 
   const retrievalStartedAt = Date.now();

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2711,9 +2711,7 @@ async function handleAskAI(
       cloudResponse = await fetch(cloudAskUrl, {
         method: "POST",
         headers: {
-          Accept: shouldStreamResponse
-            ? "text/event-stream, application/json"
-            : "application/json",
+          Accept: shouldStreamResponse ? "text/event-stream, application/json" : "application/json",
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },

--- a/packages/fumadocs/src/docs-cloud-ai-client.test.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.test.ts
@@ -46,6 +46,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
       api: "https://docs-app.farming-labs.dev/v1/projects/project_public/knowledge/ask",
       requestMode: "docs-cloud",
+      requestStream: true,
       requestHeaders: {
         Authorization: "Bearer public-key",
       },
@@ -65,6 +66,26 @@ describe("resolveDocsCloudAIClientRequest", () => {
       ),
     ).toEqual({
       api: "/api/docs",
+      requestStream: true,
+    });
+  });
+
+  it("allows Docs Cloud streaming to be disabled from ai.stream", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+
+    expect(
+      resolveDocsCloudAIClientRequest({
+        ...createDocsCloudConfig(),
+        ai: {
+          enabled: true,
+          provider: "docs-cloud",
+          stream: false,
+        } as unknown as DocsConfig["ai"],
+      }),
+    ).toMatchObject({
+      requestMode: "docs-cloud",
+      requestStream: false,
     });
   });
 });

--- a/packages/fumadocs/src/docs-cloud-ai-client.test.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { DocsConfig } from "@farming-labs/docs";
+import { resolveDocsCloudAIClientRequest } from "./docs-cloud-ai-client.js";
+
+const ENV_KEYS = [
+  "NEXT_PUBLIC_DOCS_CLOUD_API_KEY",
+  "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+  "NEXT_PUBLIC_DOCS_CLOUD_URL",
+  "DOCS_CLOUD_API_URL",
+  "DOCS_CLOUD_API_KEY",
+  "SERVER_DOCS_CLOUD_KEY",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function createDocsCloudConfig(cloud?: DocsConfig["cloud"]): DocsConfig {
+  return {
+    entry: "docs",
+    ai: {
+      enabled: true,
+      provider: "docs-cloud",
+    } as unknown as DocsConfig["ai"],
+    cloud,
+  };
+}
+
+describe("resolveDocsCloudAIClientRequest", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("uses the default public Docs Cloud API key env when no config override is set", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+
+    expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
+      api: "https://docs-app.farming-labs.dev/v1/projects/project_public/knowledge/ask",
+      requestMode: "docs-cloud",
+      requestHeaders: {
+        Authorization: "Bearer public-key",
+      },
+    });
+  });
+
+  it("falls back to the server proxy when configured API key env is not public", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.SERVER_DOCS_CLOUD_KEY = "server-key";
+
+    expect(
+      resolveDocsCloudAIClientRequest(
+        createDocsCloudConfig({
+          apiKey: { env: "SERVER_DOCS_CLOUD_KEY" },
+        }),
+      ),
+    ).toEqual({
+      api: "/api/docs",
+    });
+  });
+});

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -8,6 +8,7 @@ export interface DocsCloudAIClientRequest {
   api: string;
   requestMode?: "openai-chat" | "docs-cloud";
   requestHeaders?: Record<string, string>;
+  requestStream?: boolean;
 }
 
 function readRuntimeEnv(name: string): string | undefined {
@@ -38,6 +39,12 @@ function resolvePublicDocsCloudApiKey(config: DocsConfig): string | undefined {
   return readRuntimeEnv(configuredEnv);
 }
 
+function resolveDocsCloudAIStream(config: DocsConfig): boolean {
+  const aiConfig = config.ai as { stream?: unknown; streaming?: unknown } | undefined;
+  const stream = aiConfig?.stream ?? aiConfig?.streaming;
+  return typeof stream === "boolean" ? stream : true;
+}
+
 export function resolveDocsCloudAIClientRequest(
   config: DocsConfig,
   fallbackApi: string = DEFAULT_DOCS_API_ROUTE,
@@ -49,14 +56,16 @@ export function resolveDocsCloudAIClientRequest(
 
   const projectId = resolveDocsCloudProjectId();
   const apiKey = resolvePublicDocsCloudApiKey(config);
+  const requestStream = resolveDocsCloudAIStream(config);
   if (!projectId || !apiKey) {
-    return { api: fallbackApi };
+    return { api: fallbackApi, requestStream };
   }
 
   const apiBaseUrl = resolveDocsCloudApiBaseUrl();
   return {
     api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`,
     requestMode: "docs-cloud",
+    requestStream,
     requestHeaders: {
       Authorization: `Bearer ${apiKey}`,
     },

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -31,11 +31,11 @@ function resolveDocsCloudProjectId(): string | undefined {
 
 function resolvePublicDocsCloudApiKey(config: DocsConfig): string | undefined {
   const configuredEnv = config.cloud?.apiKey?.env?.trim();
-  const publicEnv = configuredEnv?.startsWith("NEXT_PUBLIC_")
-    ? configuredEnv
-    : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
 
-  return readRuntimeEnv(publicEnv);
+  if (!configuredEnv) return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV);
+  if (!configuredEnv.startsWith("NEXT_PUBLIC_")) return undefined;
+
+  return readRuntimeEnv(configuredEnv);
 }
 
 export function resolveDocsCloudAIClientRequest(

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -1,0 +1,64 @@
+import type { DocsConfig } from "@farming-labs/docs";
+
+const DEFAULT_DOCS_API_ROUTE = "/api/docs";
+const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
+const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
+
+export interface DocsCloudAIClientRequest {
+  api: string;
+  requestMode?: "openai-chat" | "docs-cloud";
+  requestHeaders?: Record<string, string>;
+}
+
+function readRuntimeEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function resolveDocsCloudApiBaseUrl(): string {
+  return (
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_URL") ??
+    readRuntimeEnv("DOCS_CLOUD_API_URL") ??
+    DEFAULT_DOCS_CLOUD_API_BASE_URL
+  ).replace(/\/+$/, "");
+}
+
+function resolveDocsCloudProjectId(): string | undefined {
+  return (
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID")
+  );
+}
+
+function resolvePublicDocsCloudApiKey(config: DocsConfig): string | undefined {
+  const configuredEnv = config.cloud?.apiKey?.env?.trim();
+  const publicEnv = configuredEnv?.startsWith("NEXT_PUBLIC_")
+    ? configuredEnv
+    : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+
+  return readRuntimeEnv(publicEnv);
+}
+
+export function resolveDocsCloudAIClientRequest(
+  config: DocsConfig,
+  fallbackApi: string = DEFAULT_DOCS_API_ROUTE,
+): DocsCloudAIClientRequest {
+  const aiProvider = (config.ai as { provider?: string } | undefined)?.provider;
+  if (aiProvider !== "docs-cloud") {
+    return { api: fallbackApi };
+  }
+
+  const projectId = resolveDocsCloudProjectId();
+  const apiKey = resolvePublicDocsCloudApiKey(config);
+  if (!projectId || !apiKey) {
+    return { api: fallbackApi };
+  }
+
+  const apiBaseUrl = resolveDocsCloudApiBaseUrl();
+  return {
+    api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`,
+    requestMode: "docs-cloud",
+    requestHeaders: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+}

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1116,6 +1116,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
               api={aiClientRequest.api}
               requestMode={aiClientRequest.requestMode}
               requestHeaders={aiClientRequest.requestHeaders}
+              requestStream={aiClientRequest.requestStream}
               locale={activeLocale}
               position={aiPosition}
               floatingStyle={aiFloatingStyle}

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -29,6 +29,7 @@ import type {
 } from "@farming-labs/docs";
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
+import { resolveDocsCloudAIClientRequest } from "./docs-cloud-ai-client.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
 import { resolveOpenDocsProviders } from "./open-docs-providers.js";
 import { resolvePageReadingTime, resolveReadingTimeOptions } from "./reading-time.js";
@@ -902,6 +903,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const i18n = resolveDocsI18nConfig(getDocsI18n(config));
   const activeLocale = localeContext.locale ?? i18n?.defaultLocale;
   const docsApiUrl = withLangInUrl("/api/docs", activeLocale);
+  const aiClientRequest = resolveDocsCloudAIClientRequest(config, docsApiUrl);
   const changelogConfig = resolveChangelogConfig(config.changelog);
   const changelogBasePath = changelogConfig.enabled
     ? publicDocsRoute(localeContext, [changelogConfig.path])
@@ -1111,7 +1113,9 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
           <Suspense fallback={null}>
             <DocsAIFeatures
               mode={aiMode}
-              api={docsApiUrl}
+              api={aiClientRequest.api}
+              requestMode={aiClientRequest.requestMode}
+              requestHeaders={aiClientRequest.requestHeaders}
               locale={activeLocale}
               position={aiPosition}
               floatingStyle={aiFloatingStyle}

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -12,6 +12,7 @@ import type {
 import { applySidebarFolderIndexBehavior, resolveDocsAnalyticsConfig } from "@farming-labs/docs";
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
+import { resolveDocsCloudAIClientRequest } from "./docs-cloud-ai-client.js";
 import { DocsCommandSearch } from "./docs-command-search.js";
 import { resolveReadingTimeOptions } from "./reading-time.js";
 import { resolveOpenDocsProviders } from "./open-docs-providers.js";
@@ -339,6 +340,7 @@ export function TanstackDocsLayout({
   const tocStyle = tocConfig?.style as "default" | "directional" | undefined;
   const analyticsEnabled = resolveDocsAnalyticsConfig(config.analytics).enabled;
   const docsApiUrl = withLangInUrl("/api/docs", locale);
+  const aiClientRequest = resolveDocsCloudAIClientRequest(config, docsApiUrl);
   const navTitle = (config.nav?.title as ReactNode) ?? "Docs";
   const navUrl = withLangInUrl(config.nav?.url ?? `/${config.entry ?? "docs"}`, locale);
 
@@ -489,7 +491,9 @@ export function TanstackDocsLayout({
         <Suspense fallback={null}>
           <DocsAIFeatures
             mode={aiMode}
-            api={docsApiUrl}
+            api={aiClientRequest.api}
+            requestMode={aiClientRequest.requestMode}
+            requestHeaders={aiClientRequest.requestHeaders}
             locale={locale}
             position={aiPosition}
             floatingStyle={aiFloatingStyle}

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -494,6 +494,7 @@ export function TanstackDocsLayout({
             api={aiClientRequest.api}
             requestMode={aiClientRequest.requestMode}
             requestHeaders={aiClientRequest.requestHeaders}
+            requestStream={aiClientRequest.requestStream}
             locale={locale}
             position={aiPosition}
             floatingStyle={aiFloatingStyle}

--- a/packages/fumadocs/styles/ai.css
+++ b/packages/fumadocs/styles/ai.css
@@ -777,20 +777,32 @@
 
 /* ─── Streaming cursor ───────────────────────────────────────────── */
 
+.fd-ai-streaming {
+  text-rendering: optimizeLegibility;
+}
+
 .fd-ai-streaming::after {
   content: "";
   display: inline-block;
   width: 2px;
-  height: 1em;
+  height: 0.95em;
   background: var(--color-fd-primary, #6366f1);
-  margin-left: 2px;
+  border-radius: 999px;
+  margin-left: 3px;
   vertical-align: text-bottom;
-  animation: fd-ai-cursor-blink 0.8s step-end infinite;
+  animation: fd-ai-cursor-blink 900ms ease-in-out infinite;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--color-fd-primary, #6366f1) 35%, transparent);
 }
 
 @keyframes fd-ai-cursor-blink {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+  50% { opacity: 0.25; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fd-ai-streaming::after {
+    animation: none;
+  }
 }
 
 /* ─── Floating trigger button ────────────────────────────────────── */

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -137,6 +137,42 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
   </Tab>
 </Tabs>
 
+## Hosted Docs Cloud provider
+
+Use Docs Cloud when you want the Ask AI UI to query the knowledge index built from your imported
+repository instead of running the local OpenAI-compatible RAG handler inside the docs app.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    ai: { enabled: true },
+  },
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+    mode: "floating",
+    floatingStyle: "full-modal",
+    suggestedQuestions: [
+      "How do I get started?",
+      "How do I configure this?",
+    ],
+  },
+});
+```
+
+Set the Docs Cloud project id and API key in environment variables:
+
+```bash title=".env"
+NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+DOCS_CLOUD_API_KEY=fl_key_...
+```
+
+`provider: "docs-cloud"` keeps OpenAI, Anthropic, embeddings, and retrieval credentials on the
+Docs Cloud server. Your docs app sends the user's question to
+`/v1/projects/{projectId}/knowledge/ask` using the configured Docs Cloud API key, then returns an
+OpenAI-compatible event stream to the Ask AI widget.
+
 ## Configuration Reference
 
 All options go inside the `ai` object in `docs.config.ts`:

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -145,7 +145,7 @@ repository instead of running the local OpenAI-compatible RAG handler inside the
 ```ts title="docs.config.ts"
 export default defineDocs({
   cloud: {
-    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
     ai: { enabled: true },
   },
   ai: {
@@ -165,13 +165,13 @@ Set the Docs Cloud project id and API key in environment variables:
 
 ```bash title=".env"
 NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
-DOCS_CLOUD_API_KEY=fl_key_...
+NEXT_PUBLIC_DOCS_CLOUD_API_KEY=fl_key_...
 ```
 
 `provider: "docs-cloud"` keeps OpenAI, Anthropic, embeddings, and retrieval credentials on the
-Docs Cloud server. Your docs app sends the user's question to
-`/v1/projects/{projectId}/knowledge/ask` using the configured Docs Cloud API key, then returns an
-OpenAI-compatible event stream to the Ask AI widget.
+Docs Cloud server. The Ask AI widget sends the user's question directly to
+`/v1/projects/{projectId}/knowledge/ask` using the configured project-scoped Docs Cloud API key and
+reads an OpenAI-compatible event stream.
 
 ## Configuration Reference
 

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -17,7 +17,7 @@ Add a built-in AI chat that lets users ask questions about your documentation. T
 
 ## Quick Start
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 ai: {
   enabled: true,
 }
@@ -45,7 +45,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `src/lib/docs.server.ts`:
 
-    ```ts title="src/lib/docs.server.ts"
+    ```tstitle="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/tanstack-start/server";
     import docsConfig from "../../docs.config";
 
@@ -66,7 +66,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `docs.server.ts` (SvelteKit requires server-only env access):
 
-    ```ts title="src/lib/docs.server.ts"
+    ```tstitle="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/svelte/server";
     import { env } from "$env/dynamic/private";
     import config from "./docs.config";
@@ -97,7 +97,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `docs.server.ts`:
 
-    ```ts title="src/lib/docs.server.ts"
+    ```tstitle="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/astro/server";
     import config from "./docs.config";
 
@@ -127,7 +127,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Nuxt automatically reads environment variables via Nitro's runtime config. The `defineDocsHandler` reads `process.env.OPENAI_API_KEY` on the server.
 
-    ```ts title="server/api/docs.ts"
+    ```tstitle="server/api/docs.ts"
     import { defineDocsHandler } from "@farming-labs/nuxt/server";
     import config from "../../docs.config";
 
@@ -142,7 +142,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 Use Docs Cloud when you want the Ask AI UI to query the knowledge index built from your imported
 repository instead of running the local OpenAI-compatible RAG handler inside the docs app.
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   cloud: {
     apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
@@ -151,6 +151,7 @@ export default defineDocs({
   ai: {
     enabled: true,
     provider: "docs-cloud",
+    stream: true,
     mode: "floating",
     floatingStyle: "full-modal",
     suggestedQuestions: [
@@ -171,13 +172,14 @@ NEXT_PUBLIC_DOCS_CLOUD_API_KEY=fl_key_...
 `provider: "docs-cloud"` keeps OpenAI, Anthropic, embeddings, and retrieval credentials on the
 Docs Cloud server. The Ask AI widget sends the user's question directly to
 `/v1/projects/{projectId}/knowledge/ask` using the configured project-scoped Docs Cloud API key and
-reads an OpenAI-compatible event stream.
+reads an OpenAI-compatible event stream. Streaming is enabled by default for Docs Cloud; set
+`stream: false` if you need a single JSON answer.
 
 ## Configuration Reference
 
 All options go inside the `ai` object in `docs.config.ts`:
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   ai: {
     // ... options
@@ -193,7 +195,7 @@ Whether to enable AI chat functionality.
 | --------- | ------- |
 | `boolean` | `false` |
 
-```ts 
+```ts
 ai: {
   enabled: true,
 }
@@ -210,7 +212,7 @@ How the AI chat UI is presented.
 - **`"search"`** — AI tab integrated into the `Cmd+K` search dialog. Users switch between "Search" and "AI" tabs.
 - **`"floating"`** — A floating chat widget with a button on screen. Opens as a panel, modal, or full-screen overlay.
 
-```ts 
+```ts
 ai: {
   enabled: true,
   mode: "floating",
@@ -225,7 +227,7 @@ Position of the floating chat button on screen. Only used when `mode` is `"float
 | ---------------------------------------------------- | ---------------- |
 | `"bottom-right" \| "bottom-left" \| "bottom-center"` | `"bottom-right"` |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   mode: "floating",
@@ -246,11 +248,28 @@ Visual style of the floating chat when opened. Only used when `mode` is `"floati
 - **`"popover"`** — A compact popover near the button. Suitable for quick questions.
 - **`"full-modal"`** — A full-screen immersive overlay. Messages scroll in the center, input is pinned at the bottom, suggested questions appear as horizontal pills.
 
-```ts 
+```ts
 ai: {
   enabled: true,
   mode: "floating",
   floatingStyle: "full-modal",
+}
+```
+
+### `stream`
+
+Whether Ask AI should request a streaming response when the provider supports it. Docs Cloud streams
+token deltas by default.
+
+| Type      | Default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+```ts
+ai: {
+  enabled: true,
+  provider: "docs-cloud",
+  stream: true,
 }
 ```
 
@@ -264,7 +283,7 @@ The LLM model configuration. Can be a simple string (single model) or an object 
 | -------- | --------------- |
 | `string` | `"gpt-4o-mini"` |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   model: "gpt-4o",
@@ -277,7 +296,7 @@ ai: {
 | -------- | ------- |
 | `object` | —       |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   model: {
@@ -306,7 +325,7 @@ Named provider configurations. Each provider has its own `baseUrl` and `apiKey`,
 | -------- | ------- |
 | `object` | —       |
 
-```ts title="providers.ts"
+```tstitle="providers.ts"
 ai: {
   enabled: true,
   providers: {
@@ -339,7 +358,7 @@ Default base URL for an OpenAI-compatible API endpoint. Used when no per-model `
 | -------- | ----------------------------- |
 | `string` | `"https://api.openai.com/v1"` |
 
-```ts title="baseurl.ts"
+```tstitle="baseurl.ts"
 ai: {
   enabled: true,
   model: "llama-3.1-70b-versatile",
@@ -355,7 +374,7 @@ Default API key for the LLM provider. Used when no per-model `provider` is confi
 | -------- | ---------------------------- |
 | `string` | `process.env.OPENAI_API_KEY` |
 
-```ts title="apikey.ts"
+```tstitle="apikey.ts"
 ai: {
   enabled: true,
   apiKey: process.env.GROQ_API_KEY,
@@ -372,7 +391,7 @@ Custom system prompt prepended to the AI conversation. Documentation context is 
 | -------- | ------------------------------------------------ |
 | `string` | `"You are a helpful documentation assistant..."` |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   systemPrompt: "You are a friendly assistant for Acme Corp. Always mention our support email for complex issues.",
@@ -387,7 +406,7 @@ Maximum number of search results to include as context for the AI. More results 
 | -------- | ------- |
 | `number` | `5`     |
 
-```ts title="maxresults.ts"
+```tstitle="maxresults.ts"
 ai: {
   enabled: true,
   maxResults: 10,
@@ -403,7 +422,7 @@ normal docs search API.
 | ---- | ------- |
 | `boolean \| DocsAskAIMcpConfig` | `false` |
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -416,7 +435,7 @@ export default defineDocs({
 context. By default that is the canonical `mcp.route` at `/api/docs/mcp`; if you configure
 `mcp.route`, Ask AI uses that route automatically:
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   mcp: {
     route: "/custom/docs/mcp",
@@ -432,7 +451,7 @@ Pass an object only when Ask AI should use a hosted or external MCP endpoint ins
 own MCP route. MCP handles retrieval only; the `model`, `apiKey`, `baseUrl`, or `providers` config
 still controls the LLM generation request.
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -473,7 +492,7 @@ building the model context.
 The context passed to the model is hydrated from the local docs page or matching section, preserving
 fenced code blocks so install commands, config snippets, and examples can be quoted accurately.
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 import { createCustomSearchAdapter } from "@farming-labs/docs";
 
 export default defineDocs({
@@ -508,7 +527,7 @@ to hide the action row.
 Single callback for Ask AI response actions. Use `data.type` to handle `"copy"`, `"like"`, and
 `"dislike"` from one place.
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 ai: {
   enabled: true,
   onActions(data) {
@@ -538,7 +557,7 @@ Pre-filled suggested questions shown in the AI chat when the conversation is emp
 | ---------- | ------- |
 | `string[]` | `[]`    |
 
-```ts 
+```ts
 ai: {
   enabled: true,
   suggestedQuestions: [
@@ -606,7 +625,7 @@ Loading indicator variant shown while the AI generates a response.
 
 Available variants: `"shimmer-dots"`, `"circular"`, `"dots"`, `"typing"`, `"wave"`, `"bars"`, `"pulse"`, `"pulse-dot"`, `"terminal"`, `"text-blink"`, `"text-shimmer"`, `"loading-dots"`.
 
-```ts 
+```ts
 ai: {
   enabled: true,
   loader: "wave",
@@ -716,7 +735,7 @@ Custom trigger button for the floating chat. Replaces the default sparkles butto
 
 ## Full Example — Single Provider
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -739,7 +758,7 @@ export default defineDocs({
 
 ## Full Example — Multiple Providers
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -786,7 +805,7 @@ Users see a model dropdown in the AI chat interface. When they pick a model, the
 
 Use any OpenAI-compatible API by setting `baseUrl` and `model`:
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 ai: {
   enabled: true,
   baseUrl: "https://api.groq.com/openai/v1",
@@ -802,7 +821,7 @@ OPENAI_API_KEY=gsk_...
 
 Use the `providers` map to configure multiple APIs, then reference them from each model entry:
 
-```ts title="docs.config.ts"
+```tstitle="docs.config.ts"
 ai: {
   enabled: true,
   providers: {

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -17,7 +17,7 @@ Add a built-in AI chat that lets users ask questions about your documentation. T
 
 ## Quick Start
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 ai: {
   enabled: true,
 }
@@ -45,7 +45,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `src/lib/docs.server.ts`:
 
-    ```tstitle="src/lib/docs.server.ts"
+    ```ts title="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/tanstack-start/server";
     import docsConfig from "../../docs.config";
 
@@ -66,7 +66,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `docs.server.ts` (SvelteKit requires server-only env access):
 
-    ```tstitle="src/lib/docs.server.ts"
+    ```ts title="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/svelte/server";
     import { env } from "$env/dynamic/private";
     import config from "./docs.config";
@@ -97,7 +97,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Pass it through `docs.server.ts`:
 
-    ```tstitle="src/lib/docs.server.ts"
+    ```ts title="src/lib/docs.server.ts"
     import { createDocsServer } from "@farming-labs/astro/server";
     import config from "./docs.config";
 
@@ -127,7 +127,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 
     Nuxt automatically reads environment variables via Nitro's runtime config. The `defineDocsHandler` reads `process.env.OPENAI_API_KEY` on the server.
 
-    ```tstitle="server/api/docs.ts"
+    ```ts title="server/api/docs.ts"
     import { defineDocsHandler } from "@farming-labs/nuxt/server";
     import config from "../../docs.config";
 
@@ -142,7 +142,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
 Use Docs Cloud when you want the Ask AI UI to query the knowledge index built from your imported
 repository instead of running the local OpenAI-compatible RAG handler inside the docs app.
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   cloud: {
     apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
@@ -179,7 +179,7 @@ reads an OpenAI-compatible event stream. Streaming is enabled by default for Doc
 
 All options go inside the `ai` object in `docs.config.ts`:
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   ai: {
     // ... options
@@ -325,7 +325,7 @@ Named provider configurations. Each provider has its own `baseUrl` and `apiKey`,
 | -------- | ------- |
 | `object` | —       |
 
-```tstitle="providers.ts"
+```ts title="providers.ts"
 ai: {
   enabled: true,
   providers: {
@@ -358,7 +358,7 @@ Default base URL for an OpenAI-compatible API endpoint. Used when no per-model `
 | -------- | ----------------------------- |
 | `string` | `"https://api.openai.com/v1"` |
 
-```tstitle="baseurl.ts"
+```ts title="baseurl.ts"
 ai: {
   enabled: true,
   model: "llama-3.1-70b-versatile",
@@ -374,7 +374,7 @@ Default API key for the LLM provider. Used when no per-model `provider` is confi
 | -------- | ---------------------------- |
 | `string` | `process.env.OPENAI_API_KEY` |
 
-```tstitle="apikey.ts"
+```ts title="apikey.ts"
 ai: {
   enabled: true,
   apiKey: process.env.GROQ_API_KEY,
@@ -406,7 +406,7 @@ Maximum number of search results to include as context for the AI. More results 
 | -------- | ------- |
 | `number` | `5`     |
 
-```tstitle="maxresults.ts"
+```ts title="maxresults.ts"
 ai: {
   enabled: true,
   maxResults: 10,
@@ -422,7 +422,7 @@ normal docs search API.
 | ---- | ------- |
 | `boolean \| DocsAskAIMcpConfig` | `false` |
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -435,7 +435,7 @@ export default defineDocs({
 context. By default that is the canonical `mcp.route` at `/api/docs/mcp`; if you configure
 `mcp.route`, Ask AI uses that route automatically:
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   mcp: {
     route: "/custom/docs/mcp",
@@ -451,7 +451,7 @@ Pass an object only when Ask AI should use a hosted or external MCP endpoint ins
 own MCP route. MCP handles retrieval only; the `model`, `apiKey`, `baseUrl`, or `providers` config
 still controls the LLM generation request.
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -492,7 +492,7 @@ building the model context.
 The context passed to the model is hydrated from the local docs page or matching section, preserving
 fenced code blocks so install commands, config snippets, and examples can be quoted accurately.
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 import { createCustomSearchAdapter } from "@farming-labs/docs";
 
 export default defineDocs({
@@ -527,7 +527,7 @@ to hide the action row.
 Single callback for Ask AI response actions. Use `data.type` to handle `"copy"`, `"like"`, and
 `"dislike"` from one place.
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 ai: {
   enabled: true,
   onActions(data) {
@@ -735,7 +735,7 @@ Custom trigger button for the floating chat. Replaces the default sparkles butto
 
 ## Full Example — Single Provider
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -758,7 +758,7 @@ export default defineDocs({
 
 ## Full Example — Multiple Providers
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 export default defineDocs({
   ai: {
     enabled: true,
@@ -805,7 +805,7 @@ Users see a model dropdown in the AI chat interface. When they pick a model, the
 
 Use any OpenAI-compatible API by setting `baseUrl` and `model`:
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 ai: {
   enabled: true,
   baseUrl: "https://api.groq.com/openai/v1",
@@ -821,7 +821,7 @@ OPENAI_API_KEY=gsk_...
 
 Use the `providers` map to configure multiple APIs, then reference them from each model entry:
 
-```tstitle="docs.config.ts"
+```ts title="docs.config.ts"
 ai: {
   enabled: true,
   providers: {

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -315,22 +315,10 @@ export default defineDocs({
   ordering: "numeric",
   ai: {
     enabled: true,
+    provider: "docs-cloud",
     mode: "floating",
     position: "bottom-right",
     floatingStyle: "full-modal",
-    providers: {
-      openai: {
-        baseUrl: "https://api.openai.com/v1",
-        apiKey: process.env.OPENAI_API_KEY,
-      },
-    },
-    model: {
-      models: [
-        { id: "gpt-4o-mini", label: "GPT-4o mini (fast)", provider: "openai" },
-        { id: "gpt-4o", label: "GPT-4o (quality)", provider: "openai" },
-      ],
-      defaultModel: "gpt-4o-mini",
-    },
     aiLabel: "DocsBot",
     onActions(data) {
       console.log("[@farming-labs/docs:ask-ai-action]", data);

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -316,6 +316,7 @@ export default defineDocs({
   ai: {
     enabled: true,
     provider: "docs-cloud",
+    stream: true,
     mode: "floating",
     position: "bottom-right",
     floatingStyle: "full-modal",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `docs-cloud` provider that sends Ask requests to a hosted Docs Cloud project and returns OpenAI-compatible streaming. Adds `ai.stream` and client-side request hints so SSE/JSON behavior is consistent across client and server.

- **New Features**
  - Support `ai.provider: "docs-cloud"` calling `/v1/projects/{projectId}/knowledge/ask`; proxies Docs Cloud SSE or JSON to OpenAI-style SSE; negotiates via `ai.stream` and the `Accept` header.
  - Client routing via `resolveDocsCloudAIClientRequest`: returns `api`, `requestMode`, `requestHeaders`, and `requestStream`; uses a public key to call Docs Cloud with `Authorization`, else falls back to `/api/docs`.
  - UI passes `requestMode/requestHeaders/requestStream` through `DocsAIFeatures`, dialogs, and floating chat; builds the correct body for Docs Cloud; parses OpenAI and Docs Cloud SSE/JSON; smoother streamed text rendering, better auto-scroll, and a refined streaming cursor.
  - Server reads `cloud.apiKey.env` from `docs.config.ts` (default `DOCS_CLOUD_API_KEY`), project id from `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` or `DOCS_CLOUD_PROJECT_ID`, and API base from `DOCS_CLOUD_API_URL` or `NEXT_PUBLIC_DOCS_CLOUD_URL`; adds an SSE proxy that converts Docs Cloud events to OpenAI-style deltas; returns JSON when streaming is disabled; tests cover client routing, env resolution, and SSE/JSON proxying; docs updated with the hosted provider and streaming option.

- **Migration**
  - Set `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` and either:
    - `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` for direct client calls, or
    - `DOCS_CLOUD_API_KEY` for server-side proxy (override via `cloud.apiKey.env`).
  - In `docs.config.ts`, set `ai.enabled = true`, `ai.provider = "docs-cloud"`, and optionally `ai.stream = false` to return a single JSON answer.

<sup>Written for commit 65c882a2bdf14d1a61375e89720589894a948493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

