### PR TITLE
fix: streaming markdown rendering

### DIFF
--- a/packages/fumadocs/src/ai-markdown.test.ts
+++ b/packages/fumadocs/src/ai-markdown.test.ts
@@ -26,6 +26,39 @@ After code.
     expect(html).toContain("indexed");
   });
 
+  it("keeps sections after metadata code fences rendered as markdown blocks", () => {
+    const html = renderAIResponseMarkdown(`# Getting Started with @farming-labs/docs
+
+---
+
+\`\`\`ts title="docs.config.ts"
+const provider = "docs-cloud";
+\`\`\`
+
+---
+
+## Upgrading later
+
+\`\`\`bash
+npx @farming-labs/docs upgrade
+\`\`\`
+
+**Relevant docs**
+- Configuration — full reference for \`defineDocs\`
+- CLI reference`);
+
+    expect(html).not.toContain("```");
+    expect(html).not.toContain('title="docs.config.ts"');
+    expect(html.match(/<div class="fd-ai-code-block"/g)).toHaveLength(2);
+    expect(html.split('<hr class="fd-ai-hr" />')).toHaveLength(3);
+    expect(html).toContain("<h2>Getting Started with @farming-labs/docs</h2>");
+    expect(html).toContain("<h3>Upgrading later</h3>");
+    expect(html).toContain("<strong>Relevant docs</strong>");
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<li>Configuration");
+    expect(html).toContain("<code>defineDocs</code>");
+  });
+
   it("renders an incomplete streaming code fence with metadata as a live code block", () => {
     const html = renderAIResponseMarkdown(`\`\`\`bash title="Terminal"
 pnpm dev`);

--- a/packages/fumadocs/src/ai-markdown.ts
+++ b/packages/fumadocs/src/ai-markdown.ts
@@ -6,6 +6,8 @@ type CodeFence = {
   lang: string;
 };
 
+const codeBlockTokenBoundary = String.fromCharCode(0);
+
 function buildCodeBlock(lang: string, code: string): string {
   const trimmed = code.replace(/\n$/, "");
   // Strip newlines between sh__line spans. <pre> preserves whitespace and
@@ -91,19 +93,46 @@ function replaceFencedCodeBlocks(
 }
 
 export function renderAIResponseMarkdown(text: string): string {
-  const codeBlockTokenBoundary = String.fromCharCode(0);
-  const codeBlockTokenPattern = new RegExp(
-    `${codeBlockTokenBoundary}CB(\\d+)${codeBlockTokenBoundary}`,
-    "g",
-  );
   const codeBlocks: string[] = [];
   const processed = replaceFencedCodeBlocks(text, codeBlocks, codeBlockTokenBoundary);
 
-  const lines = processed.split("\n");
+  return renderMarkdownBlocks(processed, codeBlocks);
+}
+
+function renderMarkdownBlocks(text: string, codeBlocks: string[]): string {
+  const lines = text.split("\n");
   const output: string[] = [];
   let i = 0;
 
   while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      i++;
+      continue;
+    }
+
+    const codeBlockIndex = getCodeBlockTokenIndex(trimmed);
+    if (codeBlockIndex !== null) {
+      output.push(codeBlocks[codeBlockIndex] ?? "");
+      i++;
+      continue;
+    }
+
+    if (isHorizontalRule(trimmed)) {
+      output.push('<hr class="fd-ai-hr" />');
+      i++;
+      continue;
+    }
+
+    const heading = getHeading(trimmed);
+    if (heading) {
+      output.push(`<h${heading.level}>${renderInlineMarkdown(heading.text)}</h${heading.level}>`);
+      i++;
+      continue;
+    }
+
     if (isTableRow(lines[i]) && i + 1 < lines.length && isTableSeparator(lines[i + 1])) {
       const tableLines: string[] = [lines[i]];
       i++; // separator
@@ -115,38 +144,123 @@ export function renderAIResponseMarkdown(text: string): string {
       output.push(renderTable(tableLines));
       continue;
     }
-    output.push(lines[i]);
+
+    const unorderedItems = collectListItems(lines, i, "unordered");
+    if (unorderedItems) {
+      output.push(
+        `<ul>${unorderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ul>`,
+      );
+      i = unorderedItems.nextIndex;
+      continue;
+    }
+
+    const orderedItems = collectListItems(lines, i, "ordered");
+    if (orderedItems) {
+      output.push(
+        `<ol>${orderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ol>`,
+      );
+      i = orderedItems.nextIndex;
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (i < lines.length && lines[i].trim() && !isMarkdownBlockStart(lines, i)) {
+      paragraphLines.push(lines[i].trim());
+      i++;
+    }
+
+    output.push(
+      `<p>${paragraphLines.map((paragraphLine) => renderInlineMarkdown(paragraphLine)).join("<br>")}</p>`,
+    );
+  }
+
+  return output.join("");
+}
+
+function getCodeBlockTokenIndex(line: string): number | null {
+  const prefix = `${codeBlockTokenBoundary}CB`;
+  if (!line.startsWith(prefix) || !line.endsWith(codeBlockTokenBoundary)) return null;
+
+  const rawIndex = line.slice(prefix.length, -codeBlockTokenBoundary.length);
+  if (!/^\d+$/.test(rawIndex)) return null;
+
+  return Number(rawIndex);
+}
+
+function getHeading(line: string): { level: number; text: string } | null {
+  const match = /^(#{1,4})\s+(.+)$/.exec(line);
+  if (!match) return null;
+
+  return {
+    level: match[1].length + 1,
+    text: match[2],
+  };
+}
+
+function collectListItems(
+  lines: string[],
+  startIndex: number,
+  type: "ordered" | "unordered",
+): { items: string[]; nextIndex: number } | null {
+  const pattern = type === "ordered" ? /^(?: {0,3})\d+\.\s+(.+)$/ : /^(?: {0,3})[-*+]\s+(.+)$/;
+  const items: string[] = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const match = pattern.exec(lines[i]);
+    if (!match) break;
+
+    items.push(match[1]);
     i++;
   }
 
-  let result = output.join("\n");
+  return items.length > 0 ? { items, nextIndex: i } : null;
+}
+
+function isMarkdownBlockStart(lines: string[], index: number): boolean {
+  const line = lines[index];
+  const trimmed = line.trim();
+
+  return (
+    getCodeBlockTokenIndex(trimmed) !== null ||
+    isHorizontalRule(trimmed) ||
+    Boolean(getHeading(trimmed)) ||
+    (isTableRow(line) && index + 1 < lines.length && isTableSeparator(lines[index + 1])) ||
+    Boolean(collectListItems(lines, index, "unordered")) ||
+    Boolean(collectListItems(lines, index, "ordered"))
+  );
+}
+
+function renderInlineMarkdown(text: string): string {
+  const inlineCodeTokens: string[] = [];
+  let result = escapeHtml(text).replace(/`([^`]+)`/g, (_match, code) => {
+    inlineCodeTokens.push(`<code>${code}</code>`);
+    return `${codeBlockTokenBoundary}IC${inlineCodeTokens.length - 1}${codeBlockTokenBoundary}`;
+  });
 
   result = result
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
     .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
     .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/^### (.*$)/gm, "<h4>$1</h4>")
-    .replace(/^## (.*$)/gm, "<h3>$1</h3>")
-    .replace(/^# (.*$)/gm, "<h2>$1</h2>")
-    .replace(
-      /^[-*] (.*$)/gm,
-      '<div style="display:flex;gap:8px;padding:2px 0"><span style="opacity:0.5">•</span><span>$1</span></div>',
-    )
-    .replace(
-      /^(\d+)\. (.*$)/gm,
-      '<div style="display:flex;gap:8px;padding:2px 0"><span style="opacity:0.5">$1.</span><span>$2</span></div>',
-    )
-    .replace(/\n\n/g, '<div style="height:8px"></div>')
-    .replace(/\n/g, "<br>");
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+      return `<a href="${escapeAttribute(href)}">${label}</a>`;
+    });
 
-  result = result.replace(codeBlockTokenPattern, (_m, idx) => codeBlocks[Number(idx)]);
-
-  return result;
+  return result.replace(
+    new RegExp(`${codeBlockTokenBoundary}IC(\\d+)${codeBlockTokenBoundary}`, "g"),
+    (_match, idx) => inlineCodeTokens[Number(idx)] ?? "",
+  );
 }
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(s: string): string {
+  return escapeHtml(s).replace(/"/g, "&quot;");
+}
+
+function isHorizontalRule(line: string): boolean {
+  return /^(?:-{3,}|\*{3,}|_{3,})$/.test(line);
 }
 
 function isTableRow(line: string): boolean {
@@ -168,13 +282,13 @@ function renderTable(rows: string[]): string {
       .map((c) => c.trim());
 
   const headerCells = parseRow(rows[0]);
-  const thead = `<thead><tr>${headerCells.map((c) => `<th>${c}</th>`).join("")}</tr></thead>`;
+  const thead = `<thead><tr>${headerCells.map((c) => `<th>${renderInlineMarkdown(c)}</th>`).join("")}</tr></thead>`;
 
   const bodyRows = rows
     .slice(1)
     .map((row) => {
       const cells = parseRow(row);
-      return `<tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`;
+      return `<tr>${cells.map((c) => `<td>${renderInlineMarkdown(c)}</td>`).join("")}</tr>`;
     })
     .join("");
 

--- a/packages/fumadocs/styles/ai.css
+++ b/packages/fumadocs/styles/ai.css
@@ -924,6 +924,35 @@
   color: inherit;
 }
 
+.fd-ai-bubble-ai h5 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 8px 0 4px;
+  line-height: 1.4;
+  color: inherit;
+}
+
+.fd-ai-bubble-ai ul,
+.fd-ai-bubble-ai ol {
+  margin: 6px 0 8px;
+  padding-left: 1.25rem;
+}
+
+.fd-ai-bubble-ai li {
+  margin: 3px 0;
+  padding-left: 2px;
+}
+
+.fd-ai-bubble-ai li::marker {
+  color: var(--color-fd-muted-foreground, #71717a);
+}
+
+.fd-ai-bubble-ai .fd-ai-hr {
+  border: 0;
+  border-top: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  margin: 12px 0;
+}
+
 .fd-ai-bubble-ai strong {
   font-weight: 600;
   color: var(--color-fd-foreground, #e4e4e7);
@@ -1249,6 +1278,35 @@
   margin: 10px 0 4px;
   line-height: 1.4;
   color: var(--color-fd-foreground, #e4e4e7);
+}
+
+.fd-ai-fm-msg-content h5 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 10px 0 4px;
+  line-height: 1.4;
+  color: var(--color-fd-foreground, #e4e4e7);
+}
+
+.fd-ai-fm-msg-content ul,
+.fd-ai-fm-msg-content ol {
+  margin: 8px 0 10px;
+  padding-left: 1.35rem;
+}
+
+.fd-ai-fm-msg-content li {
+  margin: 4px 0;
+  padding-left: 2px;
+}
+
+.fd-ai-fm-msg-content li::marker {
+  color: var(--color-fd-muted-foreground, #71717a);
+}
+
+.fd-ai-fm-msg-content .fd-ai-hr {
+  border: 0;
+  border-top: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  margin: 16px 0;
 }
 
 .fd-ai-fm-msg-content strong {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamed markdown now renders as structured HTML with proper blocks (headings, lists, tables, rules, code) as content arrives. It keeps sections after fenced code with metadata and adds safer HTML/attribute escaping.

- New Features
  - Incremental block parsing: headings (# -> h2–h5), unordered/ordered lists, horizontal rules, and tables with inline formatting.
  - Inline markdown: code spans, bold, italics, and links; escapes HTML and attributes.
  - Fenced code (including metadata) renders as live code blocks while preserving surrounding markdown; added tests to cover this.
  
- Styles
  - Added h5, list, and horizontal rule styles for message bubbles in `packages/fumadocs/styles/ai.css`.

<sup>Written for commit 6ebcca399f1fd74f5707f7e364891660467ca449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

