### PR TITLE
feat: rich analytics detailed callback and payloads

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -801,6 +801,10 @@ export interface DocsAnalyticsInput {
   question?: string;
   feedbackValue?: string;
   feedbackComment?: string;
+  feedbackContext?: DocsAgentFeedbackContext;
+  feedbackPayload?: Record<string, unknown>;
+  agentFeedbackContext?: DocsAgentFeedbackContext;
+  agentFeedbackPayload?: Record<string, unknown>;
   content?: string;
 }
 

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1465,7 +1465,23 @@ Install the package.
     });
     expect(events.find((event) => event.type === "agent_feedback_submit")).toMatchObject({
       properties: expect.objectContaining({
+        feedbackKind: "agent",
         handled: true,
+        hasContext: true,
+        context: {
+          page: "/docs/guides/setup",
+        },
+        payload: {
+          task: "validate analytics",
+          outcome: "implemented",
+        },
+        agentFeedbackContext: {
+          page: "/docs/guides/setup",
+        },
+        agentFeedbackPayload: {
+          task: "validate analytics",
+          outcome: "implemented",
+        },
         payloadKeys: ["task", "outcome"],
       }),
     });

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1463,28 +1463,24 @@ Install the package.
         queryLength: 7,
       }),
     });
-    expect(events.find((event) => event.type === "agent_feedback_submit")).toMatchObject({
+    const agentFeedbackSubmitEvent = events.find((event) => event.type === "agent_feedback_submit");
+    expect(agentFeedbackSubmitEvent).toMatchObject({
       properties: expect.objectContaining({
         feedbackKind: "agent",
         handled: true,
         hasContext: true,
-        context: {
-          page: "/docs/guides/setup",
-        },
-        payload: {
-          task: "validate analytics",
-          outcome: "implemented",
-        },
+        hasPayload: true,
         agentFeedbackContext: {
           page: "/docs/guides/setup",
         },
-        agentFeedbackPayload: {
-          task: "validate analytics",
-          outcome: "implemented",
-        },
+        contextPage: "/docs/guides/setup",
         payloadKeys: ["task", "outcome"],
+        payloadFieldCount: 2,
       }),
     });
+    expect(agentFeedbackSubmitEvent?.input).toBeUndefined();
+    expect(agentFeedbackSubmitEvent?.properties).not.toHaveProperty("payload");
+    expect(agentFeedbackSubmitEvent?.properties).not.toHaveProperty("agentFeedbackPayload");
     expect(events.find((event) => event.type === "api_ai_error")).toMatchObject({
       properties: expect.objectContaining({
         reason: "disabled",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -710,21 +710,33 @@ function buildAgentFeedbackAnalyticsProperties(
   } = {},
 ): Record<string, unknown> {
   const payloadKeys = Object.keys(data.payload);
+  const context = data.context;
 
   return {
     ...options.requestProperties,
     feedbackKind: "agent",
-    agentFeedbackContext: data.context,
-    agentFeedbackPayload: data.payload,
-    feedbackContext: data.context,
-    feedbackPayload: data.payload,
-    context: data.context,
-    payload: data.payload,
+    agentFeedbackContext: context,
+    contextPage: context?.page,
+    contextUrl: context?.url,
+    contextSlug: context?.slug,
+    contextLocale: context?.locale,
+    contextSource: context?.source,
     payloadKeys,
+    payloadFieldCount: payloadKeys.length,
     hasContext: Boolean(data.context),
+    hasPayload: payloadKeys.length > 0,
     ...(typeof options.handled === "boolean" ? { handled: options.handled } : {}),
     ...(options.reason ? { reason: options.reason } : {}),
     ...(options.error ? { error: options.error } : {}),
+  };
+}
+
+function buildAgentFeedbackAnalyticsInput(data: DocsAgentFeedbackData) {
+  return {
+    feedbackContext: data.context,
+    feedbackPayload: data.payload,
+    agentFeedbackContext: data.context,
+    agentFeedbackPayload: data.payload,
   };
 }
 
@@ -4259,6 +4271,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             source: "server",
             url: request.url,
             path: url.pathname,
+            input: buildAgentFeedbackAnalyticsInput(parsed.data),
             properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
               requestProperties: requestAnalyticsProperties,
               reason: "invalid_payload",
@@ -4274,6 +4287,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             source: "server",
             url: request.url,
             path: url.pathname,
+            input: buildAgentFeedbackAnalyticsInput(parsed.data),
             properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
               requestProperties: requestAnalyticsProperties,
               handled: false,
@@ -4288,6 +4302,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           source: "server",
           url: request.url,
           path: url.pathname,
+          input: buildAgentFeedbackAnalyticsInput(parsed.data),
           properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
             requestProperties: requestAnalyticsProperties,
             handled: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -700,6 +700,34 @@ async function parseAgentFeedbackData(
   };
 }
 
+function buildAgentFeedbackAnalyticsProperties(
+  data: DocsAgentFeedbackData,
+  options: {
+    requestProperties?: Record<string, unknown>;
+    handled?: boolean;
+    reason?: string;
+    error?: string;
+  } = {},
+): Record<string, unknown> {
+  const payloadKeys = Object.keys(data.payload);
+
+  return {
+    ...options.requestProperties,
+    feedbackKind: "agent",
+    agentFeedbackContext: data.context,
+    agentFeedbackPayload: data.payload,
+    feedbackContext: data.context,
+    feedbackPayload: data.payload,
+    context: data.context,
+    payload: data.payload,
+    payloadKeys,
+    hasContext: Boolean(data.context),
+    ...(typeof options.handled === "boolean" ? { handled: options.handled } : {}),
+    ...(options.reason ? { reason: options.reason } : {}),
+    ...(options.error ? { error: options.error } : {}),
+  };
+}
+
 function validateAgentFeedbackPayload(
   value: unknown,
   schema: Record<string, unknown>,
@@ -4214,6 +4242,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             path: url.pathname,
             properties: {
               ...requestAnalyticsProperties,
+              feedbackKind: "agent",
               reason: "invalid_body",
             },
           });
@@ -4230,11 +4259,11 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             source: "server",
             url: request.url,
             path: url.pathname,
-            properties: {
-              ...requestAnalyticsProperties,
+            properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
+              requestProperties: requestAnalyticsProperties,
               reason: "invalid_payload",
               error: payloadError,
-            },
+            }),
           });
           return Response.json({ error: payloadError }, { status: 400 });
         }
@@ -4245,12 +4274,10 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             source: "server",
             url: request.url,
             path: url.pathname,
-            properties: {
-              ...requestAnalyticsProperties,
+            properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
+              requestProperties: requestAnalyticsProperties,
               handled: false,
-              payloadKeys: Object.keys(parsed.data.payload),
-              hasContext: Boolean(parsed.data.context),
-            },
+            }),
           });
           return Response.json({ ok: true, handled: false }, { status: 202 });
         }
@@ -4261,12 +4288,10 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           source: "server",
           url: request.url,
           path: url.pathname,
-          properties: {
-            ...requestAnalyticsProperties,
+          properties: buildAgentFeedbackAnalyticsProperties(parsed.data, {
+            requestProperties: requestAnalyticsProperties,
             handled: true,
-            payloadKeys: Object.keys(parsed.data.payload),
-            hasContext: Boolean(parsed.data.context),
-          },
+          }),
         });
         return Response.json({ ok: true, handled: true }, { status: 201 });
       }

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -89,6 +89,25 @@ function buildFeedbackPayload(
   };
 }
 
+function buildFeedbackAnalyticsProperties(data: DocsFeedbackData) {
+  return {
+    feedbackKind: "page",
+    value: data.value,
+    feedbackValue: data.value,
+    comment: data.comment,
+    feedbackComment: data.comment,
+    hasComment: Boolean(data.comment),
+    commentLength: data.comment?.length ?? 0,
+    title: data.title,
+    description: data.description,
+    url: data.url,
+    pathname: data.pathname,
+    path: data.path,
+    entry: data.entry,
+    slug: data.slug,
+  };
+}
+
 function ThumbUpIcon() {
   return (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -160,13 +179,22 @@ export function DocsFeedback({
     setSelected(value);
     if (status !== "idle") setStatus("idle");
     if (analytics) {
+      const slug = resolveSlug(entry, normalizedPathname);
       emitClientAnalyticsEvent({
         type: "feedback_select",
         locale,
         path: normalizedPathname,
+        input: {
+          feedbackValue: value,
+        },
         properties: {
+          feedbackKind: "page",
           value,
-          slug: resolveSlug(entry, normalizedPathname),
+          feedbackValue: value,
+          entry,
+          pathname: normalizedPathname,
+          path: normalizedPathname,
+          slug,
         },
       });
     }
@@ -176,21 +204,20 @@ export function DocsFeedback({
     if (!selected || status === "submitting") return;
 
     setStatus("submitting");
+    const payload = buildFeedbackPayload(selected, normalizedPathname, entry, comment, locale);
 
     try {
-      const payload = buildFeedbackPayload(selected, normalizedPathname, entry, comment, locale);
       await emitFeedback(payload, onFeedback);
       if (analytics) {
         emitClientAnalyticsEvent({
           type: "feedback_submit",
           locale,
           path: normalizedPathname,
-          properties: {
-            value: payload.value,
-            slug: payload.slug,
-            hasComment: Boolean(payload.comment),
-            commentLength: payload.comment?.length ?? 0,
+          input: {
+            feedbackValue: payload.value,
+            feedbackComment: payload.comment,
           },
+          properties: buildFeedbackAnalyticsProperties(payload),
         });
       }
       setStatus("submitted");
@@ -200,12 +227,11 @@ export function DocsFeedback({
           type: "feedback_error",
           locale,
           path: normalizedPathname,
-          properties: {
-            value: selected,
-            slug: resolveSlug(entry, normalizedPathname),
-            hasComment: Boolean(comment.trim()),
-            commentLength: comment.trim().length,
+          input: {
+            feedbackValue: payload.value,
+            feedbackComment: payload.comment,
           },
+          properties: buildFeedbackAnalyticsProperties(payload),
         });
       }
       setStatus("error");

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -94,8 +94,6 @@ function buildFeedbackAnalyticsProperties(data: DocsFeedbackData) {
     feedbackKind: "page",
     value: data.value,
     feedbackValue: data.value,
-    comment: data.comment,
-    feedbackComment: data.comment,
     hasComment: Boolean(data.comment),
     commentLength: data.comment?.length ?? 0,
     title: data.title,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enriched analytics for page and agent feedback with structured properties and context metadata. Adds `feedbackKind`, payload key counts, and client input fields to simplify downstream processing.

- **New Features**
  - `docs-api`: Added `buildAgentFeedbackAnalyticsProperties` for agent feedback with `feedbackKind: "agent"`, `agentFeedbackContext`, `contextPage/Url/Slug/Locale/Source`, `payloadKeys`, `payloadFieldCount`, `hasContext`, `hasPayload`, and optional `handled`, `reason`, `error`. Applied to invalid body/payload, unhandled, and handled paths; raw payload values are not logged.
  - `docs-feedback`: Added `buildFeedbackAnalyticsProperties` for page feedback with `feedbackKind: "page"`, `value`/`feedbackValue`, `hasComment`, `commentLength`, `title`, `description`, `url`, `pathname`, `path`, `entry`, `slug`. `feedback_select` and submit/error events now include `input.feedbackValue` and `input.feedbackComment`.
  - Types: Extended analytics input with `feedbackContext`, `feedbackPayload`, `agentFeedbackContext`, and `agentFeedbackPayload`.

<sup>Written for commit e8bd217eb72be0f9e163755fb1b8c426a5a56efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

