### PR TITLE
docs: knowledge drift sync

### DIFF
--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -773,8 +773,13 @@ NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
 Keep local env files out of git and set the same env names in production or CI. When ready, run:
 
 ```bash title="terminal"
+pnpm dlx @farming-labs/docs cloud check --deploy --analytics --ask-ai
 pnpm dlx @farming-labs/docs deploy
 ```
+
+The check command verifies the generated `docs.json`, deploy key scope, Cloud analytics project id,
+Ask AI provider wiring, and any required browser CORS preflights before the deploy command requests a
+hosted preview.
 
 ### Optional i18n scaffold
 

--- a/website/app/docs/cloud/analytics/page.mdx
+++ b/website/app/docs/cloud/analytics/page.mdx
@@ -43,6 +43,7 @@ the runtime environment:
 
 ```bash title=".env.local"
 NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+# Use DOCS_CLOUD_PROJECT_ID instead when only the server runtime needs the id.
 ```
 
 Keep using the dashboard-provided ID. Do not invent one locally; the ID must match an imported
@@ -57,6 +58,10 @@ NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED=false
 
 Only set `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT` when the docs app should send events to a
 custom or self-hosted Docs Cloud API. The hosted Docs Cloud endpoint is the default.
+
+If your Cloud workspace issues a dedicated analytics key, set
+`NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY` for browser delivery or `DOCS_CLOUD_ANALYTICS_KEY` for
+server-only delivery. The project ID is still required; the key only authenticates the event write.
 
 ## Runtime Contract
 
@@ -146,10 +151,16 @@ Docs Cloud stores event fields that are useful for dashboard queries:
 | Event shape | type, source, timestamp |
 | Page context | URL, path, referrer, locale |
 | Optional payloads | input, properties |
+| Agent traffic hints | `trafficType`, `agentName`, `botProvider` when Cloud can infer an agent or bot source |
 | Timing | event time, received time |
 
 The dashboard can use those fields for totals, recent event lists, source filters, event type
 filters, repository filters, and activity charts.
+
+Agent-readable routes and MCP events are marked as agent traffic when the runtime can infer that from
+the event source, event type, explicit properties, or known AI crawler user agents. That lets the
+dashboard separate human docs usage from ChatGPT, Codex, Copilot, Claude, MCP clients, and crawler
+activity without requiring a custom `onEvent` callback.
 
 ## Failure Behavior
 

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -139,6 +139,13 @@ pnpm dlx @farming-labs/docs cloud check --ask-ai
 pnpm dlx @farming-labs/docs cloud check --deploy
 ```
 
+`--ask-ai` checks the Docs Cloud provider path end to end. Direct browser mode needs
+`NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe
+`cloud.apiKey.env`; the check also sends a browser-style CORS preflight to the hosted knowledge
+endpoint. If only the server-side project id and API key are available, the report marks the local
+docs API route as the proxy path and skips browser CORS for Ask AI because the browser only talks to
+the same-origin docs app.
+
 Example focused report:
 
 ```txt title="terminal"
@@ -174,6 +181,9 @@ pnpm dlx @farming-labs/docs deploy --json
 | `pnpm dlx @farming-labs/docs cloud check --analytics` | You only want to validate Docs Cloud analytics wiring and analytics CORS |
 | `pnpm dlx @farming-labs/docs cloud check --ask-ai` | You only want to validate Docs Cloud Ask AI endpoint wiring and Ask AI CORS |
 | `pnpm dlx @farming-labs/docs cloud check --deploy` | You only want to validate deploy flags, API key presence, and deploy scopes |
+| `pnpm dlx @farming-labs/docs cloud check --json` | CI or automation needs the full check result as JSON |
+| `pnpm dlx @farming-labs/docs cloud check --no-network` | You only want local config, env, and docs.json checks |
+| `pnpm dlx @farming-labs/docs cloud check --api-key-env <name>` | The deploy key lives in a custom env var |
 | `pnpm dlx @farming-labs/docs deploy` | You want to sync, validate the key, and request a preview |
 | `pnpm dlx @farming-labs/docs cloud deploy` | You prefer the explicit Cloud namespace |
 | `pnpm dlx @farming-labs/docs deploy --json` | CI needs machine-readable output |

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -170,10 +170,20 @@ NEXT_PUBLIC_DOCS_CLOUD_API_KEY=fl_key_...
 ```
 
 `provider: "docs-cloud"` keeps OpenAI, Anthropic, embeddings, and retrieval credentials on the
-Docs Cloud server. The Ask AI widget sends the user's question directly to
-`/v1/projects/{projectId}/knowledge/ask` using the configured project-scoped Docs Cloud API key and
-reads an OpenAI-compatible event stream. Streaming is enabled by default for Docs Cloud; set
+Docs Cloud server. The Ask AI widget resolves one of two request paths:
+
+| Available runtime env | Request path | Use it when |
+| --------------------- | ------------ | ----------- |
+| `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe `cloud.apiKey.env` | The browser posts directly to `/v1/projects/{projectId}/knowledge/ask` with the project-scoped Docs Cloud API key | You want the lowest-latency Cloud path and the key is safe to expose to the browser |
+| `DOCS_CLOUD_PROJECT_ID` plus the server env named by `cloud.apiKey.env` | The browser posts to the local docs API route and the server proxies the Docs Cloud request | You want the API key to stay server-only or you need same-origin browser requests |
+
+The local docs API route is also the fallback when the project id or API key is not available to the
+browser. In both paths, Docs Cloud reads the same project knowledge index and returns either an
+OpenAI-compatible event stream or a JSON answer. Streaming is enabled by default for Docs Cloud; set
 `stream: false` if you need a single JSON answer.
+
+For staging or self-hosted Cloud APIs, direct browser requests read `NEXT_PUBLIC_DOCS_CLOUD_URL`.
+Server-routed requests read `DOCS_CLOUD_API_URL` first, then `NEXT_PUBLIC_DOCS_CLOUD_URL`.
 
 ## Configuration Reference
 
@@ -272,6 +282,10 @@ ai: {
   stream: true,
 }
 ```
+
+Streaming answers render as markdown while tokens arrive. Headings, tables, lists, horizontal rules,
+inline code, and fenced code blocks stay readable during the stream; fenced code blocks render with a
+language label and copy button.
 
 ### `model`
 

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -71,13 +71,22 @@ interface DocsAnalyticsEvent {
   input?: {
     query?: string;
     question?: string;
+    feedbackValue?: string;
     feedbackComment?: string;
+    feedbackContext?: Record<string, unknown>;
+    feedbackPayload?: Record<string, unknown>;
+    agentFeedbackContext?: Record<string, unknown>;
+    agentFeedbackPayload?: Record<string, unknown>;
     content?: string;
   };
   metadata?: Record<string, unknown>;
   properties?: Record<string, unknown>;
 }
 ```
+
+`properties` carries safe operational details such as status, durations, result counts, model ids,
+provider names, message counts, content lengths, and route or delivery metadata. Raw user-authored
+text stays in `input` and is excluded unless `includeInputs: true` is set.
 
 ## Event Types
 
@@ -118,6 +127,7 @@ whether the action completed.
 | `api_ai_response`               | The docs API returned a successful Ask AI response.                     |
 | `api_ai_error`                  | The docs API rejected or failed an Ask AI request.                      |
 | `agent_read`                    | A page was read through a machine-readable docs surface.                |
+| `agents_request`                | An agent-facing generated instruction file was requested.               |
 | `markdown_request`              | A markdown route or API markdown request was served.                    |
 | `llms_request`                  | `/llms.txt` or `/llms-full.txt` was requested.                          |
 | `skill_request`                 | An Agent Skills file or skill index was requested.                      |
@@ -130,6 +140,10 @@ whether the action completed.
 
 `agent_read` includes `properties.delivery` so you can see how the page was read: `md_route`,
 `accept_header`, `signature_agent`, `user_agent`, `heuristic`, `api_format`, or `mcp_tool`.
+
+Ask AI API events include the provider, model, message count, question length, status or error
+reason, and `durationMs` when available. When `ai.provider` is `"docs-cloud"`, those events identify
+the provider as `docs-cloud` even if the request is served through the local docs API proxy.
 
 ## Input Privacy
 


### PR DESCRIPTION
## Summary
- Update existing docs pages instead of adding a standalone drift report.
- Document Docs Cloud Ask AI direct-vs-proxy routing, streaming markdown behavior, and Cloud check validation.
- Update analytics docs for richer callback payloads, Docs Cloud event storage, and inferred agent traffic hints.
- Add the Cloud check step to the CLI init flow before hosted preview deploys.

## Drift window
Based on the last-7-day change window from 79ee6122d190ff4218de0173386c59e349785661 to 227867e8ef9e004227bd65c6c01cecaa27f7cf4c, covering June 4-11, 2026. The user-facing updates map to the merged changes for Cloud onboarding (#242), Docs Cloud Ask AI provider and streaming specs (#244), Cloud check/doctor CLI (#245), CORS and proxy knowledge endpoint support (#246), streaming markdown rendering (#247/#248), and rich analytics payloads (#249).

## Validation
- git diff --check
- pnpm install --frozen-lockfile

Note: oxfmt 0.35 was installed and invoked against the edited MDX files, but this formatter build did not select MDX targets, so the applicable formatting validation here is git diff --check.

Generated via docs-cloud.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs docs with recent Cloud changes: Ask AI now documents direct vs proxy routing, streaming markdown behavior, richer analytics payloads and keys, agent traffic hints, and a new `cloud check` step before deploys.

- **New Features**
  - Added `pnpm dlx @farming-labs/docs cloud check` before deploys; validates `docs.json`, deploy key scope, analytics project id, Ask AI wiring, and CORS. New flags: `--ask-ai`, `--analytics`, `--deploy`, `--json`, `--no-network`, `--api-key-env`.
  - Clarified Ask AI routing: browser-direct when `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` + a browser-safe API key are present; otherwise use server proxy with `DOCS_CLOUD_PROJECT_ID`. CORS checks run for direct mode. Direct reads `NEXT_PUBLIC_DOCS_CLOUD_URL`; server routing prefers `DOCS_CLOUD_API_URL`, then `NEXT_PUBLIC_DOCS_CLOUD_URL`.
  - Streaming answers render readable markdown as tokens arrive, including labeled, copyable fenced code blocks.
  - Analytics docs now cover server-only `DOCS_CLOUD_PROJECT_ID`, optional `NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY`/`DOCS_CLOUD_ANALYTICS_KEY`, richer `properties` vs `input` guidance, stored agent traffic hints (`trafficType`, `agentName`, `botProvider`), and the new `agents_request` event. Provider appears as `docs-cloud` even when proxied through the local docs API.

<sup>Written for commit a0da55ce39fb09562b732a83f1abd4cb898d51ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

