### PR TITLE
feat: cors and proxy api on knowledge and docs-cloud endpoint

### DIFF
--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -305,7 +305,7 @@ void missing;
     );
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe("https://cloud.example.com/api/cloud/me");
+      expect(String(input)).toBe("https://cloud.example.com/v1/cloud/me");
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer docs_cloud_public_key");
       return new Response(
         JSON.stringify({
@@ -417,7 +417,7 @@ void missing;
     expect(checkNames).not.toContain("deploy.enabled");
   });
 
-  it("does not warn when docs-cloud Ask AI uses a server-only API key env", async () => {
+  it("checks direct Docs Cloud Ask AI with the configured API key env", async () => {
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
@@ -455,9 +455,82 @@ void missing;
       expect.arrayContaining([
         expect.objectContaining({ name: "askAi.provider", status: "pass" }),
         expect.objectContaining({ name: "project.env", status: "pass" }),
+        expect.objectContaining({
+          name: "askAi.direct",
+          status: "pass",
+          details: { apiKeyEnv: "DOCS_CLOUD_API_KEY" },
+        }),
       ]),
     );
-    expect(result.checks.some((check) => check.name === "askAi.direct")).toBe(false);
+  });
+
+  it("checks Docs Cloud browser CORS for analytics and Ask AI", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      [
+        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    analytics: { enabled: true },
+  },
+  sitemap: {
+    baseUrl: "https://docs.example.com",
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.method).toBe("OPTIONS");
+      expect(new Headers(init?.headers).get("origin")).toBe("https://docs.example.com");
+
+      return new Response(null, {
+        status: 204,
+        headers: {
+          "access-control-allow-origin": "https://docs.example.com",
+          "access-control-allow-methods": "POST, OPTIONS",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      checkTargets: ["analytics", "ask-ai"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "cloud.apiBaseUrl", status: "pass" }),
+        expect.objectContaining({ name: "cors.analytics", status: "pass" }),
+        expect.objectContaining({ name: "cors.askAi", status: "pass" }),
+      ]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.example.com/v1/analytics/events",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.example.com/v1/projects/project_cloud/knowledge/ask",
+      expect.any(Object),
+    );
   });
 
   it("prints json and exits non-zero when cloud check fails", async () => {
@@ -515,7 +588,7 @@ void missing;
       const url = String(input);
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer docs_cloud_test_key");
 
-      if (url === "https://cloud.example.com/api/cloud/me") {
+      if (url === "https://cloud.example.com/v1/cloud/me") {
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },
@@ -525,7 +598,7 @@ void missing;
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview") {
+      if (url === "https://cloud.example.com/v1/cloud/preview") {
         const requestBody = JSON.parse(String(init?.body)) as {
           repository?: {
             owner?: string;
@@ -589,7 +662,7 @@ void missing;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
-      if (url === "https://cloud.example.com/api/cloud/me") {
+      if (url === "https://cloud.example.com/v1/cloud/me") {
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },
@@ -599,7 +672,7 @@ void missing;
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview") {
+      if (url === "https://cloud.example.com/v1/cloud/preview") {
         return new Response(JSON.stringify({ url: "https://docs-cloud-acme.preview.test" }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -648,7 +721,7 @@ void missing;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
-      if (url === "https://cloud.example.com/api/cloud/me") {
+      if (url === "https://cloud.example.com/v1/cloud/me") {
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },
@@ -658,18 +731,18 @@ void missing;
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview") {
+      if (url === "https://cloud.example.com/v1/cloud/preview") {
         return new Response(
           JSON.stringify({
             status: "queued",
-            statusUrl: "/api/cloud/preview/job_1",
+            statusUrl: "/v1/cloud/preview/job_1",
             preview: { status: "queued", url: null },
           }),
           { status: 202, headers: { "content-type": "application/json" } },
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview/job_1") {
+      if (url === "https://cloud.example.com/v1/cloud/preview/job_1") {
         return new Response(
           JSON.stringify({
             job: { id: "job_1", status: "SUCCEEDED" },
@@ -717,7 +790,7 @@ void missing;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
-      if (url === "https://cloud.example.com/api/cloud/me") {
+      if (url === "https://cloud.example.com/v1/cloud/me") {
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },
@@ -727,17 +800,17 @@ void missing;
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview") {
+      if (url === "https://cloud.example.com/v1/cloud/preview") {
         return new Response(
           JSON.stringify({
             status: "queued",
-            statusUrl: "/api/cloud/preview/job_1",
+            statusUrl: "/v1/cloud/preview/job_1",
           }),
           { status: 202, headers: { "content-type": "application/json" } },
         );
       }
 
-      if (url === "https://cloud.example.com/api/cloud/preview/job_1") {
+      if (url === "https://cloud.example.com/v1/cloud/preview/job_1") {
         return new Response(
           JSON.stringify({
             status: "queued",
@@ -804,7 +877,7 @@ void missing;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
-      if (url === "https://cloud.example.com/api/cloud/me") {
+      if (url === "https://cloud.example.com/v1/cloud/me") {
         return new Response(
           JSON.stringify({
             workspace: { id: "workspace_1", name: "Acme" },

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -457,8 +457,8 @@ void missing;
         expect.objectContaining({ name: "project.env", status: "pass" }),
         expect.objectContaining({
           name: "askAi.direct",
-          status: "pass",
-          details: { apiKeyEnv: "DOCS_CLOUD_API_KEY" },
+          status: "warn",
+          details: { apiKeyEnv: "DOCS_CLOUD_API_KEY", projectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID", proxy: true },
         }),
       ]),
     );
@@ -503,6 +503,7 @@ void missing;
         headers: {
           "access-control-allow-origin": "https://docs.example.com",
           "access-control-allow-methods": "POST, OPTIONS",
+          "access-control-allow-headers": "authorization, content-type",
         },
       });
     });
@@ -538,6 +539,69 @@ void missing;
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cloud.example.com/v1/projects/project_cloud/knowledge/ask",
       expect.any(Object),
+    );
+  });
+
+  it("fails Docs Cloud Ask AI CORS when preflight does not allow authorization", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      [
+        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+  },
+  site: {
+    url: "https://docs.example.com",
+  },
+};
+`,
+      "utf-8",
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            "access-control-allow-origin": "https://docs.example.com",
+            "access-control-allow-methods": "POST, OPTIONS",
+            "access-control-allow-headers": "content-type",
+          },
+        });
+      }),
+    );
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      checkTargets: ["ask-ai"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "cors.askAi",
+          status: "fail",
+          details: expect.objectContaining({
+            allowHeaders: "content-type",
+          }),
+        }),
+      ]),
     );
   });
 

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -417,13 +417,13 @@ void missing;
     expect(checkNames).not.toContain("deploy.enabled");
   });
 
-  it("checks direct Docs Cloud Ask AI with the configured API key env", async () => {
+  it("checks direct Docs Cloud Ask AI with a browser-safe configured API key env", async () => {
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
       [
         "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
+        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -436,7 +436,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
     analytics: { enabled: true },
   },
 };
@@ -457,11 +457,10 @@ void missing;
         expect.objectContaining({ name: "project.env", status: "pass" }),
         expect.objectContaining({
           name: "askAi.direct",
-          status: "warn",
+          status: "pass",
           details: {
-            apiKeyEnv: "DOCS_CLOUD_API_KEY",
+            apiKeyEnv: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY",
             projectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
-            proxy: true,
           },
         }),
       ]),
@@ -474,7 +473,7 @@ void missing;
       path.join(tmpDir, ".env.local"),
       [
         "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
+        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -487,7 +486,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
     analytics: { enabled: true },
   },
   sitemap: {
@@ -543,6 +542,62 @@ void missing;
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cloud.example.com/v1/projects/project_cloud/knowledge/ask",
       expect.any(Object),
+    );
+  });
+
+  it("skips Docs Cloud Ask AI browser CORS when server-key config uses proxy fallback", async () => {
+    writePackageJson();
+    writeFileSync(
+      path.join(tmpDir, ".env.local"),
+      [
+        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  ai: {
+    enabled: true,
+    provider: "docs-cloud",
+  },
+  cloud: {
+    apiKey: { env: "DOCS_CLOUD_API_KEY" },
+  },
+  site: {
+    url: "https://docs.example.com",
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await checkCloudConfig({
+      rootDir: tmpDir,
+      apiBaseUrl: "https://cloud.example.com",
+      checkTargets: ["ask-ai"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "askAi.direct",
+          status: "warn",
+          details: expect.objectContaining({ proxy: true }),
+        }),
+        expect.objectContaining({
+          name: "cors.askAi",
+          status: "pass",
+          details: { proxy: true },
+        }),
+      ]),
     );
   });
 

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -458,7 +458,11 @@ void missing;
         expect.objectContaining({
           name: "askAi.direct",
           status: "warn",
-          details: { apiKeyEnv: "DOCS_CLOUD_API_KEY", projectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID", proxy: true },
+          details: {
+            apiKeyEnv: "DOCS_CLOUD_API_KEY",
+            projectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+            proxy: true,
+          },
         }),
       ]),
     );

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -518,6 +518,14 @@ void missing;
     expect(result.checks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "cloud.apiBaseUrl", status: "pass" }),
+        expect.objectContaining({
+          name: "docs.siteOrigin",
+          status: "pass",
+          details: {
+            origin: "https://docs.example.com",
+            source: "sitemap.baseUrl",
+          },
+        }),
         expect.objectContaining({ name: "cors.analytics", status: "pass" }),
         expect.objectContaining({ name: "cors.askAi", status: "pass" }),
       ]),

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1220,11 +1220,7 @@ function readDocsSiteOrigin(
   snapshot: DocsConfigSnapshot,
   env: Record<string, string>,
 ): { origin: string; source: string } | undefined {
-  const envSite = readFirstEnv(env, [
-    "NEXT_PUBLIC_BASE_URL",
-    "NEXT_PUBLIC_SITE_URL",
-    "SITE_URL",
-  ]);
+  const envSite = readFirstEnv(env, ["NEXT_PUBLIC_BASE_URL", "NEXT_PUBLIC_SITE_URL", "SITE_URL"]);
   const sitemapBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["sitemap"]);
   const llmsTxtBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["llmsTxt"]);
   const robotsBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["robots"]);
@@ -1268,7 +1264,12 @@ async function checkCorsPreflight(params: {
   url: string;
   origin: string;
   requestHeaders: string;
-}): Promise<{ ok: boolean; status: number; allowOrigin: string | null; allowMethods: string | null }> {
+}): Promise<{
+  ok: boolean;
+  status: number;
+  allowOrigin: string | null;
+  allowMethods: string | null;
+}> {
   const response = await fetch(params.url, {
     method: "OPTIONS",
     headers: {
@@ -1672,8 +1673,8 @@ export async function checkCloudConfig(
       apiBaseUrlResolution.source === "default"
         ? `Using the hosted Docs Cloud API at ${apiBaseUrl}.`
         : isLocalhostUrl(apiBaseUrl)
-        ? `Docs Cloud API base URL is ${apiBaseUrl}; production docs should use the hosted API base URL.`
-        : `Docs Cloud API base URL is ${apiBaseUrl}.`,
+          ? `Docs Cloud API base URL is ${apiBaseUrl}; production docs should use the hosted API base URL.`
+          : `Docs Cloud API base URL is ${apiBaseUrl}.`,
       {
         source: apiBaseUrlResolution.source,
         ...(apiBaseUrlResolution.env ? { env: apiBaseUrlResolution.env } : {}),
@@ -1817,10 +1818,8 @@ export async function checkCloudConfig(
       const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
       const directApiKeyEnv =
         configuredApiKeyEnv ??
-        readFirstEnv(env, [
-          DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV,
-          DOCS_CLOUD_DEFAULT_API_KEY_ENV,
-        ])?.name ??
+        readFirstEnv(env, [DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV, DOCS_CLOUD_DEFAULT_API_KEY_ENV])
+          ?.name ??
         DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
       const directApiKey = readEnvValue(env, directApiKeyEnv);
 

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -37,6 +37,11 @@ const CLOUD_CHECK_TARGETS = ["deploy", "analytics", "ask-ai"] as const;
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue | undefined };
 type JsonRecord = Record<string, JsonValue | undefined>;
+type ApiBaseUrlResolution = {
+  url: string;
+  source: "flag" | "env" | "default";
+  env?: string;
+};
 
 type CloudAnalyticsConfig =
   | boolean
@@ -1147,13 +1152,33 @@ function formatCloudCheckTargets(targets: readonly CloudCheckTarget[]): string {
   return targets.join(", ");
 }
 
-function resolveApiBaseUrl(options: CloudCommandOptions): string {
-  const value =
-    options.apiBaseUrl ??
-    process.env.DOCS_CLOUD_API_URL ??
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_URL ??
-    DEFAULT_DOCS_CLOUD_API_BASE_URL;
-  return value.replace(/\/+$/, "");
+function resolveApiBaseUrl(
+  options: CloudCommandOptions,
+  rootDir: string = process.cwd(),
+): ApiBaseUrlResolution {
+  if (options.apiBaseUrl?.trim()) {
+    return {
+      url: options.apiBaseUrl.trim().replace(/\/+$/, ""),
+      source: "flag",
+    };
+  }
+
+  const projectEnv = loadProjectEnv(rootDir);
+  for (const envName of ["DOCS_CLOUD_API_URL", "NEXT_PUBLIC_DOCS_CLOUD_URL"] as const) {
+    const value = process.env[envName]?.trim() ?? projectEnv[envName]?.trim();
+    if (value) {
+      return {
+        url: value.replace(/\/+$/, ""),
+        source: "env",
+        env: envName,
+      };
+    }
+  }
+
+  return {
+    url: DEFAULT_DOCS_CLOUD_API_BASE_URL,
+    source: "default",
+  };
 }
 
 function resolveApiKey(options: CloudCommandOptions, rootDir: string, envName: string): string {
@@ -1170,6 +1195,102 @@ function resolveApiKey(options: CloudCommandOptions, rootDir: string, envName: s
   throw new Error(
     `Missing Docs Cloud API key. Set ${envName} in your shell or .env.local, or configure cloud.apiKey.env in docs.config.ts. See ${DOCS_CLOUD_MISSING_API_KEY_DOCS_URL}.`,
   );
+}
+
+function isLocalhostUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function readNestedString(value: unknown, pathSegments: readonly string[]): string | undefined {
+  let current: unknown = value;
+  for (const segment of pathSegments) {
+    if (!isRecord(current)) return undefined;
+    current = current[segment];
+  }
+
+  return typeof current === "string" && current.trim() ? current.trim() : undefined;
+}
+
+function readDocsSiteOrigin(
+  snapshot: DocsConfigSnapshot,
+  env: Record<string, string>,
+): { origin: string; source: string } | undefined {
+  const envSite = readFirstEnv(env, [
+    "NEXT_PUBLIC_BASE_URL",
+    "NEXT_PUBLIC_SITE_URL",
+    "SITE_URL",
+  ]);
+  const sitemapBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["sitemap"]);
+  const llmsTxtBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["llmsTxt"]);
+  const robotsBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["robots"]);
+  const candidates: Array<{ value?: string; source: string }> = [
+    { value: envSite?.value, source: envSite ? envSite.name : "env" },
+    { value: readNestedString(snapshot.config, ["site", "url"]), source: "site.url" },
+    { value: readNestedString(snapshot.config, ["sitemap", "baseUrl"]), source: "sitemap.baseUrl" },
+    { value: readNestedString(snapshot.config, ["llmsTxt", "baseUrl"]), source: "llmsTxt.baseUrl" },
+    { value: readNestedString(snapshot.config, ["robots", "baseUrl"]), source: "robots.baseUrl" },
+    {
+      value: sitemapBlock ? readStringProperty(sitemapBlock, "baseUrl") : undefined,
+      source: "sitemap.baseUrl",
+    },
+    {
+      value: llmsTxtBlock ? readStringProperty(llmsTxtBlock, "baseUrl") : undefined,
+      source: "llmsTxt.baseUrl",
+    },
+    {
+      value: robotsBlock ? readStringProperty(robotsBlock, "baseUrl") : undefined,
+      source: "robots.baseUrl",
+    },
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate.value) continue;
+
+    try {
+      return {
+        origin: new URL(candidate.value).origin,
+        source: candidate.source,
+      };
+    } catch {
+      // Keep looking for a valid absolute URL.
+    }
+  }
+
+  return undefined;
+}
+
+async function checkCorsPreflight(params: {
+  url: string;
+  origin: string;
+  requestHeaders: string;
+}): Promise<{ ok: boolean; status: number; allowOrigin: string | null; allowMethods: string | null }> {
+  const response = await fetch(params.url, {
+    method: "OPTIONS",
+    headers: {
+      Origin: params.origin,
+      "Access-Control-Request-Method": "POST",
+      "Access-Control-Request-Headers": params.requestHeaders,
+    },
+  });
+  const allowOrigin = response.headers.get("access-control-allow-origin");
+  const allowMethods = response.headers.get("access-control-allow-methods");
+  const normalizedAllowOrigin = allowOrigin?.toLowerCase();
+  const normalizedOrigin = params.origin.toLowerCase();
+
+  return {
+    ok:
+      response.ok &&
+      (normalizedAllowOrigin === "*" || normalizedAllowOrigin === normalizedOrigin) &&
+      Boolean(allowMethods?.toUpperCase().includes("POST")),
+    status: response.status,
+    allowOrigin,
+    allowMethods,
+  };
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
@@ -1505,9 +1626,11 @@ export async function checkCloudConfig(
   const config = materializeDocsJsonObject({ rootDir, snapshot, existing });
   const serialized = serializeMaterializedDocsJson(config);
   const previous = existing ? fs.readFileSync(docsJsonPath, "utf-8") : undefined;
-  const apiBaseUrl = resolveApiBaseUrl(options);
+  const apiBaseUrlResolution = resolveApiBaseUrl(options, rootDir);
+  const apiBaseUrl = apiBaseUrlResolution.url;
   const apiKeyEnv = config.cloud?.apiKey?.env ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV;
   const env = readCombinedEnv(rootDir);
+  const siteOrigin = readDocsSiteOrigin(snapshot, env);
   const checks: CloudCheckItem[] = [];
   const configPath = snapshot.path ?? docsJsonPath;
   const network = options.network !== false;
@@ -1539,6 +1662,20 @@ export async function checkCloudConfig(
         : previous === serialized
           ? `${DOCS_JSON_FILE} is in sync with docs.config.`
           : `${DOCS_JSON_FILE} is stale. Run docs cloud sync before deploying.`,
+    ),
+  );
+
+  checks.push(
+    createCheck(
+      "cloud.apiBaseUrl",
+      isLocalhostUrl(apiBaseUrl) ? "warn" : "pass",
+      isLocalhostUrl(apiBaseUrl)
+        ? `Docs Cloud API base URL is ${apiBaseUrl}; production docs should use the hosted API base URL.`
+        : `Docs Cloud API base URL is ${apiBaseUrl}.`,
+      {
+        source: apiBaseUrlResolution.source,
+        ...(apiBaseUrlResolution.env ? { env: apiBaseUrlResolution.env } : {}),
+      },
     ),
   );
 
@@ -1658,25 +1795,25 @@ export async function checkCloudConfig(
       );
 
       const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
-      const directApiKeyEnv = configuredApiKeyEnv
-        ? configuredApiKeyEnv.startsWith("NEXT_PUBLIC_")
-          ? configuredApiKeyEnv
-          : undefined
-        : DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+      const directApiKeyEnv =
+        configuredApiKeyEnv ??
+        readFirstEnv(env, [
+          DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV,
+          DOCS_CLOUD_DEFAULT_API_KEY_ENV,
+        ])?.name ??
+        DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
       const directApiKey = readEnvValue(env, directApiKeyEnv);
 
-      if (directApiKeyEnv) {
-        checks.push(
-          createCheck(
-            "askAi.direct",
-            directApiKey && projectEnv ? "pass" : "fail",
-            directApiKey && projectEnv
-              ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
-              : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
-            { apiKeyEnv: directApiKeyEnv },
-          ),
-        );
-      }
+      checks.push(
+        createCheck(
+          "askAi.direct",
+          directApiKey && projectEnv ? "pass" : "fail",
+          directApiKey && projectEnv
+            ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
+            : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
+          { apiKeyEnv: directApiKeyEnv },
+        ),
+      );
     } else if (aiProvider) {
       checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));
     } else {
@@ -1687,6 +1824,98 @@ export async function checkCloudConfig(
           'Ask AI is not configured with provider: "docs-cloud".',
         ),
       );
+    }
+  }
+
+  if (checkAnalytics || checkAskAi) {
+    if (!network) {
+      checks.push(
+        createCheck(
+          "cloud.cors",
+          "warn",
+          "Skipped Docs Cloud CORS validation because --no-network was passed.",
+        ),
+      );
+    } else if (!siteOrigin) {
+      checks.push(
+        createCheck(
+          "cloud.cors",
+          "warn",
+          "Could not infer the docs site origin for CORS checks. Set NEXT_PUBLIC_BASE_URL or a docs config baseUrl.",
+        ),
+      );
+    } else {
+      if (checkAnalytics) {
+        try {
+          const cors = await checkCorsPreflight({
+            url: `${apiBaseUrl}/v1/analytics/events`,
+            origin: siteOrigin.origin,
+            requestHeaders: "content-type",
+          });
+          checks.push(
+            createCheck(
+              "cors.analytics",
+              cors.ok ? "pass" : "fail",
+              cors.ok
+                ? `Analytics CORS allows ${siteOrigin.origin}.`
+                : `Analytics CORS blocked ${siteOrigin.origin}.`,
+              {
+                origin: siteOrigin.origin,
+                originSource: siteOrigin.source,
+                status: cors.status,
+                allowOrigin: cors.allowOrigin,
+                allowMethods: cors.allowMethods,
+              },
+            ),
+          );
+        } catch (error) {
+          checks.push(
+            createCheck(
+              "cors.analytics",
+              "fail",
+              error instanceof Error
+                ? `Analytics CORS check failed: ${error.message}`
+                : "Analytics CORS check failed.",
+            ),
+          );
+        }
+      }
+
+      if (checkAskAi && projectEnv) {
+        try {
+          const cors = await checkCorsPreflight({
+            url: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectEnv.value)}/knowledge/ask`,
+            origin: siteOrigin.origin,
+            requestHeaders: "authorization, content-type",
+          });
+          checks.push(
+            createCheck(
+              "cors.askAi",
+              cors.ok ? "pass" : "fail",
+              cors.ok
+                ? `Ask AI CORS allows ${siteOrigin.origin}.`
+                : `Ask AI CORS blocked ${siteOrigin.origin}.`,
+              {
+                origin: siteOrigin.origin,
+                originSource: siteOrigin.source,
+                status: cors.status,
+                allowOrigin: cors.allowOrigin,
+                allowMethods: cors.allowMethods,
+              },
+            ),
+          );
+        } catch (error) {
+          checks.push(
+            createCheck(
+              "cors.askAi",
+              "fail",
+              error instanceof Error
+                ? `Ask AI CORS check failed: ${error.message}`
+                : "Ask AI CORS check failed.",
+            ),
+          );
+        }
+      }
     }
   }
 
@@ -1912,7 +2141,7 @@ async function runCloudDeployment(options: CloudCommandOptions = {}) {
     }
 
     const apiKey = resolveApiKey(options, rootDir, materialized.apiKeyEnv);
-    const apiBaseUrl = resolveApiBaseUrl(options);
+    const apiBaseUrl = resolveApiBaseUrl(options, rootDir).url;
 
     spinner.update("Validating Docs Cloud API key");
     const identity = await fetchCloudJson({

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1105,6 +1105,10 @@ function createCheck(
   };
 }
 
+function isBrowserSafeEnvName(name: string): boolean {
+  return name.startsWith("NEXT_PUBLIC_");
+}
+
 function summarizeIdentity(identity: unknown): JsonRecord | undefined {
   if (!isRecord(identity)) return undefined;
 
@@ -1269,6 +1273,7 @@ async function checkCorsPreflight(params: {
   status: number;
   allowOrigin: string | null;
   allowMethods: string | null;
+  allowHeaders: string | null;
 }> {
   const response = await fetch(params.url, {
     method: "OPTIONS",
@@ -1280,6 +1285,7 @@ async function checkCorsPreflight(params: {
   });
   const allowOrigin = response.headers.get("access-control-allow-origin");
   const allowMethods = response.headers.get("access-control-allow-methods");
+  const allowHeaders = response.headers.get("access-control-allow-headers");
   const normalizedAllowOrigin = allowOrigin?.toLowerCase();
   const normalizedOrigin = params.origin.toLowerCase();
 
@@ -1287,11 +1293,31 @@ async function checkCorsPreflight(params: {
     ok:
       response.ok &&
       (normalizedAllowOrigin === "*" || normalizedAllowOrigin === normalizedOrigin) &&
-      Boolean(allowMethods?.toUpperCase().includes("POST")),
+      Boolean(allowMethods?.toUpperCase().includes("POST")) &&
+      areCorsRequestHeadersAllowed(params.requestHeaders, allowHeaders),
     status: response.status,
     allowOrigin,
     allowMethods,
+    allowHeaders,
   };
+}
+
+function areCorsRequestHeadersAllowed(requestHeaders: string, allowHeaders: string | null): boolean {
+  const requested = parseCorsHeaderList(requestHeaders);
+  if (requested.length === 0) return true;
+  if (!allowHeaders) return false;
+
+  const allowed = parseCorsHeaderList(allowHeaders);
+  if (allowed.includes("*")) return true;
+
+  return requested.every((header) => allowed.includes(header));
+}
+
+function parseCorsHeaderList(value: string): string[] {
+  return value
+    .split(",")
+    .map((header) => header.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
@@ -1816,23 +1842,44 @@ export async function checkCloudConfig(
       );
 
       const configuredApiKeyEnv = readConfiguredCloudApiKeyEnv(snapshot);
-      const directApiKeyEnv =
-        configuredApiKeyEnv ??
-        readFirstEnv(env, [DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV, DOCS_CLOUD_DEFAULT_API_KEY_ENV])
-          ?.name ??
-        DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
-      const directApiKey = readEnvValue(env, directApiKeyEnv);
+      const publicApiKeyEnv =
+        configuredApiKeyEnv && isBrowserSafeEnvName(configuredApiKeyEnv)
+          ? configuredApiKeyEnv
+          : readFirstEnv(env, [DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV])?.name ??
+            DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+      const publicApiKey = readEnvValue(env, publicApiKeyEnv);
+      const publicProjectEnv = readFirstEnv(env, [DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV]);
+      const serverApiKeyEnv = configuredApiKeyEnv ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV;
+      const serverApiKey = readEnvValue(env, serverApiKeyEnv);
 
-      checks.push(
-        createCheck(
-          "askAi.direct",
-          directApiKey && projectEnv ? "pass" : "fail",
-          directApiKey && projectEnv
-            ? `Ask AI can call the Docs Cloud knowledge endpoint directly with ${directApiKeyEnv}.`
-            : `Ask AI docs-cloud direct mode needs ${directApiKeyEnv} and a Docs Cloud project id.`,
-          { apiKeyEnv: directApiKeyEnv },
-        ),
-      );
+      if (publicApiKey && publicProjectEnv) {
+        checks.push(
+          createCheck(
+            "askAi.direct",
+            "pass",
+            `Ask AI can call the Docs Cloud knowledge endpoint directly with ${publicApiKeyEnv}.`,
+            { apiKeyEnv: publicApiKeyEnv, projectIdEnv: publicProjectEnv.name },
+          ),
+        );
+      } else if (serverApiKey && projectEnv) {
+        checks.push(
+          createCheck(
+            "askAi.direct",
+            "warn",
+            `Direct browser Ask AI needs ${DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV} and ${DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV}; this app can use the local docs API route with ${serverApiKeyEnv}.`,
+            { apiKeyEnv: serverApiKeyEnv, projectIdEnv: projectEnv.name, proxy: true },
+          ),
+        );
+      } else {
+        checks.push(
+          createCheck(
+            "askAi.direct",
+            "fail",
+            `Ask AI docs-cloud direct mode needs ${DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV} and ${DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV}.`,
+            { apiKeyEnv: publicApiKeyEnv },
+          ),
+        );
+      }
     } else if (aiProvider) {
       checks.push(createCheck("askAi.provider", "pass", `Ask AI provider is ${aiProvider}.`));
     } else {
@@ -1884,6 +1931,7 @@ export async function checkCloudConfig(
                 status: cors.status,
                 allowOrigin: cors.allowOrigin,
                 allowMethods: cors.allowMethods,
+                allowHeaders: cors.allowHeaders,
               },
             ),
           );
@@ -1920,6 +1968,7 @@ export async function checkCloudConfig(
                 status: cors.status,
                 allowOrigin: cors.allowOrigin,
                 allowMethods: cors.allowMethods,
+                allowHeaders: cors.allowHeaders,
               },
             ),
           );

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1838,6 +1838,7 @@ export async function checkCloudConfig(
   }
 
   const aiProvider = readAiProvider(snapshot);
+  let askAiCorsMode: "none" | "direct" | "proxy" = "none";
   if (checkAskAi) {
     if (aiProvider === "docs-cloud") {
       checks.push(
@@ -1864,6 +1865,7 @@ export async function checkCloudConfig(
             { apiKeyEnv: publicApiKeyEnv, projectIdEnv: publicProjectEnv.name },
           ),
         );
+        askAiCorsMode = "direct";
       } else if (serverApiKey && projectEnv) {
         checks.push(
           createCheck(
@@ -1873,6 +1875,7 @@ export async function checkCloudConfig(
             { apiKeyEnv: serverApiKeyEnv, projectIdEnv: projectEnv.name, proxy: true },
           ),
         );
+        askAiCorsMode = "proxy";
       } else {
         checks.push(
           createCheck(
@@ -1951,7 +1954,7 @@ export async function checkCloudConfig(
         }
       }
 
-      if (checkAskAi && projectEnv) {
+      if (checkAskAi && projectEnv && askAiCorsMode === "direct") {
         try {
           const cors = await checkCorsPreflight({
             url: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectEnv.value)}/knowledge/ask`,
@@ -1986,6 +1989,15 @@ export async function checkCloudConfig(
             ),
           );
         }
+      } else if (checkAskAi && askAiCorsMode === "proxy") {
+        checks.push(
+          createCheck(
+            "cors.askAi",
+            "pass",
+            "Ask AI uses the local docs API route, so Docs Cloud browser CORS is not required.",
+            { proxy: true },
+          ),
+        );
       }
     }
   }

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1669,7 +1669,9 @@ export async function checkCloudConfig(
     createCheck(
       "cloud.apiBaseUrl",
       isLocalhostUrl(apiBaseUrl) ? "warn" : "pass",
-      isLocalhostUrl(apiBaseUrl)
+      apiBaseUrlResolution.source === "default"
+        ? `Using the hosted Docs Cloud API at ${apiBaseUrl}.`
+        : isLocalhostUrl(apiBaseUrl)
         ? `Docs Cloud API base URL is ${apiBaseUrl}; production docs should use the hosted API base URL.`
         : `Docs Cloud API base URL is ${apiBaseUrl}.`,
       {
@@ -1678,6 +1680,24 @@ export async function checkCloudConfig(
       },
     ),
   );
+
+  if (checkAnalytics || checkAskAi) {
+    checks.push(
+      createCheck(
+        "docs.siteOrigin",
+        siteOrigin ? "pass" : "warn",
+        siteOrigin
+          ? `Public docs origin is ${siteOrigin.origin}.`
+          : "Could not infer the public docs origin for CORS checks. Set NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_SITE_URL, SITE_URL, or a docs config baseUrl.",
+        siteOrigin
+          ? {
+              origin: siteOrigin.origin,
+              source: siteOrigin.source,
+            }
+          : undefined,
+      ),
+    );
+  }
 
   const apiKey = explicitApiKey || readEnvValue(env, apiKeyEnv);
 

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1302,7 +1302,10 @@ async function checkCorsPreflight(params: {
   };
 }
 
-function areCorsRequestHeadersAllowed(requestHeaders: string, allowHeaders: string | null): boolean {
+function areCorsRequestHeadersAllowed(
+  requestHeaders: string,
+  allowHeaders: string | null,
+): boolean {
   const requested = parseCorsHeaderList(requestHeaders);
   if (requested.length === 0) return true;
   if (!allowHeaders) return false;
@@ -1845,8 +1848,8 @@ export async function checkCloudConfig(
       const publicApiKeyEnv =
         configuredApiKeyEnv && isBrowserSafeEnvName(configuredApiKeyEnv)
           ? configuredApiKeyEnv
-          : readFirstEnv(env, [DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV])?.name ??
-            DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV;
+          : (readFirstEnv(env, [DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV])?.name ??
+            DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV);
       const publicApiKey = readEnvValue(env, publicApiKeyEnv);
       const publicProjectEnv = readFirstEnv(env, [DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV]);
       const serverApiKeyEnv = configuredApiKeyEnv ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV;

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1659,9 +1659,7 @@ Install the framework with pnpm.
       expect(await response.text()).toContain("Use Docs Cloud for hosted Ask AI.");
 
       const [cloudUrl, cloudInit] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
-      expect(cloudUrl).toBe(
-        "https://api.farming-labs.dev/v1/projects/project_cloud/knowledge/ask",
-      );
+      expect(cloudUrl).toBe("https://api.farming-labs.dev/v1/projects/project_cloud/knowledge/ask");
       expect(cloudInit?.headers).toMatchObject({
         Authorization: "Bearer cloud-key",
       });

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1660,7 +1660,7 @@ Install the framework with pnpm.
 
       const [cloudUrl, cloudInit] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
       expect(cloudUrl).toBe(
-        "https://docs-app.farming-labs.dev/v1/projects/project_cloud/knowledge/ask",
+        "https://api.farming-labs.dev/v1/projects/project_cloud/knowledge/ask",
       );
       expect(cloudInit?.headers).toMatchObject({
         Authorization: "Bearer cloud-key",
@@ -1761,7 +1761,7 @@ export default defineDocs({
 
       const [cloudUrl, cloudInit] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
       expect(cloudUrl).toBe(
-        "https://docs-app.farming-labs.dev/v1/projects/project_config/knowledge/ask",
+        "https://api.farming-labs.dev/v1/projects/project_config/knowledge/ask",
       );
       expect(cloudInit?.headers).toMatchObject({
         Authorization: "Bearer config-cloud-key",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -183,7 +183,7 @@ interface DocsMCPAPIOptions {
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
-const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
+const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
 const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";

--- a/packages/fumadocs/src/docs-cloud-ai-client.test.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.test.ts
@@ -44,7 +44,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
 
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
-      api: "https://docs-app.farming-labs.dev/v1/projects/project_public/knowledge/ask",
+      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
       requestMode: "docs-cloud",
       requestStream: true,
       requestHeaders: {
@@ -53,7 +53,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
     });
   });
 
-  it("falls back to the server proxy when configured API key env is not public", () => {
+  it("uses the configured Docs Cloud API key env for direct requests", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
     process.env.SERVER_DOCS_CLOUD_KEY = "server-key";
@@ -65,8 +65,37 @@ describe("resolveDocsCloudAIClientRequest", () => {
         }),
       ),
     ).toEqual({
-      api: "/api/docs",
+      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
+      requestMode: "docs-cloud",
       requestStream: true,
+      requestHeaders: {
+        Authorization: "Bearer server-key",
+      },
+    });
+  });
+
+  it("keeps non-cloud providers on the docs API route", () => {
+    expect(
+      resolveDocsCloudAIClientRequest({
+        entry: "docs",
+        ai: {
+          enabled: true,
+          provider: "openai",
+        } as unknown as DocsConfig["ai"],
+      }),
+    ).toEqual({
+      api: "/api/docs",
+    });
+  });
+
+  it("does not fall back to the docs API route when docs-cloud env is incomplete", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+
+    expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
+      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
+      requestMode: "docs-cloud",
+      requestStream: true,
+      requestHeaders: undefined,
     });
   });
 

--- a/packages/fumadocs/src/docs-cloud-ai-client.test.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.test.ts
@@ -9,6 +9,7 @@ const ENV_KEYS = [
   "DOCS_CLOUD_API_URL",
   "DOCS_CLOUD_API_KEY",
   "SERVER_DOCS_CLOUD_KEY",
+  "NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY",
 ] as const;
 
 const originalEnv = new Map<string, string | undefined>(
@@ -53,9 +54,29 @@ describe("resolveDocsCloudAIClientRequest", () => {
     });
   });
 
-  it("uses the configured Docs Cloud API key env for direct requests", () => {
+  it("uses a configured browser-safe Docs Cloud API key env for direct requests", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY = "custom-public-key";
+
+    expect(
+      resolveDocsCloudAIClientRequest(
+        createDocsCloudConfig({
+          apiKey: { env: "NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY" },
+        }),
+      ),
+    ).toEqual({
+      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
+      requestMode: "docs-cloud",
+      requestStream: true,
+      requestHeaders: {
+        Authorization: "Bearer custom-public-key",
+      },
+    });
+  });
+
+  it("falls back to the docs API route when the configured API key env is server-only", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.SERVER_DOCS_CLOUD_KEY = "server-key";
 
     expect(
@@ -65,12 +86,8 @@ describe("resolveDocsCloudAIClientRequest", () => {
         }),
       ),
     ).toEqual({
-      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
-      requestMode: "docs-cloud",
+      api: "/api/docs",
       requestStream: true,
-      requestHeaders: {
-        Authorization: "Bearer server-key",
-      },
     });
   });
 
@@ -88,14 +105,21 @@ describe("resolveDocsCloudAIClientRequest", () => {
     });
   });
 
-  it("does not fall back to the docs API route when docs-cloud env is incomplete", () => {
+  it("falls back to the docs API route when the public API key is missing", () => {
     process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
 
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
-      api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
-      requestMode: "docs-cloud",
+      api: "/api/docs",
       requestStream: true,
-      requestHeaders: undefined,
+    });
+  });
+
+  it("falls back to the docs API route when the public project id is missing", () => {
+    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+
+    expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
+      api: "/api/docs",
+      requestStream: true,
     });
   });
 

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -2,7 +2,7 @@ import type { DocsConfig } from "@farming-labs/docs";
 
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
-const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
+const DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
 const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
 
 export interface DocsCloudAIClientRequest {
@@ -26,20 +26,21 @@ function resolveDocsCloudApiBaseUrl(): string {
 }
 
 function resolveDocsCloudProjectId(): string | undefined {
-  return (
-    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID")
-  );
+  return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV);
 }
 
 function resolveDocsCloudApiKey(config: DocsConfig): string | undefined {
   const configuredEnv = config.cloud?.apiKey?.env?.trim();
 
-  if (configuredEnv) return readRuntimeEnv(configuredEnv);
+  if (configuredEnv && isPublicRuntimeEnvName(configuredEnv)) {
+    return readRuntimeEnv(configuredEnv);
+  }
 
-  return (
-    readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV) ??
-    readRuntimeEnv(DEFAULT_DOCS_CLOUD_API_KEY_ENV)
-  );
+  return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV);
+}
+
+function isPublicRuntimeEnvName(name: string): boolean {
+  return name.startsWith("NEXT_PUBLIC_");
 }
 
 function resolveDocsCloudAIStream(config: DocsConfig): boolean {
@@ -60,13 +61,16 @@ export function resolveDocsCloudAIClientRequest(
   const projectId = resolveDocsCloudProjectId();
   const apiKey = resolveDocsCloudApiKey(config);
   const requestStream = resolveDocsCloudAIStream(config);
+  if (!projectId || !apiKey) {
+    return { api: fallbackApi, requestStream };
+  }
+
   const apiBaseUrl = resolveDocsCloudApiBaseUrl();
-  const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined;
 
   return {
-    api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId ?? "_missing_project_id")}/knowledge/ask`,
+    api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`,
     requestMode: "docs-cloud",
     requestStream,
-    requestHeaders: headers,
+    requestHeaders: { Authorization: `Bearer ${apiKey}` },
   };
 }

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -1,7 +1,8 @@
 import type { DocsConfig } from "@farming-labs/docs";
 
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
-const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://docs-app.farming-labs.dev";
+const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
+const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
 
 export interface DocsCloudAIClientRequest {
@@ -30,13 +31,15 @@ function resolveDocsCloudProjectId(): string | undefined {
   );
 }
 
-function resolvePublicDocsCloudApiKey(config: DocsConfig): string | undefined {
+function resolveDocsCloudApiKey(config: DocsConfig): string | undefined {
   const configuredEnv = config.cloud?.apiKey?.env?.trim();
 
-  if (!configuredEnv) return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV);
-  if (!configuredEnv.startsWith("NEXT_PUBLIC_")) return undefined;
+  if (configuredEnv) return readRuntimeEnv(configuredEnv);
 
-  return readRuntimeEnv(configuredEnv);
+  return (
+    readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV) ??
+    readRuntimeEnv(DEFAULT_DOCS_CLOUD_API_KEY_ENV)
+  );
 }
 
 function resolveDocsCloudAIStream(config: DocsConfig): boolean {
@@ -55,19 +58,15 @@ export function resolveDocsCloudAIClientRequest(
   }
 
   const projectId = resolveDocsCloudProjectId();
-  const apiKey = resolvePublicDocsCloudApiKey(config);
+  const apiKey = resolveDocsCloudApiKey(config);
   const requestStream = resolveDocsCloudAIStream(config);
-  if (!projectId || !apiKey) {
-    return { api: fallbackApi, requestStream };
-  }
-
   const apiBaseUrl = resolveDocsCloudApiBaseUrl();
+  const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined;
+
   return {
-    api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`,
+    api: `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId ?? "_missing_project_id")}/knowledge/ask`,
     requestMode: "docs-cloud",
     requestStream,
-    requestHeaders: {
-      Authorization: `Bearer ${apiKey}`,
-    },
+    requestHeaders: headers,
   };
 }

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -125,9 +125,11 @@ Run a read-only health check before deploying or debugging Ask AI:
 pnpm dlx @farming-labs/docs cloud check
 ```
 
-The check validates `docs.config.ts`, `docs.json` freshness, `cloud.apiKey.env`, the Docs Cloud API
-key, required deploy scopes, analytics project envs, and `ai.provider: "docs-cloud"` wiring. Use
-`--json` in CI or `--no-network` when you only want local config checks.
+The check validates `docs.config.ts`, `docs.json` freshness, the Docs Cloud API base URL,
+`cloud.apiKey.env`, the Docs Cloud API key, required deploy scopes, analytics project envs,
+`ai.provider: "docs-cloud"` direct knowledge endpoint wiring, and browser CORS preflight for
+Cloud analytics/Ask AI. Use `--json` in CI or `--no-network` when you only want local config
+checks.
 
 Scope the report when you only want one integration area:
 
@@ -141,15 +143,17 @@ Example focused report:
 
 ```txt title="terminal"
 Docs Cloud check
-api https://docs-app.farming-labs.dev
+api https://api.farming-labs.dev
 scope analytics
 
 ok config Loaded docs.config.ts
 warn docs.json docs.json is missing. Run docs cloud sync to materialize cloud config.
+ok cloud.apiBaseUrl Docs Cloud API base URL is https://api.farming-labs.dev.
 ok cloud.enabled Docs Cloud is enabled.
 ok analytics.runtime Runtime analytics is not disabled.
 ok analytics.cloud Docs Cloud analytics is enabled in cloud.analytics.
 ok project.env Docs Cloud project id is present in NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID.
+ok cors.analytics Analytics CORS allows https://docs.example.com.
 
 ok Docs Cloud check passed with 1 warning.
 ```
@@ -165,9 +169,9 @@ pnpm dlx @farming-labs/docs deploy --json
 | Command | Use it when |
 | ------- | ----------- |
 | `pnpm dlx @farming-labs/docs cloud sync` | You only want to update `docs.json` |
-| `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, analytics envs, API key scopes, and Ask AI wiring without deploying |
-| `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring |
-| `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI wiring |
+| `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, API base URL, analytics envs, API key scopes, CORS, and Ask AI wiring without deploying |
+| `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring and analytics CORS |
+| `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI direct endpoint wiring and Ask AI CORS |
 | `pnpm dlx @farming-labs/docs cloud check --deploy` | You only want to validate deploy flags, API key presence, and deploy scopes |
 | `pnpm dlx @farming-labs/docs deploy` | You want to sync, validate the key, and request a preview |
 | `pnpm dlx @farming-labs/docs cloud deploy` | You prefer the explicit Cloud namespace |

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -125,11 +125,11 @@ Run a read-only health check before deploying or debugging Ask AI:
 pnpm dlx @farming-labs/docs cloud check
 ```
 
-The check validates `docs.config.ts`, `docs.json` freshness, the Docs Cloud API base URL,
+The check validates `docs.config.ts`, `docs.json` freshness, the hosted Docs Cloud API target,
 `cloud.apiKey.env`, the Docs Cloud API key, required deploy scopes, analytics project envs,
-`ai.provider: "docs-cloud"` direct knowledge endpoint wiring, and browser CORS preflight for
-Cloud analytics/Ask AI. Use `--json` in CI or `--no-network` when you only want local config
-checks.
+the public docs origin used for browser CORS, `ai.provider: "docs-cloud"` direct knowledge
+endpoint wiring, and browser CORS preflight for Cloud analytics/Ask AI. Use `--json` in CI or
+`--no-network` when you only want local config checks.
 
 Scope the report when you only want one integration area:
 
@@ -148,7 +148,8 @@ scope analytics
 
 ok config Loaded docs.config.ts
 warn docs.json docs.json is missing. Run docs cloud sync to materialize cloud config.
-ok cloud.apiBaseUrl Docs Cloud API base URL is https://api.farming-labs.dev.
+ok cloud.apiBaseUrl Using the hosted Docs Cloud API at https://api.farming-labs.dev.
+ok docs.siteOrigin Public docs origin is https://docs.example.com.
 ok cloud.enabled Docs Cloud is enabled.
 ok analytics.runtime Runtime analytics is not disabled.
 ok analytics.cloud Docs Cloud analytics is enabled in cloud.analytics.
@@ -169,7 +170,7 @@ pnpm dlx @farming-labs/docs deploy --json
 | Command | Use it when |
 | ------- | ----------- |
 | `pnpm dlx @farming-labs/docs cloud sync` | You only want to update `docs.json` |
-| `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, API base URL, analytics envs, API key scopes, CORS, and Ask AI wiring without deploying |
+| `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, hosted API access, analytics envs, API key scopes, CORS, and Ask AI wiring without deploying |
 | `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring and analytics CORS |
 | `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI direct endpoint wiring and Ask AI CORS |
 | `pnpm dlx @farming-labs/docs cloud check --deploy` | You only want to validate deploy flags, API key presence, and deploy scopes |
@@ -212,6 +213,15 @@ or add it to `.env.local`.
 If `cloud.deploy.enabled` is `false`, `docs deploy` stops before requesting a hosted preview. Set it
 back to `true` or remove the override.
 
+### Browser CORS blocked
+
+Make sure the public docs URL is set in one of the places the check can read:
+`NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_SITE_URL`, `SITE_URL`, `sitemap.baseUrl`,
+`llmsTxt.baseUrl`, or `robots.baseUrl`.
+
+For the hosted Docs Cloud API, you do not need to set a Docs Cloud API URL. If you are
+self-hosting the API, allow the same public docs origin in the API service CORS config.
+
 ### Wrong Cloud host
 
 For staging or self-hosted testing, pass:
@@ -219,5 +229,3 @@ For staging or self-hosted testing, pass:
 ```bash title="terminal"
 pnpm dlx @farming-labs/docs deploy --api-base-url https://cloud.example.com
 ```
-
-You can also set `DOCS_CLOUD_API_URL` in the environment.

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -127,8 +127,8 @@ pnpm dlx @farming-labs/docs cloud check
 
 The check validates `docs.config.ts`, `docs.json` freshness, the hosted Docs Cloud API target,
 `cloud.apiKey.env`, the Docs Cloud API key, required deploy scopes, analytics project envs,
-the public docs origin used for browser CORS, `ai.provider: "docs-cloud"` direct knowledge
-endpoint wiring, and browser CORS preflight for Cloud analytics/Ask AI. Use `--json` in CI or
+the public docs origin used for browser CORS, `ai.provider: "docs-cloud"` direct or proxied
+knowledge endpoint wiring, and browser CORS preflight for Cloud analytics/Ask AI. Use `--json` in CI or
 `--no-network` when you only want local config checks.
 
 Scope the report when you only want one integration area:
@@ -172,7 +172,7 @@ pnpm dlx @farming-labs/docs deploy --json
 | `pnpm dlx @farming-labs/docs cloud sync` | You only want to update `docs.json` |
 | `pnpm dlx @farming-labs/docs cloud check` | You want to validate config, hosted API access, analytics envs, API key scopes, CORS, and Ask AI wiring without deploying |
 | `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring and analytics CORS |
-| `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI direct endpoint wiring and Ask AI CORS |
+| `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI endpoint wiring and Ask AI CORS |
 | `pnpm dlx @farming-labs/docs cloud check --deploy` | You only want to validate deploy flags, API key presence, and deploy scopes |
 | `pnpm dlx @farming-labs/docs deploy` | You want to sync, validate the key, and request a preview |
 | `pnpm dlx @farming-labs/docs cloud deploy` | You prefer the explicit Cloud namespace |
@@ -216,7 +216,7 @@ back to `true` or remove the override.
 ### Browser CORS blocked
 
 Make sure the public docs URL is set in one of the places the check can read:
-`NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_SITE_URL`, `SITE_URL`, `sitemap.baseUrl`,
+`NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_SITE_URL`, `SITE_URL`, `site.url`, `sitemap.baseUrl`,
 `llmsTxt.baseUrl`, or `robots.baseUrl`.
 
 For the hosted Docs Cloud API, you do not need to set a Docs Cloud API URL. If you are


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds browser CORS validation and a proxy-aware Ask AI flow. Enables direct Docs Cloud knowledge calls from the browser when a public key is configured, and switches the default Cloud API to https://api.farming-labs.dev with unified `/v1` routes.

- **New Features**
  - `@farming-labs/docs` cloud check
    - Reports Cloud API base URL and its source (flag/env/default); warns on localhost.
    - Infers the public docs origin from env/config and runs CORS preflight for analytics; for Ask AI, runs preflight only in direct mode and skips (passes as proxy) when using the local `/api/docs` fallback. Validates required headers.
    - Validates Ask AI routing: passes with `NEXT_PUBLIC_*` key + `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`, warns when only a server key is present (proxy mode), fails otherwise.
  - Docs Cloud AI client
    - Calls `/v1/projects/.../knowledge/ask` directly when a browser-safe `cloud.apiKey.env` (or `NEXT_PUBLIC_DOCS_CLOUD_API_KEY`) and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` are set.
    - Falls back to `/api/docs` when using a server-only key or when public envs are missing; non-cloud providers stay on `/api/docs`.

- **Migration**
  - If you override the Cloud API via `DOCS_CLOUD_API_URL` or `NEXT_PUBLIC_DOCS_CLOUD_URL`, point it to `https://api.farming-labs.dev` (or ensure your override serves `/v1`).
  - Set your site origin for CORS checks via `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_SITE_URL`, `SITE_URL`, or `site.url`/`sitemap.baseUrl`/`llmsTxt.baseUrl`/`robots.baseUrl`.
  - For direct Ask AI calls, set a browser-safe Docs Cloud API key (e.g. `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` or a `NEXT_PUBLIC_*` `cloud.apiKey.env`) and `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID`; otherwise the client will use the local `/api/docs` proxy.

<sup>Written for commit 0eda131cb3dcca9079f4d99bf13c5be62b451f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

