### PR TITLE
feat: docs cloud doctor cli

### DIFF
--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -4,9 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  checkCloudConfig,
   initCloudConfig,
   materializeCloudConfig,
   runCloudDeploy,
+  runCloudCheck,
   runCloudPreview,
 } from "./cloud.js";
 
@@ -266,6 +268,188 @@ void missing;
       console: true,
       includeInputs: false,
     });
+  });
+
+  it("checks Docs Cloud config, analytics envs, API key scopes, and direct Ask AI wiring", async () => {
+    writePackageJson();
+    mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      [
+        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  analytics: { enabled: true, console: false },
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    deploy: { enabled: true },
+    analytics: {
+      enabled: true,
+      console: false,
+      includeInputs: false,
+    },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://cloud.example.com/api/cloud/me");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer docs_cloud_public_key",
+      );
+      return new Response(
+        JSON.stringify({
+          workspace: { id: "workspace_1", name: "Acme" },
+          apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.analyticsProjectIdEnv).toBe("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID");
+    expect(result.identity).toMatchObject({
+      workspace: { id: "workspace_1", name: "Acme" },
+      apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
+    });
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "analytics.cloud", status: "pass" }),
+        expect.objectContaining({ name: "project.env", status: "pass" }),
+        expect.objectContaining({ name: "askAi.direct", status: "pass" }),
+        expect.objectContaining({ name: "apiKey.network", status: "pass" }),
+        expect.objectContaining({ name: "apiKey.scopes", status: "pass" }),
+      ]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports missing analytics project envs and can skip network checks", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "DOCS_CLOUD_API_KEY=docs_cloud_test_key\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  analytics: { enabled: true, console: false },
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    analytics: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      network: false,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "project.env", status: "fail" }),
+        expect.objectContaining({ name: "apiKey.network", status: "warn" }),
+      ]),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("warns when docs-cloud Ask AI uses a server-only API key env", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      [
+        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    analytics: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      network: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "askAi.direct",
+          status: "warn",
+          message: expect.stringContaining("/api/docs"),
+        }),
+      ]),
+    );
+  });
+
+  it("prints json and exits non-zero when cloud check fails", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  cloud: {
+    analytics: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    await expect(
+      runCloudCheck({
+        rootDir: tmpDir,
+        apiBaseUrl: "https://cloud.example.com",
+        json: true,
+        network: false,
+      }),
+    ).rejects.toThrow("Docs Cloud check failed");
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"ok": false'));
   });
 
   it("validates the configured API key and prints the deployment URL", async () => {
@@ -656,6 +840,17 @@ void missing;
 
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+
+    const check = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      network: false,
+    });
+    expect(check.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "preview.enabled", status: "fail" }),
+      ]),
+    );
 
     await expect(
       runCloudPreview({

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -417,7 +417,7 @@ void missing;
     expect(checkNames).not.toContain("deploy.enabled");
   });
 
-  it("warns when docs-cloud Ask AI uses a server-only API key env", async () => {
+  it("does not warn when docs-cloud Ask AI uses a server-only API key env", async () => {
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
@@ -453,13 +453,11 @@ void missing;
     expect(result.ok).toBe(true);
     expect(result.checks).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          name: "askAi.direct",
-          status: "warn",
-          message: expect.stringContaining("/api/docs"),
-        }),
+        expect.objectContaining({ name: "askAi.provider", status: "pass" }),
+        expect.objectContaining({ name: "project.env", status: "pass" }),
       ]),
     );
+    expect(result.checks.some((check) => check.name === "askAi.direct")).toBe(false);
   });
 
   it("prints json and exits non-zero when cloud check fails", async () => {

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -380,6 +380,43 @@ void missing;
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("can narrow cloud check to analytics integration only", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  analytics: { enabled: true, console: false },
+  cloud: {
+    analytics: { enabled: true },
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      checkTargets: ["analytics"],
+    });
+    const checkNames = result.checks.map((check) => check.name);
+
+    expect(result.ok).toBe(true);
+    expect(result.targets).toEqual(["analytics"]);
+    expect(checkNames).toContain("analytics.runtime");
+    expect(checkNames).toContain("analytics.cloud");
+    expect(checkNames).toContain("project.env");
+    expect(checkNames).not.toContain("apiKey.value");
+    expect(checkNames).not.toContain("askAi.provider");
+    expect(checkNames).not.toContain("deploy.enabled");
+  });
+
   it("warns when docs-cloud Ask AI uses a server-only API key env", async () => {
     writePackageJson();
     writeFileSync(

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -306,9 +306,7 @@ void missing;
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe("https://cloud.example.com/api/cloud/me");
-      expect(new Headers(init?.headers).get("authorization")).toBe(
-        "Bearer docs_cloud_public_key",
-      );
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer docs_cloud_public_key");
       return new Response(
         JSON.stringify({
           workspace: { id: "workspace_1", name: "Acme" },

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -32,7 +32,7 @@ const DOCS_CLOUD_PROJECT_ID_ENVS = [
   "DOCS_CLOUD_PROJECT_ID",
 ] as const;
 const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
-const CLOUD_CHECK_TARGETS = ["auth", "deploy", "analytics", "ask-ai"] as const;
+const CLOUD_CHECK_TARGETS = ["deploy", "analytics", "ask-ai"] as const;
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue | undefined };
@@ -110,7 +110,7 @@ export interface MaterializeCloudConfigResult {
 }
 
 export type CloudCheckStatus = "pass" | "warn" | "fail";
-export type CloudCheckTarget = "auth" | "deploy" | "analytics" | "ask-ai";
+export type CloudCheckTarget = "deploy" | "analytics" | "ask-ai";
 
 export interface CloudCheckItem {
   name: string;
@@ -1512,6 +1512,12 @@ export async function checkCloudConfig(
   const configPath = snapshot.path ?? docsJsonPath;
   const network = options.network !== false;
   const explicitApiKey = options.apiKey?.trim();
+  const targetSet = resolveCloudCheckTargets(options);
+  const targets = CLOUD_CHECK_TARGETS.filter((target) => targetSet.has(target));
+  const checkDeploy = targetSet.has("deploy");
+  const checkAnalytics = targetSet.has("analytics");
+  const checkAskAi = targetSet.has("ask-ai");
+  const checkProjectEnv = checkAnalytics || checkAskAi;
   let identity: JsonRecord | undefined;
 
   checks.push(
@@ -1536,35 +1542,38 @@ export async function checkCloudConfig(
     ),
   );
 
-  try {
-    normalizeEnvName(apiKeyEnv, DOCS_CLOUD_DEFAULT_API_KEY_ENV);
-    checks.push(createCheck("apiKey.config", "pass", `Using cloud.apiKey.env ${apiKeyEnv}.`));
-  } catch (error) {
+  const apiKey = explicitApiKey || readEnvValue(env, apiKeyEnv);
+
+  if (checkDeploy) {
+    try {
+      normalizeEnvName(apiKeyEnv, DOCS_CLOUD_DEFAULT_API_KEY_ENV);
+      checks.push(createCheck("apiKey.config", "pass", `Using cloud.apiKey.env ${apiKeyEnv}.`));
+    } catch (error) {
+      checks.push(
+        createCheck(
+          "apiKey.config",
+          "fail",
+          error instanceof Error ? error.message : `Invalid API key env ${apiKeyEnv}.`,
+        ),
+      );
+    }
+
     checks.push(
       createCheck(
-        "apiKey.config",
-        "fail",
-        error instanceof Error ? error.message : `Invalid API key env ${apiKeyEnv}.`,
+        "apiKey.value",
+        apiKey ? "pass" : "fail",
+        apiKey
+          ? explicitApiKey
+            ? "Docs Cloud API key was provided with --api-key."
+            : `Docs Cloud API key is present in ${apiKeyEnv}.`
+          : `Missing Docs Cloud API key. Set ${apiKeyEnv} or pass --api-key.`,
+        {
+          env: apiKeyEnv,
+          source: explicitApiKey ? "flag" : apiKey ? "env" : "missing",
+        },
       ),
     );
   }
-
-  const apiKey = explicitApiKey || readEnvValue(env, apiKeyEnv);
-  checks.push(
-    createCheck(
-      "apiKey.value",
-      apiKey ? "pass" : "fail",
-      apiKey
-        ? explicitApiKey
-          ? "Docs Cloud API key was provided with --api-key."
-          : `Docs Cloud API key is present in ${apiKeyEnv}.`
-        : `Missing Docs Cloud API key. Set ${apiKeyEnv} or pass --api-key.`,
-      {
-        env: apiKeyEnv,
-        source: explicitApiKey ? "flag" : apiKey ? "env" : "missing",
-      },
-    ),
-  );
 
   checks.push(
     createCheck(
@@ -1576,169 +1585,185 @@ export async function checkCloudConfig(
     ),
   );
 
-  if (config.cloud?.deploy?.enabled === false) {
-    checks.push(
-      createCheck(
-        "deploy.enabled",
-        "fail",
-        "Docs Cloud deployment is disabled by cloud.deploy.enabled: false.",
-      ),
-    );
-  } else {
-    checks.push(createCheck("deploy.enabled", "pass", "Docs Cloud deployment is enabled."));
-  }
+  if (checkDeploy) {
+    if (config.cloud?.deploy?.enabled === false) {
+      checks.push(
+        createCheck(
+          "deploy.enabled",
+          "fail",
+          "Docs Cloud deployment is disabled by cloud.deploy.enabled: false.",
+        ),
+      );
+    } else {
+      checks.push(createCheck("deploy.enabled", "pass", "Docs Cloud deployment is enabled."));
+    }
 
-  if (config.cloud?.preview?.enabled === false) {
-    checks.push(
-      createCheck(
-        "preview.enabled",
-        "fail",
-        "Docs Cloud preview deployment is disabled by cloud.preview.enabled: false.",
-      ),
-    );
+    if (config.cloud?.preview?.enabled === false) {
+      checks.push(
+        createCheck(
+          "preview.enabled",
+          "fail",
+          "Docs Cloud preview deployment is disabled by cloud.preview.enabled: false.",
+        ),
+      );
+    }
   }
 
   const runtimeAnalyticsDisabled = readRuntimeAnalyticsDisabled(snapshot);
   const cloudAnalyticsEnabled = isCloudAnalyticsEnabled(config.cloud?.analytics);
-  if (runtimeAnalyticsDisabled) {
-    checks.push(
-      createCheck(
-        "analytics.runtime",
-        "fail",
-        "Runtime analytics is disabled by analytics: false or analytics.enabled: false.",
-      ),
-    );
-  } else {
-    checks.push(createCheck("analytics.runtime", "pass", "Runtime analytics is not disabled."));
-  }
-
-  checks.push(
-    createCheck(
-      "analytics.cloud",
-      cloudAnalyticsEnabled ? "pass" : "warn",
-      cloudAnalyticsEnabled
-        ? "Docs Cloud analytics is enabled in cloud.analytics."
-        : "cloud.analytics is not enabled; run docs cloud init to add the recommended analytics config.",
-    ),
-  );
-
-  const projectEnv = readFirstEnv(env, DOCS_CLOUD_PROJECT_ID_ENVS);
-  const analyticsNeedsProjectId = cloudAnalyticsEnabled && !runtimeAnalyticsDisabled;
-  checks.push(
-    createCheck(
-      "project.env",
-      projectEnv ? "pass" : analyticsNeedsProjectId ? "fail" : "warn",
-      projectEnv
-        ? `Docs Cloud project id is present in ${projectEnv.name}.`
-        : `Missing Docs Cloud project id. Set ${DOCS_CLOUD_PROJECT_ID_ENVS.join(" or ")} for analytics and docs-cloud Ask AI.`,
-      projectEnv ? { env: projectEnv.name } : undefined,
-    ),
-  );
-
-  const aiProvider = readAiProvider(snapshot);
-  if (aiProvider === "docs-cloud") {
-    checks.push(
-      createCheck("askAi.provider", "pass", 'Ask AI is configured with provider: "docs-cloud".'),
-    );
-
-    const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
-    const directApiKeyEnv = configuredApiKeyEnv
-      ? configuredApiKeyEnv.startsWith("NEXT_PUBLIC_")
-        ? configuredApiKeyEnv
-        : undefined
-      : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
-    const directApiKey = readEnvValue(env, directApiKeyEnv);
-
-    if (directApiKeyEnv) {
+  if (checkAnalytics) {
+    if (runtimeAnalyticsDisabled) {
       checks.push(
         createCheck(
-          "askAi.direct",
-          directApiKey && projectEnv ? "pass" : "fail",
-          directApiKey && projectEnv
-            ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
-            : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
-          { apiKeyEnv: directApiKeyEnv },
+          "analytics.runtime",
+          "fail",
+          "Runtime analytics is disabled by analytics: false or analytics.enabled: false.",
         ),
       );
     } else {
-      checks.push(
-        createCheck(
-          "askAi.direct",
-          "warn",
-          `cloud.apiKey.env is server-only (${configuredApiKeyEnv}); the browser will fall back through /api/docs instead of calling the knowledge endpoint directly.`,
-          configuredApiKeyEnv ? { apiKeyEnv: configuredApiKeyEnv } : undefined,
-        ),
-      );
+      checks.push(createCheck("analytics.runtime", "pass", "Runtime analytics is not disabled."));
     }
-  } else if (aiProvider) {
-    checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));
-  } else {
+
     checks.push(
       createCheck(
-        "askAi.provider",
-        "warn",
-        'Ask AI is not configured with provider: "docs-cloud".',
+        "analytics.cloud",
+        cloudAnalyticsEnabled ? "pass" : "warn",
+        cloudAnalyticsEnabled
+          ? "Docs Cloud analytics is enabled in cloud.analytics."
+          : "cloud.analytics is not enabled; run docs cloud init to add the recommended analytics config.",
       ),
     );
   }
 
-  if (!network) {
+  const projectEnv = readFirstEnv(env, DOCS_CLOUD_PROJECT_ID_ENVS);
+  const analyticsNeedsProjectId = cloudAnalyticsEnabled && !runtimeAnalyticsDisabled;
+  if (checkProjectEnv) {
     checks.push(
       createCheck(
-        "apiKey.network",
-        "warn",
-        "Skipped Docs Cloud API validation because --no-network was passed.",
+        "project.env",
+        projectEnv ? "pass" : analyticsNeedsProjectId || checkAskAi ? "fail" : "warn",
+        projectEnv
+          ? `Docs Cloud project id is present in ${projectEnv.name}.`
+          : `Missing Docs Cloud project id. Set ${DOCS_CLOUD_PROJECT_ID_ENVS.join(" or ")} for analytics and docs-cloud Ask AI.`,
+        projectEnv ? { env: projectEnv.name } : undefined,
       ),
     );
-  } else if (!apiKey) {
-    checks.push(
-      createCheck(
-        "apiKey.network",
-        "warn",
-        "Skipped Docs Cloud API validation because no API key value was available.",
-      ),
-    );
-  } else {
-    try {
-      const response = await fetchCloudJson({
-        url: `${apiBaseUrl}/api/cloud/me`,
-        apiKey,
-      });
-      identity = summarizeIdentity(response);
+  }
+
+  const aiProvider = readAiProvider(snapshot);
+  if (checkAskAi) {
+    if (aiProvider === "docs-cloud") {
       checks.push(
-        createCheck("apiKey.network", "pass", `Validated API key with ${apiBaseUrl}.`, identity),
+        createCheck(
+          "askAi.provider",
+          "pass",
+          'Ask AI is configured with provider: "docs-cloud".',
+        ),
       );
 
-      const scopes = readApiKeyScopes(response);
-      if (scopes.length === 0) {
+      const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
+      const directApiKeyEnv = configuredApiKeyEnv
+        ? configuredApiKeyEnv.startsWith("NEXT_PUBLIC_")
+          ? configuredApiKeyEnv
+          : undefined
+        : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+      const directApiKey = readEnvValue(env, directApiKeyEnv);
+
+      if (directApiKeyEnv) {
         checks.push(
           createCheck(
-            "apiKey.scopes",
-            "warn",
-            "Docs Cloud validated the API key but did not return scope metadata.",
+            "askAi.direct",
+            directApiKey && projectEnv ? "pass" : "fail",
+            directApiKey && projectEnv
+              ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
+              : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
+            { apiKeyEnv: directApiKeyEnv },
           ),
         );
       } else {
-        const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter((scope) => !scopes.includes(scope));
         checks.push(
           createCheck(
-            "apiKey.scopes",
-            missing.length === 0 ? "pass" : "fail",
-            missing.length === 0
-              ? `API key has required deploy scopes: ${REQUIRED_PREVIEW_API_KEY_SCOPES.join(", ")}.`
-              : `API key is missing required deploy scope${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}.`,
-            { scopes },
+            "askAi.direct",
+            "warn",
+            `cloud.apiKey.env is server-only (${configuredApiKeyEnv}); the browser will fall back through /api/docs instead of calling the knowledge endpoint directly.`,
+            configuredApiKeyEnv ? { apiKeyEnv: configuredApiKeyEnv } : undefined,
           ),
         );
       }
-    } catch (error) {
+    } else if (aiProvider) {
+      checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));
+    } else {
+      checks.push(
+        createCheck(
+          "askAi.provider",
+          "warn",
+          'Ask AI is not configured with provider: "docs-cloud".',
+        ),
+      );
+    }
+  }
+
+  if (checkDeploy) {
+    if (!network) {
       checks.push(
         createCheck(
           "apiKey.network",
-          "fail",
-          error instanceof Error ? error.message : "Could not validate Docs Cloud API key.",
+          "warn",
+          "Skipped Docs Cloud API validation because --no-network was passed.",
         ),
       );
+    } else if (!apiKey) {
+      checks.push(
+        createCheck(
+          "apiKey.network",
+          "warn",
+          "Skipped Docs Cloud API validation because no API key value was available.",
+        ),
+      );
+    } else {
+      try {
+        const response = await fetchCloudJson({
+          url: `${apiBaseUrl}/api/cloud/me`,
+          apiKey,
+        });
+        identity = summarizeIdentity(response);
+        checks.push(
+          createCheck("apiKey.network", "pass", `Validated API key with ${apiBaseUrl}.`, identity),
+        );
+
+        const scopes = readApiKeyScopes(response);
+        if (scopes.length === 0) {
+          checks.push(
+            createCheck(
+              "apiKey.scopes",
+              "warn",
+              "Docs Cloud validated the API key but did not return scope metadata.",
+            ),
+          );
+        } else {
+          const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter((scope) =>
+            !scopes.includes(scope),
+          );
+          checks.push(
+            createCheck(
+              "apiKey.scopes",
+              missing.length === 0 ? "pass" : "fail",
+              missing.length === 0
+                ? `API key has required deploy scopes: ${REQUIRED_PREVIEW_API_KEY_SCOPES.join(", ")}.`
+                : `API key is missing required deploy scope${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}.`,
+              { scopes },
+            ),
+          );
+        }
+      } catch (error) {
+        checks.push(
+          createCheck(
+            "apiKey.network",
+            "fail",
+            error instanceof Error ? error.message : "Could not validate Docs Cloud API key.",
+          ),
+        );
+      }
     }
   }
 
@@ -1750,6 +1775,7 @@ export async function checkCloudConfig(
     apiKeyEnv,
     analyticsProjectIdEnv: projectEnv?.name,
     network,
+    targets,
     checks,
     ...(identity ? { identity } : {}),
   };
@@ -1763,6 +1789,7 @@ export async function runCloudCheck(options: CloudCommandOptions = {}) {
   } else {
     console.log(pc.bold("Docs Cloud check"));
     console.log(`${pc.dim("api")} ${result.apiBaseUrl}`);
+    console.log(`${pc.dim("scope")} ${formatCloudCheckTargets(result.targets)}`);
     console.log();
 
     for (const check of result.checks) {
@@ -1974,6 +2001,9 @@ ${pc.dim("Options:")}
   ${pc.cyan("--api-key-env <name>")}      Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}      Override Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}           Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--analytics")}               Only check Docs Cloud analytics integration
+  ${pc.cyan("--ask-ai")}                  Only check Docs Cloud Ask AI integration
+  ${pc.cyan("--deploy")}                  Only check Docs Cloud deploy integration
   ${pc.cyan("--no-network")}              Skip live Docs Cloud API validation for ${pc.cyan("cloud check")}
   ${pc.cyan("--json")}                    Print machine-readable output
 

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1654,11 +1654,7 @@ export async function checkCloudConfig(
   if (checkAskAi) {
     if (aiProvider === "docs-cloud") {
       checks.push(
-        createCheck(
-          "askAi.provider",
-          "pass",
-          'Ask AI is configured with provider: "docs-cloud".',
-        ),
+        createCheck("askAi.provider", "pass", 'Ask AI is configured with provider: "docs-cloud".'),
       );
 
       const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
@@ -1741,8 +1737,8 @@ export async function checkCloudConfig(
             ),
           );
         } else {
-          const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter((scope) =>
-            !scopes.includes(scope),
+          const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter(
+            (scope) => !scopes.includes(scope),
           );
           checks.push(
             createCheck(

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1638,11 +1638,7 @@ export async function checkCloudConfig(
   const aiProvider = readAiProvider(snapshot);
   if (aiProvider === "docs-cloud") {
     checks.push(
-      createCheck(
-        "askAi.provider",
-        "pass",
-        'Ask AI is configured with provider: "docs-cloud".',
-      ),
+      createCheck("askAi.provider", "pass", 'Ask AI is configured with provider: "docs-cloud".'),
     );
 
     const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -27,6 +27,12 @@ const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
 const DEFAULT_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PREVIEW_POLL_INTERVAL_MS = 2000;
 const REQUIRED_PREVIEW_API_KEY_SCOPES = ["project:read", "preview:write", "jobs:read"] as const;
+const DOCS_CLOUD_PROJECT_ID_ENVS = [
+  "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+  "DOCS_CLOUD_PROJECT_ID",
+] as const;
+const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
+const CLOUD_CHECK_TARGETS = ["auth", "deploy", "analytics", "ask-ai"] as const;
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue | undefined };
@@ -76,6 +82,8 @@ export interface CloudCommandOptions {
   apiKey?: string;
   apiKeyEnv?: string;
   json?: boolean;
+  network?: boolean;
+  checkTargets?: CloudCheckTarget[];
   rootDir?: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
@@ -99,6 +107,29 @@ export interface MaterializeCloudConfigResult {
   apiKeyEnv: string;
   created: boolean;
   updated: boolean;
+}
+
+export type CloudCheckStatus = "pass" | "warn" | "fail";
+export type CloudCheckTarget = "auth" | "deploy" | "analytics" | "ask-ai";
+
+export interface CloudCheckItem {
+  name: string;
+  status: CloudCheckStatus;
+  message: string;
+  details?: JsonRecord;
+}
+
+export interface CloudCheckResult {
+  ok: boolean;
+  apiBaseUrl: string;
+  configPath: string;
+  docsJsonPath: string;
+  apiKeyEnv: string;
+  analyticsProjectIdEnv?: string;
+  network: boolean;
+  targets: CloudCheckTarget[];
+  checks: CloudCheckItem[];
+  identity?: JsonRecord;
 }
 
 interface DocsConfigSnapshot {
@@ -987,6 +1018,135 @@ export async function materializeCloudConfig(
   };
 }
 
+function readCombinedEnv(rootDir: string): Record<string, string> {
+  const env: Record<string, string> = {
+    ...loadProjectEnv(rootDir),
+  };
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  return env;
+}
+
+function readEnvValue(env: Record<string, string>, name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  const value = env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function readFirstEnv(
+  env: Record<string, string>,
+  names: readonly string[],
+): { name: string; value: string } | undefined {
+  for (const name of names) {
+    const value = readEnvValue(env, name);
+    if (value) return { name, value };
+  }
+  return undefined;
+}
+
+function readConfiguredCloudApiKeyEnv(snapshot: DocsConfigSnapshot): string | undefined {
+  const moduleEnv = snapshot.config?.cloud?.apiKey?.env?.trim();
+  if (moduleEnv) return moduleEnv;
+
+  const apiKeyBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["cloud", "apiKey"]);
+  const staticEnv = apiKeyBlock ? readStringProperty(apiKeyBlock, "env") : undefined;
+  return staticEnv?.trim() || undefined;
+}
+
+function readAiProvider(snapshot: DocsConfigSnapshot): string | undefined {
+  const moduleProvider = (snapshot.config?.ai as { provider?: unknown } | undefined)?.provider;
+  if (typeof moduleProvider === "string" && moduleProvider.trim()) return moduleProvider.trim();
+
+  const aiBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["ai"]);
+  const staticProvider = aiBlock ? readStringProperty(aiBlock, "provider") : undefined;
+  return staticProvider?.trim() || undefined;
+}
+
+function readRuntimeAnalyticsDisabled(snapshot: DocsConfigSnapshot): boolean {
+  const moduleAnalytics = snapshot.config?.analytics;
+  if (moduleAnalytics === false) return true;
+  if (isRecord(moduleAnalytics) && moduleAnalytics.enabled === false) return true;
+
+  const staticBoolean = readTopLevelBooleanProperty(snapshot.content ?? "", "analytics");
+  if (staticBoolean === false) return true;
+
+  const analyticsBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["analytics"]);
+  const staticEnabled = analyticsBlock
+    ? readTopLevelBooleanProperty(analyticsBlock, "enabled")
+    : undefined;
+  return staticEnabled === false;
+}
+
+function isCloudAnalyticsEnabled(analytics: DocsCloudConfig["analytics"] | undefined): boolean {
+  if (analytics === false) return false;
+  if (isRecord(analytics) && analytics.enabled === false) return false;
+  return typeof analytics !== "undefined";
+}
+
+function createCheck(
+  name: string,
+  status: CloudCheckStatus,
+  message: string,
+  details?: JsonRecord,
+): CloudCheckItem {
+  return {
+    name,
+    status,
+    message,
+    ...(details ? { details } : {}),
+  };
+}
+
+function summarizeIdentity(identity: unknown): JsonRecord | undefined {
+  if (!isRecord(identity)) return undefined;
+
+  const workspace = isRecord(identity.workspace) ? identity.workspace : undefined;
+  const apiKey = isRecord(identity.apiKey) ? identity.apiKey : undefined;
+  const scopes = readApiKeyScopes(identity);
+
+  return {
+    ...(workspace
+      ? {
+          workspace: {
+            ...(typeof workspace.id === "string" ? { id: workspace.id } : {}),
+            ...(typeof workspace.name === "string" ? { name: workspace.name } : {}),
+          },
+        }
+      : {}),
+    ...(apiKey
+      ? {
+          apiKey: {
+            ...(typeof apiKey.id === "string" ? { id: apiKey.id } : {}),
+            ...(scopes.length > 0 ? { scopes } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function formatCheckStatus(status: CloudCheckStatus): string {
+  if (status === "pass") return pc.green("ok");
+  if (status === "warn") return pc.yellow("warn");
+  return pc.red("fail");
+}
+
+function countChecks(checks: CloudCheckItem[], status: CloudCheckStatus): number {
+  return checks.filter((check) => check.status === status).length;
+}
+
+function resolveCloudCheckTargets(options: CloudCommandOptions): Set<CloudCheckTarget> {
+  const targets = new Set(options.checkTargets);
+  if (targets.size > 0) return targets;
+  return new Set(CLOUD_CHECK_TARGETS);
+}
+
+function formatCloudCheckTargets(targets: readonly CloudCheckTarget[]): string {
+  return targets.join(", ");
+}
+
 function resolveApiBaseUrl(options: CloudCommandOptions): string {
   const value =
     options.apiBaseUrl ??
@@ -1335,6 +1495,306 @@ function createSpinner(initialMessage: string, options: { json?: boolean } = {})
   };
 }
 
+export async function checkCloudConfig(
+  options: CloudCommandOptions = {},
+): Promise<CloudCheckResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const docsJsonPath = path.join(rootDir, DOCS_JSON_FILE);
+  const existing = readExistingDocsJson(docsJsonPath);
+  const snapshot = await loadDocsConfigSnapshot(rootDir, options.configPath);
+  const config = materializeDocsJsonObject({ rootDir, snapshot, existing });
+  const serialized = serializeMaterializedDocsJson(config);
+  const previous = existing ? fs.readFileSync(docsJsonPath, "utf-8") : undefined;
+  const apiBaseUrl = resolveApiBaseUrl(options);
+  const apiKeyEnv = config.cloud?.apiKey?.env ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV;
+  const env = readCombinedEnv(rootDir);
+  const checks: CloudCheckItem[] = [];
+  const configPath = snapshot.path ?? docsJsonPath;
+  const network = options.network !== false;
+  const explicitApiKey = options.apiKey?.trim();
+  let identity: JsonRecord | undefined;
+
+  checks.push(
+    createCheck(
+      "config",
+      snapshot.path ? "pass" : "warn",
+      snapshot.path
+        ? `Loaded ${path.relative(rootDir, snapshot.path) || "docs.config.ts"}`
+        : `No docs.config.* found; checking ${DOCS_JSON_FILE} defaults instead.`,
+    ),
+  );
+
+  checks.push(
+    createCheck(
+      "docs.json",
+      !existing ? "warn" : previous === serialized ? "pass" : "warn",
+      !existing
+        ? `${DOCS_JSON_FILE} is missing. Run docs cloud sync to materialize cloud config.`
+        : previous === serialized
+          ? `${DOCS_JSON_FILE} is in sync with docs.config.`
+          : `${DOCS_JSON_FILE} is stale. Run docs cloud sync before deploying.`,
+    ),
+  );
+
+  try {
+    normalizeEnvName(apiKeyEnv, DOCS_CLOUD_DEFAULT_API_KEY_ENV);
+    checks.push(createCheck("apiKey.config", "pass", `Using cloud.apiKey.env ${apiKeyEnv}.`));
+  } catch (error) {
+    checks.push(
+      createCheck(
+        "apiKey.config",
+        "fail",
+        error instanceof Error ? error.message : `Invalid API key env ${apiKeyEnv}.`,
+      ),
+    );
+  }
+
+  const apiKey = explicitApiKey || readEnvValue(env, apiKeyEnv);
+  checks.push(
+    createCheck(
+      "apiKey.value",
+      apiKey ? "pass" : "fail",
+      apiKey
+        ? explicitApiKey
+          ? "Docs Cloud API key was provided with --api-key."
+          : `Docs Cloud API key is present in ${apiKeyEnv}.`
+        : `Missing Docs Cloud API key. Set ${apiKeyEnv} or pass --api-key.`,
+      {
+        env: apiKeyEnv,
+        source: explicitApiKey ? "flag" : apiKey ? "env" : "missing",
+      },
+    ),
+  );
+
+  checks.push(
+    createCheck(
+      "cloud.enabled",
+      config.cloud?.enabled === false ? "fail" : "pass",
+      config.cloud?.enabled === false
+        ? "Docs Cloud is disabled by cloud.enabled: false."
+        : "Docs Cloud is enabled.",
+    ),
+  );
+
+  if (config.cloud?.deploy?.enabled === false) {
+    checks.push(
+      createCheck(
+        "deploy.enabled",
+        "fail",
+        "Docs Cloud deployment is disabled by cloud.deploy.enabled: false.",
+      ),
+    );
+  } else {
+    checks.push(createCheck("deploy.enabled", "pass", "Docs Cloud deployment is enabled."));
+  }
+
+  if (config.cloud?.preview?.enabled === false) {
+    checks.push(
+      createCheck(
+        "preview.enabled",
+        "fail",
+        "Docs Cloud preview deployment is disabled by cloud.preview.enabled: false.",
+      ),
+    );
+  }
+
+  const runtimeAnalyticsDisabled = readRuntimeAnalyticsDisabled(snapshot);
+  const cloudAnalyticsEnabled = isCloudAnalyticsEnabled(config.cloud?.analytics);
+  if (runtimeAnalyticsDisabled) {
+    checks.push(
+      createCheck(
+        "analytics.runtime",
+        "fail",
+        "Runtime analytics is disabled by analytics: false or analytics.enabled: false.",
+      ),
+    );
+  } else {
+    checks.push(createCheck("analytics.runtime", "pass", "Runtime analytics is not disabled."));
+  }
+
+  checks.push(
+    createCheck(
+      "analytics.cloud",
+      cloudAnalyticsEnabled ? "pass" : "warn",
+      cloudAnalyticsEnabled
+        ? "Docs Cloud analytics is enabled in cloud.analytics."
+        : "cloud.analytics is not enabled; run docs cloud init to add the recommended analytics config.",
+    ),
+  );
+
+  const projectEnv = readFirstEnv(env, DOCS_CLOUD_PROJECT_ID_ENVS);
+  const analyticsNeedsProjectId = cloudAnalyticsEnabled && !runtimeAnalyticsDisabled;
+  checks.push(
+    createCheck(
+      "project.env",
+      projectEnv ? "pass" : analyticsNeedsProjectId ? "fail" : "warn",
+      projectEnv
+        ? `Docs Cloud project id is present in ${projectEnv.name}.`
+        : `Missing Docs Cloud project id. Set ${DOCS_CLOUD_PROJECT_ID_ENVS.join(" or ")} for analytics and docs-cloud Ask AI.`,
+      projectEnv ? { env: projectEnv.name } : undefined,
+    ),
+  );
+
+  const aiProvider = readAiProvider(snapshot);
+  if (aiProvider === "docs-cloud") {
+    checks.push(
+      createCheck(
+        "askAi.provider",
+        "pass",
+        'Ask AI is configured with provider: "docs-cloud".',
+      ),
+    );
+
+    const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
+    const directApiKeyEnv = configuredApiKeyEnv
+      ? configuredApiKeyEnv.startsWith("NEXT_PUBLIC_")
+        ? configuredApiKeyEnv
+        : undefined
+      : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+    const directApiKey = readEnvValue(env, directApiKeyEnv);
+
+    if (directApiKeyEnv) {
+      checks.push(
+        createCheck(
+          "askAi.direct",
+          directApiKey && projectEnv ? "pass" : "fail",
+          directApiKey && projectEnv
+            ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
+            : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
+          { apiKeyEnv: directApiKeyEnv },
+        ),
+      );
+    } else {
+      checks.push(
+        createCheck(
+          "askAi.direct",
+          "warn",
+          `cloud.apiKey.env is server-only (${configuredApiKeyEnv}); the browser will fall back through /api/docs instead of calling the knowledge endpoint directly.`,
+          configuredApiKeyEnv ? { apiKeyEnv: configuredApiKeyEnv } : undefined,
+        ),
+      );
+    }
+  } else if (aiProvider) {
+    checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));
+  } else {
+    checks.push(
+      createCheck(
+        "askAi.provider",
+        "warn",
+        'Ask AI is not configured with provider: "docs-cloud".',
+      ),
+    );
+  }
+
+  if (!network) {
+    checks.push(
+      createCheck(
+        "apiKey.network",
+        "warn",
+        "Skipped Docs Cloud API validation because --no-network was passed.",
+      ),
+    );
+  } else if (!apiKey) {
+    checks.push(
+      createCheck(
+        "apiKey.network",
+        "warn",
+        "Skipped Docs Cloud API validation because no API key value was available.",
+      ),
+    );
+  } else {
+    try {
+      const response = await fetchCloudJson({
+        url: `${apiBaseUrl}/api/cloud/me`,
+        apiKey,
+      });
+      identity = summarizeIdentity(response);
+      checks.push(
+        createCheck("apiKey.network", "pass", `Validated API key with ${apiBaseUrl}.`, identity),
+      );
+
+      const scopes = readApiKeyScopes(response);
+      if (scopes.length === 0) {
+        checks.push(
+          createCheck(
+            "apiKey.scopes",
+            "warn",
+            "Docs Cloud validated the API key but did not return scope metadata.",
+          ),
+        );
+      } else {
+        const missing = REQUIRED_PREVIEW_API_KEY_SCOPES.filter((scope) => !scopes.includes(scope));
+        checks.push(
+          createCheck(
+            "apiKey.scopes",
+            missing.length === 0 ? "pass" : "fail",
+            missing.length === 0
+              ? `API key has required deploy scopes: ${REQUIRED_PREVIEW_API_KEY_SCOPES.join(", ")}.`
+              : `API key is missing required deploy scope${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}.`,
+            { scopes },
+          ),
+        );
+      }
+    } catch (error) {
+      checks.push(
+        createCheck(
+          "apiKey.network",
+          "fail",
+          error instanceof Error ? error.message : "Could not validate Docs Cloud API key.",
+        ),
+      );
+    }
+  }
+
+  return {
+    ok: countChecks(checks, "fail") === 0,
+    apiBaseUrl,
+    configPath,
+    docsJsonPath,
+    apiKeyEnv,
+    analyticsProjectIdEnv: projectEnv?.name,
+    network,
+    checks,
+    ...(identity ? { identity } : {}),
+  };
+}
+
+export async function runCloudCheck(options: CloudCommandOptions = {}) {
+  const result = await checkCloudConfig(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(pc.bold("Docs Cloud check"));
+    console.log(`${pc.dim("api")} ${result.apiBaseUrl}`);
+    console.log();
+
+    for (const check of result.checks) {
+      console.log(`${formatCheckStatus(check.status)} ${pc.bold(check.name)} ${check.message}`);
+    }
+
+    console.log();
+    if (result.ok) {
+      const warnings = countChecks(result.checks, "warn");
+      const suffix = warnings > 0 ? ` with ${warnings} warning${warnings === 1 ? "" : "s"}` : "";
+      console.log(`${pc.green("ok")} Docs Cloud check passed${suffix}.`);
+    } else {
+      const failures = countChecks(result.checks, "fail");
+      console.log(
+        `${pc.red("fail")} Docs Cloud check failed with ${failures} failed check${failures === 1 ? "" : "s"}.`,
+      );
+    }
+  }
+
+  if (!result.ok) {
+    const error = new Error("Docs Cloud check failed.");
+    markCliErrorReported(error);
+    throw error;
+  }
+
+  return result;
+}
+
 export async function syncCloudConfig(options: CloudCommandOptions = {}) {
   const result = await materializeCloudConfig(options);
 
@@ -1506,6 +1966,7 @@ ${pc.bold("@farming-labs/docs cloud")}
 
 ${pc.dim("Usage:")}
   ${pc.cyan("docs cloud init")}           Add Docs Cloud config to ${pc.dim("docs.config.ts")} and ${pc.dim("docs.json")}
+  ${pc.cyan("docs cloud check")}          Validate Docs Cloud config, analytics envs, API key, and Ask AI wiring
   ${pc.cyan("docs deploy")}               Sync ${pc.dim("docs.config.ts")} to ${pc.dim("docs.json")} and deploy hosted preview docs
   ${pc.cyan("docs cloud deploy")}         Same as ${pc.cyan("docs deploy")}
   ${pc.cyan("docs preview")}              Compatibility alias for ${pc.cyan("docs deploy")}
@@ -1517,6 +1978,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--api-key-env <name>")}      Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}      Override Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}           Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--no-network")}              Skip live Docs Cloud API validation for ${pc.cyan("cloud check")}
   ${pc.cyan("--json")}                    Print machine-readable output
 
 ${pc.dim("API key scopes:")}

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1676,15 +1676,6 @@ export async function checkCloudConfig(
             { apiKeyEnv: directApiKeyEnv },
           ),
         );
-      } else {
-        checks.push(
-          createCheck(
-            "askAi.direct",
-            "warn",
-            `cloud.apiKey.env is server-only (${configuredApiKeyEnv}); the browser will fall back through /api/docs instead of calling the knowledge endpoint directly.`,
-            configuredApiKeyEnv ? { apiKeyEnv: configuredApiKeyEnv } : undefined,
-          ),
-        );
       }
     } else if (aiProvider) {
       checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));

--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -74,6 +74,13 @@ describe("parseFlags", () => {
     expect(flags.json).toBe(true);
   });
 
+  it("parses cloud check target flags", () => {
+    const flags = parseFlags(["cloud", "check", "--analytics", "--ask-ai", "--deploy"]);
+    expect(flags.analytics).toBe(true);
+    expect(flags["ask-ai"]).toBe(true);
+    expect(flags.deploy).toBe(true);
+  });
+
   it("parses dev flags including verbose and hostname aliases", () => {
     const flags = parseFlags(["dev", "--verbose", "--port", "4010", "--host", "0.0.0.0"]);
     expect(flags.verbose).toBe(true);

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -40,6 +40,9 @@ export function parseFlags(argv: string[]): Record<string, string | boolean | un
     "host",
     "json",
     "network",
+    "analytics",
+    "ask-ai",
+    "deploy",
   ]);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -117,6 +120,11 @@ async function main() {
     apiKeyEnv: typeof flags["api-key-env"] === "string" ? flags["api-key-env"] : undefined,
     json: typeof flags.json === "boolean" ? flags.json : undefined,
     network: typeof flags.network === "boolean" ? flags.network : undefined,
+    checkTargets: [
+      ...(flags.deploy === true ? (["deploy"] as const) : []),
+      ...(flags.analytics === true ? (["analytics"] as const) : []),
+      ...(flags["ask-ai"] === true ? (["ask-ai"] as const) : []),
+    ],
   };
 
   if (!parsedCommand.command || parsedCommand.command === "init") {
@@ -357,6 +365,9 @@ ${pc.dim("Options for cloud:")}
   ${pc.cyan("--api-key-env <name>")}                 Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}                 Override the Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}                      Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--analytics")}                          Only check Docs Cloud analytics integration
+  ${pc.cyan("--ask-ai")}                             Only check Docs Cloud Ask AI integration
+  ${pc.cyan("--deploy")}                             Only check Docs Cloud deploy integration
   ${pc.cyan("--no-network")}                         Skip live Docs Cloud API validation for ${pc.cyan("cloud check")}
   ${pc.cyan("--json")}                              Print machine-readable output
   ${pc.dim("required scopes")}                       project:read, preview:write, jobs:read

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -39,6 +39,7 @@ export function parseFlags(argv: string[]): Record<string, string | boolean | un
     "verbose",
     "host",
     "json",
+    "network",
   ]);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -115,6 +116,7 @@ async function main() {
     apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
     apiKeyEnv: typeof flags["api-key-env"] === "string" ? flags["api-key-env"] : undefined,
     json: typeof flags.json === "boolean" ? flags.json : undefined,
+    network: typeof flags.network === "boolean" ? flags.network : undefined,
   };
 
   if (!parsedCommand.command || parsedCommand.command === "init") {
@@ -141,6 +143,9 @@ async function main() {
   } else if (parsedCommand.command === "cloud" && subcommand === "sync") {
     const { syncCloudConfig } = await import("./cloud.js");
     await syncCloudConfig(cloudOptions);
+  } else if (parsedCommand.command === "cloud" && subcommand === "check") {
+    const { runCloudCheck } = await import("./cloud.js");
+    await runCloudCheck(cloudOptions);
   } else if (parsedCommand.command === "cloud") {
     console.error(pc.red(`Unknown cloud subcommand: ${subcommand ?? "(missing)"}`));
     console.error();
@@ -304,7 +309,7 @@ ${pc.dim("Commands:")}
   ${pc.cyan("dev")}      Run frameworkless docs locally from ${pc.dim("docs.json")}
   ${pc.cyan("deploy")}   Sync cloud config and deploy hosted preview docs
   ${pc.cyan("preview")}  Alias for ${pc.cyan("deploy")}
-  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("init")}, ${pc.dim("deploy")}, ${pc.dim("preview")}, ${pc.dim("sync")})
+  ${pc.cyan("cloud")}    Docs Cloud utilities (${pc.dim("init")}, ${pc.dim("check")}, ${pc.dim("deploy")}, ${pc.dim("preview")}, ${pc.dim("sync")})
   ${pc.cyan("agent")}    Agent utilities (${pc.dim("compact")} to generate sibling agent.md files)
   ${pc.cyan("agents")}   AGENTS.md utilities (${pc.dim("generate")} for static agent instructions)
   ${pc.cyan("doctor")}   Inspect and score agent or reader-facing docs quality
@@ -340,17 +345,19 @@ ${pc.dim("Options for dev:")}
   ${pc.cyan("--host [host]")}       Expose the preview on your network; optionally pass a host value
   ${pc.cyan("--verbose")}           Show raw runtime logs in addition to branded CLI output
 
-${pc.dim("Options for cloud deploy:")}
+${pc.dim("Options for cloud:")}
   ${pc.cyan("cloud init")}                           Add Docs Cloud config to ${pc.dim("docs.config.ts")} and ${pc.dim("docs.json")}
   ${pc.cyan("deploy")}                               Sync ${pc.dim("docs.config.ts")} into ${pc.dim("docs.json")} and deploy hosted preview docs
   ${pc.cyan("cloud deploy")}                         Same as ${pc.cyan("deploy")}
   ${pc.cyan("preview")}                              Alias for ${pc.cyan("deploy")}
   ${pc.cyan("cloud preview")}                        Compatibility alias for ${pc.cyan("cloud deploy")}
   ${pc.cyan("cloud sync")}                           Only materialize cloud settings into ${pc.dim("docs.json")}
+  ${pc.cyan("cloud check")}                          Validate Docs Cloud config, analytics envs, API key, and Ask AI wiring
   ${pc.cyan("--config <path>")}                      Use a custom docs config path
   ${pc.cyan("--api-key-env <name>")}                 Env var that stores the Docs Cloud API key
   ${pc.cyan("--api-base-url <url>")}                 Override the Docs Cloud API base URL
   ${pc.cyan("--api-key <key>")}                      Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--no-network")}                         Skip live Docs Cloud API validation for ${pc.cyan("cloud check")}
   ${pc.cyan("--json")}                              Print machine-readable output
   ${pc.dim("required scopes")}                       project:read, preview:write, jobs:read
 

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -129,6 +129,31 @@ The check validates `docs.config.ts`, `docs.json` freshness, `cloud.apiKey.env`,
 key, required deploy scopes, analytics project envs, and `ai.provider: "docs-cloud"` wiring. Use
 `--json` in CI or `--no-network` when you only want local config checks.
 
+Scope the report when you only want one integration area:
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs cloud check --analytics
+pnpm dlx @farming-labs/docs cloud check --ask-ai
+pnpm dlx @farming-labs/docs cloud check --deploy
+```
+
+Example focused report:
+
+```txt title="terminal"
+Docs Cloud check
+api https://docs-app.farming-labs.dev
+scope analytics
+
+ok config Loaded docs.config.ts
+warn docs.json docs.json is missing. Run docs cloud sync to materialize cloud config.
+ok cloud.enabled Docs Cloud is enabled.
+ok analytics.runtime Runtime analytics is not disabled.
+ok analytics.cloud Docs Cloud analytics is enabled in cloud.analytics.
+ok project.env Docs Cloud project id is present in NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID.
+
+ok Docs Cloud check passed with 1 warning.
+```
+
 Use JSON output when CI or another tool needs the preview URL:
 
 ```bash title="terminal"
@@ -141,6 +166,9 @@ pnpm dlx @farming-labs/docs deploy --json
 | ------- | ----------- |
 | `pnpm dlx @farming-labs/docs cloud sync` | You only want to update `docs.json` |
 | `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, analytics envs, API key scopes, and Ask AI wiring without deploying |
+| `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring |
+| `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI wiring |
+| `pnpm dlx @farming-labs/docs cloud check --deploy` | You only want to validate deploy flags, API key presence, and deploy scopes |
 | `pnpm dlx @farming-labs/docs deploy` | You want to sync, validate the key, and request a preview |
 | `pnpm dlx @farming-labs/docs cloud deploy` | You prefer the explicit Cloud namespace |
 | `pnpm dlx @farming-labs/docs deploy --json` | CI needs machine-readable output |

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -117,6 +117,18 @@ The explicit Cloud command is equivalent:
 pnpm dlx @farming-labs/docs cloud deploy
 ```
 
+## Check Cloud Setup
+
+Run a read-only health check before deploying or debugging Ask AI:
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs cloud check
+```
+
+The check validates `docs.config.ts`, `docs.json` freshness, `cloud.apiKey.env`, the Docs Cloud API
+key, required deploy scopes, analytics project envs, and `ai.provider: "docs-cloud"` wiring. Use
+`--json` in CI or `--no-network` when you only want local config checks.
+
 Use JSON output when CI or another tool needs the preview URL:
 
 ```bash title="terminal"
@@ -128,6 +140,7 @@ pnpm dlx @farming-labs/docs deploy --json
 | Command | Use it when |
 | ------- | ----------- |
 | `pnpm dlx @farming-labs/docs cloud sync` | You only want to update `docs.json` |
+| `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, analytics envs, API key scopes, and Ask AI wiring without deploying |
 | `pnpm dlx @farming-labs/docs deploy` | You want to sync, validate the key, and request a preview |
 | `pnpm dlx @farming-labs/docs cloud deploy` | You prefer the explicit Cloud namespace |
 | `pnpm dlx @farming-labs/docs deploy --json` | CI needs machine-readable output |


### PR DESCRIPTION
- **feat: docs cloud doctor cli**
- **chore: format**
- **feat: more flag with cli log buffers**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs cloud check` to the `@farming-labs/docs` CLI to validate Docs Cloud setup across deploy, analytics, and Ask AI. Supports scoped checks, offline mode, and JSON output for CI.

- **New Features**
  - New command: `docs cloud check` validates `docs.config.ts`/`docs.json` sync, `cloud.enabled`, deploy/preview flags, analytics runtime/cloud settings, project ID envs, API key presence, and Ask AI `provider: "docs-cloud"`. Verifies API key via `/api/cloud/me`, checks required scopes (`project:read`, `preview:write`, `jobs:read`), and includes identity summary (workspace and key scopes). Exits non-zero on failure.
  - Flags: `--analytics`, `--ask-ai`, `--deploy` to scope checks; `--no-network` to skip live API; `--json` for machine-readable output. Ask AI direct mode is only checked when a public API key env is configured; no warning for server-only keys.
  - Updates CLI help and docs with a “Check Cloud Setup” section and examples; adds tests for parsing flags and cloud check behavior.

<sup>Written for commit 1f1bc733aa2e72a48261cbce616a682097440347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

