### PR TITLE
fix: docs layout hyration style leak

### DIFF
--- a/examples/sveltekit/src/app.css
+++ b/examples/sveltekit/src/app.css
@@ -1,1 +1,12 @@
 @import "@farming-labs/svelte-theme/hardline/css";
+
+html,
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+body {
+  background: #0b0b0c;
+  color: #f4f1e8;
+}

--- a/packages/svelte-theme/src/components/DocsLayout.svelte
+++ b/packages/svelte-theme/src/components/DocsLayout.svelte
@@ -194,7 +194,7 @@
       vars.push(`${COLOR_MAP[key]}: ${value};`);
     }
     if (vars.length === 0) return "";
-    return `.dark {\n  ${vars.join("\n  ")}\n}`;
+    return `html.dark body:has(#nd-docs-layout),\nbody.dark:has(#nd-docs-layout),\nbody:has(#nd-docs-layout.dark),\n:is(html.dark, body.dark) #nd-docs-layout,\n#nd-docs-layout.dark {\n  ${vars.join("\n  ")}\n}`;
   }
 
   function buildFontStyleVars(prefix, style) {
@@ -221,7 +221,7 @@
       }
     }
     if (vars.length === 0) return "";
-    return `:root {\n  ${vars.join("\n  ")}\n}`;
+    return `body:has(#nd-docs-layout),\n#nd-docs-layout {\n  ${vars.join("\n  ")}\n}`;
   }
 
   function buildLayoutCSS(layout) {
@@ -233,8 +233,8 @@
     if (layout.tocWidth) desktopVars.push(`--fd-toc-width: ${layout.tocWidth}px;`);
     if (rootVars.length === 0 && desktopVars.length === 0) return "";
     const parts = [];
-    if (rootVars.length > 0) parts.push(`:root {\n  ${rootVars.join("\n  ")}\n}`);
-    if (desktopVars.length > 0) parts.push(`@media (min-width: 1024px) {\n  :root {\n    ${desktopVars.join("\n    ")}\n  }\n}`);
+    if (rootVars.length > 0) parts.push(`#nd-docs-layout {\n  ${rootVars.join("\n  ")}\n}`);
+    if (desktopVars.length > 0) parts.push(`@media (min-width: 1024px) {\n  #nd-docs-layout {\n    ${desktopVars.join("\n    ")}\n  }\n}`);
     return parts.join("\n");
   }
 
@@ -259,7 +259,7 @@
   {/if}
 </svelte:head>
 
-<div class="fd-layout">
+<div id="nd-docs-layout" class="fd-layout">
   <!-- Mobile header -->
   <header class="fd-header">
     <button class="fd-menu-btn" onclick={toggleSidebar} aria-label="Toggle sidebar">
@@ -505,19 +505,19 @@
   <main class="fd-main">
     {@render children()}
   </main>
+
+  {#if showFloatingAI}
+    <FloatingAIChat
+      api={localizedApi}
+      suggestedQuestions={config.ai.suggestedQuestions ?? []}
+      aiLabel={config.ai.aiLabel ?? "AI"}
+      position={config.ai.position ?? "bottom-right"}
+      floatingStyle={config.ai.floatingStyle ?? "panel"}
+      {triggerComponent}
+    />
+  {/if}
+
+  {#if showSearch && searchOpen}
+    <SearchDialog onclose={closeSearch} />
+  {/if}
 </div>
-
-{#if showFloatingAI}
-  <FloatingAIChat
-    api={localizedApi}
-    suggestedQuestions={config.ai.suggestedQuestions ?? []}
-    aiLabel={config.ai.aiLabel ?? "AI"}
-    position={config.ai.position ?? "bottom-right"}
-    floatingStyle={config.ai.floatingStyle ?? "panel"}
-    {triggerComponent}
-  />
-{/if}
-
-{#if showSearch && searchOpen}
-  <SearchDialog onclose={closeSearch} />
-{/if}

--- a/packages/svelte-theme/styles/colorful.css
+++ b/packages/svelte-theme/styles/colorful.css
@@ -5,13 +5,18 @@
 
 /* ─── Colorful yellow accent overrides ────────────────────────────── */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: hsl(40, 96%, 40%);
   --color-fd-primary-foreground: hsl(0, 0%, 100%);
   --color-fd-ring: hsl(40, 80%, 50%);
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: hsl(45, 100%, 60%);
   --color-fd-primary-foreground: hsl(0, 0%, 5%);
   --color-fd-ring: hsl(45, 90%, 55%);
@@ -19,7 +24,7 @@
 
 /* ─── Description under title ──────────────────────────────────────── */
 
-.fd-page-description {
+#nd-docs-layout .fd-page-description {
   margin-bottom: 1rem;
   font-size: 1.125rem;
   line-height: 1.75;
@@ -28,7 +33,8 @@
 
 /* ─── Sidebar dark overrides (fumadocs neutral) ────────────────────── */
 
-.dark .fd-sidebar {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar,
+#nd-docs-layout.dark .fd-sidebar {
   --color-fd-muted: hsl(0, 0%, 16%);
   --color-fd-secondary: hsl(0, 0%, 18%);
   --color-fd-muted-foreground: hsl(0, 0%, 72%);
@@ -36,7 +42,7 @@
 
 /* ─── Cards (fumadocs style) ────────────────────────────────────────── */
 
-.fd-card {
+#nd-docs-layout .fd-card {
   display: block;
   border-radius: 0.75rem;
   border: 1px solid var(--color-fd-border);
@@ -50,11 +56,11 @@
     border-color 150ms;
 }
 
-.fd-card:hover {
+#nd-docs-layout .fd-card:hover {
   background: var(--color-fd-accent);
 }
 
-.fd-card-icon {
+#nd-docs-layout .fd-card-icon {
   margin-bottom: 0.5rem;
   width: fit-content;
   border-radius: 0.375rem;
@@ -63,48 +69,48 @@
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-card-title {
+#nd-docs-layout .fd-card-title {
   font-weight: 500;
 }
 
-.fd-card-description {
+#nd-docs-layout .fd-card-description {
   color: var(--color-fd-muted-foreground);
   margin-top: 0.25rem;
 }
 
-.fd-cards {
+#nd-docs-layout .fd-cards {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
 }
 
 @media (min-width: 640px) {
-  .fd-cards {
+  #nd-docs-layout .fd-cards {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 /* ─── Omni Command Palette — colorful theme ────────────────────────── */
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border-radius: 0.75rem;
 }
 
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   background: color-mix(in srgb, var(--color-fd-primary) 15%, transparent);
 }
 
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary) 30%, transparent);
 }
 
-.omni-search-input:focus {
+#nd-docs-layout .omni-search-input:focus {
   caret-color: var(--color-fd-primary);
 }
 
 /* ─── Sidebar AI trigger (sidebar-icon mode) — search + Ask AI row ───── */
 
-.fd-sidebar-search-ai-row {
+#nd-docs-layout .fd-sidebar-search-ai-row {
   display: flex;
   gap: 10px;
   align-items: stretch;
@@ -112,7 +118,7 @@
   margin-bottom: 2px;
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-search-btn {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -128,18 +134,18 @@
   transition: background-color 150ms, border-color 150ms, color 150ms;
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-search-btn:hover {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-search-btn svg {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-search-btn svg {
   flex-shrink: 0;
   width: 16px;
   height: 16px;
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-search-kbd {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-search-kbd {
   display: flex;
   gap: 2px;
   margin-left: auto;
@@ -147,7 +153,7 @@
   opacity: 0.8;
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-search-kbd kbd {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-search-kbd kbd {
   font-family: inherit;
   font-size: 0.7rem;
   padding: 2px 5px;
@@ -156,7 +162,7 @@
   background: var(--color-fd-muted);
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-ai-btn {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-ai-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -171,40 +177,45 @@
   transition: background-color 150ms, color 150ms, border-color 150ms;
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-ai-btn:hover {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-primary);
   border-color: var(--color-fd-primary);
 }
 
-.fd-sidebar-search-ai-row .fd-sidebar-ai-btn svg {
+#nd-docs-layout .fd-sidebar-search-ai-row .fd-sidebar-ai-btn svg {
   width: 16px;
   height: 16px;
 }
 
-.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn {
   background: var(--color-fd-secondary);
   border-color: var(--color-fd-border);
   color: var(--color-fd-muted-foreground);
 }
 
-.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn:hover,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
-.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-kbd kbd {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-kbd kbd,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-search-kbd kbd {
   background: var(--color-fd-muted);
   border-color: var(--color-fd-border);
 }
 
-.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn {
   background: var(--color-fd-secondary);
   border-color: var(--color-fd-border);
   color: var(--color-fd-muted-foreground);
 }
 
-.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn:hover,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-ai-row .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-primary);
   border-color: var(--color-fd-primary);
@@ -212,7 +223,7 @@
 
 /* ─── Page Actions — colorful theme ────────────────────────────────── */
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   border-radius: 0.375rem !important;
   font-size: 0.8125rem !important;
   letter-spacing: normal !important;
@@ -221,37 +232,37 @@
   font-family: var(--fd-font-sans, ui-sans-serif, system-ui, sans-serif) !important;
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative !important;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   border-radius: 0.5rem !important;
   border: 1px solid var(--color-fd-border) !important;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2) !important;
   background: var(--color-fd-popover) !important;
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   border-radius: 0.25rem !important;
   font-size: 0.8125rem !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   background: var(--color-fd-accent) !important;
   color: var(--color-fd-accent-foreground) !important;
 }
 
 /* ─── Page nav cards ───────────────────────────────────────────────── */
 
-.fd-page-nav-card {
+#nd-docs-layout .fd-page-nav-card {
   border-radius: 0.75rem;
 }
 
 /* ─── Inline code ──────────────────────────────────────────────────── */
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   padding: 3px;
   border: 1px solid var(--color-fd-border);
   font-size: 13px;
@@ -261,7 +272,7 @@
 
 /* ─── Links in prose ───────────────────────────────────────────────── */
 
-.fd-docs-content a:not(.fd-page-nav-card):not([class]) {
+#nd-docs-layout .fd-docs-content a:not(.fd-page-nav-card):not([class]) {
   text-decoration: underline;
   text-underline-offset: 3.5px;
   text-decoration-color: var(--color-fd-primary);
@@ -271,7 +282,7 @@
 
 /* ─── Tables (rounded) ─────────────────────────────────────────────── */
 
-.fd-docs-content table {
+#nd-docs-layout .fd-docs-content table {
   border-collapse: separate;
   border-spacing: 0;
   background: var(--color-fd-card);
@@ -280,66 +291,66 @@
   overflow: hidden;
 }
 
-.fd-docs-content th {
+#nd-docs-layout .fd-docs-content th {
   background: var(--color-fd-muted);
   font-weight: 600;
 }
 
-.fd-docs-content th,
-.fd-docs-content td {
+#nd-docs-layout .fd-docs-content th,
+#nd-docs-layout .fd-docs-content td {
   padding: 0.625rem;
   border-bottom: 1px solid var(--color-fd-border);
 }
 
-.fd-docs-content tr:last-child td {
+#nd-docs-layout .fd-docs-content tr:last-child td {
   border-bottom: none;
 }
 
 /* ─── Blockquotes ──────────────────────────────────────────────────── */
 
-.fd-docs-content blockquote {
+#nd-docs-layout .fd-docs-content blockquote {
   border-left: 2px solid var(--color-fd-primary);
   padding-left: 1rem;
   color: var(--color-fd-foreground);
   font-style: normal;
 }
 
-.fd-docs-content hr {
+#nd-docs-layout .fd-docs-content hr {
   border-color: var(--color-fd-border);
 }
 
 /* ─── Ask AI button (floating + custom trigger) — sync with Next.js ───── */
 
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-floating-btn {
   border-radius: 26px;
   box-shadow: 0 8px 32px rgba(180, 140, 20, 0.3);
 }
 
-.fd-ai-floating-btn:hover {
+#nd-docs-layout .fd-ai-floating-btn:hover {
   box-shadow: 0 10px 40px rgba(180, 140, 20, 0.4);
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger {
   font-family: var(--fd-font-sans, inherit);
   border-radius: 26px !important;
   box-shadow: 0 8px 32px rgba(180, 140, 20, 0.3) !important;
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover {
   box-shadow: 0 10px 40px rgba(180, 140, 20, 0.4);
 }
 
 /* ─── Feedback (colorful theme) ──────────────────────────────────── */
 
-.fd-feedback-input,
-.fd-feedback-submit {
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit {
   border-radius: 0.5rem;
 }
 
-.fd-feedback-choice[data-selected="true"] {
+#nd-docs-layout .fd-feedback-choice[data-selected="true"] {
   background: color-mix(in srgb, var(--color-fd-primary) 12%, var(--color-fd-secondary));
 }
 
-.fd-feedback-status[data-status="success"] {
+#nd-docs-layout .fd-feedback-status[data-status="success"] {
   color: var(--color-fd-primary);
 }

--- a/packages/svelte-theme/styles/command-grid-bundle.css
+++ b/packages/svelte-theme/styles/command-grid-bundle.css
@@ -1,7 +1,8 @@
 /* @farming-labs/theme - command-grid theme CSS */
 @import "./concrete.css";
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #141414;
   --color-fd-primary-foreground: #f8f6ed;
   --color-fd-ring: #141414;
@@ -24,7 +25,11 @@
   --fd-nav-height: 64px;
 }
 
-:is(html.dark, body.dark) {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #f8f6ed;
   --color-fd-primary-foreground: #121212;
   --color-fd-ring: #f8f6ed;
@@ -44,7 +49,8 @@
   --color-fd-border: #f8f6ed;
 }
 
-body:has(#nd-docs-layout) {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   background: var(--color-fd-background);
   background-image:
     linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
@@ -53,120 +59,124 @@ body:has(#nd-docs-layout) {
   background-attachment: fixed;
 }
 
-:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   background-image:
     linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
     linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
 }
 
 #nd-docs-layout > header,
-[role="banner"] {
+#nd-docs-layout [role="banner"] {
   border-bottom: 4px solid var(--color-fd-border) !important;
   background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
   backdrop-filter: blur(8px);
   box-shadow: none !important;
 }
 
-aside#nd-sidebar {
+#nd-docs-layout aside#nd-sidebar {
   border-right: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-background) !important;
 }
 
-aside#nd-sidebar,
-.fd-sidebar {
+#nd-docs-layout aside#nd-sidebar,
+#nd-docs-layout .fd-sidebar {
   color: var(--color-fd-foreground);
 }
 
-aside#nd-sidebar [data-radix-scroll-area-viewport],
-aside#nd-sidebar [data-radix-scroll-area-content],
-aside#nd-sidebar .fd-sidebar {
+#nd-docs-layout aside#nd-sidebar [data-radix-scroll-area-viewport],
+#nd-docs-layout aside#nd-sidebar [data-radix-scroll-area-content],
+#nd-docs-layout aside#nd-sidebar .fd-sidebar {
   background: transparent !important;
 }
 
-aside#nd-sidebar > *,
-.fd-sidebar > * {
+#nd-docs-layout aside#nd-sidebar > *,
+#nd-docs-layout .fd-sidebar > * {
   background: transparent;
 }
 
-aside a[data-active],
-aside button[data-active],
-.fd-sidebar a,
-.fd-sidebar button {
+#nd-docs-layout aside a[data-active],
+#nd-docs-layout aside button[data-active],
+#nd-docs-layout .fd-sidebar a,
+#nd-docs-layout .fd-sidebar button {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.77rem;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+#nd-docs-layout aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout .fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout .fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
   border: 2px solid transparent;
   border-radius: 0 !important;
   min-height: 2.9rem;
 }
 
-aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+#nd-docs-layout aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout .fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout .fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
   background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
   color: var(--color-fd-foreground) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-aside#nd-sidebar a.inline-flex,
-.fd-sidebar a.inline-flex {
+#nd-docs-layout aside#nd-sidebar a.inline-flex,
+#nd-docs-layout .fd-sidebar a.inline-flex {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   font-size: 0.92rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-aside [data-active="false"] {
+#nd-docs-layout aside [data-active="false"] {
   color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
 }
 
-aside a[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"] {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-aside div.overflow-hidden.relative[data-state]::before {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state]::before {
   inset-inline-start: 1.125rem !important;
 }
 
-aside div.overflow-hidden.relative[data-state] a[data-active] {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state] a[data-active] {
   padding-inline-start: 1.75rem !important;
 }
 
-aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   inset-inline-start: 1.125rem !important;
 }
 
-#nd-toc {
+#nd-docs-layout #nd-toc {
   border-left: 2px solid var(--color-fd-border) !important;
   padding-left: 1rem;
   background: transparent !important;
 }
 
-#toc-title,
-.fd-toc-link,
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout #toc-title,
+#nd-docs-layout .fd-toc-link,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   text-transform: uppercase;
 }
 
-#toc-title {
+#nd-docs-layout #toc-title {
   letter-spacing: 0.16em;
   font-size: 0.72rem;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }
 
-.fd-toc-link,
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout .fd-toc-link,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   letter-spacing: 0.08em;
   font-size: 0.72rem;
   border-left: 2px solid transparent;
@@ -174,27 +184,27 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
 }
 
-.fd-toc-link:hover,
-.fd-toc-clerk .fd-toc-link:hover {
+#nd-docs-layout .fd-toc-link:hover,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link:hover {
   border-left-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
   color: var(--color-fd-foreground);
 }
 
-.fd-toc-link-active,
-.fd-toc-clerk .fd-toc-link[data-active="true"] {
+#nd-docs-layout .fd-toc-link-active,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link[data-active="true"] {
   border-left-color: var(--color-fd-foreground);
   color: var(--color-fd-foreground);
 }
 
-.fd-page-title,
-#nd-page > h1,
-.fd-docs-content article h1,
-#nd-page h1,
-.fd-docs-content h1,
-.fd-docs-content article h2,
-#nd-page h2,
-.fd-docs-content h2 {
+#nd-docs-layout .fd-page-title,
+#nd-docs-layout #nd-page > h1,
+#nd-docs-layout .fd-docs-content article h1,
+#nd-docs-layout #nd-page h1,
+#nd-docs-layout .fd-docs-content h1,
+#nd-docs-layout .fd-docs-content article h2,
+#nd-docs-layout #nd-page h2,
+#nd-docs-layout .fd-docs-content h2 {
   max-width: none;
   font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
   font-weight: 400 !important;
@@ -203,34 +213,34 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-page-title,
-#nd-page > h1,
-.fd-docs-content article h1,
-#nd-page h1,
-.fd-docs-content h1 {
+#nd-docs-layout .fd-page-title,
+#nd-docs-layout #nd-page > h1,
+#nd-docs-layout .fd-docs-content article h1,
+#nd-docs-layout #nd-page h1,
+#nd-docs-layout .fd-docs-content h1 {
   font-size: clamp(3.1rem, 7vw, 5.75rem);
   letter-spacing: 0.04em;
   text-wrap: balance;
   margin-bottom: 0.9rem;
 }
 
-.fd-docs-content article h2,
-#nd-page h2,
-.fd-docs-content h2 {
+#nd-docs-layout .fd-docs-content article h2,
+#nd-docs-layout #nd-page h2,
+#nd-docs-layout .fd-docs-content h2 {
   font-size: clamp(2rem, 4vw, 3.25rem);
   letter-spacing: 0.045em;
   margin-top: 3rem;
   margin-bottom: 1rem;
 }
 
-.fd-page-title > a,
-#nd-page > h1 > a,
-.fd-docs-content article h1 > a,
-#nd-page h1 > a,
-.fd-docs-content h1 > a,
-.fd-docs-content article h2 > a,
-#nd-page h2 > a,
-.fd-docs-content h2 > a {
+#nd-docs-layout .fd-page-title > a,
+#nd-docs-layout #nd-page > h1 > a,
+#nd-docs-layout .fd-docs-content article h1 > a,
+#nd-docs-layout #nd-page h1 > a,
+#nd-docs-layout .fd-docs-content h1 > a,
+#nd-docs-layout .fd-docs-content article h2 > a,
+#nd-docs-layout #nd-page h2 > a,
+#nd-docs-layout .fd-docs-content h2 > a {
   font-family: inherit !important;
   font-size: inherit !important;
   font-weight: inherit !important;
@@ -239,39 +249,39 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   line-height: inherit !important;
 }
 
-.fd-docs-content article h3,
-#nd-page h3,
-.fd-docs-content h3,
-.fd-docs-content article h4,
-#nd-page h4,
-.fd-docs-content h4 {
+#nd-docs-layout .fd-docs-content article h3,
+#nd-docs-layout #nd-page h3,
+#nd-docs-layout .fd-docs-content h3,
+#nd-docs-layout .fd-docs-content article h4,
+#nd-docs-layout #nd-page h4,
+#nd-docs-layout .fd-docs-content h4 {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
 }
 
-.fd-docs-content h3 {
+#nd-docs-layout .fd-docs-content h3 {
   font-size: 0.96rem;
   margin-top: 2rem;
   margin-bottom: 0.8rem;
 }
 
-.fd-docs-content h4 {
+#nd-docs-layout .fd-docs-content h4 {
   font-size: 0.82rem;
   margin-top: 1.6rem;
   margin-bottom: 0.7rem;
 }
 
-.fd-page-description,
-.fd-docs-content p,
-.fd-docs-content li,
-.fd-docs-content td,
-.fd-docs-content blockquote {
+#nd-docs-layout .fd-page-description,
+#nd-docs-layout .fd-docs-content p,
+#nd-docs-layout .fd-docs-content li,
+#nd-docs-layout .fd-docs-content td,
+#nd-docs-layout .fd-docs-content blockquote {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-page-description {
+#nd-docs-layout .fd-page-description {
   color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -280,81 +290,81 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   max-width: 72ch;
 }
 
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn,
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card,
-.fd-page-body .fd-table-wrapper,
-.fd-docs-content table,
-.fd-tabs,
-.fd-tabs-list,
-.fd-tabs-trigger,
-.fd-feedback-input,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-dialog,
-.fd-ai-fm-input-container,
-.fd-ai-fm-suggestion,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-menu,
-.fd-ai-model-dropdown-item,
-.fd-ai-floating-btn,
-.omni-content,
-.omni-item,
-.omni-item-ext,
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-page-body .fd-table-wrapper,
+#nd-docs-layout .fd-docs-content table,
+#nd-docs-layout .fd-tabs,
+#nd-docs-layout .fd-tabs-list,
+#nd-docs-layout .fd-tabs-trigger,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .omni-content,
+#nd-docs-layout .omni-item,
+#nd-docs-layout .omni-item-ext,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   box-shadow: none !important;
   border-radius: 0 !important;
 }
 
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn,
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card,
-.fd-feedback-input,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-dialog,
-.fd-ai-fm-input-container,
-.fd-ai-fm-suggestion,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-menu,
-.fd-ai-model-dropdown-item,
-.fd-ai-floating-btn,
-.omni-content,
-.omni-item,
-.omni-item-ext,
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .omni-content,
+#nd-docs-layout .omni-item,
+#nd-docs-layout .omni-item-ext,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   background-image: none !important;
 }
 
-.fd-page-action-btn,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-tab,
-.fd-copy-btn,
-.fd-ai-code-copy,
-.fd-ai-floating-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-fm-suggestion {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -365,37 +375,44 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
     transform 140ms ease !important;
 }
 
-aside a[data-active="true"],
-aside a[data-active="true"]:hover,
-.fd-page-action-btn:hover,
-.fd-page-action-btn[data-selected="true"],
-.fd-page-action-btn[data-copied="true"],
-.fd-feedback-choice:hover,
-.fd-feedback-choice[data-selected="true"],
-.fd-ai-tab[data-active="true"],
-.fd-copy-btn:hover,
-.fd-ai-code-copy:hover,
-.fd-sidebar-search-btn:hover,
-.fd-sidebar-ai-btn:hover,
-.fd-ai-floating-btn:hover,
-.fd-ai-model-dropdown-item:hover,
-.fd-ai-fm-suggestion:hover {
+#nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout aside a[data-active="true"]:hover,
+#nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout .fd-copy-btn:hover,
+#nd-docs-layout .fd-ai-code-copy:hover,
+#nd-docs-layout .fd-sidebar-search-btn:hover,
+#nd-docs-layout .fd-sidebar-ai-btn:hover,
+#nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item:hover,
+#nd-docs-layout .fd-ai-fm-suggestion:hover {
   box-shadow: none !important;
   transform: translateY(-2px);
 }
 
-.dark aside a[data-active="true"],
-.dark .fd-page-action-btn:hover,
-.dark .fd-page-action-btn[data-selected="true"],
-.dark .fd-page-action-btn[data-copied="true"],
-.dark .fd-feedback-choice:hover,
-.dark .fd-feedback-choice[data-selected="true"],
-.dark .fd-ai-tab[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout.dark aside a[data-active="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout.dark .fd-page-action-btn:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-copied="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout.dark .fd-feedback-choice:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout.dark .fd-feedback-choice[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout.dark .fd-ai-tab[data-active="true"] {
   box-shadow: none !important;
 }
 
-.fd-sidebar-search-btn,
-.fd-sidebar-ai-btn {
+#nd-docs-layout .fd-sidebar-search-btn,
+#nd-docs-layout .fd-sidebar-ai-btn {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-secondary) !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
@@ -404,21 +421,21 @@ aside a[data-active="true"]:hover,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-sidebar-search-btn:hover,
-.fd-sidebar-ai-btn:hover {
+#nd-docs-layout .fd-sidebar-search-btn:hover,
+#nd-docs-layout .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-.fd-sidebar-search-kbd,
-.fd-sidebar-search-kbd kbd {
+#nd-docs-layout .fd-sidebar-search-kbd,
+#nd-docs-layout .fd-sidebar-search-kbd kbd {
   color: inherit !important;
   border-color: currentColor !important;
 }
 
-button[data-search-full],
-[data-search-full] {
+#nd-docs-layout button[data-search-full],
+#nd-docs-layout [data-search-full] {
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-secondary) !important;
@@ -430,15 +447,15 @@ button[data-search-full],
   box-shadow: none !important;
 }
 
-button[data-search-full]:hover,
-[data-search-full]:hover {
+#nd-docs-layout button[data-search-full]:hover,
+#nd-docs-layout [data-search-full]:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-button[data-search-full] kbd,
-[data-search-full] kbd {
+#nd-docs-layout button[data-search-full] kbd,
+#nd-docs-layout [data-search-full] kbd {
   border: 1px solid currentColor !important;
   border-radius: 0 !important;
   background: transparent !important;
@@ -446,46 +463,46 @@ button[data-search-full] kbd,
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-ai-code-block {
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-ai-code-block {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   background-image: none !important;
 }
 
-.fd-codeblock-title,
-figure.shiki:has(figcaption) > div:first-child,
-.fd-ai-code-header {
+#nd-docs-layout .fd-codeblock-title,
+#nd-docs-layout figure.shiki:has(figcaption) > div:first-child,
+#nd-docs-layout .fd-ai-code-header {
   background: var(--color-fd-secondary) !important;
   border-bottom: 2px solid var(--color-fd-border) !important;
 }
 
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border: 2px solid var(--color-fd-border) !important;
 }
 
-.fd-copy-btn:hover,
-.fd-ai-code-copy:hover {
+#nd-docs-layout .fd-copy-btn:hover,
+#nd-docs-layout .fd-ai-code-copy:hover {
   background: var(--color-fd-card) !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-table-wrapper,
-.fd-table-wrapper table,
-.prose table {
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   border-radius: 0 !important;
 }
 
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a {
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a {
   transition:
     background-color 140ms ease,
     color 140ms ease,
@@ -493,8 +510,8 @@ figure.shiki:has(figcaption) > div:first-child,
     transform 140ms ease !important;
 }
 
-.fd-page-nav-card:hover,
-[class*="page-nav"] a:hover {
+#nd-docs-layout .fd-page-nav-card:hover,
+#nd-docs-layout [class*="page-nav"] a:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
@@ -502,53 +519,53 @@ figure.shiki:has(figcaption) > div:first-child,
   transform: none !important;
 }
 
-.fd-page-nav-card:hover *,
-[class*="page-nav"] a:hover * {
+#nd-docs-layout .fd-page-nav-card:hover *,
+#nd-docs-layout [class*="page-nav"] a:hover * {
   color: inherit !important;
 }
 
-.fd-table-wrapper {
+#nd-docs-layout .fd-table-wrapper {
   overflow: hidden;
 }
 
-.fd-table-wrapper table,
-.prose .fd-table-wrapper table {
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .prose .fd-table-wrapper table {
   border: 0 !important;
   background: transparent !important;
   border-radius: 0 !important;
 }
 
-.prose table,
-.prose thead,
-.prose tbody,
-.prose tr,
-.prose th,
-.prose td,
-.prose table *,
-.fd-table-wrapper,
-.fd-table-wrapper *,
-.fd-table-wrapper table,
-.fd-table-wrapper thead,
-.fd-table-wrapper tbody,
-.fd-table-wrapper tr,
-.fd-table-wrapper th,
-.fd-table-wrapper td {
+#nd-docs-layout .prose table,
+#nd-docs-layout .prose thead,
+#nd-docs-layout .prose tbody,
+#nd-docs-layout .prose tr,
+#nd-docs-layout .prose th,
+#nd-docs-layout .prose td,
+#nd-docs-layout .prose table *,
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-table-wrapper *,
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .fd-table-wrapper thead,
+#nd-docs-layout .fd-table-wrapper tbody,
+#nd-docs-layout .fd-table-wrapper tr,
+#nd-docs-layout .fd-table-wrapper th,
+#nd-docs-layout .fd-table-wrapper td {
   border-radius: 0 !important;
 }
 
-.prose thead tr:first-child th:first-child,
-.prose thead tr:first-child th:last-child,
-.prose tbody tr:last-child td:first-child,
-.prose tbody tr:last-child td:last-child,
-.fd-table-wrapper thead tr:first-child th:first-child,
-.fd-table-wrapper thead tr:first-child th:last-child,
-.fd-table-wrapper tbody tr:last-child td:first-child,
-.fd-table-wrapper tbody tr:last-child td:last-child {
+#nd-docs-layout .prose thead tr:first-child th:first-child,
+#nd-docs-layout .prose thead tr:first-child th:last-child,
+#nd-docs-layout .prose tbody tr:last-child td:first-child,
+#nd-docs-layout .prose tbody tr:last-child td:last-child,
+#nd-docs-layout .fd-table-wrapper thead tr:first-child th:first-child,
+#nd-docs-layout .fd-table-wrapper thead tr:first-child th:last-child,
+#nd-docs-layout .fd-table-wrapper tbody tr:last-child td:first-child,
+#nd-docs-layout .fd-table-wrapper tbody tr:last-child td:last-child {
   border-radius: 0 !important;
 }
 
-.prose th,
-.fd-table-wrapper th {
+#nd-docs-layout .prose th,
+#nd-docs-layout .fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
@@ -556,8 +573,8 @@ figure.shiki:has(figcaption) > div:first-child,
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-callout,
-[class*="fd-callout"] {
+#nd-docs-layout .fd-callout,
+#nd-docs-layout [class*="fd-callout"] {
   border: 2px solid var(--color-fd-border) !important;
   background: color-mix(
     in srgb,
@@ -567,160 +584,160 @@ figure.shiki:has(figcaption) > div:first-child,
   border-radius: 0 !important;
 }
 
-.fd-callout-indicator {
+#nd-docs-layout .fd-callout-indicator {
   width: 8px;
   background: var(--color-fd-accent) !important;
 }
 
-.fd-callout-title {
+#nd-docs-layout .fd-callout-title {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
 }
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   background: var(--color-fd-secondary);
 }
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
 }
 
-.omni-header,
-.omni-footer {
+#nd-docs-layout .omni-header,
+#nd-docs-layout .omni-footer {
   border-color: var(--color-fd-border) !important;
   background: var(--color-fd-secondary) !important;
 }
 
-.omni-search-input,
-.omni-item-label,
-.omni-item-subtitle,
-.omni-group-label,
-.omni-footer-inner,
-.omni-kbd,
-.omni-close-btn {
+#nd-docs-layout .omni-search-input,
+#nd-docs-layout .omni-item-label,
+#nd-docs-layout .omni-item-subtitle,
+#nd-docs-layout .omni-group-label,
+#nd-docs-layout .omni-footer-inner,
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-close-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.omni-group-label {
+#nd-docs-layout .omni-group-label {
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border: 1px solid transparent !important;
 }
 
-.omni-item:hover {
+#nd-docs-layout .omni-item:hover {
   border-color: var(--color-fd-border) !important;
 }
 
-.omni-kbd,
-.omni-close-btn,
-.omni-item-ext {
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-close-btn,
+#nd-docs-layout .omni-item-ext {
   border: 1px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: transparent !important;
 }
 
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-.omni-item-active .omni-item-icon,
-.omni-item-active .omni-item-badge,
-.omni-item-active .omni-item-ext,
-.omni-item-active .omni-item-chevron,
-.omni-item-active .omni-item-subtitle,
-.omni-item-active .omni-item-shortcuts {
+#nd-docs-layout .omni-item-active .omni-item-icon,
+#nd-docs-layout .omni-item-active .omni-item-badge,
+#nd-docs-layout .omni-item-active .omni-item-ext,
+#nd-docs-layout .omni-item-active .omni-item-chevron,
+#nd-docs-layout .omni-item-active .omni-item-subtitle,
+#nd-docs-layout .omni-item-active .omni-item-shortcuts {
   color: inherit !important;
   opacity: 1 !important;
 }
 
-.fd-ai-dialog,
-.fd-ai-header,
-.fd-ai-tab-bar,
-.fd-ai-search-wrap,
-.fd-ai-chat-footer,
-.fd-ai-fm-topbar,
-.fd-ai-input-wrap,
-.fd-ai-results,
-.fd-ai-messages {
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-header,
+#nd-docs-layout .fd-ai-tab-bar,
+#nd-docs-layout .fd-ai-search-wrap,
+#nd-docs-layout .fd-ai-chat-footer,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-results,
+#nd-docs-layout .fd-ai-messages {
   border-color: var(--color-fd-border) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-header,
-.fd-ai-tab-bar,
-.fd-ai-search-wrap,
-.fd-ai-chat-footer,
-.fd-ai-fm-topbar,
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-header,
+#nd-docs-layout .fd-ai-tab-bar,
+#nd-docs-layout .fd-ai-search-wrap,
+#nd-docs-layout .fd-ai-chat-footer,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
 
-.fd-ai-header-title,
-.fd-ai-tab,
-.fd-ai-input,
-.fd-ai-result,
-.fd-ai-result-empty,
-.fd-ai-esc,
-.fd-ai-close-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-model-dropdown-label,
-.fd-ai-fm-suggestion,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-header-title,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-input,
+#nd-docs-layout .fd-ai-result,
+#nd-docs-layout .fd-ai-result-empty,
+#nd-docs-layout .fd-ai-esc,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-model-dropdown-label,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-floating-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.fd-ai-header-title,
-.fd-ai-tab,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-header-title,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-floating-btn {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
 
-.fd-ai-esc,
-.fd-ai-close-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-tab,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-fm-suggestion,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-esc,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-floating-btn {
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   margin-block-start: 0.5rem;
   margin-inline-end: 0.5rem;
 }
 
-.fd-ai-tab[data-active="true"],
-.fd-ai-close-btn:hover,
-.fd-ai-fm-close-btn:hover,
-.fd-ai-model-dropdown-item[data-active="true"],
-.fd-ai-floating-btn:hover,
-.fd-ai-model-dropdown-btn:hover,
-.fd-ai-model-dropdown-item:hover,
-.fd-ai-fm-suggestion:hover,
-.fd-ai-result[data-active="true"] {
+#nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout .fd-ai-close-btn:hover,
+#nd-docs-layout .fd-ai-fm-close-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item[data-active="true"],
+#nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item:hover,
+#nd-docs-layout .fd-ai-fm-suggestion:hover,
+#nd-docs-layout .fd-ai-result[data-active="true"] {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-input,
-.fd-ai-input::placeholder {
+#nd-docs-layout .fd-ai-input,
+#nd-docs-layout .fd-ai-input::placeholder {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }

--- a/packages/svelte-theme/styles/command-grid.css
+++ b/packages/svelte-theme/styles/command-grid.css
@@ -1,7 +1,8 @@
 /* @farming-labs/theme - command-grid theme CSS */
 @import "./concrete.css";
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #141414;
   --color-fd-primary-foreground: #f8f6ed;
   --color-fd-ring: #141414;
@@ -24,7 +25,11 @@
   --fd-nav-height: 64px;
 }
 
-:is(html.dark, body.dark) {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #f8f6ed;
   --color-fd-primary-foreground: #121212;
   --color-fd-ring: #f8f6ed;
@@ -44,7 +49,8 @@
   --color-fd-border: #f8f6ed;
 }
 
-body:has(#nd-docs-layout) {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   background: var(--color-fd-background);
   background-image:
     linear-gradient(to right, rgb(20 20 20 / 6%) 1px, transparent 1px),
@@ -53,120 +59,124 @@ body:has(#nd-docs-layout) {
   background-attachment: fixed;
 }
 
-:is(html.dark, body.dark) body:has(#nd-docs-layout) {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   background-image:
     linear-gradient(to right, rgb(248 246 237 / 5%) 1px, transparent 1px),
     linear-gradient(to bottom, rgb(248 246 237 / 5%) 1px, transparent 1px);
 }
 
 #nd-docs-layout > header,
-[role="banner"] {
+#nd-docs-layout [role="banner"] {
   border-bottom: 4px solid var(--color-fd-border) !important;
   background: color-mix(in srgb, var(--color-fd-background) 95%, transparent) !important;
   backdrop-filter: blur(8px);
   box-shadow: none !important;
 }
 
-aside#nd-sidebar {
+#nd-docs-layout aside#nd-sidebar {
   border-right: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-background) !important;
 }
 
-aside#nd-sidebar,
-.fd-sidebar {
+#nd-docs-layout aside#nd-sidebar,
+#nd-docs-layout .fd-sidebar {
   color: var(--color-fd-foreground);
 }
 
-aside#nd-sidebar [data-radix-scroll-area-viewport],
-aside#nd-sidebar [data-radix-scroll-area-content],
-aside#nd-sidebar .fd-sidebar {
+#nd-docs-layout aside#nd-sidebar [data-radix-scroll-area-viewport],
+#nd-docs-layout aside#nd-sidebar [data-radix-scroll-area-content],
+#nd-docs-layout aside#nd-sidebar .fd-sidebar {
   background: transparent !important;
 }
 
-aside#nd-sidebar > *,
-.fd-sidebar > * {
+#nd-docs-layout aside#nd-sidebar > *,
+#nd-docs-layout .fd-sidebar > * {
   background: transparent;
 }
 
-aside a[data-active],
-aside button[data-active],
-.fd-sidebar a,
-.fd-sidebar button {
+#nd-docs-layout aside a[data-active],
+#nd-docs-layout aside button[data-active],
+#nd-docs-layout .fd-sidebar a,
+#nd-docs-layout .fd-sidebar button {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.77rem;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
-.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
+#nd-docs-layout aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout .fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn),
+#nd-docs-layout .fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn) {
   border: 2px solid transparent;
   border-radius: 0 !important;
   min-height: 2.9rem;
 }
 
-aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-.fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
-.fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
+#nd-docs-layout aside#nd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout aside#nd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout .fd-sidebar a:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover,
+#nd-docs-layout .fd-sidebar button:not(.fd-sidebar-search-btn):not(.fd-sidebar-ai-btn):hover {
   background: color-mix(in srgb, var(--color-fd-secondary) 70%, transparent) !important;
   color: var(--color-fd-foreground) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-aside#nd-sidebar a.inline-flex,
-.fd-sidebar a.inline-flex {
+#nd-docs-layout aside#nd-sidebar a.inline-flex,
+#nd-docs-layout .fd-sidebar a.inline-flex {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   font-size: 0.92rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-aside [data-active="false"] {
+#nd-docs-layout aside [data-active="false"] {
   color: color-mix(in srgb, var(--color-fd-foreground) 80%, transparent) !important;
 }
 
-aside a[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"] {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-aside div.overflow-hidden.relative[data-state]::before {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state]::before {
   inset-inline-start: 1.125rem !important;
 }
 
-aside div.overflow-hidden.relative[data-state] a[data-active] {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state] a[data-active] {
   padding-inline-start: 1.75rem !important;
 }
 
-aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
+#nd-docs-layout aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   inset-inline-start: 1.125rem !important;
 }
 
-#nd-toc {
+#nd-docs-layout #nd-toc {
   border-left: 2px solid var(--color-fd-border) !important;
   padding-left: 1rem;
   background: transparent !important;
 }
 
-#toc-title,
-.fd-toc-link,
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout #toc-title,
+#nd-docs-layout .fd-toc-link,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   text-transform: uppercase;
 }
 
-#toc-title {
+#nd-docs-layout #toc-title {
   letter-spacing: 0.16em;
   font-size: 0.72rem;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }
 
-.fd-toc-link,
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout .fd-toc-link,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   letter-spacing: 0.08em;
   font-size: 0.72rem;
   border-left: 2px solid transparent;
@@ -174,27 +184,27 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   color: color-mix(in srgb, var(--color-fd-foreground) 82%, transparent);
 }
 
-.fd-toc-link:hover,
-.fd-toc-clerk .fd-toc-link:hover {
+#nd-docs-layout .fd-toc-link:hover,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link:hover {
   border-left-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-secondary) 58%, transparent);
   color: var(--color-fd-foreground);
 }
 
-.fd-toc-link-active,
-.fd-toc-clerk .fd-toc-link[data-active="true"] {
+#nd-docs-layout .fd-toc-link-active,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link[data-active="true"] {
   border-left-color: var(--color-fd-foreground);
   color: var(--color-fd-foreground);
 }
 
-.fd-page-title,
-#nd-page > h1,
-.fd-docs-content article h1,
-#nd-page h1,
-.fd-docs-content h1,
-.fd-docs-content article h2,
-#nd-page h2,
-.fd-docs-content h2 {
+#nd-docs-layout .fd-page-title,
+#nd-docs-layout #nd-page > h1,
+#nd-docs-layout .fd-docs-content article h1,
+#nd-docs-layout #nd-page h1,
+#nd-docs-layout .fd-docs-content h1,
+#nd-docs-layout .fd-docs-content article h2,
+#nd-docs-layout #nd-page h2,
+#nd-docs-layout .fd-docs-content h2 {
   max-width: none;
   font-family: var(--font-bebas), var(--fd-font-sans), sans-serif !important;
   font-weight: 400 !important;
@@ -203,34 +213,34 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-page-title,
-#nd-page > h1,
-.fd-docs-content article h1,
-#nd-page h1,
-.fd-docs-content h1 {
+#nd-docs-layout .fd-page-title,
+#nd-docs-layout #nd-page > h1,
+#nd-docs-layout .fd-docs-content article h1,
+#nd-docs-layout #nd-page h1,
+#nd-docs-layout .fd-docs-content h1 {
   font-size: clamp(3.1rem, 7vw, 5.75rem);
   letter-spacing: 0.04em;
   text-wrap: balance;
   margin-bottom: 0.9rem;
 }
 
-.fd-docs-content article h2,
-#nd-page h2,
-.fd-docs-content h2 {
+#nd-docs-layout .fd-docs-content article h2,
+#nd-docs-layout #nd-page h2,
+#nd-docs-layout .fd-docs-content h2 {
   font-size: clamp(2rem, 4vw, 3.25rem);
   letter-spacing: 0.045em;
   margin-top: 3rem;
   margin-bottom: 1rem;
 }
 
-.fd-page-title > a,
-#nd-page > h1 > a,
-.fd-docs-content article h1 > a,
-#nd-page h1 > a,
-.fd-docs-content h1 > a,
-.fd-docs-content article h2 > a,
-#nd-page h2 > a,
-.fd-docs-content h2 > a {
+#nd-docs-layout .fd-page-title > a,
+#nd-docs-layout #nd-page > h1 > a,
+#nd-docs-layout .fd-docs-content article h1 > a,
+#nd-docs-layout #nd-page h1 > a,
+#nd-docs-layout .fd-docs-content h1 > a,
+#nd-docs-layout .fd-docs-content article h2 > a,
+#nd-docs-layout #nd-page h2 > a,
+#nd-docs-layout .fd-docs-content h2 > a {
   font-family: inherit !important;
   font-size: inherit !important;
   font-weight: inherit !important;
@@ -239,39 +249,39 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   line-height: inherit !important;
 }
 
-.fd-docs-content article h3,
-#nd-page h3,
-.fd-docs-content h3,
-.fd-docs-content article h4,
-#nd-page h4,
-.fd-docs-content h4 {
+#nd-docs-layout .fd-docs-content article h3,
+#nd-docs-layout #nd-page h3,
+#nd-docs-layout .fd-docs-content h3,
+#nd-docs-layout .fd-docs-content article h4,
+#nd-docs-layout #nd-page h4,
+#nd-docs-layout .fd-docs-content h4 {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--color-fd-foreground) 88%, transparent);
 }
 
-.fd-docs-content h3 {
+#nd-docs-layout .fd-docs-content h3 {
   font-size: 0.96rem;
   margin-top: 2rem;
   margin-bottom: 0.8rem;
 }
 
-.fd-docs-content h4 {
+#nd-docs-layout .fd-docs-content h4 {
   font-size: 0.82rem;
   margin-top: 1.6rem;
   margin-bottom: 0.7rem;
 }
 
-.fd-page-description,
-.fd-docs-content p,
-.fd-docs-content li,
-.fd-docs-content td,
-.fd-docs-content blockquote {
+#nd-docs-layout .fd-page-description,
+#nd-docs-layout .fd-docs-content p,
+#nd-docs-layout .fd-docs-content li,
+#nd-docs-layout .fd-docs-content td,
+#nd-docs-layout .fd-docs-content blockquote {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-page-description {
+#nd-docs-layout .fd-page-description {
   color: color-mix(in srgb, var(--color-fd-foreground) 90%, transparent);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -280,81 +290,81 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
   max-width: 72ch;
 }
 
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn,
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card,
-.fd-page-body .fd-table-wrapper,
-.fd-docs-content table,
-.fd-tabs,
-.fd-tabs-list,
-.fd-tabs-trigger,
-.fd-feedback-input,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-dialog,
-.fd-ai-fm-input-container,
-.fd-ai-fm-suggestion,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-menu,
-.fd-ai-model-dropdown-item,
-.fd-ai-floating-btn,
-.omni-content,
-.omni-item,
-.omni-item-ext,
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-page-body .fd-table-wrapper,
+#nd-docs-layout .fd-docs-content table,
+#nd-docs-layout .fd-tabs,
+#nd-docs-layout .fd-tabs-list,
+#nd-docs-layout .fd-tabs-trigger,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .omni-content,
+#nd-docs-layout .omni-item,
+#nd-docs-layout .omni-item-ext,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   box-shadow: none !important;
   border-radius: 0 !important;
 }
 
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn,
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card,
-.fd-feedback-input,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-dialog,
-.fd-ai-fm-input-container,
-.fd-ai-fm-suggestion,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-menu,
-.fd-ai-model-dropdown-item,
-.fd-ai-floating-btn,
-.omni-content,
-.omni-item,
-.omni-item-ext,
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .omni-content,
+#nd-docs-layout .omni-item,
+#nd-docs-layout .omni-item-ext,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   background-image: none !important;
 }
 
-.fd-page-action-btn,
-.fd-feedback-submit,
-.fd-feedback-choice,
-.fd-ai-tab,
-.fd-copy-btn,
-.fd-ai-code-copy,
-.fd-ai-floating-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-fm-suggestion {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -365,37 +375,44 @@ aside div.overflow-hidden.relative[data-state] a[data-active="true"]::before {
     transform 140ms ease !important;
 }
 
-aside a[data-active="true"],
-aside a[data-active="true"]:hover,
-.fd-page-action-btn:hover,
-.fd-page-action-btn[data-selected="true"],
-.fd-page-action-btn[data-copied="true"],
-.fd-feedback-choice:hover,
-.fd-feedback-choice[data-selected="true"],
-.fd-ai-tab[data-active="true"],
-.fd-copy-btn:hover,
-.fd-ai-code-copy:hover,
-.fd-sidebar-search-btn:hover,
-.fd-sidebar-ai-btn:hover,
-.fd-ai-floating-btn:hover,
-.fd-ai-model-dropdown-item:hover,
-.fd-ai-fm-suggestion:hover {
+#nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout aside a[data-active="true"]:hover,
+#nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout .fd-copy-btn:hover,
+#nd-docs-layout .fd-ai-code-copy:hover,
+#nd-docs-layout .fd-sidebar-search-btn:hover,
+#nd-docs-layout .fd-sidebar-ai-btn:hover,
+#nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item:hover,
+#nd-docs-layout .fd-ai-fm-suggestion:hover {
   box-shadow: none !important;
   transform: translateY(-2px);
 }
 
-.dark aside a[data-active="true"],
-.dark .fd-page-action-btn:hover,
-.dark .fd-page-action-btn[data-selected="true"],
-.dark .fd-page-action-btn[data-copied="true"],
-.dark .fd-feedback-choice:hover,
-.dark .fd-feedback-choice[data-selected="true"],
-.dark .fd-ai-tab[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout.dark aside a[data-active="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout.dark .fd-page-action-btn:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-copied="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout.dark .fd-feedback-choice:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout.dark .fd-feedback-choice[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout.dark .fd-ai-tab[data-active="true"] {
   box-shadow: none !important;
 }
 
-.fd-sidebar-search-btn,
-.fd-sidebar-ai-btn {
+#nd-docs-layout .fd-sidebar-search-btn,
+#nd-docs-layout .fd-sidebar-ai-btn {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-secondary) !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
@@ -404,21 +421,21 @@ aside a[data-active="true"]:hover,
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-sidebar-search-btn:hover,
-.fd-sidebar-ai-btn:hover {
+#nd-docs-layout .fd-sidebar-search-btn:hover,
+#nd-docs-layout .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-.fd-sidebar-search-kbd,
-.fd-sidebar-search-kbd kbd {
+#nd-docs-layout .fd-sidebar-search-kbd,
+#nd-docs-layout .fd-sidebar-search-kbd kbd {
   color: inherit !important;
   border-color: currentColor !important;
 }
 
-button[data-search-full],
-[data-search-full] {
+#nd-docs-layout button[data-search-full],
+#nd-docs-layout [data-search-full] {
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-secondary) !important;
@@ -430,15 +447,15 @@ button[data-search-full],
   box-shadow: none !important;
 }
 
-button[data-search-full]:hover,
-[data-search-full]:hover {
+#nd-docs-layout button[data-search-full]:hover,
+#nd-docs-layout [data-search-full]:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-button[data-search-full] kbd,
-[data-search-full] kbd {
+#nd-docs-layout button[data-search-full] kbd,
+#nd-docs-layout [data-search-full] kbd {
   border: 1px solid currentColor !important;
   border-radius: 0 !important;
   background: transparent !important;
@@ -446,46 +463,46 @@ button[data-search-full] kbd,
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-ai-code-block {
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-ai-code-block {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   background-image: none !important;
 }
 
-.fd-codeblock-title,
-figure.shiki:has(figcaption) > div:first-child,
-.fd-ai-code-header {
+#nd-docs-layout .fd-codeblock-title,
+#nd-docs-layout figure.shiki:has(figcaption) > div:first-child,
+#nd-docs-layout .fd-ai-code-header {
   background: var(--color-fd-secondary) !important;
   border-bottom: 2px solid var(--color-fd-border) !important;
 }
 
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border: 2px solid var(--color-fd-border) !important;
 }
 
-.fd-copy-btn:hover,
-.fd-ai-code-copy:hover {
+#nd-docs-layout .fd-copy-btn:hover,
+#nd-docs-layout .fd-ai-code-copy:hover {
   background: var(--color-fd-card) !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-table-wrapper,
-.fd-table-wrapper table,
-.prose table {
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .prose table {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   border-radius: 0 !important;
 }
 
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a {
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a {
   transition:
     background-color 140ms ease,
     color 140ms ease,
@@ -493,8 +510,8 @@ figure.shiki:has(figcaption) > div:first-child,
     transform 140ms ease !important;
 }
 
-.fd-page-nav-card:hover,
-[class*="page-nav"] a:hover {
+#nd-docs-layout .fd-page-nav-card:hover,
+#nd-docs-layout [class*="page-nav"] a:hover {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
@@ -502,53 +519,53 @@ figure.shiki:has(figcaption) > div:first-child,
   transform: none !important;
 }
 
-.fd-page-nav-card:hover *,
-[class*="page-nav"] a:hover * {
+#nd-docs-layout .fd-page-nav-card:hover *,
+#nd-docs-layout [class*="page-nav"] a:hover * {
   color: inherit !important;
 }
 
-.fd-table-wrapper {
+#nd-docs-layout .fd-table-wrapper {
   overflow: hidden;
 }
 
-.fd-table-wrapper table,
-.prose .fd-table-wrapper table {
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .prose .fd-table-wrapper table {
   border: 0 !important;
   background: transparent !important;
   border-radius: 0 !important;
 }
 
-.prose table,
-.prose thead,
-.prose tbody,
-.prose tr,
-.prose th,
-.prose td,
-.prose table *,
-.fd-table-wrapper,
-.fd-table-wrapper *,
-.fd-table-wrapper table,
-.fd-table-wrapper thead,
-.fd-table-wrapper tbody,
-.fd-table-wrapper tr,
-.fd-table-wrapper th,
-.fd-table-wrapper td {
+#nd-docs-layout .prose table,
+#nd-docs-layout .prose thead,
+#nd-docs-layout .prose tbody,
+#nd-docs-layout .prose tr,
+#nd-docs-layout .prose th,
+#nd-docs-layout .prose td,
+#nd-docs-layout .prose table *,
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-table-wrapper *,
+#nd-docs-layout .fd-table-wrapper table,
+#nd-docs-layout .fd-table-wrapper thead,
+#nd-docs-layout .fd-table-wrapper tbody,
+#nd-docs-layout .fd-table-wrapper tr,
+#nd-docs-layout .fd-table-wrapper th,
+#nd-docs-layout .fd-table-wrapper td {
   border-radius: 0 !important;
 }
 
-.prose thead tr:first-child th:first-child,
-.prose thead tr:first-child th:last-child,
-.prose tbody tr:last-child td:first-child,
-.prose tbody tr:last-child td:last-child,
-.fd-table-wrapper thead tr:first-child th:first-child,
-.fd-table-wrapper thead tr:first-child th:last-child,
-.fd-table-wrapper tbody tr:last-child td:first-child,
-.fd-table-wrapper tbody tr:last-child td:last-child {
+#nd-docs-layout .prose thead tr:first-child th:first-child,
+#nd-docs-layout .prose thead tr:first-child th:last-child,
+#nd-docs-layout .prose tbody tr:last-child td:first-child,
+#nd-docs-layout .prose tbody tr:last-child td:last-child,
+#nd-docs-layout .fd-table-wrapper thead tr:first-child th:first-child,
+#nd-docs-layout .fd-table-wrapper thead tr:first-child th:last-child,
+#nd-docs-layout .fd-table-wrapper tbody tr:last-child td:first-child,
+#nd-docs-layout .fd-table-wrapper tbody tr:last-child td:last-child {
   border-radius: 0 !important;
 }
 
-.prose th,
-.fd-table-wrapper th {
+#nd-docs-layout .prose th,
+#nd-docs-layout .fd-table-wrapper th {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   text-transform: uppercase;
@@ -556,8 +573,8 @@ figure.shiki:has(figcaption) > div:first-child,
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-callout,
-[class*="fd-callout"] {
+#nd-docs-layout .fd-callout,
+#nd-docs-layout [class*="fd-callout"] {
   border: 2px solid var(--color-fd-border) !important;
   background: color-mix(
     in srgb,
@@ -567,160 +584,160 @@ figure.shiki:has(figcaption) > div:first-child,
   border-radius: 0 !important;
 }
 
-.fd-callout-indicator {
+#nd-docs-layout .fd-callout-indicator {
   width: 8px;
   background: var(--color-fd-accent) !important;
 }
 
-.fd-callout-title {
+#nd-docs-layout .fd-callout-title {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
 }
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   background: var(--color-fd-secondary);
 }
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
 }
 
-.omni-header,
-.omni-footer {
+#nd-docs-layout .omni-header,
+#nd-docs-layout .omni-footer {
   border-color: var(--color-fd-border) !important;
   background: var(--color-fd-secondary) !important;
 }
 
-.omni-search-input,
-.omni-item-label,
-.omni-item-subtitle,
-.omni-group-label,
-.omni-footer-inner,
-.omni-kbd,
-.omni-close-btn {
+#nd-docs-layout .omni-search-input,
+#nd-docs-layout .omni-item-label,
+#nd-docs-layout .omni-item-subtitle,
+#nd-docs-layout .omni-group-label,
+#nd-docs-layout .omni-footer-inner,
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-close-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.omni-group-label {
+#nd-docs-layout .omni-group-label {
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border: 1px solid transparent !important;
 }
 
-.omni-item:hover {
+#nd-docs-layout .omni-item:hover {
   border-color: var(--color-fd-border) !important;
 }
 
-.omni-kbd,
-.omni-close-btn,
-.omni-item-ext {
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-close-btn,
+#nd-docs-layout .omni-item-ext {
   border: 1px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: transparent !important;
 }
 
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-.omni-item-active .omni-item-icon,
-.omni-item-active .omni-item-badge,
-.omni-item-active .omni-item-ext,
-.omni-item-active .omni-item-chevron,
-.omni-item-active .omni-item-subtitle,
-.omni-item-active .omni-item-shortcuts {
+#nd-docs-layout .omni-item-active .omni-item-icon,
+#nd-docs-layout .omni-item-active .omni-item-badge,
+#nd-docs-layout .omni-item-active .omni-item-ext,
+#nd-docs-layout .omni-item-active .omni-item-chevron,
+#nd-docs-layout .omni-item-active .omni-item-subtitle,
+#nd-docs-layout .omni-item-active .omni-item-shortcuts {
   color: inherit !important;
   opacity: 1 !important;
 }
 
-.fd-ai-dialog,
-.fd-ai-header,
-.fd-ai-tab-bar,
-.fd-ai-search-wrap,
-.fd-ai-chat-footer,
-.fd-ai-fm-topbar,
-.fd-ai-input-wrap,
-.fd-ai-results,
-.fd-ai-messages {
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-header,
+#nd-docs-layout .fd-ai-tab-bar,
+#nd-docs-layout .fd-ai-search-wrap,
+#nd-docs-layout .fd-ai-chat-footer,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-results,
+#nd-docs-layout .fd-ai-messages {
   border-color: var(--color-fd-border) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-header,
-.fd-ai-tab-bar,
-.fd-ai-search-wrap,
-.fd-ai-chat-footer,
-.fd-ai-fm-topbar,
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-header,
+#nd-docs-layout .fd-ai-tab-bar,
+#nd-docs-layout .fd-ai-search-wrap,
+#nd-docs-layout .fd-ai-chat-footer,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-fm-input-container {
   background: var(--color-fd-secondary) !important;
 }
 
-.fd-ai-header-title,
-.fd-ai-tab,
-.fd-ai-input,
-.fd-ai-result,
-.fd-ai-result-empty,
-.fd-ai-esc,
-.fd-ai-close-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-model-dropdown-label,
-.fd-ai-fm-suggestion,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-header-title,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-input,
+#nd-docs-layout .fd-ai-result,
+#nd-docs-layout .fd-ai-result-empty,
+#nd-docs-layout .fd-ai-esc,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-model-dropdown-label,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-floating-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.fd-ai-header-title,
-.fd-ai-tab,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-header-title,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-floating-btn {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
 
-.fd-ai-esc,
-.fd-ai-close-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-tab,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-item,
-.fd-ai-fm-suggestion,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-esc,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-floating-btn {
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-card) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   margin-block-start: 0.5rem;
   margin-inline-end: 0.5rem;
 }
 
-.fd-ai-tab[data-active="true"],
-.fd-ai-close-btn:hover,
-.fd-ai-fm-close-btn:hover,
-.fd-ai-model-dropdown-item[data-active="true"],
-.fd-ai-floating-btn:hover,
-.fd-ai-model-dropdown-btn:hover,
-.fd-ai-model-dropdown-item:hover,
-.fd-ai-fm-suggestion:hover,
-.fd-ai-result[data-active="true"] {
+#nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout .fd-ai-close-btn:hover,
+#nd-docs-layout .fd-ai-fm-close-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item[data-active="true"],
+#nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-item:hover,
+#nd-docs-layout .fd-ai-fm-suggestion:hover,
+#nd-docs-layout .fd-ai-result[data-active="true"] {
   background: var(--color-fd-foreground) !important;
   color: var(--color-fd-background) !important;
   border-color: var(--color-fd-border) !important;
   box-shadow: none !important;
 }
 
-.fd-ai-input,
-.fd-ai-input::placeholder {
+#nd-docs-layout .fd-ai-input,
+#nd-docs-layout .fd-ai-input::placeholder {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }

--- a/packages/svelte-theme/styles/concrete.css
+++ b/packages/svelte-theme/styles/concrete.css
@@ -1,6 +1,7 @@
 @import "./hardline.css";
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #ff5b31;
   --color-fd-primary-foreground: #140f0c;
   --color-fd-ring: #141210;
@@ -20,7 +21,11 @@
   --fd-nav-height: 68px;
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #ff744d;
   --color-fd-primary-foreground: #180f0b;
   --color-fd-ring: #ff744d;
@@ -40,103 +45,125 @@
 }
 
 #nd-docs-layout > header,
-[role="banner"] {
+#nd-docs-layout [role="banner"] {
   background: linear-gradient(180deg, color-mix(in srgb, var(--color-fd-primary) 10%, var(--color-fd-background)), var(--color-fd-background));
 }
 
-aside a[data-active] {
+#nd-docs-layout aside a[data-active] {
   text-transform: uppercase;
   letter-spacing: 0.045em;
   font-size: 0.79rem;
 }
 
-aside a[data-active="true"],
-.fd-page-action-btn:hover,
-.fd-page-action-btn[data-selected="true"],
-.fd-page-action-btn[data-copied="true"],
-.fd-feedback-choice:hover,
-.fd-feedback-choice[data-selected="true"],
-.fd-ai-tab[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout .fd-ai-tab[data-active="true"] {
   box-shadow: 5px 5px 0 var(--color-fd-border);
   transform: translate(-2px, -2px);
 }
 
-.dark aside a[data-active="true"],
-.dark .fd-page-action-btn:hover,
-.dark .fd-page-action-btn[data-selected="true"],
-.dark .fd-page-action-btn[data-copied="true"],
-.dark .fd-feedback-choice:hover,
-.dark .fd-feedback-choice[data-selected="true"],
-.dark .fd-ai-tab[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout.dark aside a[data-active="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout.dark .fd-page-action-btn:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn[data-copied="true"],
+#nd-docs-layout.dark .fd-page-action-btn[data-copied="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout.dark .fd-feedback-choice:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout.dark .fd-feedback-choice[data-selected="true"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-tab[data-active="true"],
+#nd-docs-layout.dark .fd-ai-tab[data-active="true"] {
   box-shadow: 5px 5px 0 color-mix(in srgb, var(--color-fd-primary) 55%, transparent);
 }
 
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   background: color-mix(in srgb, var(--color-fd-primary) 20%, var(--color-fd-card)) !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.omni-item-active .omni-item-icon,
-.omni-item-active .omni-item-badge,
-.omni-item-active .omni-item-ext,
-.omni-item-active .omni-item-chevron {
+#nd-docs-layout .omni-item-active .omni-item-icon,
+#nd-docs-layout .omni-item-active .omni-item-badge,
+#nd-docs-layout .omni-item-active .omni-item-ext,
+#nd-docs-layout .omni-item-active .omni-item-chevron {
   color: var(--color-fd-foreground) !important;
 }
 
-.omni-item-active .omni-item-subtitle,
-.omni-item-active .omni-item-shortcuts {
+#nd-docs-layout .omni-item-active .omni-item-subtitle,
+#nd-docs-layout .omni-item-active .omni-item-shortcuts {
   color: color-mix(in srgb, var(--color-fd-foreground) 78%, var(--color-fd-muted-foreground)) !important;
   opacity: 1;
 }
 
-.dark .omni-item-active {
+:is(html.dark, body.dark) #nd-docs-layout .omni-item-active,
+#nd-docs-layout.dark .omni-item-active {
   background: color-mix(in srgb, var(--color-fd-primary) 26%, var(--color-fd-card)) !important;
 }
 
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn,
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card {
   box-shadow: 6px 6px 0 var(--color-fd-border);
 }
 
-.dark .fd-card,
-.dark [data-card],
-.dark [class*="fd-callout"],
-.dark .fd-page-action-menu,
-.dark .fd-page-action-btn,
-.dark .fd-docs-content pre,
-.dark .fd-docs-content .shiki,
-.dark .fd-docs-content [data-codeblock],
-.dark .fd-page-nav,
-.dark .fd-page-nav-card,
-.dark [class*="page-nav"] a,
-.dark .fd-hover-link-card {
+:is(html.dark, body.dark) #nd-docs-layout .fd-card,
+#nd-docs-layout.dark .fd-card,
+:is(html.dark, body.dark) #nd-docs-layout [data-card],
+#nd-docs-layout.dark [data-card],
+:is(html.dark, body.dark) #nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout.dark [class*="fd-callout"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout.dark .fd-page-action-menu,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout.dark .fd-page-action-btn,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout.dark .fd-docs-content pre,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout.dark .fd-docs-content .shiki,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout.dark .fd-docs-content [data-codeblock],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav,
+#nd-docs-layout.dark .fd-page-nav,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout.dark .fd-page-nav-card,
+:is(html.dark, body.dark) #nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout.dark [class*="page-nav"] a,
+:is(html.dark, body.dark) #nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout.dark .fd-hover-link-card {
   box-shadow: 6px 6px 0 color-mix(in srgb, var(--color-fd-primary) 42%, transparent);
 }
 
-.fd-page-body .fd-table-wrapper,
-.fd-docs-content table {
+#nd-docs-layout .fd-page-body .fd-table-wrapper,
+#nd-docs-layout .fd-docs-content table {
   border: 3px solid var(--color-fd-border);
   box-shadow: 6px 6px 0 var(--color-fd-border);
   background: var(--color-fd-card);
 }
 
-.dark .fd-page-body .fd-table-wrapper,
-.dark .fd-docs-content table {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-body .fd-table-wrapper,
+#nd-docs-layout.dark .fd-page-body .fd-table-wrapper,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content table,
+#nd-docs-layout.dark .fd-docs-content table {
   box-shadow: 6px 6px 0 color-mix(in srgb, var(--color-fd-primary) 42%, transparent);
 }
 
-.fd-docs-content th,
-.fd-page-body th {
+#nd-docs-layout .fd-docs-content th,
+#nd-docs-layout .fd-page-body th {
   background: var(--color-fd-foreground);
   color: var(--color-fd-background);
   text-transform: uppercase;
@@ -145,48 +172,55 @@ aside a[data-active="true"],
   font-size: 0.74rem;
 }
 
-.fd-docs-content td,
-.fd-page-body td {
+#nd-docs-layout .fd-docs-content td,
+#nd-docs-layout .fd-page-body td {
   font-weight: 550;
 }
 
-.fd-docs-content tbody tr:nth-child(odd) td,
-.fd-page-body tbody tr:nth-child(odd) td {
+#nd-docs-layout .fd-docs-content tbody tr:nth-child(odd) td,
+#nd-docs-layout .fd-page-body tbody tr:nth-child(odd) td {
   background: color-mix(in srgb, var(--color-fd-secondary) 72%, white 28%);
 }
 
-.dark .fd-docs-content tbody tr:nth-child(odd) td,
-.dark .fd-page-body tbody tr:nth-child(odd) td {
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content tbody tr:nth-child(odd) td,
+#nd-docs-layout.dark .fd-docs-content tbody tr:nth-child(odd) td,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-body tbody tr:nth-child(odd) td,
+#nd-docs-layout.dark .fd-page-body tbody tr:nth-child(odd) td {
   background: color-mix(in srgb, var(--color-fd-secondary) 92%, black 8%);
 }
 
-.fd-docs-content tbody tr:hover td,
-.fd-page-body tbody tr:hover td {
+#nd-docs-layout .fd-docs-content tbody tr:hover td,
+#nd-docs-layout .fd-page-body tbody tr:hover td {
   background: color-mix(in srgb, var(--color-fd-primary) 16%, var(--color-fd-card));
 }
 
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock],
-.fd-docs-content .fd-codeblock,
-.fd-ai-code-block {
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout .fd-docs-content .fd-codeblock,
+#nd-docs-layout .fd-ai-code-block {
   border-width: 3px !important;
   box-shadow: 6px 6px 0 var(--color-fd-border);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--color-fd-primary) 7%, var(--color-fd-card)) 0, var(--color-fd-card) 56px) !important;
 }
 
-.dark .fd-docs-content pre,
-.dark .fd-docs-content .shiki,
-.dark .fd-docs-content [data-codeblock],
-.dark .fd-docs-content .fd-codeblock,
-.dark .fd-ai-code-block {
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout.dark .fd-docs-content pre,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout.dark .fd-docs-content .shiki,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout.dark .fd-docs-content [data-codeblock],
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .fd-codeblock,
+#nd-docs-layout.dark .fd-docs-content .fd-codeblock,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-code-block,
+#nd-docs-layout.dark .fd-ai-code-block {
   box-shadow: 6px 6px 0 color-mix(in srgb, var(--color-fd-primary) 42%, transparent);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--color-fd-primary) 10%, var(--color-fd-card)) 0, var(--color-fd-card) 56px) !important;
 }
 
-.fd-codeblock-title {
+#nd-docs-layout .fd-codeblock-title {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -198,8 +232,8 @@ aside a[data-active="true"],
   background: color-mix(in srgb, var(--color-fd-primary) 12%, var(--color-fd-card));
 }
 
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   border: 2px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background: var(--color-fd-background) !important;
@@ -211,29 +245,30 @@ aside a[data-active="true"],
   text-transform: uppercase;
 }
 
-.fd-copy-btn:hover,
-.fd-ai-code-copy:hover {
+#nd-docs-layout .fd-copy-btn:hover,
+#nd-docs-layout .fd-ai-code-copy:hover {
   background: var(--color-fd-primary) !important;
   color: var(--color-fd-primary-foreground) !important;
   transform: translate(-1px, -1px);
 }
 
-.fd-tabs {
+#nd-docs-layout .fd-tabs {
   border: 3px solid var(--color-fd-border);
   box-shadow: 6px 6px 0 var(--color-fd-border);
   background: var(--color-fd-card);
 }
 
-.dark .fd-tabs {
+:is(html.dark, body.dark) #nd-docs-layout .fd-tabs,
+#nd-docs-layout.dark .fd-tabs {
   box-shadow: 6px 6px 0 color-mix(in srgb, var(--color-fd-primary) 42%, transparent);
 }
 
-.fd-tabs-list {
+#nd-docs-layout .fd-tabs-list {
   border-bottom: 3px solid var(--color-fd-border);
   background: var(--color-fd-foreground);
 }
 
-.fd-tab-trigger {
+#nd-docs-layout .fd-tab-trigger {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -242,73 +277,75 @@ aside a[data-active="true"],
   border-bottom-width: 0;
 }
 
-.fd-tab-trigger:hover {
+#nd-docs-layout .fd-tab-trigger:hover {
   color: var(--color-fd-background);
   background: color-mix(in srgb, var(--color-fd-primary) 18%, transparent);
 }
 
-.fd-tab-trigger.fd-tab-active {
+#nd-docs-layout .fd-tab-trigger.fd-tab-active {
   color: var(--color-fd-primary-foreground);
   background: var(--color-fd-primary);
   box-shadow: inset -3px 0 0 var(--color-fd-border);
 }
 
-.fd-callout,
-[class*="fd-callout"] {
+#nd-docs-layout .fd-callout,
+#nd-docs-layout [class*="fd-callout"] {
   border-width: 3px !important;
   box-shadow: 6px 6px 0 var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-secondary) 82%, white 18%);
 }
 
-.dark .fd-callout,
-.dark [class*="fd-callout"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-callout,
+#nd-docs-layout.dark .fd-callout,
+:is(html.dark, body.dark) #nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout.dark [class*="fd-callout"] {
   box-shadow: 6px 6px 0 color-mix(in srgb, var(--color-fd-primary) 42%, transparent);
   background: color-mix(in srgb, var(--color-fd-secondary) 92%, black 8%);
 }
 
-.fd-callout-indicator {
+#nd-docs-layout .fd-callout-indicator {
   width: 10px;
 }
 
-.fd-callout-title {
+#nd-docs-layout .fd-callout-title {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
 }
 
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a,
-.fd-hover-link-card,
-.fd-page-action-menu,
-.fd-ai-dialog,
-.fd-ai-input-wrap,
-.fd-ai-model-dropdown-menu,
-.fd-ai-fm-topbar,
-.fd-ai-fm-input-container,
-.fd-feedback {
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-feedback {
   border-width: 3px !important;
 }
 
-.fd-page-nav-card:hover,
-[class*="page-nav"] a:hover {
+#nd-docs-layout .fd-page-nav-card:hover,
+#nd-docs-layout [class*="page-nav"] a:hover {
   transform: translate(-2px, -2px);
 }
 
-.fd-hover-link-card {
+#nd-docs-layout .fd-hover-link-card {
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--color-fd-primary) 10%, var(--color-fd-card)) 0, var(--color-fd-card) 52px);
 }
 
-.fd-hover-link-title,
-.fd-hover-link-description + a {
+#nd-docs-layout .fd-hover-link-title,
+#nd-docs-layout .fd-hover-link-description + a {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.fd-toc-link,
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout .fd-toc-link,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -317,27 +354,27 @@ aside a[data-active="true"],
   padding-left: 0.75rem;
 }
 
-.fd-toc-link:hover,
-.fd-toc-clerk .fd-toc-link:hover {
+#nd-docs-layout .fd-toc-link:hover,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link:hover {
   border-left-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-primary) 12%, transparent);
 }
 
-.fd-toc-link-active,
-.fd-toc-clerk .fd-toc-link[data-active="true"] {
+#nd-docs-layout .fd-toc-link-active,
+#nd-docs-layout .fd-toc-clerk .fd-toc-link[data-active="true"] {
   border-left-color: var(--color-fd-primary);
   color: var(--color-fd-foreground);
   background: color-mix(in srgb, var(--color-fd-primary) 16%, transparent);
 }
 
-.fd-ai-tab,
-.fd-feedback-choice,
-.fd-feedback-submit,
-.fd-ai-send-btn,
-.fd-ai-clear-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-fm-send-btn,
-.fd-ai-fm-trigger-btn {
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-clear-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-fm-send-btn,
+#nd-docs-layout .fd-ai-fm-trigger-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.07em;

--- a/packages/svelte-theme/styles/darksharp.css
+++ b/packages/svelte-theme/styles/darksharp.css
@@ -5,7 +5,8 @@
 
 /* ─── Color overrides (light) ─────────────────────────────────────── */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-background: oklch(1 0 0);
   --color-fd-foreground: oklch(0.147 0.004 49.25);
   --color-fd-card: oklch(1 0 0);
@@ -26,7 +27,11 @@
 
 /* ─── Color overrides (dark) ──────────────────────────────────────── */
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-background: hsl(0 0% 0%);
   --color-fd-foreground: oklch(0.985 0.001 106.423);
   --color-fd-card: hsl(0 0% 0%);
@@ -49,65 +54,69 @@
  * Sharp radius — override all rounded utilities
  * ═══════════════════════════════════════════════════════════════════ */
 
-.fd-sidebar,
-.fd-nav,
-.fd-card,
-.fd-callout,
-.fd-code-block,
-.fd-search-dialog,
-.fd-toc,
-[class*="rounded-lg"] {
+#nd-docs-layout .fd-sidebar,
+#nd-docs-layout .fd-nav,
+#nd-docs-layout .fd-card,
+#nd-docs-layout .fd-callout,
+#nd-docs-layout .fd-code-block,
+#nd-docs-layout .fd-search-dialog,
+#nd-docs-layout .fd-toc,
+#nd-docs-layout [class*="rounded-lg"] {
   border-radius: 0.2rem !important;
 }
 
-[class*="rounded-md"] {
+#nd-docs-layout [class*="rounded-md"] {
   border-radius: 0.1rem !important;
 }
 
-[class*="rounded-xl"],
-[class*="rounded-2xl"] {
+#nd-docs-layout [class*="rounded-xl"],
+#nd-docs-layout [class*="rounded-2xl"] {
   border-radius: 0.2rem !important;
 }
 
 /* ─── Tables ──────────────────────────────────────────────────────── */
 
-table {
+#nd-docs-layout table {
   border-radius: 0 !important;
   border-collapse: collapse;
 }
 
-.dark th {
+:is(html.dark, body.dark) #nd-docs-layout th,
+#nd-docs-layout.dark th {
   background: hsl(0 0% 8%);
   color: hsl(0 0% 80%);
   font-weight: 500;
 }
 
-.dark td {
+:is(html.dark, body.dark) #nd-docs-layout td,
+#nd-docs-layout.dark td {
   background: hsl(0 0% 2%);
 }
 
-.dark tr {
+:is(html.dark, body.dark) #nd-docs-layout tr,
+#nd-docs-layout.dark tr {
   border-color: hsl(0 0% 14%);
 }
 
 /* ─── Code blocks ─────────────────────────────────────────────────── */
 
-.fd-code-block,
-.fd-code-block pre {
+#nd-docs-layout .fd-code-block,
+#nd-docs-layout .fd-code-block pre {
   border-radius: 0.2rem !important;
 }
 
-.fd-code-block button {
+#nd-docs-layout .fd-code-block button {
   border-radius: 0.1rem !important;
 }
 
 /* ─── Inline code ─────────────────────────────────────────────────── */
 
-code:not(pre code) {
+#nd-docs-layout code:not(pre code) {
   border-radius: 0.1rem !important;
 }
 
-.dark code:not(pre code) {
+:is(html.dark, body.dark) #nd-docs-layout code:not(pre code),
+#nd-docs-layout.dark code:not(pre code) {
   background: hsl(0 0% 10%);
   border: 1px solid hsl(0 0% 16%);
   color: hsl(0 0% 85%);
@@ -115,118 +124,128 @@ code:not(pre code) {
 
 /* ─── Callouts ────────────────────────────────────────────────────── */
 
-.dark .fd-card,
-.dark .fd-callout {
+:is(html.dark, body.dark) #nd-docs-layout .fd-card,
+#nd-docs-layout.dark .fd-card,
+:is(html.dark, body.dark) #nd-docs-layout .fd-callout,
+#nd-docs-layout.dark .fd-callout {
   border-color: hsl(0 0% 14%);
 }
 
 /* ─── Selection ───────────────────────────────────────────────────── */
 
-::selection {
+#nd-docs-layout::selection,
+#nd-docs-layout *::selection {
   background: var(--color-fd-foreground);
   color: var(--color-fd-background);
 }
 
 /* ─── Sidebar (dark) ──────────────────────────────────────────────── */
 
-.dark .fd-sidebar {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar,
+#nd-docs-layout.dark .fd-sidebar {
   background: hsl(0 0% 0%);
   border-color: hsl(0 0% 12%);
 }
 
-.dark .fd-sidebar a[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar a[data-active="true"],
+#nd-docs-layout.dark .fd-sidebar a[data-active="true"] {
   background: hsl(0 0% 14%) !important;
   color: hsl(0 0% 96%) !important;
 }
 
-.dark .fd-sidebar a:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar a:hover,
+#nd-docs-layout.dark .fd-sidebar a:hover {
   background: hsl(0 0% 10%);
   color: hsl(0 0% 90%);
 }
 
 /* ─── TOC ─────────────────────────────────────────────────────────── */
 
-.dark .fd-toc {
+:is(html.dark, body.dark) #nd-docs-layout .fd-toc,
+#nd-docs-layout.dark .fd-toc {
   border-color: hsl(0 0% 12%);
 }
 
 /* ─── Separator ───────────────────────────────────────────────────── */
 
-.dark hr {
+:is(html.dark, body.dark) #nd-docs-layout hr,
+#nd-docs-layout.dark hr {
   border-color: hsl(0 0% 14%);
 }
 
 /* ─── Nav cards (prev/next) ───────────────────────────────────────── */
 
-.dark .fd-nav-card {
+:is(html.dark, body.dark) #nd-docs-layout .fd-nav-card,
+#nd-docs-layout.dark .fd-nav-card {
   border-color: hsl(0 0% 14%);
 }
 
-.dark .fd-nav-card:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-nav-card:hover,
+#nd-docs-layout.dark .fd-nav-card:hover {
   background: hsl(0 0% 8%);
   border-color: hsl(0 0% 20%);
 }
 
 /* ─── Search dialog ───────────────────────────────────────────────── */
 
-.fd-search-dialog {
+#nd-docs-layout .fd-search-dialog {
   border-radius: 0.2rem !important;
 }
 
 /* ─── AI Chat (sharp edges) ───────────────────────────────────────── */
 
-.fd-ai-dialog,
-.fd-ai-bubble-user,
-.fd-ai-bubble-ai,
-.fd-ai-input-wrap,
-.fd-ai-send-btn,
-.fd-ai-close-btn,
-.fd-ai-floating-btn,
-.fd-ai-suggestion,
-.fd-ai-result,
-.fd-ai-esc,
-.fd-ai-clear-btn,
-.fd-ai-fm-input-container,
-.fd-ai-fm-send-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-fm-suggestion,
-.fd-ai-fm-trigger-btn,
-.fd-ai-code-block,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-bubble-user,
+#nd-docs-layout .fd-ai-bubble-ai,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .fd-ai-suggestion,
+#nd-docs-layout .fd-ai-result,
+#nd-docs-layout .fd-ai-esc,
+#nd-docs-layout .fd-ai-clear-btn,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-send-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-fm-trigger-btn,
+#nd-docs-layout .fd-ai-code-block,
+#nd-docs-layout .fd-ai-code-copy {
   border-radius: 2px !important;
 }
 
-.fd-ai-floating-btn:hover {
+#nd-docs-layout .fd-ai-floating-btn:hover {
   box-shadow: 0 0 0 1px var(--color-fd-ring);
   transform: none;
 }
 
-.fd-ai-fm-trigger-btn:hover {
+#nd-docs-layout .fd-ai-fm-trigger-btn:hover {
   transform: none;
 }
 
 /* Custom Ask AI trigger — same as fd-ai-floating-btn for theme */
-.fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger {
   font-family: var(--fd-font-sans, inherit);
   border-radius: 2px !important;
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover {
   box-shadow: 0 0 0 1px var(--color-fd-ring);
   transform: none;
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
   border-radius: 2px !important;
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
   transform: none;
 }
 
 /* ─── Omni Command Palette — darksharp theme ────────────────────── */
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border-radius: 0.5rem !important;
   border: 1px solid var(--color-fd-border) !important;
   background: var(--color-fd-popover) !important;
@@ -235,17 +254,17 @@ code:not(pre code) {
     0 0 0 1px rgba(255, 255, 255, 0.06) !important;
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border-radius: 0.25rem !important;
 }
 
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary) 30%, transparent) !important;
 }
 
 /* ─── Page Actions — darksharp theme ────────────────────────────── */
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   border-radius: 0.2rem !important;
   font-size: 0.8125rem !important;
   letter-spacing: normal !important;
@@ -254,43 +273,46 @@ code:not(pre code) {
   font-family: var(--fd-font-sans, ui-sans-serif, system-ui, sans-serif) !important;
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative !important;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   border-radius: 0.2rem !important;
   border: 1px solid var(--color-fd-border) !important;
   box-shadow: 0 4px 24px hsl(0 0% 0% / 0.4) !important;
   background: var(--color-fd-popover) !important;
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   border-radius: 0.1rem !important;
   font-size: 0.8125rem !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   background: var(--color-fd-accent) !important;
   color: var(--color-fd-accent-foreground) !important;
 }
 
 /* ─── Feedback (darksharp theme) ─────────────────────────────────── */
 
-.fd-feedback-input,
-.fd-feedback-submit {
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit {
   border-radius: 0.2rem !important;
 }
 
-.dark .fd-feedback-input {
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-input,
+#nd-docs-layout.dark .fd-feedback-input {
   background: hsl(0 0% 4%);
 }
 
-.dark .fd-feedback-choice[data-selected="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-choice[data-selected="true"],
+#nd-docs-layout.dark .fd-feedback-choice[data-selected="true"] {
   background: hsl(0 0% 8%);
 }
 
-.dark .fd-feedback-status[data-status="success"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-feedback-status[data-status="success"],
+#nd-docs-layout.dark .fd-feedback-status[data-status="success"] {
   color: hsl(0 0% 90%);
 }

--- a/packages/svelte-theme/styles/docs.css
+++ b/packages/svelte-theme/styles/docs.css
@@ -10,16 +10,18 @@
 
 /* ─── CSS Reset ──────────────────────────────────────────────────────── */
 
-*,
-*::before,
-*::after {
+#nd-docs-layout,
+#nd-docs-layout *,
+#nd-docs-layout *::before,
+#nd-docs-layout *::after {
   box-sizing: border-box;
   margin: 0;
 }
 
 /* ─── Color Tokens (light by default, matching fumadocs neutral) ──── */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-background: hsl(0, 0%, 96%);
   --color-fd-foreground: hsl(0, 0%, 3.9%);
   --color-fd-muted: hsl(0, 0%, 96.1%);
@@ -44,7 +46,11 @@
   --fd-nav-height: 48px;
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-background: hsl(0, 0%, 7.04%);
   --color-fd-foreground: hsl(0, 0%, 92%);
   --color-fd-muted: hsl(0, 0%, 12.9%);
@@ -65,12 +71,13 @@
 
 /* ─── Base ───────────────────────────────────────────────────────────── */
 
-html {
+html:has(#nd-docs-layout) {
   scroll-behavior: smooth;
   scroll-padding-top: 80px;
 }
 
-body {
+body:has(#nd-docs-layout) {
+  margin: 0;
   font-family: var(--fd-font-sans, ui-sans-serif, system-ui, -apple-system, sans-serif);
   font-size: var(--fd-body-size, 1rem);
   font-weight: var(--fd-body-weight, 400);
@@ -81,10 +88,23 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-code,
-kbd,
-pre,
-samp {
+#nd-docs-layout {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+  font-family: var(--fd-font-sans, ui-sans-serif, system-ui, -apple-system, sans-serif);
+  font-size: var(--fd-body-size, 1rem);
+  font-weight: var(--fd-body-weight, 400);
+  line-height: var(--fd-body-line-height, 1.75);
+  background: var(--color-fd-background);
+  color: var(--color-fd-foreground);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#nd-docs-layout code,
+#nd-docs-layout kbd,
+#nd-docs-layout pre,
+#nd-docs-layout samp {
   font-family: var(
     --fd-font-mono,
     ui-monospace,
@@ -98,7 +118,7 @@ samp {
 
 /* ─── Layout (sidebar + content, TOC lives inside content area) ──────── */
 
-.fd-layout {
+#nd-docs-layout {
   display: grid;
   grid-template-columns: var(--fd-sidebar-width) 1fr;
   min-height: 100dvh;
@@ -106,7 +126,7 @@ samp {
 
 /* ─── Mobile header ──────────────────────────────────────────────────── */
 
-.fd-header {
+#nd-docs-layout .fd-header {
   display: none;
   position: sticky;
   top: 0;
@@ -119,7 +139,7 @@ samp {
   gap: 8px;
 }
 
-.fd-header-title {
+#nd-docs-layout .fd-header-title {
   font-weight: 600;
   font-size: 14px;
   color: var(--color-fd-foreground);
@@ -127,8 +147,8 @@ samp {
   flex: 1;
 }
 
-.fd-menu-btn,
-.fd-search-trigger-mobile {
+#nd-docs-layout .fd-menu-btn,
+#nd-docs-layout .fd-search-trigger-mobile {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -144,39 +164,39 @@ samp {
     color 0.15s;
 }
 
-.fd-menu-btn:hover,
-.fd-search-trigger-mobile:hover {
+#nd-docs-layout .fd-menu-btn:hover,
+#nd-docs-layout .fd-search-trigger-mobile:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
 @media (max-width: 1023px) {
-  .fd-header {
+  #nd-docs-layout .fd-header {
     display: flex;
   }
 
-  .fd-layout {
+  #nd-docs-layout {
     display: flex;
     flex-direction: column;
   }
 }
 
 @media (min-width: 1024px) {
-  .fd-layout {
+  #nd-docs-layout {
     grid-template-columns: var(--fd-sidebar-width) minmax(0, 1fr);
   }
 
-  .fd-main {
+  #nd-docs-layout .fd-main {
     min-width: 0;
   }
 
-  .fd-page {
+  #nd-docs-layout .fd-page {
     grid-template-columns: minmax(0, 1fr) var(--fd-toc-width);
   }
 
-  .fd-page-article,
-  .fd-page-body,
-  .fd-docs-content {
+  #nd-docs-layout .fd-page-article,
+#nd-docs-layout .fd-page-body,
+#nd-docs-layout .fd-docs-content {
     max-width: none;
     margin-inline: 0;
   }
@@ -184,7 +204,7 @@ samp {
 
 /* ─── Sidebar ────────────────────────────────────────────────────────── */
 
-.fd-sidebar {
+#nd-docs-layout .fd-sidebar {
   position: sticky;
   top: 0;
   width: var(--fd-sidebar-width);
@@ -199,7 +219,7 @@ samp {
   z-index: 50;
 }
 
-.fd-sidebar-header {
+#nd-docs-layout .fd-sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -207,7 +227,7 @@ samp {
   gap: 4px;
 }
 
-.fd-sidebar-title {
+#nd-docs-layout .fd-sidebar-title {
   font-weight: 600;
   font-size: 14px;
   letter-spacing: 0.02em;
@@ -220,11 +240,11 @@ samp {
   flex: 1;
 }
 
-.fd-sidebar-title:hover {
+#nd-docs-layout .fd-sidebar-title:hover {
   text-decoration: none;
 }
 
-.fd-sidebar-collapse-btn {
+#nd-docs-layout .fd-sidebar-collapse-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -241,18 +261,18 @@ samp {
   flex-shrink: 0;
 }
 
-.fd-sidebar-collapse-btn:hover {
+#nd-docs-layout .fd-sidebar-collapse-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
 /* ─── Search button (fumadocs style) ─────────────────────────────────── */
 
-.fd-sidebar-search {
+#nd-docs-layout .fd-sidebar-search {
   padding: 8px 12px;
 }
 
-.fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search-btn {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -270,21 +290,21 @@ samp {
     background 0.15s;
 }
 
-.fd-sidebar-search-btn:hover {
+#nd-docs-layout .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent);
 }
 
-.fd-sidebar-search-btn svg {
+#nd-docs-layout .fd-sidebar-search-btn svg {
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.fd-sidebar-search-btn span {
+#nd-docs-layout .fd-sidebar-search-btn span {
   flex: 1;
   text-align: left;
 }
 
-.fd-sidebar-search-btn kbd {
+#nd-docs-layout .fd-sidebar-search-btn kbd {
   font-size: 11px;
   padding: 1px 6px;
   border: 1px solid var(--color-fd-border);
@@ -296,13 +316,13 @@ samp {
 
 /* ─── Sidebar nav ────────────────────────────────────────────────────── */
 
-.fd-sidebar-nav {
+#nd-docs-layout .fd-sidebar-nav {
   flex: 1;
   padding: 4px 12px;
   overflow-y: auto;
 }
 
-.fd-sidebar-link {
+#nd-docs-layout .fd-sidebar-link {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -318,20 +338,20 @@ samp {
     background 0.15s;
 }
 
-.fd-sidebar-link:hover {
+#nd-docs-layout .fd-sidebar-link:hover {
   color: var(--color-fd-accent-foreground);
   background: var(--color-fd-accent);
   text-decoration: none;
 }
 
-.fd-sidebar-link-active,
-.fd-sidebar-link[data-active="true"] {
+#nd-docs-layout .fd-sidebar-link-active,
+#nd-docs-layout .fd-sidebar-link[data-active="true"] {
   color: var(--color-fd-foreground) !important;
   background: var(--color-fd-accent) !important;
   font-weight: 600;
 }
 
-.fd-sidebar-folder-content .fd-sidebar-link-active::before {
+#nd-docs-layout .fd-sidebar-folder-content .fd-sidebar-link-active::before {
   content: "";
   position: absolute;
   left: -9px;
@@ -344,19 +364,19 @@ samp {
 
 /* ─── Sidebar folders ────────────────────────────────────────────────── */
 
-.fd-sidebar-folder {
+#nd-docs-layout .fd-sidebar-folder {
   margin: 2px 0;
 }
 
-.fd-sidebar-folder summary {
+#nd-docs-layout .fd-sidebar-folder summary {
   list-style: none;
 }
 
-.fd-sidebar-folder summary::-webkit-details-marker {
+#nd-docs-layout .fd-sidebar-folder summary::-webkit-details-marker {
   display: none;
 }
 
-.fd-sidebar-folder-trigger {
+#nd-docs-layout .fd-sidebar-folder-trigger {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -369,15 +389,15 @@ samp {
   transition: background 0.15s;
 }
 
-.fd-sidebar-folder-trigger:hover {
+#nd-docs-layout .fd-sidebar-folder-trigger:hover {
   background: var(--color-fd-accent);
 }
 
-.fd-sidebar-folder-trigger-link {
+#nd-docs-layout .fd-sidebar-folder-trigger-link {
   gap: 8px;
 }
 
-.fd-sidebar-folder-parent-link {
+#nd-docs-layout .fd-sidebar-folder-parent-link {
   min-width: 0;
   flex: 1;
   padding: 0;
@@ -385,12 +405,12 @@ samp {
   background: transparent !important;
 }
 
-.fd-sidebar-folder-parent-link:hover {
+#nd-docs-layout .fd-sidebar-folder-parent-link:hover {
   color: inherit;
   background: transparent !important;
 }
 
-.fd-sidebar-folder-toggle {
+#nd-docs-layout .fd-sidebar-folder-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -403,25 +423,25 @@ samp {
   flex-shrink: 0;
 }
 
-.fd-sidebar-chevron {
+#nd-docs-layout .fd-sidebar-chevron {
   transition: transform 0.2s;
   flex-shrink: 0;
   opacity: 0.5;
 }
 
-.fd-sidebar-folder[open] > .fd-sidebar-folder-trigger .fd-sidebar-chevron,
-.fd-sidebar-folder[open] > .fd-sidebar-folder-trigger-link .fd-sidebar-chevron {
+#nd-docs-layout .fd-sidebar-folder[open] > .fd-sidebar-folder-trigger .fd-sidebar-chevron,
+#nd-docs-layout .fd-sidebar-folder[open] > .fd-sidebar-folder-trigger-link .fd-sidebar-chevron {
   transform: rotate(180deg);
 }
 
-.fd-sidebar-folder-content {
+#nd-docs-layout .fd-sidebar-folder-content {
   position: relative;
   padding-left: 12px;
   margin-left: 10px;
   margin-top: 2px;
 }
 
-.fd-sidebar-folder-content::before {
+#nd-docs-layout .fd-sidebar-folder-content::before {
   content: "";
   position: absolute;
   left: 4px;
@@ -431,17 +451,17 @@ samp {
   background: var(--color-fd-border);
 }
 
-.fd-sidebar-banner {
+#nd-docs-layout .fd-sidebar-banner {
   padding: 12px 16px;
   border-bottom: 1px solid var(--color-fd-border);
 }
 
-.fd-sidebar-footer-custom {
+#nd-docs-layout .fd-sidebar-footer-custom {
   padding: 12px 16px;
   border-top: 1px solid var(--color-fd-border);
 }
 
-.fd-sidebar-footer {
+#nd-docs-layout .fd-sidebar-footer {
   padding: 12px 16px;
   border-top: 1px solid var(--color-fd-border);
   margin-top: auto;
@@ -449,7 +469,7 @@ samp {
 
 /* ─── Sidebar overlay + responsive ───────────────────────────────────── */
 
-.fd-sidebar-overlay {
+#nd-docs-layout .fd-sidebar-overlay {
   display: none;
   position: fixed;
   inset: 0;
@@ -459,7 +479,7 @@ samp {
 }
 
 @media (max-width: 1023px) {
-  .fd-sidebar {
+  #nd-docs-layout .fd-sidebar {
     position: fixed;
     left: 0;
     top: 0;
@@ -468,31 +488,31 @@ samp {
     z-index: 50;
   }
 
-  .fd-sidebar-open {
+  #nd-docs-layout .fd-sidebar-open {
     transform: translateX(0);
   }
 
-  .fd-sidebar-open + .fd-sidebar-overlay {
+  #nd-docs-layout .fd-sidebar-open + .fd-sidebar-overlay {
     display: block;
   }
 }
 
 /* ─── Main content ───────────────────────────────────────────────────── */
 
-.fd-main {
+#nd-docs-layout .fd-main {
   min-width: 0;
   padding: 0;
 }
 
 /* ─── Page layout (article + TOC) ────────────────────────────────────── */
 
-.fd-page {
+#nd-docs-layout .fd-page {
   display: grid;
   grid-template-columns: 1fr var(--fd-toc-width);
   width: 100%;
 }
 
-.fd-page-article {
+#nd-docs-layout .fd-page-article {
   min-width: 0;
   padding: 32px 48px 64px;
   display: flex;
@@ -502,7 +522,7 @@ samp {
 
 /* ─── Table of Contents (right column, flush to right edge) ──────────── */
 
-.fd-toc {
+#nd-docs-layout .fd-toc {
   width: var(--fd-toc-width);
   position: sticky;
   top: 0;
@@ -511,10 +531,10 @@ samp {
   padding: 40px 24px;
 }
 
-.fd-toc-inner {
+#nd-docs-layout .fd-toc-inner {
 }
 
-.fd-toc-title {
+#nd-docs-layout .fd-toc-title {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -524,11 +544,11 @@ samp {
   margin-bottom: 12px;
 }
 
-.fd-toc-title svg {
+#nd-docs-layout .fd-toc-title svg {
   opacity: 0.5;
 }
 
-.fd-toc-list {
+#nd-docs-layout .fd-toc-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -538,11 +558,11 @@ samp {
   border-left: 1px solid var(--color-fd-border);
 }
 
-.fd-toc-item {
+#nd-docs-layout .fd-toc-item {
   margin: 0;
 }
 
-.fd-toc-link {
+#nd-docs-layout .fd-toc-link {
   display: block;
   padding: 4px 12px;
   font-size: 13px;
@@ -555,23 +575,23 @@ samp {
     border-color 0.15s;
 }
 
-.fd-toc-link:hover {
+#nd-docs-layout .fd-toc-link:hover {
   color: var(--color-fd-foreground);
   text-decoration: none;
 }
 
-.fd-toc-link-active {
+#nd-docs-layout .fd-toc-link-active {
   color: var(--color-fd-primary);
   border-left-color: var(--color-fd-primary);
 }
 
 /* ─── Clerk TOC (tree-line style) ────────────────────────────────────── */
 
-.fd-toc-clerk {
+#nd-docs-layout .fd-toc-clerk {
   border-left: none !important;
 }
 
-.fd-toc-clerk .fd-toc-link {
+#nd-docs-layout .fd-toc-clerk .fd-toc-link {
   display: block;
   border-left: none;
   margin-left: 0;
@@ -580,45 +600,45 @@ samp {
   transition: color 0.15s;
 }
 
-.fd-toc-clerk .fd-toc-link:hover {
+#nd-docs-layout .fd-toc-clerk .fd-toc-link:hover {
   color: var(--color-fd-foreground);
 }
 
-.fd-toc-clerk .fd-toc-link[data-active="true"] {
+#nd-docs-layout .fd-toc-clerk .fd-toc-link[data-active="true"] {
   color: var(--color-fd-primary);
 }
 
-.fd-toc-clerk-mask {
+#nd-docs-layout .fd-toc-clerk-mask {
   overflow: hidden;
 }
 
-.fd-toc-clerk-thumb {
+#nd-docs-layout .fd-toc-clerk-thumb {
   width: 100%;
 }
 
 @media (max-width: 1279px) {
-  .fd-toc {
+  #nd-docs-layout .fd-toc {
     display: none;
   }
 
-  .fd-page {
+  #nd-docs-layout .fd-page {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 1023px) {
-  .fd-toc {
+  #nd-docs-layout .fd-toc {
     display: none;
   }
 
-  .fd-page {
+  #nd-docs-layout .fd-page {
     grid-template-columns: 1fr;
   }
 }
 
 /* ─── Page title + description (match Nuxt/Astro: title first, then description) ─────── */
 
-.fd-page-title {
+#nd-docs-layout .fd-page-title {
   font-size: var(--fd-h1-size, 2.25rem);
   font-weight: var(--fd-h1-weight, 700);
   line-height: var(--fd-h1-line-height, 1.2);
@@ -627,7 +647,7 @@ samp {
   scroll-margin-top: 80px;
 }
 
-.fd-page-description {
+#nd-docs-layout .fd-page-description {
   margin-top: 0;
   margin-bottom: 1rem;
   font-size: var(--fd-body-size, 1.125rem);
@@ -638,14 +658,14 @@ samp {
 
 /* ─── Page Actions (Copy page / Open in …) ─────────────────────────────── */
 
-.fd-page-actions-divider {
+#nd-docs-layout .fd-page-actions-divider {
   border: none;
   border-top: 1px solid var(--color-fd-border);
   margin: 1rem 0 0.75rem;
 }
 
-.fd-page-actions,
-[data-page-actions] {
+#nd-docs-layout .fd-page-actions,
+#nd-docs-layout [data-page-actions] {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -655,17 +675,17 @@ samp {
   width: 100%;
 }
 
-.fd-page-actions[data-actions-alignment="right"],
-[data-page-actions][data-actions-alignment="right"] {
+#nd-docs-layout .fd-page-actions[data-actions-alignment="right"],
+#nd-docs-layout [data-page-actions][data-actions-alignment="right"] {
   justify-content: flex-end;
 }
 
-.fd-page-actions[data-actions-alignment="left"],
-[data-page-actions][data-actions-alignment="left"] {
+#nd-docs-layout .fd-page-actions[data-actions-alignment="left"],
+#nd-docs-layout [data-page-actions][data-actions-alignment="left"] {
   justify-content: flex-start;
 }
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -687,33 +707,33 @@ samp {
   user-select: none;
 }
 
-.fd-page-action-btn:hover {
+#nd-docs-layout .fd-page-action-btn:hover {
   color: var(--color-fd-accent-foreground);
   background: var(--color-fd-accent);
 }
 
-.fd-page-action-btn[data-copied="true"] {
+#nd-docs-layout .fd-page-action-btn[data-copied="true"] {
   color: var(--color-fd-foreground);
 }
 
-.fd-page-action-btn[data-selected="true"] {
+#nd-docs-layout .fd-page-action-btn[data-selected="true"] {
   color: var(--color-fd-accent-foreground);
   background: var(--color-fd-accent);
 }
 
-.fd-page-action-btn svg {
+#nd-docs-layout .fd-page-action-btn svg {
   flex-shrink: 0;
 }
 
-.fd-page-action-btn[data-selected="true"] svg {
+#nd-docs-layout .fd-page-action-btn[data-selected="true"] svg {
   color: currentColor;
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   position: absolute;
   top: calc(100% + 0.375rem);
   left: 0;
@@ -729,11 +749,11 @@ samp {
   gap: 0.125rem;
 }
 
-.fd-page-action-menu[hidden] {
+#nd-docs-layout .fd-page-action-menu[hidden] {
   display: none !important;
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -751,32 +771,32 @@ samp {
   transition: background 0.1s, color 0.1s;
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
 }
 
-.fd-page-action-menu-label {
+#nd-docs-layout .fd-page-action-menu-label {
   flex: 1;
 }
 
-.fd-page-actions a,
-.fd-page-actions button,
-.fd-page-action-menu-item,
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-actions a,
+#nd-docs-layout .fd-page-actions button,
+#nd-docs-layout .fd-page-action-menu-item,
+#nd-docs-layout .fd-page-action-btn {
   text-decoration: none !important;
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   text-decoration: none !important;
 }
 
-.fd-last-modified-below-title {
+#nd-docs-layout .fd-last-modified-below-title {
   margin-top: 0.25rem;
   margin-bottom: 1rem;
 }
 
-.fd-page-meta {
+#nd-docs-layout .fd-page-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -784,7 +804,7 @@ samp {
   margin-bottom: 0.75rem;
 }
 
-.fd-page-meta-dot {
+#nd-docs-layout .fd-page-meta-dot {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -794,7 +814,7 @@ samp {
   color: color-mix(in srgb, var(--color-fd-muted-foreground) 78%, transparent);
 }
 
-.fd-page-meta-item {
+#nd-docs-layout .fd-page-meta-item {
   font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
   font-size: 0.6875rem;
   font-weight: 500;
@@ -803,14 +823,14 @@ samp {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-feedback {
+#nd-docs-layout .fd-feedback {
   margin-top: 2rem;
   margin-bottom: 1.25rem;
   padding-top: 1.25rem;
   border-top: 1px solid var(--color-fd-border);
 }
 
-.fd-feedback-content {
+#nd-docs-layout .fd-feedback-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -818,7 +838,7 @@ samp {
   flex-wrap: wrap;
 }
 
-.fd-feedback-question {
+#nd-docs-layout .fd-feedback-question {
   margin: 0;
   font-size: 0.9375rem;
   font-weight: 600;
@@ -826,34 +846,34 @@ samp {
   color: var(--color-fd-foreground);
 }
 
-.fd-feedback-actions {
+#nd-docs-layout .fd-feedback-actions {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-.fd-feedback-form {
+#nd-docs-layout .fd-feedback-form {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   margin-top: 0.875rem;
 }
 
-.fd-feedback-form[hidden],
-.fd-feedback-spinner[hidden],
-.fd-feedback-status[hidden],
-.fd-feedback-submit svg[hidden] {
+#nd-docs-layout .fd-feedback-form[hidden],
+#nd-docs-layout .fd-feedback-spinner[hidden],
+#nd-docs-layout .fd-feedback-status[hidden],
+#nd-docs-layout .fd-feedback-submit svg[hidden] {
   display: none !important;
 }
 
-.fd-feedback-choice[data-selected="true"] {
+#nd-docs-layout .fd-feedback-choice[data-selected="true"] {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
   border-color: color-mix(in srgb, var(--color-fd-primary, currentColor) 65%, transparent);
 }
 
-.fd-feedback-input {
+#nd-docs-layout .fd-feedback-input {
   width: 100%;
   min-height: 4.75rem;
   resize: vertical;
@@ -872,16 +892,16 @@ samp {
     background-color 150ms ease;
 }
 
-.fd-feedback-input::placeholder {
+#nd-docs-layout .fd-feedback-input::placeholder {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-feedback-input:focus {
+#nd-docs-layout .fd-feedback-input:focus {
   border-color: var(--color-fd-ring, var(--color-fd-primary, currentColor));
   box-shadow: 0 0 0 1px var(--color-fd-ring, var(--color-fd-primary, currentColor));
 }
 
-.fd-feedback-submit-row {
+#nd-docs-layout .fd-feedback-submit-row {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -889,18 +909,18 @@ samp {
   min-height: 2rem;
 }
 
-.fd-feedback-submit {
+#nd-docs-layout .fd-feedback-submit {
   min-width: 7rem;
   padding-inline: 0.875rem;
   justify-content: center;
 }
 
-.fd-feedback-submit:disabled {
+#nd-docs-layout .fd-feedback-submit:disabled {
   cursor: not-allowed;
   opacity: 0.65;
 }
 
-.fd-feedback-spinner {
+#nd-docs-layout .fd-feedback-spinner {
   width: 0.875rem;
   height: 0.875rem;
   border-radius: 9999px;
@@ -909,14 +929,14 @@ samp {
   animation: fd-feedback-spin 0.8s linear infinite;
 }
 
-.fd-feedback-status {
+#nd-docs-layout .fd-feedback-status {
   margin: 0 !important;
   font-size: 0.75rem;
   line-height: 1.3;
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-feedback-status[data-status="success"] {
+#nd-docs-layout .fd-feedback-status[data-status="success"] {
   display: inline-flex;
   align-self: center;
   align-items: center;
@@ -924,11 +944,11 @@ samp {
   min-height: 2rem;
 }
 
-.fd-feedback-status[data-status="success"] {
+#nd-docs-layout .fd-feedback-status[data-status="success"] {
   color: color-mix(in srgb, var(--color-fd-primary) 85%, var(--color-fd-foreground));
 }
 
-.fd-feedback-status[data-status="error"] {
+#nd-docs-layout .fd-feedback-status[data-status="error"] {
   color: var(--color-fd-foreground);
 }
 
@@ -939,19 +959,19 @@ samp {
 }
 
 @media (max-width: 640px) {
-  .fd-feedback-content {
+  #nd-docs-layout .fd-feedback-content {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .fd-feedback-submit-row {
+  #nd-docs-layout .fd-feedback-submit-row {
     flex-wrap: wrap;
   }
 }
 
 /* ─── Breadcrumb ─────────────────────────────────────────────────────── */
 
-.fd-breadcrumb {
+#nd-docs-layout .fd-breadcrumb {
   display: flex;
   align-items: center;
   gap: 0;
@@ -961,23 +981,23 @@ samp {
   margin-bottom: 2rem;
 }
 
-.fd-breadcrumb-item {
+#nd-docs-layout .fd-breadcrumb-item {
   display: inline-flex;
   align-items: center;
 }
 
-.fd-breadcrumb-sep {
+#nd-docs-layout .fd-breadcrumb-sep {
   margin: 0 6px;
   opacity: 0.4;
   font-size: var(--fd-small-size, 0.75rem);
 }
 
-.fd-breadcrumb-parent {
+#nd-docs-layout .fd-breadcrumb-parent {
   opacity: 0.7;
   font-weight: 400;
 }
 
-.fd-breadcrumb-link {
+#nd-docs-layout .fd-breadcrumb-link {
   color: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -986,20 +1006,20 @@ samp {
     color 0.15s;
 }
 
-.fd-breadcrumb-link:hover {
+#nd-docs-layout .fd-breadcrumb-link:hover {
   opacity: 1;
   color: var(--color-fd-foreground);
   text-decoration: none;
 }
 
-.fd-breadcrumb-current {
+#nd-docs-layout .fd-breadcrumb-current {
   font-weight: 500;
   color: var(--color-fd-foreground);
 }
 
 /* ─── Prompt Cards ─────────────────────────────────────────────────── */
 
-.fd-prompt {
+#nd-docs-layout .fd-prompt {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
@@ -1010,22 +1030,22 @@ samp {
   background: color-mix(in srgb, var(--color-fd-card) 78%, transparent);
 }
 
-.fd-prompt-header {
+#nd-docs-layout .fd-prompt-header {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
 }
 
-.fd-prompt-icon,
-.fd-prompt-action-icon,
-.fd-prompt-menu-icon {
+#nd-docs-layout .fd-prompt-icon,
+#nd-docs-layout .fd-prompt-action-icon,
+#nd-docs-layout .fd-prompt-menu-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
 }
 
-.fd-prompt-icon {
+#nd-docs-layout .fd-prompt-icon {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 0.5rem;
@@ -1034,18 +1054,18 @@ samp {
   color: var(--color-fd-foreground);
 }
 
-.fd-prompt-icon svg,
-.fd-prompt-action-icon svg,
-.fd-prompt-menu-icon svg {
+#nd-docs-layout .fd-prompt-icon svg,
+#nd-docs-layout .fd-prompt-action-icon svg,
+#nd-docs-layout .fd-prompt-menu-icon svg {
   width: 1rem;
   height: 1rem;
 }
 
-.fd-prompt-copy {
+#nd-docs-layout .fd-prompt-copy {
   min-width: 0;
 }
 
-.fd-prompt-title {
+#nd-docs-layout .fd-prompt-title {
   margin: 0;
   color: var(--color-fd-foreground);
   font-size: 0.9375rem;
@@ -1053,14 +1073,14 @@ samp {
   line-height: 1.35;
 }
 
-.fd-prompt-description {
+#nd-docs-layout .fd-prompt-description {
   margin: 0.25rem 0 0;
   color: var(--color-fd-muted-foreground);
   font-size: 0.875rem;
   line-height: 1.55;
 }
 
-.fd-prompt-body {
+#nd-docs-layout .fd-prompt-body {
   margin: 0;
   padding: 0.875rem 1rem;
   border-radius: 0.625rem;
@@ -1069,7 +1089,7 @@ samp {
   overflow-x: auto;
 }
 
-.fd-prompt-body > pre.fd-prompt-code {
+#nd-docs-layout .fd-prompt-body > pre.fd-prompt-code {
   margin: 0;
   padding: 0 !important;
   border: 0 !important;
@@ -1092,7 +1112,7 @@ samp {
   );
 }
 
-.fd-prompt-actions {
+#nd-docs-layout .fd-prompt-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -1100,7 +1120,7 @@ samp {
   justify-content: flex-end;
 }
 
-.fd-prompt-action-btn {
+#nd-docs-layout .fd-prompt-action-btn {
   display: inline-flex;
   align-items: center;
   gap: 0.4375rem;
@@ -1117,24 +1137,24 @@ samp {
   transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 
-.fd-prompt-action-btn:hover {
+#nd-docs-layout .fd-prompt-action-btn:hover {
   color: var(--color-fd-accent-foreground);
   background: var(--color-fd-accent);
 }
 
-.fd-prompt-action-btn[data-copied="true"] {
+#nd-docs-layout .fd-prompt-action-btn[data-copied="true"] {
   color: var(--color-fd-foreground);
 }
 
-.fd-prompt-action-icon-copied[hidden] {
+#nd-docs-layout .fd-prompt-action-icon-copied[hidden] {
   display: none !important;
 }
 
-.fd-prompt-dropdown {
+#nd-docs-layout .fd-prompt-dropdown {
   position: relative;
 }
 
-.fd-prompt-menu {
+#nd-docs-layout .fd-prompt-menu {
   position: absolute;
   top: calc(100% + 0.375rem);
   right: 0;
@@ -1150,11 +1170,11 @@ samp {
   gap: 0.125rem;
 }
 
-.fd-prompt-menu[hidden] {
+#nd-docs-layout .fd-prompt-menu[hidden] {
   display: none !important;
 }
 
-.fd-prompt-menu-item {
+#nd-docs-layout .fd-prompt-menu-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1171,18 +1191,18 @@ samp {
   transition: background 0.1s, color 0.1s;
 }
 
-.fd-prompt-menu-item:hover {
+#nd-docs-layout .fd-prompt-menu-item:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
 }
 
-.fd-prompt-menu-label {
+#nd-docs-layout .fd-prompt-menu-label {
   flex: 1;
 }
 
 /* ─── Theme Toggle ───────────────────────────────────────────────────── */
 
-.fd-theme-toggle {
+#nd-docs-layout .fd-theme-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1198,14 +1218,14 @@ samp {
     background 0.15s;
 }
 
-.fd-theme-toggle:hover {
+#nd-docs-layout .fd-theme-toggle:hover {
   color: var(--color-fd-foreground);
   background: var(--color-fd-accent);
 }
 
 /* ─── Search Dialog (matching fumadocs Cmd+K) ────────────────────────── */
 
-.fd-search-overlay {
+#nd-docs-layout .fd-search-overlay {
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -1218,7 +1238,7 @@ samp {
   animation: fd-fade-in 0.12s ease-out;
 }
 
-.fd-search-dialog {
+#nd-docs-layout .fd-search-dialog {
   width: 90%;
   max-width: 540px;
   background: var(--color-fd-popover);
@@ -1229,7 +1249,7 @@ samp {
   animation: fd-slide-up 0.15s ease-out;
 }
 
-.fd-search-input-wrap {
+#nd-docs-layout .fd-search-input-wrap {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -1237,12 +1257,12 @@ samp {
   border-bottom: 1px solid var(--color-fd-border);
 }
 
-.fd-search-input-wrap svg {
+#nd-docs-layout .fd-search-input-wrap svg {
   color: var(--color-fd-muted-foreground);
   flex-shrink: 0;
 }
 
-.fd-search-input {
+#nd-docs-layout .fd-search-input {
   flex: 1;
   background: transparent;
   border: none;
@@ -1252,11 +1272,11 @@ samp {
   font-family: inherit;
 }
 
-.fd-search-input::placeholder {
+#nd-docs-layout .fd-search-input::placeholder {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-search-kbd {
+#nd-docs-layout .fd-search-kbd {
   font-size: 11px;
   padding: 2px 6px;
   border: 1px solid var(--color-fd-border);
@@ -1266,20 +1286,20 @@ samp {
   background: var(--color-fd-background);
 }
 
-.fd-search-results {
+#nd-docs-layout .fd-search-results {
   max-height: 360px;
   overflow-y: auto;
   padding: 8px;
 }
 
-.fd-search-empty {
+#nd-docs-layout .fd-search-empty {
   padding: 32px;
   text-align: center;
   color: var(--color-fd-muted-foreground);
   font-size: 14px;
 }
 
-.fd-search-result {
+#nd-docs-layout .fd-search-result {
   display: block;
   width: 100%;
   text-align: left;
@@ -1293,17 +1313,17 @@ samp {
   color: var(--color-fd-foreground);
 }
 
-.fd-search-result:hover {
+#nd-docs-layout .fd-search-result:hover {
   background: var(--color-fd-accent);
 }
 
-.fd-search-result-title {
+#nd-docs-layout .fd-search-result-title {
   display: block;
   font-size: 14px;
   font-weight: 500;
 }
 
-.fd-search-result-url {
+#nd-docs-layout .fd-search-result-url {
   display: block;
   font-size: 12px;
   color: var(--color-fd-muted-foreground);
@@ -1312,14 +1332,14 @@ samp {
 
 /* ─── Prose / Markdown content (matching fumadocs) ───────────────────── */
 
-.fd-page-body {
+#nd-docs-layout .fd-page-body {
   color: var(--color-fd-foreground);
   line-height: 1.75;
   font-size: 15px;
   flex: 1;
 }
 
-.fd-page-body a {
+#nd-docs-layout .fd-page-body a {
   color: var(--color-fd-foreground);
   font-weight: 500;
   text-decoration: underline;
@@ -1327,18 +1347,18 @@ samp {
   text-decoration-color: var(--color-fd-primary);
 }
 
-.fd-page-body a:hover {
+#nd-docs-layout .fd-page-body a:hover {
   opacity: 0.8;
 }
 
-.fd-hover-link {
+#nd-docs-layout .fd-hover-link {
   position: relative;
   display: inline-block;
   vertical-align: baseline;
   max-width: 100%;
 }
 
-.fd-hover-link-trigger {
+#nd-docs-layout .fd-hover-link-trigger {
   display: inline !important;
   border: none;
   background: transparent;
@@ -1358,17 +1378,17 @@ samp {
   transition: text-decoration-color 180ms ease, opacity 180ms ease;
 }
 
-.fd-hover-link-trigger:hover,
-.fd-hover-link-trigger:focus-visible,
-.fd-hover-link-open > .fd-hover-link-trigger {
+#nd-docs-layout .fd-hover-link-trigger:hover,
+#nd-docs-layout .fd-hover-link-trigger:focus-visible,
+#nd-docs-layout .fd-hover-link-open > .fd-hover-link-trigger {
   text-decoration-color: color-mix(in srgb, var(--color-fd-foreground) 68%, transparent);
 }
 
-.fd-hover-link-trigger:focus-visible {
+#nd-docs-layout .fd-hover-link-trigger:focus-visible {
   outline: none;
 }
 
-.fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link-popover {
   --fd-hover-link-rest-x: -50%;
   --fd-hover-link-rest-y: 8px;
   --fd-hover-link-open-x: -50%;
@@ -1386,27 +1406,27 @@ samp {
   transition: opacity 180ms ease, transform 180ms ease, visibility 180ms linear;
 }
 
-.fd-hover-link[data-align="start"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-align="start"] > .fd-hover-link-popover {
   left: 0;
   --fd-hover-link-rest-x: 0;
   --fd-hover-link-open-x: 0;
 }
 
-.fd-hover-link[data-align="end"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-align="end"] > .fd-hover-link-popover {
   left: auto;
   right: 0;
   --fd-hover-link-rest-x: 0;
   --fd-hover-link-open-x: 0;
 }
 
-.fd-hover-link[data-side="top"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="top"] > .fd-hover-link-popover {
   top: auto;
   bottom: calc(100% + var(--fd-hover-link-side-offset, 12px));
   --fd-hover-link-rest-y: -8px;
   --fd-hover-link-open-y: 0;
 }
 
-.fd-hover-link[data-side="right"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="right"] > .fd-hover-link-popover {
   top: 50%;
   left: calc(100% + var(--fd-hover-link-side-offset, 12px));
   right: auto;
@@ -1416,20 +1436,20 @@ samp {
   --fd-hover-link-open-y: -50%;
 }
 
-.fd-hover-link[data-side="right"][data-align="start"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="right"][data-align="start"] > .fd-hover-link-popover {
   top: 0;
   --fd-hover-link-rest-y: 0;
   --fd-hover-link-open-y: 0;
 }
 
-.fd-hover-link[data-side="right"][data-align="end"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="right"][data-align="end"] > .fd-hover-link-popover {
   top: auto;
   bottom: 0;
   --fd-hover-link-rest-y: 0;
   --fd-hover-link-open-y: 0;
 }
 
-.fd-hover-link[data-side="left"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="left"] > .fd-hover-link-popover {
   top: 50%;
   left: auto;
   right: calc(100% + var(--fd-hover-link-side-offset, 12px));
@@ -1439,27 +1459,27 @@ samp {
   --fd-hover-link-open-y: -50%;
 }
 
-.fd-hover-link[data-side="left"][data-align="start"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="left"][data-align="start"] > .fd-hover-link-popover {
   top: 0;
   --fd-hover-link-rest-y: 0;
   --fd-hover-link-open-y: 0;
 }
 
-.fd-hover-link[data-side="left"][data-align="end"] > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link[data-side="left"][data-align="end"] > .fd-hover-link-popover {
   top: auto;
   bottom: 0;
   --fd-hover-link-rest-y: 0;
   --fd-hover-link-open-y: 0;
 }
 
-.fd-hover-link-open > .fd-hover-link-popover {
+#nd-docs-layout .fd-hover-link-open > .fd-hover-link-popover {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transform: translate3d(var(--fd-hover-link-open-x), var(--fd-hover-link-open-y), 0);
 }
 
-.fd-hover-link-card {
+#nd-docs-layout .fd-hover-link-card {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1473,13 +1493,13 @@ samp {
   backdrop-filter: blur(14px);
 }
 
-.fd-hover-link-body {
+#nd-docs-layout .fd-hover-link-body {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
 }
 
-.fd-hover-link-preview-label {
+#nd-docs-layout .fd-hover-link-preview-label {
   font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -1487,30 +1507,30 @@ samp {
   color: color-mix(in srgb, var(--color-fd-popover-foreground, var(--color-fd-foreground)) 55%, transparent);
 }
 
-.fd-hover-link-title,
-.fd-hover-link-cta {
+#nd-docs-layout .fd-hover-link-title,
+#nd-docs-layout .fd-hover-link-cta {
   text-decoration: none !important;
 }
 
-.fd-hover-link-title {
+#nd-docs-layout .fd-hover-link-title {
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground));
   font-size: 1rem;
   font-weight: 600 !important;
   line-height: 1.3;
 }
 
-.fd-hover-link-title:hover,
-.fd-hover-link-cta:hover {
+#nd-docs-layout .fd-hover-link-title:hover,
+#nd-docs-layout .fd-hover-link-cta:hover {
   opacity: 1;
 }
 
-.fd-hover-link-description {
+#nd-docs-layout .fd-hover-link-description {
   font-size: 0.92rem;
   line-height: 1.6;
   color: color-mix(in srgb, var(--color-fd-popover-foreground, var(--color-fd-foreground)) 74%, transparent);
 }
 
-.fd-hover-link-footer {
+#nd-docs-layout .fd-hover-link-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1519,7 +1539,7 @@ samp {
   border-top: 1px solid color-mix(in srgb, var(--color-fd-border) 72%, transparent);
 }
 
-.fd-hover-link-cta {
+#nd-docs-layout .fd-hover-link-cta {
   display: inline-flex !important;
   align-items: center;
   gap: 0.4rem;
@@ -1531,7 +1551,7 @@ samp {
   font-family: var(--fd-font-mono, var(--font-geist-mono, ui-monospace, monospace));
 }
 
-.fd-page-body h1 {
+#nd-docs-layout .fd-page-body h1 {
   font-size: var(--fd-h1-size, 2.25rem);
   font-weight: var(--fd-h1-weight, 700);
   line-height: var(--fd-h1-line-height, 1.2);
@@ -1540,7 +1560,7 @@ samp {
   scroll-margin-top: 80px;
 }
 
-.fd-page-body h2 {
+#nd-docs-layout .fd-page-body h2 {
   font-size: var(--fd-h2-size, 1.5rem);
   font-weight: var(--fd-h2-weight, 600);
   line-height: var(--fd-h2-line-height, 1.3);
@@ -1551,7 +1571,7 @@ samp {
   scroll-margin-top: 80px;
 }
 
-.fd-page-body h3 {
+#nd-docs-layout .fd-page-body h3 {
   font-size: var(--fd-h3-size, 1.25rem);
   font-weight: var(--fd-h3-weight, 600);
   line-height: var(--fd-h3-line-height, 1.4);
@@ -1559,7 +1579,7 @@ samp {
   scroll-margin-top: 80px;
 }
 
-.fd-page-body h4 {
+#nd-docs-layout .fd-page-body h4 {
   font-size: var(--fd-h4-size, 1.125rem);
   font-weight: var(--fd-h4-weight, 600);
   line-height: var(--fd-h4-line-height, 1.4);
@@ -1567,49 +1587,49 @@ samp {
   scroll-margin-top: 80px;
 }
 
-.fd-page-body p {
+#nd-docs-layout .fd-page-body p {
   margin: 0 0 16px;
   font-size: var(--fd-body-size, 1rem);
   font-weight: var(--fd-body-weight, 400);
   line-height: var(--fd-body-line-height, 1.75);
 }
 
-.fd-page-body ul,
-.fd-page-body ol {
+#nd-docs-layout .fd-page-body ul,
+#nd-docs-layout .fd-page-body ol {
   margin: 0 0 16px;
   padding-left: 24px;
 }
 
-.fd-page-body li {
+#nd-docs-layout .fd-page-body li {
   margin: 4px 0;
   font-size: var(--fd-body-size, 1rem);
   font-weight: var(--fd-body-weight, 400);
   line-height: var(--fd-body-line-height, 1.75);
 }
 
-.fd-page-body li::marker {
+#nd-docs-layout .fd-page-body li::marker {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-page-body strong {
+#nd-docs-layout .fd-page-body strong {
   font-weight: 600;
   color: var(--color-fd-foreground);
 }
 
-.fd-page-body hr {
+#nd-docs-layout .fd-page-body hr {
   border: none;
   border-top: 1px solid var(--color-fd-border);
   margin: 32px 0;
 }
 
-.fd-page-body blockquote {
+#nd-docs-layout .fd-page-body blockquote {
   border-left: 3px solid var(--color-fd-border);
   padding: 8px 16px;
   margin: 16px 0;
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-page-body code {
+#nd-docs-layout .fd-page-body code {
   font-size: 0.875em;
   padding: 2px 5px;
   background: var(--color-fd-secondary);
@@ -1618,7 +1638,7 @@ samp {
   color: var(--color-fd-foreground);
 }
 
-.fd-page-body pre {
+#nd-docs-layout .fd-page-body pre {
   margin: 16px 0;
   padding: 14px 16px;
   background: var(--color-fd-card);
@@ -1630,7 +1650,7 @@ samp {
   position: relative;
 }
 
-.fd-page-body pre code {
+#nd-docs-layout .fd-page-body pre code {
   background: transparent;
   border: none;
   padding: 0;
@@ -1640,36 +1660,36 @@ samp {
 }
 
 /* Shiki dual-theme: light uses inline styles, dark uses --shiki-dark vars */
-.fd-page-body pre.shiki {
+#nd-docs-layout .fd-page-body pre.shiki {
   background-color: var(--color-fd-card) !important;
 }
 
-.fd-page-body pre.shiki code {
+#nd-docs-layout .fd-page-body pre.shiki code {
   counter-reset: line;
 }
 
-html.dark .shiki,
-html.dark .shiki span {
+html.dark #nd-docs-layout .shiki,
+html.dark #nd-docs-layout .shiki span {
   color: var(--shiki-dark) !important;
   background-color: transparent !important;
 }
 
-html.dark pre.shiki {
+html.dark #nd-docs-layout pre.shiki {
   background-color: var(--color-fd-card) !important;
 }
 
 /* ─── Code block wrapper + copy button ────────────────────────────────── */
 
-.fd-codeblock {
+#nd-docs-layout .fd-codeblock {
   position: relative;
   margin: 16px 0;
 }
 
-.fd-codeblock pre {
+#nd-docs-layout .fd-codeblock pre {
   margin: 0;
 }
 
-.fd-codeblock-title {
+#nd-docs-layout .fd-codeblock-title {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1684,17 +1704,17 @@ html.dark pre.shiki {
   border-radius: var(--radius, 12px) var(--radius, 12px) 0 0;
 }
 
-.fd-codeblock-title + .fd-copy-btn ~ pre {
+#nd-docs-layout .fd-codeblock-title + .fd-copy-btn ~ pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }
 
-.fd-codeblock:has(.fd-codeblock-title) pre {
+#nd-docs-layout .fd-codeblock:has(.fd-codeblock-title) pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }
 
-.fd-copy-btn {
+#nd-docs-layout .fd-copy-btn {
   position: absolute;
   top: 4px;
   right: 4px;
@@ -1717,23 +1737,23 @@ html.dark pre.shiki {
     background 0.15s;
 }
 
-.fd-codeblock:hover .fd-copy-btn {
+#nd-docs-layout .fd-codeblock:hover .fd-copy-btn {
   opacity: 1;
 }
 
-.fd-copy-btn:hover {
+#nd-docs-layout .fd-copy-btn:hover {
   color: var(--color-fd-foreground);
   background: var(--color-fd-accent);
 }
 
-.fd-copy-btn-copied {
+#nd-docs-layout .fd-copy-btn-copied {
   color: hsl(142, 71%, 45%) !important;
   opacity: 1 !important;
 }
 
 /* ─── Tabs ────────────────────────────────────────────────────────────── */
 
-.fd-tabs {
+#nd-docs-layout .fd-tabs {
   margin: 16px 0;
   border: 1px solid var(--color-fd-border);
   border-radius: 12px;
@@ -1742,14 +1762,14 @@ html.dark pre.shiki {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.fd-tabs-list {
+#nd-docs-layout .fd-tabs-list {
   display: flex;
   border-bottom: 1px solid var(--color-fd-border);
   background: transparent;
   overflow-x: auto;
 }
 
-.fd-tab-trigger {
+#nd-docs-layout .fd-tab-trigger {
   padding: 8px 14px;
   font-size: 13px;
   font-weight: 500;
@@ -1765,58 +1785,58 @@ html.dark pre.shiki {
   white-space: nowrap;
 }
 
-.fd-tab-trigger:hover {
+#nd-docs-layout .fd-tab-trigger:hover {
   color: var(--color-fd-foreground);
 }
 
-.fd-tab-trigger.fd-tab-active {
+#nd-docs-layout .fd-tab-trigger.fd-tab-active {
   color: var(--color-fd-foreground);
   font-weight: 600;
   border-bottom-color: var(--color-fd-primary);
 }
 
-.fd-tab-panel {
+#nd-docs-layout .fd-tab-panel {
   display: none;
 }
 
-.fd-tab-panel-active {
+#nd-docs-layout .fd-tab-panel-active {
   display: block;
 }
 
-.fd-tab-panel .fd-codeblock {
+#nd-docs-layout .fd-tab-panel .fd-codeblock {
   margin: 0;
 }
 
-.fd-tab-panel .fd-codeblock pre {
+#nd-docs-layout .fd-tab-panel .fd-codeblock pre {
   border: none;
   border-radius: 0;
   margin: 0;
   background: transparent !important;
 }
 
-.fd-tab-panel .fd-copy-btn {
+#nd-docs-layout .fd-tab-panel .fd-copy-btn {
   top: 6px;
   right: 6px;
 }
 
-.fd-page-body .fd-table-wrapper {
+#nd-docs-layout .fd-page-body .fd-table-wrapper {
   margin: 16px 0;
   overflow-x: auto;
   border: 1px solid var(--color-fd-border);
   border-radius: 8px;
 }
 
-.fd-page-body table {
+#nd-docs-layout .fd-page-body table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
 }
 
-.fd-page-body thead {
+#nd-docs-layout .fd-page-body thead {
   background: var(--color-fd-muted);
 }
 
-.fd-page-body th {
+#nd-docs-layout .fd-page-body th {
   padding: 10px 16px;
   text-align: left;
   font-weight: 600;
@@ -1826,22 +1846,22 @@ html.dark pre.shiki {
   white-space: nowrap;
 }
 
-.fd-page-body td {
+#nd-docs-layout .fd-page-body td {
   padding: 10px 16px;
   text-align: left;
   border-bottom: 1px solid var(--color-fd-border);
   color: var(--color-fd-foreground);
 }
 
-.fd-page-body tbody tr:last-child td {
+#nd-docs-layout .fd-page-body tbody tr:last-child td {
   border-bottom: none;
 }
 
-.fd-page-body tbody tr:hover {
+#nd-docs-layout .fd-page-body tbody tr:hover {
   background: var(--color-fd-accent);
 }
 
-.fd-page-body td code {
+#nd-docs-layout .fd-page-body td code {
   font-size: 12px;
   padding: 1px 5px;
   background: var(--color-fd-secondary);
@@ -1850,7 +1870,7 @@ html.dark pre.shiki {
   white-space: nowrap;
 }
 
-.fd-page-body img {
+#nd-docs-layout .fd-page-body img {
   max-width: 100%;
   border-radius: 8px;
   margin: 16px 0;
@@ -1858,13 +1878,13 @@ html.dark pre.shiki {
 
 /* ─── Animations ─────────────────────────────────────────────────────── */
 
-.fd-toc-empty {
+#nd-docs-layout .fd-toc-empty {
   font-size: 13px;
   color: var(--color-fd-muted-foreground);
   padding: 4px 0;
 }
 
-.fd-sidebar-folder-label {
+#nd-docs-layout .fd-sidebar-folder-label {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1892,7 +1912,7 @@ html.dark pre.shiki {
 
 /* ─── Callout / Admonition ──────────────────────────────────────────── */
 
-.fd-callout {
+#nd-docs-layout .fd-callout {
   position: relative;
   display: flex;
   gap: 10px;
@@ -1906,7 +1926,7 @@ html.dark pre.shiki {
   overflow: hidden;
 }
 
-.fd-callout-indicator {
+#nd-docs-layout .fd-callout-indicator {
   position: absolute;
   left: 0;
   top: 0;
@@ -1915,81 +1935,81 @@ html.dark pre.shiki {
   border-radius: 8px 0 0 8px;
 }
 
-.fd-callout-note .fd-callout-indicator {
+#nd-docs-layout .fd-callout-note .fd-callout-indicator {
   background: hsl(221, 83%, 53%);
 }
-.fd-callout-warning .fd-callout-indicator {
+#nd-docs-layout .fd-callout-warning .fd-callout-indicator {
   background: hsl(38, 92%, 50%);
 }
-.fd-callout-tip .fd-callout-indicator {
+#nd-docs-layout .fd-callout-tip .fd-callout-indicator {
   background: hsl(142, 71%, 45%);
 }
-.fd-callout-important .fd-callout-indicator {
+#nd-docs-layout .fd-callout-important .fd-callout-indicator {
   background: hsl(262, 83%, 58%);
 }
-.fd-callout-caution .fd-callout-indicator {
+#nd-docs-layout .fd-callout-caution .fd-callout-indicator {
   background: hsl(0, 72%, 51%);
 }
 
-.fd-callout-icon {
+#nd-docs-layout .fd-callout-icon {
   flex-shrink: 0;
   margin-top: 2px;
 }
 
-.fd-callout-note .fd-callout-icon {
+#nd-docs-layout .fd-callout-note .fd-callout-icon {
   color: hsl(221, 83%, 53%);
 }
-.fd-callout-warning .fd-callout-icon {
+#nd-docs-layout .fd-callout-warning .fd-callout-icon {
   color: hsl(38, 92%, 50%);
 }
-.fd-callout-tip .fd-callout-icon {
+#nd-docs-layout .fd-callout-tip .fd-callout-icon {
   color: hsl(142, 71%, 45%);
 }
-.fd-callout-important .fd-callout-icon {
+#nd-docs-layout .fd-callout-important .fd-callout-icon {
   color: hsl(262, 83%, 58%);
 }
-.fd-callout-caution .fd-callout-icon {
+#nd-docs-layout .fd-callout-caution .fd-callout-icon {
   color: hsl(0, 72%, 51%);
 }
 
-.fd-callout-content {
+#nd-docs-layout .fd-callout-content {
   flex: 1;
   min-width: 0;
 }
 
-.fd-callout-title {
+#nd-docs-layout .fd-callout-title {
   font-weight: 600;
   font-size: 13px;
 }
 
-.fd-callout-note .fd-callout-title {
+#nd-docs-layout .fd-callout-note .fd-callout-title {
   color: hsl(221, 83%, 53%);
 }
-.fd-callout-warning .fd-callout-title {
+#nd-docs-layout .fd-callout-warning .fd-callout-title {
   color: hsl(38, 92%, 50%);
 }
-.fd-callout-tip .fd-callout-title {
+#nd-docs-layout .fd-callout-tip .fd-callout-title {
   color: hsl(142, 71%, 45%);
 }
-.fd-callout-important .fd-callout-title {
+#nd-docs-layout .fd-callout-important .fd-callout-title {
   color: hsl(262, 83%, 58%);
 }
-.fd-callout-caution .fd-callout-title {
+#nd-docs-layout .fd-callout-caution .fd-callout-title {
   color: hsl(0, 72%, 51%);
 }
 
-.fd-callout-content p:last-child {
+#nd-docs-layout .fd-callout-content p:last-child {
   margin-bottom: 0;
 }
 
 /* ─── Edit on GitHub ────────────────────────────────────────────────── */
 
-.fd-page-footer {
+#nd-docs-layout .fd-page-footer {
   margin-top: auto;
   padding-top: 16px;
 }
 
-.fd-edit-on-github {
+#nd-docs-layout .fd-edit-on-github {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -2000,7 +2020,7 @@ html.dark pre.shiki {
   font-size: 13px;
 }
 
-.fd-edit-on-github a {
+#nd-docs-layout .fd-edit-on-github a {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2009,29 +2029,29 @@ html.dark pre.shiki {
   transition: color 0.15s;
 }
 
-.fd-edit-on-github a:hover {
+#nd-docs-layout .fd-edit-on-github a:hover {
   color: var(--color-fd-foreground);
 }
 
-.fd-last-modified {
+#nd-docs-layout .fd-last-modified {
   color: var(--color-fd-muted-foreground);
   font-size: var(--fd-small-size, 0.75rem);
   font-weight: var(--fd-small-weight, 400);
 }
 
 @media (max-width: 640px) {
-  .fd-last-modified {
+  #nd-docs-layout .fd-last-modified {
     width: 100%;
   }
 }
 
-.fd-llms-txt-links {
+#nd-docs-layout .fd-llms-txt-links {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.fd-llms-txt-link {
+#nd-docs-layout .fd-llms-txt-link {
   color: var(--color-fd-muted-foreground);
   font-size: 0.75rem;
   font-family: var(--fd-font-mono, ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace);
@@ -2042,7 +2062,7 @@ html.dark pre.shiki {
   transition: color 150ms, border-color 150ms;
 }
 
-.fd-llms-txt-link:hover {
+#nd-docs-layout .fd-llms-txt-link:hover {
   color: var(--color-fd-foreground);
   border-color: var(--color-fd-foreground);
   text-decoration: none;
@@ -2050,7 +2070,7 @@ html.dark pre.shiki {
 
 /* ─── Previous / Next Navigation ────────────────────────────────────── */
 
-.fd-page-nav {
+#nd-docs-layout .fd-page-nav {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
@@ -2059,7 +2079,7 @@ html.dark pre.shiki {
   border-top: 1px solid var(--color-fd-border);
 }
 
-.fd-page-nav-card {
+#nd-docs-layout .fd-page-nav-card {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -2073,17 +2093,17 @@ html.dark pre.shiki {
     border-color 0.15s;
 }
 
-.fd-page-nav-card:hover {
+#nd-docs-layout .fd-page-nav-card:hover {
   background: var(--color-fd-accent);
   border-color: var(--color-fd-border);
 }
 
-.fd-page-nav-next {
+#nd-docs-layout .fd-page-nav-next {
   text-align: right;
   align-items: flex-end;
 }
 
-.fd-page-nav-label {
+#nd-docs-layout .fd-page-nav-label {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -2094,7 +2114,7 @@ html.dark pre.shiki {
   letter-spacing: 0.05em;
 }
 
-.fd-page-nav-title {
+#nd-docs-layout .fd-page-nav-title {
   font-size: 14px;
   font-weight: 600;
   color: var(--color-fd-foreground);
@@ -2102,14 +2122,14 @@ html.dark pre.shiki {
 
 /* ─── Sidebar icon ───────────────────────────────────────────────────── */
 
-.fd-sidebar-icon {
+#nd-docs-layout .fd-sidebar-icon {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.fd-sidebar-link-active .fd-sidebar-icon {
+#nd-docs-layout .fd-sidebar-link-active .fd-sidebar-icon {
   opacity: 1;
 }
 
@@ -2159,7 +2179,7 @@ html.dark pre.shiki {
   }
 }
 
-.fd-ai-overlay {
+#nd-docs-layout .fd-ai-overlay {
   position: fixed;
   inset: 0;
   z-index: 9998;
@@ -2169,7 +2189,7 @@ html.dark pre.shiki {
   animation: fd-ai-fade-in 150ms ease-out;
 }
 
-.fd-ai-dialog {
+#nd-docs-layout .fd-ai-dialog {
   position: fixed;
   z-index: 9999;
   display: flex;
@@ -2185,7 +2205,7 @@ html.dark pre.shiki {
   font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif);
 }
 
-.fd-ai-tab-bar {
+#nd-docs-layout .fd-ai-tab-bar {
   display: flex;
   align-items: stretch;
   gap: 0;
@@ -2194,7 +2214,7 @@ html.dark pre.shiki {
   background: var(--color-fd-card);
 }
 
-.fd-ai-tab {
+#nd-docs-layout .fd-ai-tab {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2216,27 +2236,27 @@ html.dark pre.shiki {
   position: relative;
 }
 
-.fd-ai-tab svg {
+#nd-docs-layout .fd-ai-tab svg {
   opacity: 0.7;
   flex-shrink: 0;
 }
 
-.fd-ai-tab[data-active="true"] {
+#nd-docs-layout .fd-ai-tab[data-active="true"] {
   color: var(--color-fd-foreground);
   border-bottom-color: var(--color-fd-primary);
   background: transparent;
 }
 
-.fd-ai-tab[data-active="true"] svg {
+#nd-docs-layout .fd-ai-tab[data-active="true"] svg {
   opacity: 1;
 }
 
-.fd-ai-tab:hover:not([data-active="true"]) {
+#nd-docs-layout .fd-ai-tab:hover:not([data-active="true"]) {
   color: var(--color-fd-foreground);
   background: var(--color-fd-accent);
 }
 
-.fd-ai-esc {
+#nd-docs-layout .fd-ai-esc {
   padding: 2px 8px;
   border-radius: 6px;
   border: 1px solid var(--color-fd-border);
@@ -2249,7 +2269,7 @@ html.dark pre.shiki {
 
 /* ─── Header ─────────────────────────────────────────────────── */
 
-.fd-ai-header {
+#nd-docs-layout .fd-ai-header {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2257,13 +2277,13 @@ html.dark pre.shiki {
   border-bottom: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.06));
 }
 
-.fd-ai-header-title {
+#nd-docs-layout .fd-ai-header-title {
   font-size: 14px;
   font-weight: 600;
   flex: 1;
 }
 
-.fd-ai-close-btn {
+#nd-docs-layout .fd-ai-close-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2277,12 +2297,12 @@ html.dark pre.shiki {
   transition: all 150ms;
 }
 
-.fd-ai-close-btn:hover {
+#nd-docs-layout .fd-ai-close-btn:hover {
   color: var(--color-fd-foreground, #e4e4e7);
   background: var(--color-fd-accent, rgba(255, 255, 255, 0.06));
 }
 
-.fd-ai-search-wrap {
+#nd-docs-layout .fd-ai-search-wrap {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -2291,12 +2311,12 @@ html.dark pre.shiki {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-ai-search-wrap svg {
+#nd-docs-layout .fd-ai-search-wrap svg {
   flex-shrink: 0;
   opacity: 0.5;
 }
 
-.fd-ai-input {
+#nd-docs-layout .fd-ai-input {
   flex: 1;
   background: transparent;
   border: none;
@@ -2306,19 +2326,19 @@ html.dark pre.shiki {
   font-family: inherit;
 }
 
-.fd-ai-input::placeholder {
+#nd-docs-layout .fd-ai-input::placeholder {
   color: var(--color-fd-muted-foreground);
   opacity: 0.7;
 }
 
-.fd-ai-results {
+#nd-docs-layout .fd-ai-results {
   flex: 1;
   overflow-y: auto;
   padding: 8px;
   max-height: 360px;
 }
 
-.fd-ai-result {
+#nd-docs-layout .fd-ai-result {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -2338,21 +2358,21 @@ html.dark pre.shiki {
   color: var(--color-fd-foreground);
 }
 
-.fd-ai-result svg {
+#nd-docs-layout .fd-ai-result svg {
   flex-shrink: 0;
   opacity: 0.5;
 }
 
-.fd-ai-result[data-active="true"] {
+#nd-docs-layout .fd-ai-result[data-active="true"] {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
-.fd-ai-result[data-active="true"] svg {
+#nd-docs-layout .fd-ai-result[data-active="true"] svg {
   opacity: 1;
 }
 
-.fd-ai-result-empty {
+#nd-docs-layout .fd-ai-result-empty {
   padding: 48px 16px;
   text-align: center;
   color: var(--color-fd-muted-foreground);
@@ -2360,7 +2380,7 @@ html.dark pre.shiki {
   line-height: 1.6;
 }
 
-.fd-ai-messages {
+#nd-docs-layout .fd-ai-messages {
   flex: 1;
   overflow-y: auto;
   padding: 12px 16px;
@@ -2369,7 +2389,7 @@ html.dark pre.shiki {
   gap: 16px;
 }
 
-.fd-ai-empty {
+#nd-docs-layout .fd-ai-empty {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2380,12 +2400,12 @@ html.dark pre.shiki {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-ai-empty-title {
+#nd-docs-layout .fd-ai-empty-title {
   font-size: 14px;
   font-weight: 500;
 }
 
-.fd-ai-empty-desc {
+#nd-docs-layout .fd-ai-empty-desc {
   font-size: 12px;
   opacity: 0.7;
   text-align: center;
@@ -2393,7 +2413,7 @@ html.dark pre.shiki {
   line-height: 1.5;
 }
 
-.fd-ai-suggestions {
+#nd-docs-layout .fd-ai-suggestions {
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -2402,7 +2422,7 @@ html.dark pre.shiki {
   margin-top: 8px;
 }
 
-.fd-ai-suggestion {
+#nd-docs-layout .fd-ai-suggestion {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2420,27 +2440,27 @@ html.dark pre.shiki {
   transition: all 150ms;
 }
 
-.fd-ai-suggestion:hover {
+#nd-docs-layout .fd-ai-suggestion:hover {
   background: var(--color-fd-accent);
   border-color: var(--color-fd-ring);
   opacity: 1;
 }
 
-.fd-ai-msg {
+#nd-docs-layout .fd-ai-msg {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.fd-ai-msg[data-role="user"] {
+#nd-docs-layout .fd-ai-msg[data-role="user"] {
   align-items: flex-end;
 }
 
-.fd-ai-msg[data-role="assistant"] {
+#nd-docs-layout .fd-ai-msg[data-role="assistant"] {
   align-items: flex-start;
 }
 
-.fd-ai-msg-label {
+#nd-docs-layout .fd-ai-msg-label {
   font-size: 10px;
   font-weight: 500;
   text-transform: uppercase;
@@ -2449,7 +2469,7 @@ html.dark pre.shiki {
   padding: 0 2px;
 }
 
-.fd-ai-bubble-user {
+#nd-docs-layout .fd-ai-bubble-user {
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
   padding: 8px 14px;
@@ -2460,7 +2480,7 @@ html.dark pre.shiki {
   word-break: break-word;
 }
 
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-ai {
   background: var(--color-fd-muted, rgba(255, 255, 255, 0.04));
   padding: 10px 14px;
   border-radius: var(--radius, 14px);
@@ -2476,12 +2496,12 @@ html.dark pre.shiki {
   to { opacity: 1; transform: translateY(0); }
 }
 
-.fd-ai-chat-footer {
+#nd-docs-layout .fd-ai-chat-footer {
   padding: 8px 12px 12px;
   border-top: 1px solid var(--color-fd-border);
 }
 
-.fd-ai-clear-btn {
+#nd-docs-layout .fd-ai-clear-btn {
   font-size: 11px;
   color: var(--color-fd-muted-foreground);
   background: transparent;
@@ -2492,11 +2512,11 @@ html.dark pre.shiki {
   font-family: inherit;
 }
 
-.fd-ai-clear-btn:hover {
+#nd-docs-layout .fd-ai-clear-btn:hover {
   color: var(--color-fd-foreground);
 }
 
-.fd-ai-input-wrap {
+#nd-docs-layout .fd-ai-input-wrap {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2506,7 +2526,7 @@ html.dark pre.shiki {
   border: 1px solid var(--color-fd-border);
 }
 
-.fd-ai-send-btn {
+#nd-docs-layout .fd-ai-send-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2520,13 +2540,13 @@ html.dark pre.shiki {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-ai-send-btn[data-active="true"] {
+#nd-docs-layout .fd-ai-send-btn[data-active="true"] {
   cursor: pointer;
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
-.fd-ai-loader {
+#nd-docs-layout .fd-ai-loader {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2538,7 +2558,7 @@ html.dark pre.shiki {
   to { opacity: 1; transform: translateY(0); }
 }
 
-.fd-ai-loader-shimmer-text {
+#nd-docs-layout .fd-ai-loader-shimmer-text {
   font-size: 13px;
   font-weight: 500;
   background: linear-gradient(to right, var(--color-fd-muted-foreground, #888) 40%, var(--color-fd-foreground, #fff) 60%, var(--color-fd-muted-foreground, #888) 80%);
@@ -2554,13 +2574,13 @@ html.dark pre.shiki {
   100% { background-position: -150% center; }
 }
 
-.fd-ai-loader-typing-dots {
+#nd-docs-layout .fd-ai-loader-typing-dots {
   display: inline-flex;
   align-items: center;
   gap: 2px;
 }
 
-.fd-ai-loader-typing-dot {
+#nd-docs-layout .fd-ai-loader-typing-dot {
   width: 4px;
   height: 4px;
   border-radius: 50%;
@@ -2568,15 +2588,15 @@ html.dark pre.shiki {
   animation: fd-ai-typing 1s infinite;
 }
 
-.fd-ai-loader-typing-dot:nth-child(2) { animation-delay: 250ms; }
-.fd-ai-loader-typing-dot:nth-child(3) { animation-delay: 500ms; }
+#nd-docs-layout .fd-ai-loader-typing-dot:nth-child(2) { animation-delay: 250ms; }
+#nd-docs-layout .fd-ai-loader-typing-dot:nth-child(3) { animation-delay: 500ms; }
 
 @keyframes fd-ai-typing {
   0%, 100% { transform: translateY(0); opacity: 0.5; }
   50% { transform: translateY(-2px); opacity: 1; }
 }
 
-.fd-ai-streaming::after {
+#nd-docs-layout .fd-ai-streaming::after {
   content: "";
   display: inline-block;
   width: 2px;
@@ -2594,7 +2614,7 @@ html.dark pre.shiki {
 
 /* ─── Markdown in AI responses ───────────────────────────────── */
 
-.fd-ai-bubble-ai code {
+#nd-docs-layout .fd-ai-bubble-ai code {
   background: var(--color-fd-muted, #1a1a2e);
   padding: 2px 6px;
   border-radius: var(--radius, 4px);
@@ -2602,33 +2622,33 @@ html.dark pre.shiki {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-ai-bubble-ai a {
+#nd-docs-layout .fd-ai-bubble-ai a {
   color: var(--color-fd-primary, #6366f1);
   text-decoration: underline;
 }
 
-.fd-ai-bubble-ai .fd-ai-code-block code {
+#nd-docs-layout .fd-ai-bubble-ai .fd-ai-code-block code {
   background: transparent;
   padding: 0;
   border-radius: 0;
   font-size: inherit;
 }
 
-.fd-ai-bubble-ai table {
+#nd-docs-layout .fd-ai-bubble-ai table {
   width: 100%;
   border-collapse: collapse;
   margin: 8px 0;
   font-size: 13px;
 }
 
-.fd-ai-bubble-ai th,
-.fd-ai-bubble-ai td {
+#nd-docs-layout .fd-ai-bubble-ai th,
+#nd-docs-layout .fd-ai-bubble-ai td {
   border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
   padding: 6px 12px;
   text-align: left;
 }
 
-.fd-ai-bubble-ai th {
+#nd-docs-layout .fd-ai-bubble-ai th {
   background: var(--color-fd-muted, #1a1a2e);
   font-weight: 600;
   font-size: 12px;
@@ -2636,47 +2656,47 @@ html.dark pre.shiki {
 
 /* ─── Markdown prose inside AI bubbles (panel/modal/popover) ─────── */
 
-.fd-ai-bubble-ai h2 {
+#nd-docs-layout .fd-ai-bubble-ai h2 {
   font-size: 1.125rem;
   font-weight: 600;
   margin: 12px 0 6px;
   line-height: 1.3;
 }
 
-.fd-ai-bubble-ai h3 {
+#nd-docs-layout .fd-ai-bubble-ai h3 {
   font-size: 1rem;
   font-weight: 600;
   margin: 10px 0 4px;
   line-height: 1.4;
 }
 
-.fd-ai-bubble-ai h4 {
+#nd-docs-layout .fd-ai-bubble-ai h4 {
   font-size: 0.9375rem;
   font-weight: 600;
   margin: 8px 0 4px;
   line-height: 1.4;
 }
 
-.fd-ai-bubble-ai strong {
+#nd-docs-layout .fd-ai-bubble-ai strong {
   font-weight: 600;
   color: var(--color-fd-foreground, #e4e4e7);
 }
 
-.fd-ai-bubble-ai em {
+#nd-docs-layout .fd-ai-bubble-ai em {
   font-style: italic;
 }
 
-.fd-ai-bubble-ai p {
+#nd-docs-layout .fd-ai-bubble-ai p {
   margin: 0 0 6px;
 }
 
-.fd-ai-bubble-ai br {
+#nd-docs-layout .fd-ai-bubble-ai br {
   content: "";
   display: block;
   margin-top: 2px;
 }
 
-.fd-ai-bubble-ai pre {
+#nd-docs-layout .fd-ai-bubble-ai pre {
   margin: 8px 0;
   border-radius: 0;
   border: none;
@@ -2688,7 +2708,7 @@ html.dark pre.shiki {
  * Code blocks in AI chat — fd-ai-code-*
  * ═══════════════════════════════════════════════════════════════════ */
 
-.fd-ai-code-block {
+#nd-docs-layout .fd-ai-code-block {
   --sh-class: #8be9fd;
   --sh-identifier: #c9d1d9;
   --sh-keyword: #ff7b72;
@@ -2707,7 +2727,7 @@ html.dark pre.shiki {
   overflow: hidden;
 }
 
-.fd-ai-code-header {
+#nd-docs-layout .fd-ai-code-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2717,7 +2737,7 @@ html.dark pre.shiki {
   min-height: 32px;
 }
 
-.fd-ai-code-lang {
+#nd-docs-layout .fd-ai-code-lang {
   font-size: 11px;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   color: var(--color-fd-muted-foreground, #71717a);
@@ -2725,7 +2745,7 @@ html.dark pre.shiki {
   letter-spacing: 0.04em;
 }
 
-.fd-ai-code-copy {
+#nd-docs-layout .fd-ai-code-copy {
   font-size: 11px;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   color: var(--color-fd-muted-foreground, #71717a);
@@ -2737,7 +2757,7 @@ html.dark pre.shiki {
   transition: all 150ms;
 }
 
-.fd-ai-code-copy:hover {
+#nd-docs-layout .fd-ai-code-copy:hover {
   color: var(--color-fd-foreground, #e4e4e7);
   background: color-mix(
     in srgb,
@@ -2746,7 +2766,7 @@ html.dark pre.shiki {
   );
 }
 
-.fd-ai-code-block pre {
+#nd-docs-layout .fd-ai-code-block pre {
   margin: 0;
   padding: 12px 16px;
   overflow-x: auto;
@@ -2755,7 +2775,7 @@ html.dark pre.shiki {
   border-radius: 0;
 }
 
-.fd-ai-code-block code {
+#nd-docs-layout .fd-ai-code-block code {
   font-size: 13px;
   line-height: 1.45;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
@@ -2764,7 +2784,7 @@ html.dark pre.shiki {
   border-radius: 0;
 }
 
-.fd-ai-code-block .sh__line {
+#nd-docs-layout .fd-ai-code-block .sh__line {
   display: block;
   min-height: 1.2em;
 }
@@ -2774,66 +2794,66 @@ html.dark pre.shiki {
    (matches Next.js fumadocs default.css)
    ═══════════════════════════════════════════════════════════════ */
 
-.fd-ai-dialog {
+#nd-docs-layout .fd-ai-dialog {
   border-radius: 12px;
   box-shadow:
     0 20px 60px rgba(99, 102, 241, 0.08),
     0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
-.fd-ai-bubble-user {
+#nd-docs-layout .fd-ai-bubble-user {
   border-radius: 16px 16px 4px 16px;
 }
 
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-ai {
   border-radius: 16px 16px 16px 4px;
 }
 
-.fd-ai-input-wrap {
+#nd-docs-layout .fd-ai-input-wrap {
   border-radius: 10px;
 }
 
-.fd-ai-send-btn {
+#nd-docs-layout .fd-ai-send-btn {
   border-radius: 8px;
 }
 
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-floating-btn {
   border-radius: 26px;
 }
 
-.fd-ai-suggestion {
+#nd-docs-layout .fd-ai-suggestion {
   border-radius: 8px;
 }
 
-.fd-ai-result {
+#nd-docs-layout .fd-ai-result {
   border-radius: 8px;
 }
 
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-fm-input-container {
   border-radius: 12px;
 }
 
-.fd-ai-fm-send-btn {
+#nd-docs-layout .fd-ai-fm-send-btn {
   border-radius: 9999px;
 }
 
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-ai-fm-suggestion {
   border-radius: 9999px;
 }
 
-.fd-ai-fm-trigger-btn {
+#nd-docs-layout .fd-ai-fm-trigger-btn {
   border-radius: 16px;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   border-radius: 9999px;
 }
 
-.fd-ai-code-block {
+#nd-docs-layout .fd-ai-code-block {
   border-radius: 8px;
 }
 
-.fd-ai-code-copy {
+#nd-docs-layout .fd-ai-code-copy {
   border-radius: 4px;
 }
 
@@ -2844,7 +2864,7 @@ html.dark pre.shiki {
 
 /* ─── Floating trigger button ────────────────────────────────── */
 
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-floating-btn {
   position: fixed;
   z-index: 9997;
   display: flex;
@@ -2869,37 +2889,41 @@ html.dark pre.shiki {
   animation: fd-ai-fade-in 300ms ease-out;
 }
 
-.fd-ai-floating-btn:hover {
+#nd-docs-layout .fd-ai-floating-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
   transform: scale(1.03);
 }
 
-.fd-ai-floating-btn:active {
+#nd-docs-layout .fd-ai-floating-btn:active {
   transform: scale(0.97);
 }
 
-.dark .fd-ai-floating-btn,
-.dark .fd-ai-fm-trigger-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout.dark .fd-ai-floating-btn,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-fm-trigger-btn,
+#nd-docs-layout.dark .fd-ai-fm-trigger-btn {
   background: color-mix(in srgb, var(--color-fd-secondary, rgba(255, 255, 255, 0.08)) 90%, transparent);
   color: var(--color-fd-foreground, #e4e4e7);
   border-color: var(--color-fd-border, rgba(255, 255, 255, 0.12));
 }
 
-.dark .fd-ai-floating-btn:hover,
-.dark .fd-ai-fm-trigger-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout.dark .fd-ai-floating-btn:hover,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-fm-trigger-btn:hover,
+#nd-docs-layout.dark .fd-ai-fm-trigger-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
 }
 
-.fd-ai-floating-trigger {
+#nd-docs-layout .fd-ai-floating-trigger {
   position: fixed;
   z-index: 9997;
   cursor: pointer;
   animation: fd-ai-fade-in 300ms ease-out;
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2918,24 +2942,26 @@ html.dark pre.shiki {
   transition: transform 150ms, background 150ms, color 150ms;
 }
 
-.dark .fd-ai-floating-trigger .ask-ai-trigger {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger,
+#nd-docs-layout.dark .fd-ai-floating-trigger .ask-ai-trigger {
   background: color-mix(in srgb, var(--color-fd-secondary, rgba(255, 255, 255, 0.08)) 90%, transparent);
   color: var(--color-fd-foreground, #e4e4e7);
   border-color: var(--color-fd-border, rgba(255, 255, 255, 0.12));
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
   transform: scale(1.03);
 }
 
-.dark .fd-ai-floating-trigger .ask-ai-trigger:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover,
+#nd-docs-layout.dark .fd-ai-floating-trigger .ask-ai-trigger:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger:active {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:active {
   transform: scale(0.97);
 }
 
@@ -2944,17 +2970,17 @@ html.dark pre.shiki {
    ═══════════════════════════════════════════════════════════════ */
 
 /* Fixed wrapper for trigger when closed — never morphs, so no "stuck" feel */
-.fd-ai-fm-trigger-fixed {
+#nd-docs-layout .fd-ai-fm-trigger-fixed {
   position: fixed;
   z-index: 9997;
   animation: fd-ai-fade-in 200ms ease-out;
 }
 
-.fd-ai-floating-trigger--static {
+#nd-docs-layout .fd-ai-floating-trigger--static {
   position: static;
 }
 
-.fd-ai-fm-overlay {
+#nd-docs-layout .fd-ai-fm-overlay {
   position: fixed;
   inset: 0;
   display: flex;
@@ -2966,13 +2992,13 @@ html.dark pre.shiki {
   padding: 0 8px;
 }
 
-.fd-ai-fm-overlay--animate {
+#nd-docs-layout .fd-ai-fm-overlay--animate {
   animation: fd-ai-fade-in 200ms ease-out;
 }
 
 /* ─── Top bar (close button) ─────────────────────────────────── */
 
-.fd-ai-fm-topbar {
+#nd-docs-layout .fd-ai-fm-topbar {
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -2983,7 +3009,7 @@ html.dark pre.shiki {
   z-index: 2;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2997,13 +3023,13 @@ html.dark pre.shiki {
   transition: all 150ms;
 }
 
-.fd-ai-fm-close-btn:hover {
+#nd-docs-layout .fd-ai-fm-close-btn:hover {
   background: var(--color-fd-accent, rgba(255, 255, 255, 0.1));
 }
 
 /* ─── Message list ───────────────────────────────────────────── */
 
-.fd-ai-fm-messages {
+#nd-docs-layout .fd-ai-fm-messages {
   flex: 1;
   overflow-y: auto;
   width: min(800px, 100%);
@@ -3024,7 +3050,7 @@ html.dark pre.shiki {
   );
 }
 
-.fd-ai-fm-messages-inner {
+#nd-docs-layout .fd-ai-fm-messages-inner {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -3032,29 +3058,29 @@ html.dark pre.shiki {
 
 /* ─── Message ────────────────────────────────────────────────── */
 
-.fd-ai-fm-msg {
+#nd-docs-layout .fd-ai-fm-msg {
   display: flex;
   flex-direction: column;
 }
 
-.fd-ai-fm-msg-label {
+#nd-docs-layout .fd-ai-fm-msg-label {
   font-size: 13px;
   font-weight: 500;
   margin-bottom: 4px;
   color: var(--color-fd-muted-foreground, #71717a);
 }
 
-.fd-ai-fm-msg-label[data-role="assistant"] {
+#nd-docs-layout .fd-ai-fm-msg-label[data-role="assistant"] {
   color: var(--color-fd-primary, #6366f1);
 }
 
-.fd-ai-fm-msg-content {
+#nd-docs-layout .fd-ai-fm-msg-content {
   font-size: 14px;
   line-height: 1.7;
   color: var(--color-fd-foreground, #e4e4e7);
 }
 
-.fd-ai-fm-msg-content code {
+#nd-docs-layout .fd-ai-fm-msg-content code {
   background: var(--color-fd-muted, #1a1a2e);
   padding: 2px 6px;
   border-radius: var(--radius, 4px);
@@ -3062,33 +3088,33 @@ html.dark pre.shiki {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-ai-fm-msg-content .fd-ai-code-block code {
+#nd-docs-layout .fd-ai-fm-msg-content .fd-ai-code-block code {
   background: transparent;
   padding: 0;
   border-radius: 0;
   font-size: inherit;
 }
 
-.fd-ai-fm-msg-content a {
+#nd-docs-layout .fd-ai-fm-msg-content a {
   color: var(--color-fd-primary, #6366f1);
   text-decoration: underline;
 }
 
-.fd-ai-fm-msg-content table {
+#nd-docs-layout .fd-ai-fm-msg-content table {
   width: 100%;
   border-collapse: collapse;
   margin: 8px 0;
   font-size: 13px;
 }
 
-.fd-ai-fm-msg-content th,
-.fd-ai-fm-msg-content td {
+#nd-docs-layout .fd-ai-fm-msg-content th,
+#nd-docs-layout .fd-ai-fm-msg-content td {
   border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
   padding: 6px 12px;
   text-align: left;
 }
 
-.fd-ai-fm-msg-content th {
+#nd-docs-layout .fd-ai-fm-msg-content th {
   background: var(--color-fd-muted, #1a1a2e);
   font-weight: 600;
   font-size: 12px;
@@ -3096,47 +3122,47 @@ html.dark pre.shiki {
 
 /* ─── Markdown prose inside full-modal messages ──────────────────── */
 
-.fd-ai-fm-msg-content h2 {
+#nd-docs-layout .fd-ai-fm-msg-content h2 {
   font-size: 1.25rem;
   font-weight: 600;
   margin: 16px 0 8px;
   line-height: 1.3;
 }
 
-.fd-ai-fm-msg-content h3 {
+#nd-docs-layout .fd-ai-fm-msg-content h3 {
   font-size: 1.0625rem;
   font-weight: 600;
   margin: 12px 0 6px;
   line-height: 1.4;
 }
 
-.fd-ai-fm-msg-content h4 {
+#nd-docs-layout .fd-ai-fm-msg-content h4 {
   font-size: 1rem;
   font-weight: 600;
   margin: 10px 0 4px;
   line-height: 1.4;
 }
 
-.fd-ai-fm-msg-content strong {
+#nd-docs-layout .fd-ai-fm-msg-content strong {
   font-weight: 600;
   color: var(--color-fd-foreground, #e4e4e7);
 }
 
-.fd-ai-fm-msg-content em {
+#nd-docs-layout .fd-ai-fm-msg-content em {
   font-style: italic;
 }
 
-.fd-ai-fm-msg-content p {
+#nd-docs-layout .fd-ai-fm-msg-content p {
   margin: 0 0 8px;
 }
 
-.fd-ai-fm-msg-content br {
+#nd-docs-layout .fd-ai-fm-msg-content br {
   content: "";
   display: block;
   margin-top: 2px;
 }
 
-.fd-ai-fm-msg-content pre {
+#nd-docs-layout .fd-ai-fm-msg-content pre {
   margin: 8px 0;
   border-radius: 0;
   border: none;
@@ -3148,12 +3174,12 @@ html.dark pre.shiki {
 
 /* ─── Bottom input bar ───────────────────────────────────────── */
 
-.fd-ai-fm-input-bar {
+#nd-docs-layout .fd-ai-fm-input-bar {
   position: fixed;
   z-index: 9999;
 }
 
-.fd-ai-fm-input-bar--open {
+#nd-docs-layout .fd-ai-fm-input-bar--open {
   bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
@@ -3161,7 +3187,7 @@ html.dark pre.shiki {
   animation: fd-ai-fade-in 200ms ease-out;
 }
 
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-fm-input-container {
   display: flex;
   flex-direction: column;
   border-radius: var(--radius, 12px);
@@ -3171,13 +3197,13 @@ html.dark pre.shiki {
   overflow: hidden;
 }
 
-.fd-ai-fm-input-wrap {
+#nd-docs-layout .fd-ai-fm-input-wrap {
   display: flex;
   align-items: flex-start;
   padding-right: 8px;
 }
 
-.fd-ai-fm-input {
+#nd-docs-layout .fd-ai-fm-input {
   flex: 1;
   padding: 16px;
   background: transparent;
@@ -3192,11 +3218,11 @@ html.dark pre.shiki {
   max-height: 120px;
 }
 
-.fd-ai-fm-input::placeholder {
+#nd-docs-layout .fd-ai-fm-input::placeholder {
   color: var(--color-fd-muted-foreground, #71717a);
 }
 
-.fd-ai-fm-send-btn {
+#nd-docs-layout .fd-ai-fm-send-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3211,7 +3237,7 @@ html.dark pre.shiki {
   color: var(--color-fd-muted-foreground, #71717a);
 }
 
-.fd-ai-fm-send-btn[data-active="true"] {
+#nd-docs-layout .fd-ai-fm-send-btn[data-active="true"] {
   cursor: pointer;
   background: var(--color-fd-primary, #6366f1);
   color: var(--color-fd-primary-foreground, #fff);
@@ -3219,18 +3245,18 @@ html.dark pre.shiki {
 
 /* ─── Suggestions (horizontal pills) ────────────────────────── */
 
-.fd-ai-fm-suggestions-area {
+#nd-docs-layout .fd-ai-fm-suggestions-area {
   padding: 12px 16px 4px;
 }
 
-.fd-ai-fm-suggestions-label {
+#nd-docs-layout .fd-ai-fm-suggestions-label {
   font-size: 12px;
   font-weight: 500;
   color: var(--color-fd-muted-foreground, #71717a);
   margin-bottom: 8px;
 }
 
-.fd-ai-fm-suggestions {
+#nd-docs-layout .fd-ai-fm-suggestions {
   display: flex;
   gap: 8px;
   overflow-x: auto;
@@ -3251,7 +3277,7 @@ html.dark pre.shiki {
   );
 }
 
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-ai-fm-suggestion {
   flex-shrink: 0;
   white-space: nowrap;
   padding: 6px 14px;
@@ -3266,7 +3292,7 @@ html.dark pre.shiki {
   transition: all 200ms;
 }
 
-.fd-ai-fm-suggestion:hover {
+#nd-docs-layout .fd-ai-fm-suggestion:hover {
   background: color-mix(in srgb, var(--color-fd-muted, rgba(255, 255, 255, 0.04)) 50%, transparent);
   color: var(--color-fd-foreground, #e4e4e7);
   border-color: var(--color-fd-border, rgba(255, 255, 255, 0.1));
@@ -3274,7 +3300,7 @@ html.dark pre.shiki {
 
 /* ─── Footer bar ─────────────────────────────────────────────── */
 
-.fd-ai-fm-footer-bar {
+#nd-docs-layout .fd-ai-fm-footer-bar {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -3289,7 +3315,7 @@ html.dark pre.shiki {
   color: var(--color-fd-muted-foreground, #71717a);
 }
 
-.fd-ai-fm-clear-btn {
+#nd-docs-layout .fd-ai-fm-clear-btn {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -3303,22 +3329,22 @@ html.dark pre.shiki {
   padding: 0;
 }
 
-.fd-ai-fm-clear-btn:hover {
+#nd-docs-layout .fd-ai-fm-clear-btn:hover {
   color: var(--color-fd-foreground, #e4e4e7);
 }
 
-.fd-ai-fm-clear-btn[aria-disabled="true"] {
+#nd-docs-layout .fd-ai-fm-clear-btn[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.fd-ai-fm-footer-hint {
+#nd-docs-layout .fd-ai-fm-footer-hint {
   flex: 1;
 }
 
 /* ─── Closed trigger button ──────────────────────────────────── */
 
-.fd-ai-fm-trigger-btn {
+#nd-docs-layout .fd-ai-fm-trigger-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3342,12 +3368,12 @@ html.dark pre.shiki {
   white-space: nowrap;
 }
 
-.fd-ai-fm-trigger-btn:hover {
+#nd-docs-layout .fd-ai-fm-trigger-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
   transform: scale(1.03);
 }
 
-.fd-ai-fm-trigger-btn:active {
+#nd-docs-layout .fd-ai-fm-trigger-btn:active {
   transform: scale(0.97);
 }

--- a/packages/svelte-theme/styles/greentree.css
+++ b/packages/svelte-theme/styles/greentree.css
@@ -4,7 +4,8 @@
 
 /* ─── GreenTree color overrides ────────────────────────────────── */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #0d9373;
   --color-fd-primary-foreground: #fff;
   --color-fd-ring: #0d9373;
@@ -24,7 +25,11 @@
   --color-fd-border: #dfe1e0;
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #26bd6c;
   --color-fd-primary-foreground: #0a0d0d;
   --color-fd-ring: #26bd6c;
@@ -53,27 +58,27 @@
 
 /* ─── Typography — Inter, Mintlify-style values ──────────────── */
 
-h1 {
+#nd-docs-layout h1 {
   letter-spacing: -0.025em;
   font-weight: 500;
   line-height: 1.2;
 }
 
-h2 {
+#nd-docs-layout h2 {
   letter-spacing: -0.02em;
   font-weight: 600;
   line-height: 1.25;
 }
 
-h3 {
+#nd-docs-layout h3 {
   letter-spacing: -0.01em;
   font-weight: 600;
   line-height: 1.3;
 }
-.fd-docs-content {
+#nd-docs-layout .fd-docs-content {
   border: none !important;
 }
-.fd-docs-content p {
+#nd-docs-layout .fd-docs-content p {
   font-size: 1rem;
   line-height: 1.7;
 }
@@ -81,11 +86,10 @@ h3 {
 /* ═══════════════════════════════════════════════════════════════════
  * ═══════════════════════════════════════════════════════════════════ */
 
-aside,
-#nd-sidebar,
-aside#nd-sidebar,
 #nd-docs-layout aside,
-.fd-sidebar {
+#nd-docs-layout #nd-sidebar,
+#nd-docs-layout aside#nd-sidebar,
+#nd-docs-layout .fd-sidebar {
   border: none;
   border-right: 1px solid var(--color-fd-border);
   border-left: none;
@@ -93,17 +97,20 @@ aside#nd-sidebar,
   background: var(--color-fd-background);
 }
 
-.dark .fd-sidebar {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar,
+#nd-docs-layout.dark .fd-sidebar {
   background: var(--color-fd-background);
 }
 
-.dark .fd-sidebar .fd-sidebar-title {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-title,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-title {
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--color-fd-foreground);
 }
 
-.dark .fd-sidebar .fd-sidebar-search-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-btn,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-btn {
   background: var(--color-fd-secondary) !important;
   border: 1px solid var(--color-fd-border);
   border-radius: 8px;
@@ -111,11 +118,13 @@ aside#nd-sidebar,
   font-size: 0.875rem;
 }
 
-.dark .fd-sidebar .fd-sidebar-search-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-btn:hover,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent) !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-search-btn kbd {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-btn kbd,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-btn kbd {
   background: var(--color-fd-muted) !important;
   border-color: var(--color-fd-border);
   color: var(--color-fd-muted-foreground);
@@ -126,13 +135,13 @@ aside#nd-sidebar,
 }
 
 /* Nav padding */
-.fd-sidebar .fd-sidebar-nav {
+#nd-docs-layout .fd-sidebar .fd-sidebar-nav {
   padding: 8px 12px;
 }
 
 /* All sidebar links — 14px, 500 weight, 6px 10px padding */
-aside a[data-active],
-.fd-sidebar .fd-sidebar-link {
+#nd-docs-layout aside a[data-active],
+#nd-docs-layout .fd-sidebar .fd-sidebar-link {
   font-size: 0.875rem;
   line-height: 1.5;
   font-weight: 500;
@@ -142,24 +151,26 @@ aside a[data-active],
   transition: color 150ms, background-color 150ms;
 }
 
-.dark .fd-sidebar .fd-sidebar-link {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-link,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-link {
   color: var(--color-fd-muted-foreground);
 }
 
-aside a[data-active]:hover,
-.fd-sidebar .fd-sidebar-link:hover {
+#nd-docs-layout aside a[data-active]:hover,
+#nd-docs-layout .fd-sidebar .fd-sidebar-link:hover {
   color: var(--color-fd-foreground);
   background: var(--color-fd-accent);
 }
 
-.dark .fd-sidebar .fd-sidebar-link:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-link:hover,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-link:hover {
   color: var(--color-fd-foreground);
   background: var(--color-fd-accent);
 }
 
-aside a[data-active="true"],
-.fd-sidebar .fd-sidebar-link-active,
-.fd-sidebar .fd-sidebar-link[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"],
+#nd-docs-layout .fd-sidebar .fd-sidebar-link-active,
+#nd-docs-layout .fd-sidebar .fd-sidebar-link[data-active="true"] {
   position: relative !important;
   color: var(--color-fd-primary) !important;
   font-weight: 600 !important;
@@ -167,15 +178,17 @@ aside a[data-active="true"],
   background-color: rgba(13, 147, 115, 0.08) !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-link-active,
-.dark .fd-sidebar .fd-sidebar-link[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-link-active,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-link-active,
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-link[data-active="true"],
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-link[data-active="true"] {
   color: var(--color-fd-primary) !important;
   background: rgba(38, 189, 108, 0.1) !important;
   background-color: rgba(38, 189, 108, 0.1) !important;
 }
 
-.fd-sidebar-folder-content .fd-sidebar-link-active::before,
-.fd-sidebar-folder-content .fd-sidebar-link[data-active="true"]::before {
+#nd-docs-layout .fd-sidebar-folder-content .fd-sidebar-link-active::before,
+#nd-docs-layout .fd-sidebar-folder-content .fd-sidebar-link[data-active="true"]::before {
   content: "" !important;
   display: block !important;
   position: absolute !important;
@@ -187,19 +200,22 @@ aside a[data-active="true"],
   background: var(--color-fd-primary) !important;
 }
 
-.fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
-.fd-sidebar .fd-sidebar-top-link[data-active="true"] {
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
   background: rgba(13, 147, 115, 0.08) !important;
   background-color: rgba(13, 147, 115, 0.08) !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
-.dark .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-top-link[data-active="true"],
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
   background: rgba(38, 189, 108, 0.1) !important;
   background-color: rgba(38, 189, 108, 0.1) !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-folder {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-folder,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-folder {
   margin: 2px 0;
   padding: 0;
   border-radius: 0;
@@ -207,19 +223,20 @@ aside a[data-active="true"],
   background: transparent;
   overflow: visible;
 }
-.fd-sidebar .fd-sidebar-folder {
+#nd-docs-layout .fd-sidebar .fd-sidebar-folder {
   border: none;
 }
-.fd-page-body .fd-table-wrapper {
+#nd-docs-layout .fd-page-body .fd-table-wrapper {
   border: none !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-folder.fd-sidebar-first-item {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-folder.fd-sidebar-first-item,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-folder.fd-sidebar-first-item {
   margin-top: 0;
 }
 
-aside a[data-active].w-full,
-.fd-sidebar .fd-sidebar-folder-trigger {
+#nd-docs-layout aside a[data-active].w-full,
+#nd-docs-layout .fd-sidebar .fd-sidebar-folder-trigger {
   font-weight: 600;
   font-size: 0.875rem;
   color: var(--color-fd-foreground);
@@ -229,46 +246,50 @@ aside a[data-active].w-full,
   background: transparent !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-folder-trigger {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-folder-trigger,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-folder-trigger {
   color: var(--color-fd-muted-foreground);
   border: none;
 }
 
-.fd-sidebar .fd-sidebar-folder-trigger:hover {
+#nd-docs-layout .fd-sidebar .fd-sidebar-folder-trigger:hover {
   background: var(--color-fd-accent) !important;
 
 }
 
-.dark .fd-sidebar .fd-sidebar-folder-trigger:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-folder-trigger:hover,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-folder-trigger:hover {
   background: var(--color-fd-accent) !important;
 }
 
-aside a[data-active].w-full:first-child,
-.fd-sidebar-nav > .fd-sidebar-folder.fd-sidebar-first-item > .fd-sidebar-folder-trigger {
+#nd-docs-layout aside a[data-active].w-full:first-child,
+#nd-docs-layout .fd-sidebar-nav > .fd-sidebar-folder.fd-sidebar-first-item > .fd-sidebar-folder-trigger {
   margin-top: 0;
 }
 
-.fd-sidebar .fd-sidebar-top-link {
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link {
   margin-top: 0;
   padding: 6px 10px;
 }
 
-.fd-sidebar .fd-sidebar-top-link.fd-sidebar-first-item {
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link.fd-sidebar-first-item {
   margin-top: 0;
 }
 
-aside a[data-active="true"].w-full,
-.fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
-.fd-sidebar .fd-sidebar-top-link[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"].w-full,
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+#nd-docs-layout .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
   color: var(--color-fd-primary) !important;
 }
 
-.dark .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
-.dark .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-top-link.fd-sidebar-link-active,
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-top-link[data-active="true"],
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-top-link[data-active="true"] {
   color: var(--color-fd-primary) !important;
 }
 
-aside div.w-full:not([role]) {
+#nd-docs-layout aside div.w-full:not([role]) {
   font-weight: 600;
   font-size: 0.875rem;
   color: var(--color-fd-foreground);
@@ -277,14 +298,14 @@ aside div.w-full:not([role]) {
   margin-top: 0.5rem;
 }
 
-.fd-sidebar .fd-sidebar-folder-content {
+#nd-docs-layout .fd-sidebar .fd-sidebar-folder-content {
   position: relative;
   padding-left: 16px;
   margin-left: 8px;
   margin-top: -12px;
 }
 
-.fd-sidebar .fd-sidebar-folder-content::before {
+#nd-docs-layout .fd-sidebar .fd-sidebar-folder-content::before {
   content: "";
   position: absolute;
   left: 8px;
@@ -295,22 +316,24 @@ aside div.w-full:not([role]) {
   background: var(--color-fd-border);
 }
 
-.dark .fd-sidebar .fd-sidebar-folder-content::before {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-folder-content::before,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-folder-content::before {
   background: var(--fd-sidebar-indent-line, var(--color-fd-border));
 }
 
-aside button[class*="bg-fd-secondary"],
-.dark .fd-sidebar .fd-sidebar-search-btn {
+#nd-docs-layout aside button[class*="bg-fd-secondary"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar .fd-sidebar-search-btn,
+#nd-docs-layout.dark .fd-sidebar .fd-sidebar-search-btn {
   background: transparent;
   border: 1px solid var(--color-fd-border);
   border-radius: 8px;
   font-size: 0.875rem;
 }
 
-aside .border-t,
-aside [class*="border-t"],
-.fd-sidebar .fd-sidebar-footer,
-.fd-sidebar .fd-sidebar-footer-custom {
+#nd-docs-layout aside .border-t,
+#nd-docs-layout aside [class*="border-t"],
+#nd-docs-layout .fd-sidebar .fd-sidebar-footer,
+#nd-docs-layout .fd-sidebar .fd-sidebar-footer-custom {
   border-top: 1px solid var(--color-fd-border);
 }
 
@@ -318,10 +341,10 @@ aside [class*="border-t"],
  * HEADER — clean, no heavy border
  * ═══════════════════════════════════════════════════════════════════ */
 
-header,
-[role="banner"],
+#nd-docs-layout header,
+#nd-docs-layout [role="banner"],
 #nd-docs-layout > header,
-nav[class*="header"] {
+#nd-docs-layout nav[class*="header"] {
   border-bottom: 1px solid var(--color-fd-border);
 }
 
@@ -329,7 +352,7 @@ nav[class*="header"] {
  * CONTENT — links, code, tables, etc.
  * ═══════════════════════════════════════════════════════════════════ */
 
-.fd-docs-content a:not(.fd-page-nav-card):not([class]) {
+#nd-docs-layout .fd-docs-content a:not(.fd-page-nav-card):not([class]) {
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-color: rgba(13, 147, 115, 0.3);
@@ -339,11 +362,11 @@ nav[class*="header"] {
   transition: text-decoration-color 150ms;
 }
 
-.fd-docs-content a:not(.fd-page-nav-card):not([class]):hover {
+#nd-docs-layout .fd-docs-content a:not(.fd-page-nav-card):not([class]):hover {
   text-decoration-color: var(--color-fd-primary);
 }
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   padding: 2px 5px;
   border: 1px solid var(--color-fd-border);
   font-size: 0.875rem;
@@ -353,7 +376,7 @@ nav[class*="header"] {
   font-weight: 400;
 }
 
-.fd-docs-content table {
+#nd-docs-layout .fd-docs-content table {
   border-collapse: separate;
   border-spacing: 0;
   background: var(--color-fd-card);
@@ -363,7 +386,7 @@ nav[class*="header"] {
   width: 100%;
 }
 
-.fd-docs-content th {
+#nd-docs-layout .fd-docs-content th {
   background: var(--color-fd-muted);
   font-weight: 500;
   font-size: 0.8125rem;
@@ -372,18 +395,18 @@ nav[class*="header"] {
   letter-spacing: normal;
 }
 
-.fd-docs-content th,
-.fd-docs-content td {
+#nd-docs-layout .fd-docs-content th,
+#nd-docs-layout .fd-docs-content td {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--color-fd-border);
   font-size: 0.875rem;
 }
 
-.fd-docs-content tr:last-child td {
+#nd-docs-layout .fd-docs-content tr:last-child td {
   border-bottom: none;
 }
 
-.fd-docs-content blockquote {
+#nd-docs-layout .fd-docs-content blockquote {
   border-left: 3px solid var(--color-fd-primary);
   padding-left: 1rem;
   color: var(--color-fd-muted-foreground);
@@ -391,8 +414,8 @@ nav[class*="header"] {
   margin: 1rem 0;
 }
 
-.fd-page-actions,
-[data-page-actions] {
+#nd-docs-layout .fd-page-actions,
+#nd-docs-layout [data-page-actions] {
   gap: 0 !important;
   margin-right: 10px;
 }
@@ -409,7 +432,7 @@ nav[class*="header"] {
   border-left: none !important;
 } */
 
-.fd-docs-content hr {
+#nd-docs-layout .fd-docs-content hr {
   border-color: var(--color-fd-border);
 }
 
@@ -417,7 +440,7 @@ nav[class*="header"] {
  * CARDS
  * ═══════════════════════════════════════════════════════════════════ */
 
-.fd-card {
+#nd-docs-layout .fd-card {
   display: block;
   border-radius: 12px;
   border: 1px solid var(--color-fd-border);
@@ -431,12 +454,12 @@ nav[class*="header"] {
     border-color 150ms;
 }
 
-.fd-card:hover {
+#nd-docs-layout .fd-card:hover {
   border-color: var(--color-fd-primary);
   box-shadow: none;
 }
 
-.fd-card-icon {
+#nd-docs-layout .fd-card-icon {
   margin-bottom: 0.5rem;
   width: fit-content;
   border-radius: 8px;
@@ -446,35 +469,36 @@ nav[class*="header"] {
   background: rgba(13, 147, 115, 0.06);
 }
 
-.dark .fd-card-icon {
+:is(html.dark, body.dark) #nd-docs-layout .fd-card-icon,
+#nd-docs-layout.dark .fd-card-icon {
   background: rgba(38, 189, 108, 0.08);
 }
 
-.fd-card-title {
+#nd-docs-layout .fd-card-title {
   font-weight: 500;
   font-size: 0.9375rem;
 }
 
-.fd-card-description {
+#nd-docs-layout .fd-card-description {
   color: var(--color-fd-muted-foreground);
   margin-top: 0.25rem;
   font-size: 0.8125rem;
   line-height: 1.5;
 }
 
-.fd-cards {
+#nd-docs-layout .fd-cards {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0.75rem;
 }
 
 @media (min-width: 640px) {
-  .fd-cards {
+  #nd-docs-layout .fd-cards {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-.fd-page-nav-card {
+#nd-docs-layout .fd-page-nav-card {
   border-radius: 12px;
 }
 
@@ -482,17 +506,17 @@ nav[class*="header"] {
  * CODE BLOCKS, TABS, CALLOUT, TOC, etc.
  * ═══════════════════════════════════════════════════════════════════ */
 
-figure.shiki {
+#nd-docs-layout figure.shiki {
   border-radius: 10px;
   overflow: hidden;
   border: 1px solid var(--color-fd-border);
 }
 
-[role="tablist"] {
+#nd-docs-layout [role="tablist"] {
   border-bottom: 1px solid var(--color-fd-border);
 }
 
-[role="tab"] {
+#nd-docs-layout [role="tab"] {
   font-size: 0.875rem;
   font-weight: 400;
   padding: 0.5rem 0.75rem;
@@ -504,19 +528,19 @@ figure.shiki {
     border-color 150ms;
 }
 
-[role="tab"][aria-selected="true"],
-[role="tab"][data-state="active"] {
+#nd-docs-layout [role="tab"][aria-selected="true"],
+#nd-docs-layout [role="tab"][data-state="active"] {
   color: var(--color-fd-primary);
   border-bottom-color: var(--color-fd-primary);
   font-weight: 500;
 }
 
-[style*="--callout-color"] {
+#nd-docs-layout [style*="--callout-color"] {
   border-radius: 10px;
   border-width: 1px;
 }
 
-details {
+#nd-docs-layout details {
   border: 1px solid var(--color-fd-border);
   border-radius: 10px;
   padding: 0;
@@ -524,7 +548,7 @@ details {
   overflow: hidden;
 }
 
-details summary {
+#nd-docs-layout details summary {
   padding: 0.75rem 1rem;
   font-weight: 500;
   font-size: 0.9375rem;
@@ -534,133 +558,135 @@ details summary {
   transition: background 150ms;
 }
 
-details summary:hover {
+#nd-docs-layout details summary:hover {
   background: var(--color-fd-accent);
 }
 
-details[open] summary {
+#nd-docs-layout details[open] summary {
   border-bottom: 1px solid var(--color-fd-border);
 }
 
-details > :not(summary) {
+#nd-docs-layout details > :not(summary) {
   padding: 0.75rem 1rem;
 }
 
-.fd-toc .fd-toc-link,
-.fd-toc .fd-toc-clerk-link {
+#nd-docs-layout .fd-toc .fd-toc-link,
+#nd-docs-layout .fd-toc .fd-toc-clerk-link {
   transition: color 0.2s ease;
 }
 
-.fd-toc .fd-toc-link-active,
-.fd-toc .fd-toc-link[data-active="true"],
-.fd-toc .fd-toc-clerk-link[data-active="true"] {
+#nd-docs-layout .fd-toc .fd-toc-link-active,
+#nd-docs-layout .fd-toc .fd-toc-link[data-active="true"],
+#nd-docs-layout .fd-toc .fd-toc-clerk-link[data-active="true"] {
   color: var(--color-fd-primary);
   font-weight: 500;
 }
 
-.fd-toc .fd-toc-link:not(.fd-toc-link-active):not([data-active="true"]),
-.fd-toc .fd-toc-clerk-link:not([data-active="true"]) {
+#nd-docs-layout .fd-toc .fd-toc-link:not(.fd-toc-link-active):not([data-active="true"]),
+#nd-docs-layout .fd-toc .fd-toc-clerk-link:not([data-active="true"]) {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-toc .fd-toc-link,
-.fd-toc .fd-toc-clerk-link {
+#nd-docs-layout .fd-toc .fd-toc-link,
+#nd-docs-layout .fd-toc .fd-toc-clerk-link {
   font-size: 0.875rem;
   line-height: 1.3;
 }
 
-.fd-toc .fd-toc-title {
+#nd-docs-layout .fd-toc .fd-toc-title {
   font-size: 0.875rem;
   font-weight: 500;
 }
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border-radius: 12px;
   border: 1px solid var(--color-fd-border);
   background: var(--color-fd-popover);
   box-shadow: 0 16px 70px rgba(0, 0, 0, 0.1);
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border-radius: 8px;
 }
 
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   background: var(--color-fd-accent);
 }
 
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   background: rgba(13, 147, 115, 0.1);
   color: var(--color-fd-primary);
 }
 
-.dark .omni-highlight {
+:is(html.dark, body.dark) #nd-docs-layout .omni-highlight,
+#nd-docs-layout.dark .omni-highlight {
   background: rgba(38, 189, 108, 0.15);
 }
 
-.omni-search-input:focus {
+#nd-docs-layout .omni-search-input:focus {
   caret-color: var(--color-fd-primary);
 }
 
-.fd-page-footer {
+#nd-docs-layout .fd-page-footer {
   border-top: 1px solid var(--color-fd-border);
 }
 
-.fd-page-description {
+#nd-docs-layout .fd-page-description {
   margin-bottom: 1rem;
   font-size: 1rem;
   line-height: 1.7;
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   border-radius: 8px;
   font-size: 0.8125rem;
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   border-radius: 10px;
   border: 1px solid var(--color-fd-border);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   background: var(--color-fd-popover);
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   border-radius: 6px;
   color: var(--color-fd-foreground);
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-accent-foreground);
 }
 
-.fd-ai-dialog {
+#nd-docs-layout .fd-ai-dialog {
   border-radius: 14px;
   box-shadow: 0 16px 70px rgba(0, 0, 0, 0.1);
 }
 
-.fd-ai-bubble-user {
+#nd-docs-layout .fd-ai-bubble-user {
   border-radius: 16px 16px 4px 16px;
 }
 
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-ai {
   border-radius: 16px 16px 16px 4px;
 }
 
-.fd-ai-input-wrap {
+#nd-docs-layout .fd-ai-input-wrap {
   border-radius: 10px;
 }
 
-.fd-ai-send-btn {
+#nd-docs-layout .fd-ai-send-btn {
   border-radius: 10px;
 }
 
-.dark .fd-ai-floating-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout.dark .fd-ai-floating-btn {
   border-radius: 999px;
   background: var(--color-fd-primary);
   color: #fff;
@@ -668,11 +694,12 @@ details > :not(summary) {
   border: none;
 }
 
-.dark .fd-ai-floating-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout.dark .fd-ai-floating-btn:hover {
   filter: brightness(1.1);
 }
 
-:root:not(.dark) .fd-ai-floating-btn {
+:root:not(.dark) #nd-docs-layout .fd-ai-floating-btn {
   border-radius: 999px;
   background: var(--color-fd-primary);
   color: #fff;
@@ -680,12 +707,13 @@ details > :not(summary) {
   border: none;
 }
 
-:root:not(.dark) .fd-ai-floating-btn:hover {
+:root:not(.dark) #nd-docs-layout .fd-ai-floating-btn:hover {
   filter: brightness(1.1);
 }
 
 /* Custom Ask AI trigger — same as fd-ai-floating-btn for theme */
-.dark .fd-ai-floating-trigger .ask-ai-trigger {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger,
+#nd-docs-layout.dark .fd-ai-floating-trigger .ask-ai-trigger {
   font-family: var(--fd-font-sans, inherit);
   border-radius: 999px !important;
   background: var(--color-fd-primary) !important;
@@ -694,11 +722,12 @@ details > :not(summary) {
   border: none !important;
 }
 
-.dark .fd-ai-floating-trigger .ask-ai-trigger:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover,
+#nd-docs-layout.dark .fd-ai-floating-trigger .ask-ai-trigger:hover {
   filter: brightness(1.1);
 }
 
-:root:not(.dark) .fd-ai-floating-trigger .ask-ai-trigger {
+:root:not(.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger {
   font-family: var(--fd-font-sans, inherit);
   border-radius: 999px !important;
   background: var(--color-fd-primary) !important;
@@ -707,71 +736,72 @@ details > :not(summary) {
   border: none !important;
 }
 
-:root:not(.dark) .fd-ai-floating-trigger .ask-ai-trigger:hover {
+:root:not(.dark) #nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover {
   filter: brightness(1.1);
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
   border-radius: 999px !important;
   background: var(--color-fd-primary) !important;
   color: #fff !important;
   border: none !important;
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
   filter: brightness(1.1);
 }
 
-.fd-ai-suggestion {
+#nd-docs-layout .fd-ai-suggestion {
   border-radius: 10px;
 }
-.dark .fd-ai-suggestion:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-suggestion:hover,
+#nd-docs-layout.dark .fd-ai-suggestion:hover {
   border: 1px solid var(--color-fd-primary/50);
 }
 
-.fd-ai-result {
+#nd-docs-layout .fd-ai-result {
   border-radius: 10px;
 }
 
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-fm-input-container {
   border-radius: 12px;
 }
 
-.fd-ai-fm-send-btn {
+#nd-docs-layout .fd-ai-fm-send-btn {
   border-radius: 9999px;
 }
 
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-ai-fm-suggestion {
   border-radius: 9999px;
 }
 
-.fd-ai-fm-trigger-btn {
+#nd-docs-layout .fd-ai-fm-trigger-btn {
   border-radius: 16px;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   border-radius: 9999px;
 }
 
-.fd-ai-code-block {
+#nd-docs-layout .fd-ai-code-block {
   border-radius: 20px;
 }
 
-.fd-ai-fm-msg-content table  {
+#nd-docs-layout .fd-ai-fm-msg-content table  {
   border-radius: 20px;
 }
-.fd-ai-code-copy {
+#nd-docs-layout .fd-ai-code-copy {
   border-radius: 6px;
 }
 
-.fd-sidebar-search-ai-row {
+#nd-docs-layout .fd-sidebar-search-ai-row {
   display: flex;
   gap: 8px;
   align-items: stretch;
   width: 100%;
 }
 
-.fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search-btn {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -787,15 +817,15 @@ details > :not(summary) {
   transition: background-color 150ms;
 }
 
-.fd-sidebar-search-btn:hover {
+#nd-docs-layout .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent) ;
 }
 
-.fd-sidebar-search-btn svg {
+#nd-docs-layout .fd-sidebar-search-btn svg {
   flex-shrink: 0;
 }
 
-.fd-sidebar-search-kbd kbd {
+#nd-docs-layout .fd-sidebar-search-kbd kbd {
   font-family: inherit;
   font-size: 0.7rem;
   padding: 1px 4px;
@@ -804,7 +834,7 @@ details > :not(summary) {
   background: var(--color-fd-muted);
 }
 
-.fd-sidebar-ai-btn {
+#nd-docs-layout .fd-sidebar-ai-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -821,24 +851,24 @@ details > :not(summary) {
     border-color 150ms;
 }
 
-.fd-sidebar-ai-btn:hover {
+#nd-docs-layout .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-primary);
   border-color: var(--color-fd-primary);
 }
 
-.fd-sidebar-ai-btn svg {
+#nd-docs-layout .fd-sidebar-ai-btn svg {
   width: 16px;
   height: 16px;
 }
 
-.fd-page-actions {
+#nd-docs-layout .fd-page-actions {
   display: flex;
   gap: 0;
   align-items: stretch;
 }
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -855,55 +885,55 @@ details > :not(summary) {
   white-space: nowrap;
 }
 
-.fd-page-action-btn:hover {
+#nd-docs-layout .fd-page-action-btn:hover {
   background: var(--color-fd-accent);
   color: var(--color-fd-foreground);
 }
 
-.fd-page-actions .fd-page-action-btn:first-child {
+#nd-docs-layout .fd-page-actions .fd-page-action-btn:first-child {
   border-radius: 8px 0 0 8px;
 }
 
-.fd-page-actions .fd-page-action-dropdown:last-child .fd-page-action-btn,
-.fd-page-actions > .fd-page-action-btn:last-child {
+#nd-docs-layout .fd-page-actions .fd-page-action-dropdown:last-child .fd-page-action-btn,
+#nd-docs-layout .fd-page-actions > .fd-page-action-btn:last-child {
   border-radius: 0 8px 8px 0;
   border-left: 1px solid var(--color-fd-border);
   padding: 6px 8px;
 }
 
-.fd-page-actions .fd-page-action-btn:only-child {
+#nd-docs-layout .fd-page-actions .fd-page-action-btn:only-child {
   border-radius: 8px;
   border: 1px solid var(--color-fd-border);
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative;
 }
 
-.fd-sidebar::-webkit-scrollbar {
+#nd-docs-layout .fd-sidebar::-webkit-scrollbar {
   width: 4px;
 }
 
-.fd-sidebar::-webkit-scrollbar-thumb {
+#nd-docs-layout .fd-sidebar::-webkit-scrollbar-thumb {
   background: var(--color-fd-border);
   border-radius: 4px;
 }
 
-.fd-sidebar::-webkit-scrollbar-track {
+#nd-docs-layout .fd-sidebar::-webkit-scrollbar-track {
   background: transparent;
 }
 
 /* ─── Feedback (greentree theme) ─────────────────────────────────── */
 
-.fd-feedback-input,
-.fd-feedback-submit {
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit {
   border-radius: 0.75rem;
 }
 
-.fd-feedback-choice[data-selected="true"] {
+#nd-docs-layout .fd-feedback-choice[data-selected="true"] {
   background: color-mix(in srgb, var(--color-fd-primary) 12%, var(--color-fd-secondary));
 }
 
-.fd-feedback-status[data-status="success"] {
+#nd-docs-layout .fd-feedback-status[data-status="success"] {
   color: var(--color-fd-primary);
 }

--- a/packages/svelte-theme/styles/hardline.css
+++ b/packages/svelte-theme/styles/hardline.css
@@ -1,6 +1,7 @@
 /* @farming-labs/theme - hardline theme CSS */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #ffd335;
   --color-fd-primary-foreground: #121212;
   --color-fd-ring: #121212;
@@ -23,7 +24,11 @@
   --fd-nav-height: 64px;
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #ffcf3a;
   --color-fd-primary-foreground: #101010;
   --color-fd-ring: #ffcf3a;
@@ -43,19 +48,20 @@
   --color-fd-border: rgba(213, 204, 185, 0.82);
 }
 
-* {
+#nd-docs-layout,
+#nd-docs-layout * {
   scrollbar-width: auto;
 }
 
-::selection {
+#nd-docs-layout::selection,
+#nd-docs-layout *::selection {
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
 /* Hard-edge layout baseline */
 #nd-docs-layout [class*="rounded-"],
-#nd-docs-layout [style*="border-radius"],
-#nd-docs-layout code:not(pre code) {
+#nd-docs-layout [style*="border-radius"] {
   border-radius: 0 !important;
 }
 
@@ -65,19 +71,18 @@
 
 /* Header and sidebar structure */
 #nd-docs-layout > header,
-[role="banner"] {
+#nd-docs-layout [role="banner"] {
   border-bottom: 2px solid var(--color-fd-border);
   background: var(--color-fd-background);
 }
 
-aside#nd-sidebar,
-#nd-docs-layout aside {
+#nd-docs-layout aside#nd-sidebar {
   background: var(--color-fd-background);
   border-right: 2px solid var(--color-fd-border);
 }
 
 /* Sidebar links and categories */
-aside a[data-active] {
+#nd-docs-layout aside a[data-active] {
   font-weight: 600;
   font-size: 0.92rem;
   letter-spacing: 0.01em;
@@ -86,23 +91,23 @@ aside a[data-active] {
   color: var(--color-fd-foreground);
 }
 
-aside a[data-active]:hover {
+#nd-docs-layout aside a[data-active]:hover {
   border-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-primary) 24%, transparent);
 }
 
-aside a[data-active="true"] {
+#nd-docs-layout aside a[data-active="true"] {
   font-weight: 800;
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
   border-color: var(--color-fd-border);
 }
 
-aside a[data-active="true"]::before {
+#nd-docs-layout aside a[data-active="true"]::before {
   display: none !important;
 }
 
-aside button.text-fd-muted-foreground {
+#nd-docs-layout aside button.text-fd-muted-foreground {
   font-size: 0.83rem;
   font-weight: 800;
   letter-spacing: 0.06em;
@@ -111,30 +116,32 @@ aside button.text-fd-muted-foreground {
 }
 
 /* Search/action inputs in sidebar */
-aside button[class*="bg-fd-secondary"] {
+#nd-docs-layout aside button[class*="bg-fd-secondary"] {
   border: 2px solid var(--color-fd-border);
   background: var(--color-fd-card);
   font-weight: 600;
 }
 
-.dark aside a[data-active]:hover {
+:is(html.dark, body.dark) #nd-docs-layout aside a[data-active]:hover,
+#nd-docs-layout.dark aside a[data-active]:hover {
   background: color-mix(in srgb, var(--color-fd-primary) 16%, transparent);
 }
 
-.dark aside button[class*="bg-fd-secondary"] {
+:is(html.dark, body.dark) #nd-docs-layout aside button[class*="bg-fd-secondary"],
+#nd-docs-layout.dark aside button[class*="bg-fd-secondary"] {
   background: #151516;
 }
 
 /* Search UI (sidebar + command palette) */
-.fd-sidebar-search-ai-row {
+#nd-docs-layout .fd-sidebar-search-ai-row {
   display: flex;
   gap: 8px;
   align-items: stretch;
   width: 100%;
 }
 
-.fd-sidebar-search-ai-row > .fd-sidebar-search-btn,
-.fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search-ai-row > .fd-sidebar-search-btn,
+#nd-docs-layout .fd-sidebar-search-btn {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -148,18 +155,18 @@ aside button[class*="bg-fd-secondary"] {
   font-weight: 600;
 }
 
-.fd-sidebar-search-ai-row > .fd-sidebar-search-btn:hover,
-.fd-sidebar-search-btn:hover {
+#nd-docs-layout .fd-sidebar-search-ai-row > .fd-sidebar-search-btn:hover,
+#nd-docs-layout .fd-sidebar-search-btn:hover {
   background: color-mix(in srgb, var(--color-fd-primary) 18%, var(--color-fd-card)) !important;
 }
 
-.fd-sidebar-search-kbd {
+#nd-docs-layout .fd-sidebar-search-kbd {
   margin-left: auto;
   display: flex;
   gap: 3px;
 }
 
-.fd-sidebar-search-kbd kbd {
+#nd-docs-layout .fd-sidebar-search-kbd kbd {
   border: 1px solid var(--color-fd-border);
   border-radius: 0 !important;
   background: var(--color-fd-secondary);
@@ -168,8 +175,8 @@ aside button[class*="bg-fd-secondary"] {
   font-size: 0.68rem;
 }
 
-.fd-sidebar-search-ai-row > .fd-sidebar-ai-btn,
-.fd-sidebar-ai-btn {
+#nd-docs-layout .fd-sidebar-search-ai-row > .fd-sidebar-ai-btn,
+#nd-docs-layout .fd-sidebar-ai-btn {
   width: 38px;
   min-width: 38px;
   display: inline-flex;
@@ -181,66 +188,66 @@ aside button[class*="bg-fd-secondary"] {
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-sidebar-search-ai-row > .fd-sidebar-ai-btn:hover,
-.fd-sidebar-ai-btn:hover {
+#nd-docs-layout .fd-sidebar-search-ai-row > .fd-sidebar-ai-btn:hover,
+#nd-docs-layout .fd-sidebar-ai-btn:hover {
   background: var(--color-fd-primary) !important;
   color: var(--color-fd-primary-foreground) !important;
 }
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border-radius: 0 !important;
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-popover);
   box-shadow: 6px 6px 0 var(--color-fd-border);
 }
 
-.omni-header {
+#nd-docs-layout .omni-header {
   border-bottom: 2px solid var(--color-fd-border) !important;
 }
 
-.omni-search-row {
+#nd-docs-layout .omni-search-row {
   gap: 0.625rem;
   padding: 0.625rem 0.75rem;
 }
 
-.omni-search-input {
+#nd-docs-layout .omni-search-input {
   font-weight: 600;
 }
 
-.omni-search-input:focus {
+#nd-docs-layout .omni-search-input:focus {
   caret-color: var(--color-fd-primary);
 }
 
-.omni-kbd,
-.omni-kbd-sm,
-.omni-close-btn {
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-kbd-sm,
+#nd-docs-layout .omni-close-btn {
   border-radius: 0 !important;
 }
 
-.omni-kbd,
-.omni-kbd-sm {
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-kbd-sm {
   border: 1px solid var(--color-fd-border);
   background: var(--color-fd-secondary);
 }
 
-.omni-close-btn:hover {
+#nd-docs-layout .omni-close-btn:hover {
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border-radius: 0 !important;
   border: 1px solid transparent;
   font-weight: 600;
 }
 
-.omni-item:hover,
-.omni-item-active {
+#nd-docs-layout .omni-item:hover,
+#nd-docs-layout .omni-item-active {
   border-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-primary) 16%, transparent);
 }
 
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   border-radius: 0 !important;
   background: color-mix(in srgb, var(--color-fd-primary) 36%, transparent);
 }
@@ -257,23 +264,23 @@ aside button[class*="bg-fd-secondary"] {
 }
 
 /* Typography */
-.fd-docs-content h1,
-.fd-docs-content h2,
-.fd-docs-content h3,
-.fd-docs-content h4 {
+#nd-docs-layout .fd-docs-content h1,
+#nd-docs-layout .fd-docs-content h2,
+#nd-docs-layout .fd-docs-content h3,
+#nd-docs-layout .fd-docs-content h4 {
   text-transform: uppercase;
   letter-spacing: 0.01em;
 }
 
-.fd-docs-content h1 {
+#nd-docs-layout .fd-docs-content h1 {
   font-weight: 900;
 }
 
-.fd-docs-content p {
+#nd-docs-layout .fd-docs-content p {
   font-weight: 500;
 }
 
-.fd-docs-content a:not(.fd-page-nav-card):not([class]) {
+#nd-docs-layout .fd-docs-content a:not(.fd-page-nav-card):not([class]) {
   color: inherit;
   text-decoration: underline;
   text-decoration-thickness: 2px;
@@ -282,33 +289,38 @@ aside button[class*="bg-fd-secondary"] {
 }
 
 /* Cards, callouts, tabs, and generic surfaces */
-.fd-card,
-[data-card],
-[class*="fd-callout"],
-.fd-page-action-menu,
-.fd-page-action-btn {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-btn {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card);
   box-shadow: 4px 4px 0 var(--color-fd-border);
 }
 
-.dark .fd-card,
-.dark [data-card],
-.dark [class*="fd-callout"],
-.dark .fd-page-action-menu,
-.dark .fd-page-action-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-card,
+#nd-docs-layout.dark .fd-card,
+:is(html.dark, body.dark) #nd-docs-layout [data-card],
+#nd-docs-layout.dark [data-card],
+:is(html.dark, body.dark) #nd-docs-layout [class*="fd-callout"],
+#nd-docs-layout.dark [class*="fd-callout"],
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout.dark .fd-page-action-menu,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout.dark .fd-page-action-btn {
   box-shadow: 4px 4px 0 color-mix(in srgb, var(--color-fd-primary) 40%, transparent);
 }
 
 /* Page actions: hardline hard edges */
-.fd-page-action-btn,
-.fd-page-action-menu,
-.fd-page-action-menu-item,
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-page-action-menu-item,
+#nd-docs-layout .fd-page-action-dropdown {
   border-radius: 0 !important;
 }
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   color: var(--color-fd-foreground) !important;
@@ -316,69 +328,72 @@ aside button[class*="bg-fd-secondary"] {
   letter-spacing: 0.01em;
 }
 
-.fd-page-action-btn:hover,
-.fd-page-action-btn[data-selected="true"],
-.fd-page-action-btn[data-copied="true"] {
+#nd-docs-layout .fd-page-action-btn:hover,
+#nd-docs-layout .fd-page-action-btn[data-selected="true"],
+#nd-docs-layout .fd-page-action-btn[data-copied="true"] {
   background: var(--color-fd-primary) !important;
   color: var(--color-fd-primary-foreground) !important;
   border-color: var(--color-fd-border) !important;
 }
 
-.fd-page-action-btn svg,
-.fd-page-action-btn[data-selected="true"] svg,
-.fd-page-action-btn[data-copied="true"] svg {
+#nd-docs-layout .fd-page-action-btn svg,
+#nd-docs-layout .fd-page-action-btn[data-selected="true"] svg,
+#nd-docs-layout .fd-page-action-btn[data-copied="true"] svg {
   color: currentColor;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   border: 2px solid var(--color-fd-border);
   padding: 0.35rem;
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   border: 1px solid transparent;
   font-weight: 600;
 }
 
-.fd-page-action-menu-item:hover {
+#nd-docs-layout .fd-page-action-menu-item:hover {
   border-color: var(--color-fd-border);
   background: color-mix(in srgb, var(--color-fd-primary) 20%, transparent);
 }
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   border: 2px solid var(--color-fd-border);
   background: var(--color-fd-secondary);
   padding: 1px 6px;
   font-weight: 700;
 }
 
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-docs-content [data-codeblock] {
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-docs-content [data-codeblock] {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
 }
 
-.dark .fd-docs-content pre,
-.dark .fd-docs-content .shiki,
-.dark .fd-docs-content [data-codeblock] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout.dark .fd-docs-content pre,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout.dark .fd-docs-content .shiki,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content [data-codeblock],
+#nd-docs-layout.dark .fd-docs-content [data-codeblock] {
   background: #121214 !important;
 }
 
-.fd-docs-content table {
+#nd-docs-layout .fd-docs-content table {
   border-collapse: collapse;
   border: 2px solid var(--color-fd-border);
   width: 100%;
   background: var(--color-fd-card);
 }
 
-.fd-docs-content th,
-.fd-docs-content td {
+#nd-docs-layout .fd-docs-content th,
+#nd-docs-layout .fd-docs-content td {
   border: 2px solid var(--color-fd-border);
   padding: 0.7rem 0.85rem;
 }
 
-.fd-docs-content th {
+#nd-docs-layout .fd-docs-content th {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-size: 0.78rem;
@@ -386,170 +401,180 @@ aside button[class*="bg-fd-secondary"] {
   color: var(--color-fd-primary-foreground);
 }
 
-.fd-docs-content tbody tr:nth-child(even) td {
+#nd-docs-layout .fd-docs-content tbody tr:nth-child(even) td {
   background: color-mix(in srgb, var(--color-fd-secondary) 85%, transparent);
 }
 
-.dark .fd-docs-content tbody tr:nth-child(even) td {
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content tbody tr:nth-child(even) td,
+#nd-docs-layout.dark .fd-docs-content tbody tr:nth-child(even) td {
   background: #1a1a1d;
 }
 
 /* Prev/next cards */
-.fd-page-nav,
-.fd-page-nav-card,
-[class*="page-nav"] a {
+#nd-docs-layout .fd-page-nav,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout [class*="page-nav"] a {
   border: 2px solid var(--color-fd-border);
   background: var(--color-fd-card);
   box-shadow: 4px 4px 0 var(--color-fd-border);
   border-radius: 0 !important;
 }
 
-.fd-page-nav-card:hover,
-[class*="page-nav"] a:hover {
+#nd-docs-layout .fd-page-nav-card:hover,
+#nd-docs-layout [class*="page-nav"] a:hover {
   background: color-mix(in srgb, var(--color-fd-primary) 18%, var(--color-fd-card));
 }
 
-.fd-page-nav-card [class*="text-"] {
+#nd-docs-layout .fd-page-nav-card [class*="text-"] {
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
 
-.dark .fd-page-nav,
-.dark .fd-page-nav-card,
-.dark [class*="page-nav"] a {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav,
+#nd-docs-layout.dark .fd-page-nav,
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout.dark .fd-page-nav-card,
+:is(html.dark, body.dark) #nd-docs-layout [class*="page-nav"] a,
+#nd-docs-layout.dark [class*="page-nav"] a {
   box-shadow: 4px 4px 0 color-mix(in srgb, var(--color-fd-primary) 35%, transparent);
 }
 
 /* Ask AI and feedback - hardline treatment */
-.fd-ai-dialog,
-.fd-ai-tab,
-.fd-ai-input-wrap,
-.fd-ai-send-btn,
-.fd-ai-close-btn,
-.fd-ai-clear-btn,
-.fd-ai-floating-btn,
-.fd-ai-suggestion,
-.fd-ai-result,
-.fd-ai-model-dropdown-btn,
-.fd-ai-model-dropdown-menu,
-.fd-ai-model-dropdown-item,
-.fd-ai-fm-input-container,
-.fd-ai-fm-send-btn,
-.fd-ai-fm-suggestion,
-.fd-ai-fm-trigger-btn,
-.fd-ai-fm-close-btn,
-.fd-ai-code-block,
-.fd-ai-code-copy,
-.fd-feedback-input,
-.fd-feedback-submit,
-.fd-feedback-choice {
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-tab,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-clear-btn,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .fd-ai-suggestion,
+#nd-docs-layout .fd-ai-result,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-model-dropdown-item,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-fm-send-btn,
+#nd-docs-layout .fd-ai-fm-suggestion,
+#nd-docs-layout .fd-ai-fm-trigger-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-ai-code-block,
+#nd-docs-layout .fd-ai-code-copy,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice {
   border-radius: 0 !important;
 }
 
-.fd-ai-dialog,
-.fd-ai-input-wrap,
-.fd-ai-model-dropdown-menu,
-.fd-ai-fm-topbar,
-.fd-ai-fm-input-container,
-.fd-ai-code-block {
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout .fd-ai-code-block {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-card) !important;
   box-shadow: 4px 4px 0 var(--color-fd-border);
 }
 
-.dark .fd-ai-dialog,
-.dark .fd-ai-input-wrap,
-.dark .fd-ai-model-dropdown-menu,
-.dark .fd-ai-fm-topbar,
-.dark .fd-ai-fm-input-container,
-.dark .fd-ai-code-block {
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout.dark .fd-ai-dialog,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-input-wrap,
+#nd-docs-layout.dark .fd-ai-input-wrap,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-model-dropdown-menu,
+#nd-docs-layout.dark .fd-ai-model-dropdown-menu,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-fm-topbar,
+#nd-docs-layout.dark .fd-ai-fm-topbar,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-fm-input-container,
+#nd-docs-layout.dark .fd-ai-fm-input-container,
+:is(html.dark, body.dark) #nd-docs-layout .fd-ai-code-block,
+#nd-docs-layout.dark .fd-ai-code-block {
   box-shadow: 4px 4px 0 color-mix(in srgb, var(--color-fd-primary) 35%, transparent);
 }
 
-.fd-ai-send-btn,
-.fd-ai-close-btn,
-.fd-ai-clear-btn,
-.fd-ai-floating-btn,
-.fd-ai-model-dropdown-btn,
-.fd-ai-fm-send-btn,
-.fd-ai-fm-trigger-btn,
-.fd-ai-fm-close-btn,
-.fd-feedback-submit,
-.fd-feedback-choice {
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-close-btn,
+#nd-docs-layout .fd-ai-clear-btn,
+#nd-docs-layout .fd-ai-floating-btn,
+#nd-docs-layout .fd-ai-model-dropdown-btn,
+#nd-docs-layout .fd-ai-fm-send-btn,
+#nd-docs-layout .fd-ai-fm-trigger-btn,
+#nd-docs-layout .fd-ai-fm-close-btn,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-feedback-choice {
   border: 2px solid var(--color-fd-border) !important;
   background: var(--color-fd-secondary) !important;
   color: var(--color-fd-foreground) !important;
   font-weight: 700;
 }
 
-.fd-ai-send-btn:hover,
-.fd-ai-clear-btn:hover,
-.fd-ai-floating-btn:hover,
-.fd-ai-model-dropdown-btn:hover,
-.fd-ai-fm-send-btn:hover,
-.fd-ai-fm-trigger-btn:hover,
-.fd-feedback-submit:hover,
-.fd-feedback-choice:hover,
-.fd-feedback-choice[data-selected="true"] {
+#nd-docs-layout .fd-ai-send-btn:hover,
+#nd-docs-layout .fd-ai-clear-btn:hover,
+#nd-docs-layout .fd-ai-floating-btn:hover,
+#nd-docs-layout .fd-ai-model-dropdown-btn:hover,
+#nd-docs-layout .fd-ai-fm-send-btn:hover,
+#nd-docs-layout .fd-ai-fm-trigger-btn:hover,
+#nd-docs-layout .fd-feedback-submit:hover,
+#nd-docs-layout .fd-feedback-choice:hover,
+#nd-docs-layout .fd-feedback-choice[data-selected="true"] {
   background: var(--color-fd-primary) !important;
   color: var(--color-fd-primary-foreground) !important;
 }
 
-.fd-ai-tab {
+#nd-docs-layout .fd-ai-tab {
   border: 2px solid transparent;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-tab[data-active="true"] {
+#nd-docs-layout .fd-ai-tab[data-active="true"] {
   border-color: var(--color-fd-border);
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
-.fd-ai-bubble-user,
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-user,
+#nd-docs-layout .fd-ai-bubble-ai {
   border: 2px solid var(--color-fd-border);
   border-radius: 0 !important;
 }
 
-.fd-ai-bubble-user {
+#nd-docs-layout .fd-ai-bubble-user {
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-ai {
   background: var(--color-fd-card);
   color: var(--color-fd-card-foreground);
 }
 
-.fd-ai-bubble-ai table,
-.fd-ai-fm-msg-content table {
+#nd-docs-layout .fd-ai-bubble-ai table,
+#nd-docs-layout .fd-ai-fm-msg-content table {
   border-collapse: collapse;
   border: 2px solid var(--color-fd-border);
 }
 
-.fd-ai-bubble-ai th,
-.fd-ai-bubble-ai td,
-.fd-ai-fm-msg-content th,
-.fd-ai-fm-msg-content td {
+#nd-docs-layout .fd-ai-bubble-ai th,
+#nd-docs-layout .fd-ai-bubble-ai td,
+#nd-docs-layout .fd-ai-fm-msg-content th,
+#nd-docs-layout .fd-ai-fm-msg-content td {
   border: 2px solid var(--color-fd-border);
 }
 
 /* API reference panels */
-[data-api-reference] [class*="border"],
-[class*="fd-api"] [class*="border"] {
+#nd-docs-layout [data-api-reference] [class*="border"],
+#nd-docs-layout [class*="fd-api"] [class*="border"] {
   border-color: var(--color-fd-border) !important;
 }
 
-[class*="fd-api"] button,
-[class*="fd-api"] [role="tab"] {
+#nd-docs-layout [class*="fd-api"] button,
+#nd-docs-layout [class*="fd-api"] [role="tab"] {
   border-radius: 0 !important;
   border: 2px solid transparent;
 }
 
-[class*="fd-api"] [role="tab"][data-state="active"] {
+#nd-docs-layout [class*="fd-api"] [role="tab"][data-state="active"] {
   border-color: var(--color-fd-border);
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);

--- a/packages/svelte-theme/styles/ledger.css
+++ b/packages/svelte-theme/styles/ledger.css
@@ -1,5 +1,6 @@
 /* @farming-labs/svelte-theme - ledger theme overrides */
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-primary: #5f6cf6;
   --color-fd-primary-foreground: #ffffff;
   --color-fd-ring: #5f6cf6;
@@ -31,7 +32,11 @@
   --fd-ledger-action-icon: #5f6cf6;
 }
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-primary: #9aa8ff;
   --color-fd-primary-foreground: #10131a;
   --color-fd-ring: #9aa8ff;
@@ -61,21 +66,21 @@
   --fd-ledger-action-icon: #a8b5ff;
 }
 
-body,
-.fd-layout {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   background: var(--color-fd-background);
   color: var(--color-fd-foreground);
 }
 
-.fd-header {
+#nd-docs-layout .fd-header {
   min-height: var(--fd-nav-height);
   border-bottom: 1px solid var(--fd-ledger-soft-border);
   background: color-mix(in srgb, var(--color-fd-background) 88%, transparent);
   backdrop-filter: blur(14px);
 }
 
-.fd-nav a,
-.fd-header a {
+#nd-docs-layout .fd-nav a,
+#nd-docs-layout .fd-header a {
   border-radius: 999px;
   color: var(--color-fd-muted-foreground);
   font-size: 0.875rem;
@@ -84,20 +89,20 @@ body,
   padding: 0.375rem 0.625rem;
 }
 
-.fd-nav a:hover,
-.fd-nav a[data-active="true"],
-.fd-nav a[aria-current="page"] {
+#nd-docs-layout .fd-nav a:hover,
+#nd-docs-layout .fd-nav a[data-active="true"],
+#nd-docs-layout .fd-nav a[aria-current="page"] {
   background: color-mix(in srgb, var(--color-fd-primary) 12%, transparent);
   color: var(--color-fd-primary);
 }
 
-.fd-sidebar {
+#nd-docs-layout .fd-sidebar {
   background: color-mix(in srgb, var(--color-fd-background) 90%, var(--color-fd-card));
   border-right: 1px solid var(--fd-ledger-soft-border);
 }
 
-.fd-sidebar a,
-.fd-sidebar button {
+#nd-docs-layout .fd-sidebar a,
+#nd-docs-layout .fd-sidebar button {
   border-radius: 0.5rem;
   color: var(--color-fd-muted-foreground);
   font-size: 0.875rem;
@@ -105,21 +110,21 @@ body,
   letter-spacing: 0;
 }
 
-.fd-sidebar a:hover,
-.fd-sidebar button:hover {
+#nd-docs-layout .fd-sidebar a:hover,
+#nd-docs-layout .fd-sidebar button:hover {
   background: color-mix(in srgb, var(--color-fd-primary) 9%, transparent);
   color: var(--color-fd-foreground);
 }
 
-.fd-sidebar a[data-active="true"],
-.fd-sidebar a[aria-current="page"] {
+#nd-docs-layout .fd-sidebar a[data-active="true"],
+#nd-docs-layout .fd-sidebar a[aria-current="page"] {
   background: color-mix(in srgb, var(--color-fd-primary) 13%, transparent);
   color: var(--color-fd-primary);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-fd-primary) 18%, transparent);
 }
 
-.fd-sidebar-search-btn,
-.fd-search-trigger-mobile {
+#nd-docs-layout .fd-sidebar-search-btn,
+#nd-docs-layout .fd-search-trigger-mobile {
   border: 1px solid var(--fd-ledger-soft-border);
   border-radius: 0.5rem;
   background: color-mix(in srgb, var(--color-fd-card) 88%, transparent);
@@ -127,25 +132,25 @@ body,
   box-shadow: 0 1px 2px rgba(48, 54, 74, 0.05);
 }
 
-.fd-toc {
+#nd-docs-layout .fd-toc {
   border-left: 0;
   box-shadow: none;
 }
 
-.fd-toc .border-s,
-.fd-toc [class*="border-s"] {
+#nd-docs-layout .fd-toc .border-s,
+#nd-docs-layout .fd-toc [class*="border-s"] {
   border-inline-start-width: 0;
   border-left: 0;
 }
 
-.fd-toc-title {
+#nd-docs-layout .fd-toc-title {
   color: var(--color-fd-muted-foreground);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0;
 }
 
-.fd-toc-link {
+#nd-docs-layout .fd-toc-link {
   border-left: 0;
   border-radius: 0.375rem;
   color: var(--color-fd-muted-foreground);
@@ -153,15 +158,15 @@ body,
   padding-left: 0.625rem;
 }
 
-.fd-toc-link:hover,
-.fd-toc-link-active,
-.fd-toc-link[data-active="true"] {
+#nd-docs-layout .fd-toc-link:hover,
+#nd-docs-layout .fd-toc-link-active,
+#nd-docs-layout .fd-toc-link[data-active="true"] {
   background: transparent;
   color: var(--color-fd-primary);
 }
 
-.fd-docs-content h1,
-.fd-page-title {
+#nd-docs-layout .fd-docs-content h1,
+#nd-docs-layout .fd-page-title {
   color: var(--color-fd-foreground);
   font-size: 2.25rem;
   font-weight: 700;
@@ -169,7 +174,7 @@ body,
   line-height: 1.18;
 }
 
-.fd-docs-content h2 {
+#nd-docs-layout .fd-docs-content h2 {
   color: var(--color-fd-foreground);
   font-size: 1.625rem;
   font-weight: 700;
@@ -177,14 +182,14 @@ body,
   line-height: 1.28;
 }
 
-.fd-docs-content h3 {
+#nd-docs-layout .fd-docs-content h3 {
   color: var(--color-fd-foreground);
   font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: 0;
 }
 
-.fd-docs-content :is(h1, h2, h3, h4) > a.peer {
+#nd-docs-layout .fd-docs-content :is(h1, h2, h3, h4) > a.peer {
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -194,152 +199,156 @@ body,
   text-decoration: none;
 }
 
-.fd-page-description,
-.fd-docs-content p,
-.fd-docs-content li,
-.fd-docs-content td {
+#nd-docs-layout .fd-page-description,
+#nd-docs-layout .fd-docs-content p,
+#nd-docs-layout .fd-docs-content li,
+#nd-docs-layout .fd-docs-content td {
   color: var(--color-fd-muted-foreground);
   line-height: 1.7;
 }
 
-.fd-docs-content a {
+#nd-docs-layout .fd-docs-content a {
   color: var(--color-fd-primary);
   text-underline-offset: 3px;
 }
 
-.fd-card,
-[data-card],
-.fd-hover-link-card,
-.fd-page-nav-card,
-.fd-callout,
-.fd-page-action-menu,
-.fd-ai-dialog,
-.omni-content,
-.fd-feedback-input,
-.fd-feedback-choice,
-.fd-feedback-submit {
+#nd-docs-layout .fd-card,
+#nd-docs-layout [data-card],
+#nd-docs-layout .fd-hover-link-card,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout .fd-callout,
+#nd-docs-layout .fd-page-action-menu,
+#nd-docs-layout .fd-ai-dialog,
+#nd-docs-layout .omni-content,
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-choice,
+#nd-docs-layout .fd-feedback-submit {
   border: 1px solid var(--fd-ledger-soft-border);
   border-radius: 0.5rem;
   background: color-mix(in srgb, var(--color-fd-card) 96%, transparent);
   box-shadow: 0 1px 2px rgba(48, 54, 74, 0.05);
 }
 
-.fd-card:hover,
-[data-card]:hover,
-.fd-hover-link-card:hover,
-.fd-page-nav-card:hover {
+#nd-docs-layout .fd-card:hover,
+#nd-docs-layout [data-card]:hover,
+#nd-docs-layout .fd-hover-link-card:hover,
+#nd-docs-layout .fd-page-nav-card:hover {
   border-color: color-mix(in srgb, var(--color-fd-primary) 28%, var(--color-fd-border));
   box-shadow: var(--fd-ledger-shadow);
 }
 
-.fd-page-action-btn,
-.fd-feedback-submit,
-.fd-ai-send-btn,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-page-action-btn,
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-floating-btn {
   border-radius: 0.5rem;
 }
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   background: var(--fd-ledger-action-bg);
   color: var(--fd-ledger-action-color);
   border: 1px solid var(--fd-ledger-soft-border);
   box-shadow: 0 1px 2px rgba(48, 54, 74, 0.06);
 }
 
-.fd-page-action-btn svg {
+#nd-docs-layout .fd-page-action-btn svg {
   color: var(--fd-ledger-action-icon);
   stroke: currentColor;
 }
 
-.fd-page-action-btn:hover {
+#nd-docs-layout .fd-page-action-btn:hover {
   background: var(--fd-ledger-action-hover);
   border-color: color-mix(in srgb, var(--color-fd-primary) 34%, var(--color-fd-border));
   color: var(--color-fd-foreground);
 }
 
-.fd-feedback-submit,
-.fd-ai-send-btn,
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-feedback-submit,
+#nd-docs-layout .fd-ai-send-btn,
+#nd-docs-layout .fd-ai-floating-btn {
   background: var(--color-fd-primary);
   color: var(--color-fd-primary-foreground);
 }
 
-.fd-tabs,
-.fd-tabs-list,
-[role="tablist"] {
+#nd-docs-layout .fd-tabs,
+#nd-docs-layout .fd-tabs-list,
+#nd-docs-layout [role="tablist"] {
   border: 1px solid var(--fd-ledger-soft-border);
   border-radius: 0.5rem;
   background: var(--color-fd-secondary);
   padding: 0.25rem;
 }
 
-.fd-tabs-trigger,
-.fd-tab-trigger,
-[role="tab"] {
+#nd-docs-layout .fd-tabs-trigger,
+#nd-docs-layout .fd-tab-trigger,
+#nd-docs-layout [role="tab"] {
   border-radius: 0.375rem;
   color: var(--color-fd-muted-foreground);
   font-weight: 600;
 }
 
-.fd-tabs-trigger[data-state="active"],
-.fd-tab-trigger[data-state="active"],
-[role="tab"][aria-selected="true"] {
+#nd-docs-layout .fd-tabs-trigger[data-state="active"],
+#nd-docs-layout .fd-tab-trigger[data-state="active"],
+#nd-docs-layout [role="tab"][aria-selected="true"] {
   background: var(--color-fd-card);
   color: var(--color-fd-primary);
   box-shadow: 0 1px 2px rgba(48, 54, 74, 0.08);
 }
 
-.fd-codeblock,
-.fd-codeblock pre,
-.fd-docs-content pre,
-.fd-docs-content .shiki,
-.fd-ai-code-block {
+#nd-docs-layout .fd-codeblock,
+#nd-docs-layout .fd-codeblock pre,
+#nd-docs-layout .fd-docs-content pre,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-ai-code-block {
   border-radius: 0.5rem;
   background: var(--fd-ledger-code-bg);
   color: var(--fd-ledger-code-fg);
 }
 
-figure.shiki,
-.fd-docs-content .shiki {
+#nd-docs-layout figure.shiki,
+#nd-docs-layout .fd-docs-content .shiki {
   background: var(--fd-ledger-code-bg);
   color: var(--shiki-light, var(--fd-ledger-code-fg));
 }
 
-figure.shiki :is(pre, code, span),
-.fd-docs-content .shiki :is(pre, code, span) {
+#nd-docs-layout figure.shiki :is(pre, code, span),
+#nd-docs-layout .fd-docs-content .shiki :is(pre, code, span) {
   color: var(--shiki-light, var(--fd-ledger-code-fg));
 }
 
-.dark figure.shiki,
-.dark .fd-docs-content .shiki {
+:is(html.dark, body.dark) #nd-docs-layout figure.shiki,
+#nd-docs-layout.dark figure.shiki,
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout.dark .fd-docs-content .shiki {
   background: var(--fd-ledger-code-bg);
   color: var(--shiki-dark, var(--fd-ledger-code-fg));
 }
 
-.dark figure.shiki :is(pre, code, span),
-.dark .fd-docs-content .shiki :is(pre, code, span) {
+:is(html.dark, body.dark) #nd-docs-layout figure.shiki :is(pre, code, span),
+#nd-docs-layout.dark figure.shiki :is(pre, code, span),
+:is(html.dark, body.dark) #nd-docs-layout .fd-docs-content .shiki :is(pre, code, span),
+#nd-docs-layout.dark .fd-docs-content .shiki :is(pre, code, span) {
   color: var(--shiki-dark, var(--fd-ledger-code-fg));
 }
 
-.fd-codeblock,
-.fd-docs-content .shiki,
-.fd-ai-code-block {
+#nd-docs-layout .fd-codeblock,
+#nd-docs-layout .fd-docs-content .shiki,
+#nd-docs-layout .fd-ai-code-block {
   border: 1px solid var(--fd-ledger-code-border);
   box-shadow: var(--fd-ledger-code-shadow);
   overflow: hidden;
 }
 
-.fd-codeblock-title,
-.fd-codeblock-title-text,
-figure.shiki figcaption,
-.fd-ai-code-header {
+#nd-docs-layout .fd-codeblock-title,
+#nd-docs-layout .fd-codeblock-title-text,
+#nd-docs-layout figure.shiki figcaption,
+#nd-docs-layout .fd-ai-code-header {
   color: var(--fd-ledger-code-title);
 }
 
-.fd-codeblock-title,
-figure.shiki:has(figcaption) > div:first-child,
-figure.shiki figcaption,
-.fd-ai-code-header {
+#nd-docs-layout .fd-codeblock-title,
+#nd-docs-layout figure.shiki:has(figcaption) > div:first-child,
+#nd-docs-layout figure.shiki figcaption,
+#nd-docs-layout .fd-ai-code-header {
   display: flex;
   min-height: 2.5rem;
   align-items: center;
@@ -353,42 +362,42 @@ figure.shiki figcaption,
   padding: 0 0.875rem;
 }
 
-.fd-codeblock-title-text,
-figure.shiki figcaption,
-.fd-ai-code-header span {
+#nd-docs-layout .fd-codeblock-title-text,
+#nd-docs-layout figure.shiki figcaption,
+#nd-docs-layout .fd-ai-code-header span {
   font-weight: 700;
 }
 
-.fd-codeblock-title .fd-copy-btn,
-figure.shiki:has(figcaption) > div:first-child > button,
-figure.shiki:has(figcaption) > div:first-child > div:last-child {
+#nd-docs-layout .fd-codeblock-title .fd-copy-btn,
+#nd-docs-layout figure.shiki:has(figcaption) > div:first-child > button,
+#nd-docs-layout figure.shiki:has(figcaption) > div:first-child > div:last-child {
   margin-left: auto;
 }
 
-.fd-copy-btn,
-.fd-ai-code-copy {
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-ai-code-copy {
   border: 1px solid color-mix(in srgb, var(--fd-ledger-code-fg) 12%, transparent);
   border-radius: 0.5rem;
   background: color-mix(in srgb, var(--fd-ledger-code-fg) 8%, transparent);
   color: var(--fd-ledger-code-fg);
 }
 
-.fd-docs-content :not(pre) > code {
+#nd-docs-layout .fd-docs-content :not(pre) > code {
   border: 1px solid color-mix(in srgb, var(--color-fd-primary) 16%, transparent);
   border-radius: 0.375rem;
   background: color-mix(in srgb, var(--color-fd-primary) 9%, transparent);
   color: var(--color-fd-foreground);
 }
 
-.fd-table-wrapper,
-.fd-docs-content table {
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-docs-content table {
   border: 1px solid var(--fd-ledger-soft-border);
   border-radius: 0.5rem;
   background: var(--color-fd-card);
   overflow: hidden;
 }
 
-.fd-table-wrapper th {
+#nd-docs-layout .fd-table-wrapper th {
   background: var(--color-fd-secondary);
   color: var(--color-fd-foreground);
   font-weight: 700;

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -49,11 +49,11 @@
   }
 }
 
-.omni-spin {
+#nd-docs-layout .omni-spin {
   animation: omni-spin 1s linear infinite;
 }
 
-.omni-overlay {
+#nd-docs-layout .omni-overlay {
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -62,7 +62,7 @@
   animation: omni-fade-in 150ms ease-out;
 }
 
-.omni-content {
+#nd-docs-layout .omni-content {
   position: fixed;
   z-index: 101;
   top: 18%;
@@ -82,31 +82,31 @@
 }
 
 @media (max-width: 639px) {
-  .omni-content {
+  #nd-docs-layout .omni-content {
     top: 10%;
     width: calc(100% - 24px);
     max-height: 75vh;
   }
-  .omni-kbd {
+  #nd-docs-layout .omni-kbd {
     display: none;
   }
 }
 
 /* Header */
-.omni-header {
+#nd-docs-layout .omni-header {
   border-bottom: 1px solid var(--color-fd-border, #262626);
 }
-.omni-search-row {
+#nd-docs-layout .omni-search-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.625rem 0.875rem;
 }
-.omni-search-icon {
+#nd-docs-layout .omni-search-icon {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
-.omni-search-input {
+#nd-docs-layout .omni-search-input {
   flex: 1;
   background: transparent;
   outline: none;
@@ -115,10 +115,10 @@
   color: var(--color-fd-foreground, #fafafa);
   border: none;
 }
-.omni-search-input::placeholder {
+#nd-docs-layout .omni-search-input::placeholder {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-.omni-kbd {
+#nd-docs-layout .omni-kbd {
   border-radius: 0.25rem;
   background: var(--color-fd-muted, #262626);
   padding: 0.125rem 0.375rem;
@@ -127,7 +127,7 @@
   font-family: inherit;
   line-height: 1.4;
 }
-.omni-close-btn {
+#nd-docs-layout .omni-close-btn {
   margin-left: 0.25rem;
   border-radius: 0.25rem;
   padding: 0.25rem;
@@ -137,29 +137,29 @@
   border: none;
   background: none;
 }
-.omni-close-btn:hover {
+#nd-docs-layout .omni-close-btn:hover {
   background: var(--color-fd-muted, #262626);
 }
 
 /* Body / listbox */
-.omni-body {
+#nd-docs-layout .omni-body {
   max-height: 60vh;
   overflow: auto;
   padding: 0.25rem;
 }
-.omni-body::-webkit-scrollbar {
+#nd-docs-layout .omni-body::-webkit-scrollbar {
   width: 6px;
 }
-.omni-body::-webkit-scrollbar-track {
+#nd-docs-layout .omni-body::-webkit-scrollbar-track {
   background: transparent;
 }
-.omni-body::-webkit-scrollbar-thumb {
+#nd-docs-layout .omni-body::-webkit-scrollbar-thumb {
   background: var(--color-fd-muted, #262626);
   border-radius: 3px;
 }
 
 /* Loading */
-.omni-loading {
+#nd-docs-layout .omni-loading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -169,10 +169,10 @@
 }
 
 /* Groups */
-.omni-group {
+#nd-docs-layout .omni-group {
   padding: 0.25rem 0;
 }
-.omni-group-label {
+#nd-docs-layout .omni-group-label {
   padding: 0.25rem 0.75rem;
   font-size: 10px;
   text-transform: uppercase;
@@ -180,13 +180,13 @@
   color: var(--color-fd-muted-foreground, #a3a3a3);
   font-weight: 500;
 }
-.omni-group-items {
+#nd-docs-layout .omni-group-items {
   display: flex;
   flex-direction: column;
 }
 
 /* Items */
-.omni-item {
+#nd-docs-layout .omni-item {
   display: flex;
   width: 100%;
   align-items: center;
@@ -202,35 +202,35 @@
   color: var(--color-fd-foreground, #fafafa);
   transition: background 80ms;
 }
-.omni-item:hover,
-.omni-item-active {
+#nd-docs-layout .omni-item:hover,
+#nd-docs-layout .omni-item-active {
   background: color-mix(in srgb, var(--color-fd-accent, #262626) 60%, transparent);
 }
-.omni-item-active {
+#nd-docs-layout .omni-item-active {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
-.omni-item-disabled {
+#nd-docs-layout .omni-item-disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.omni-item-icon {
+#nd-docs-layout .omni-item-icon {
   flex-shrink: 0;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-.omni-item-active .omni-item-icon {
+#nd-docs-layout .omni-item-active .omni-item-icon {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
-.omni-item-text {
+#nd-docs-layout .omni-item-text {
   flex: 1;
   min-width: 0;
 }
-.omni-item-label {
+#nd-docs-layout .omni-item-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.omni-item-subtitle {
+#nd-docs-layout .omni-item-subtitle {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -238,18 +238,18 @@
   color: var(--color-fd-muted-foreground, #a3a3a3);
   opacity: 0.8;
 }
-.omni-item-active .omni-item-subtitle {
+#nd-docs-layout .omni-item-active .omni-item-subtitle {
   color: var(--color-fd-accent-foreground, #fafafa);
   opacity: 0.7;
 }
-.omni-item-badge {
+#nd-docs-layout .omni-item-badge {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
-a.omni-item-badge:hover {
+#nd-docs-layout a.omni-item-badge:hover {
   color: var(--color-fd-foreground, #fafafa);
 }
-.omni-item-ext {
+#nd-docs-layout .omni-item-ext {
   position: relative;
   z-index: 2;
   display: inline-flex;
@@ -264,11 +264,11 @@ a.omni-item-badge:hover {
     background 100ms;
   text-decoration: none;
 }
-.omni-item-ext:hover {
+#nd-docs-layout .omni-item-ext:hover {
   color: var(--color-fd-foreground, #fafafa);
   background: var(--color-fd-muted, #262626);
 }
-.omni-item-shortcuts {
+#nd-docs-layout .omni-item-shortcuts {
   display: none;
   align-items: center;
   gap: 0.25rem;
@@ -276,17 +276,17 @@ a.omni-item-badge:hover {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 @media (min-width: 640px) {
-  .omni-item-shortcuts {
+  #nd-docs-layout .omni-item-shortcuts {
     display: flex;
   }
 }
-.omni-kbd-sm {
+#nd-docs-layout .omni-kbd-sm {
   border-radius: 0.25rem;
   background: var(--color-fd-muted, #262626);
   padding: 0.125rem 0.25rem;
   font-family: inherit;
 }
-.omni-item-chevron {
+#nd-docs-layout .omni-item-chevron {
   width: 0.875rem;
   height: 0.875rem;
   margin-left: 0.25rem;
@@ -295,12 +295,12 @@ a.omni-item-badge:hover {
   transition: opacity 120ms;
   flex-shrink: 0;
 }
-.omni-item:hover .omni-item-chevron {
+#nd-docs-layout .omni-item:hover .omni-item-chevron {
   opacity: 1;
 }
 
 /* Highlight */
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   border-radius: 2px;
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 30%, transparent);
   padding: 0 2px;
@@ -308,18 +308,18 @@ a.omni-item-badge:hover {
 }
 
 /* Empty states */
-.omni-empty-group {
+#nd-docs-layout .omni-empty-group {
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-.omni-empty {
+#nd-docs-layout .omni-empty {
   padding: 2rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-.omni-empty-icon {
+#nd-docs-layout .omni-empty-icon {
   width: 2rem;
   height: 2rem;
   margin: 0 auto 0.5rem;
@@ -331,10 +331,10 @@ a.omni-item-badge:hover {
 }
 
 /* Footer */
-.omni-footer {
+#nd-docs-layout .omni-footer {
   border-top: 1px solid var(--color-fd-border, #262626);
 }
-.omni-footer-inner {
+#nd-docs-layout .omni-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -342,21 +342,21 @@ a.omni-item-badge:hover {
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-.omni-footer-hints {
+#nd-docs-layout .omni-footer-hints {
   display: flex;
   align-items: center;
   gap: 1rem;
 }
-.omni-footer-hint {
+#nd-docs-layout .omni-footer-hint {
   display: flex;
   align-items: center;
   gap: 0.25rem;
 }
-.omni-footer-hint-desktop {
+#nd-docs-layout .omni-footer-hint-desktop {
   display: none;
 }
 @media (min-width: 640px) {
-  .omni-footer-hint-desktop {
+  #nd-docs-layout .omni-footer-hint-desktop {
     display: flex;
   }
 }

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -6,7 +6,8 @@
 
 /* ─── Color Tokens (light) ───────────────────────────────────────── */
 
-:root {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   --color-fd-background: oklch(1 0 0);
   --color-fd-foreground: oklch(0.147 0.004 49.25);
   --color-fd-card: oklch(0.985 0.001 106.423);
@@ -34,7 +35,11 @@
 
 /* ─── Color Tokens (dark) ────────────────────────────────────────── */
 
-.dark {
+html.dark body:has(#nd-docs-layout),
+body.dark:has(#nd-docs-layout),
+body:has(#nd-docs-layout.dark),
+:is(html.dark, body.dark) #nd-docs-layout,
+#nd-docs-layout.dark {
   --color-fd-background: hsl(0 0% 2%);
   --color-fd-foreground: oklch(0.985 0.001 106.423);
   --color-fd-card: hsl(0 0% 4%);
@@ -58,94 +63,102 @@
 
 /* ─── Scroll (light + dark) ──────────────────────────────────────── */
 
-html {
+#nd-docs-layout {
   scroll-behavior: auto;
   scroll-padding-top: calc(
     var(--fd-nav-height, 56px) + var(--fd-banner-height, 0px) + var(--fd-tocnav-height, 0px) + 24px
   );
 }
 
-html:not([data-anchor-scrolling]) {
+html:not([data-anchor-scrolling]) #nd-docs-layout {
   scroll-behavior: smooth;
 }
 
 /* ─── Custom scrollbar (light + dark) ─────────────────────────────── */
 
-* {
+#nd-docs-layout,
+#nd-docs-layout * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
-::-webkit-scrollbar {
+#nd-docs-layout::-webkit-scrollbar,
+#nd-docs-layout *::-webkit-scrollbar {
   width: 12px;
   height: 12px;
 }
 
-::-webkit-scrollbar-track {
+#nd-docs-layout::-webkit-scrollbar-track,
+#nd-docs-layout *::-webkit-scrollbar-track {
   background: var(--scrollbar-track);
 }
 
-::-webkit-scrollbar-thumb {
+#nd-docs-layout::-webkit-scrollbar-thumb,
+#nd-docs-layout *::-webkit-scrollbar-thumb {
   background-color: var(--scrollbar-thumb);
   border-radius: 9999px;
   border: 3px solid transparent;
   background-clip: content-box;
 }
 
-::-webkit-scrollbar-thumb:hover {
+#nd-docs-layout::-webkit-scrollbar-thumb:hover,
+#nd-docs-layout *::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-thumb-hover);
 }
 
-::-webkit-scrollbar-corner {
+#nd-docs-layout::-webkit-scrollbar-corner,
+#nd-docs-layout *::-webkit-scrollbar-corner {
   background: transparent;
 }
 
 /* ─── Selection (light + dark) ───────────────────────────────────── */
 
-body {
+body:has(#nd-docs-layout),
+#nd-docs-layout {
   overscroll-behavior: none;
 }
 
-::selection {
+#nd-docs-layout::selection,
+#nd-docs-layout *::selection {
   background: var(--color-fd-foreground);
   color: var(--color-fd-background);
 }
 
 /* ─── Inline code word break ─────────────────────────────────────── */
 
-code:not(pre code) {
+#nd-docs-layout code:not(pre code) {
   overflow-wrap: break-word;
   word-break: break-word;
 }
 
 /* ─── Sharp corners everywhere (both modes) ──────────────────────── */
 
-.fd-sidebar-search-btn,
-.fd-search-dialog,
-.fd-search-overlay .fd-search-dialog,
-.fd-search-result,
-.fd-codeblock,
-.fd-codeblock pre,
-.fd-codeblock-title,
-.fd-tabs,
-.fd-tab-trigger,
-.fd-tab-panel,
-.fd-callout,
-.fd-page-nav-card,
-.fd-table-wrapper,
-.fd-copy-btn,
-.fd-sidebar-search-btn kbd,
-.fd-sidebar-collapse-btn,
-.fd-theme-toggle {
+#nd-docs-layout .fd-sidebar-search-btn,
+#nd-docs-layout .fd-search-dialog,
+#nd-docs-layout .fd-search-overlay .fd-search-dialog,
+#nd-docs-layout .fd-search-result,
+#nd-docs-layout .fd-codeblock,
+#nd-docs-layout .fd-codeblock pre,
+#nd-docs-layout .fd-codeblock-title,
+#nd-docs-layout .fd-tabs,
+#nd-docs-layout .fd-tab-trigger,
+#nd-docs-layout .fd-tab-panel,
+#nd-docs-layout .fd-callout,
+#nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout .fd-copy-btn,
+#nd-docs-layout .fd-sidebar-search-btn kbd,
+#nd-docs-layout .fd-sidebar-collapse-btn,
+#nd-docs-layout .fd-theme-toggle {
   border-radius: 0 !important;
 }
 
 /* ─── Docs grid: sidebar (sticky left, full height) — no clipping ─────── */
 @media (min-width: 1024px) {
-  .fd-layout {
+  #nd-docs-layout {
     grid-template-columns: var(--fd-sidebar-width) minmax(0, 1fr);
   }
-  .fd-sidebar {
+  #nd-docs-layout .fd-sidebar {
     position: sticky;
     top: 0;
     align-self: start;
@@ -153,16 +166,16 @@ code:not(pre code) {
     height: 100%;
   }
 
-  .fd-main {
+  #nd-docs-layout .fd-main {
     min-width: 0;
   }
 
-  .fd-page {
+  #nd-docs-layout .fd-page {
     grid-template-columns: minmax(0, 1fr) var(--fd-toc-width);
   }
 
-  .fd-page-article,
-  .fd-page-body {
+  #nd-docs-layout .fd-page-article,
+#nd-docs-layout .fd-page-body {
     max-width: none;
     margin-inline: 0;
   }
@@ -170,7 +183,7 @@ code:not(pre code) {
 
 /* ─── Mobile: ensure sidebar drawer/content isn't clipped ───────────────── */
 @media (max-width: 1023px) {
-  .fd-sidebar {
+  #nd-docs-layout .fd-sidebar {
     max-height: none;
     overflow-y: visible;
   }
@@ -179,8 +192,8 @@ code:not(pre code) {
 /* ─── Sidebar (pixel-border style — BOTH light and dark) ─────────── */
 
 /* Full-width border separators between top-level items */
-.fd-sidebar-top-link,
-.fd-sidebar-nav > .fd-sidebar-folder {
+#nd-docs-layout .fd-sidebar-top-link,
+#nd-docs-layout .fd-sidebar-nav > .fd-sidebar-folder {
   border-top: 1px solid var(--color-fd-border);
   margin-left: -12px;
   margin-right: -12px;
@@ -188,7 +201,7 @@ code:not(pre code) {
   padding-right: 12px;
 }
 
-.fd-sidebar-folder-content::before {
+#nd-docs-layout .fd-sidebar-folder-content::before {
   content: "";
   position: absolute;
   left: 4px;
@@ -198,16 +211,16 @@ code:not(pre code) {
   background: var(--color-fd-border);
 }
 
-.fd-sidebar-top-link.fd-sidebar-first-item,
-.fd-sidebar-folder.fd-sidebar-first-item {
+#nd-docs-layout .fd-sidebar-top-link.fd-sidebar-first-item,
+#nd-docs-layout .fd-sidebar-folder.fd-sidebar-first-item {
   border-top: none;
 }
 
-.fd-sidebar-top-link:last-child,
-.fd-sidebar-nav > .fd-sidebar-folder:last-child {
+#nd-docs-layout .fd-sidebar-top-link:last-child,
+#nd-docs-layout .fd-sidebar-nav > .fd-sidebar-folder:last-child {
   border-bottom: 1px solid var(--color-fd-border);
 }
-.fd-sidebar-folder-content::before {
+#nd-docs-layout .fd-sidebar-folder-content::before {
   content: "";
   position: absolute;
   left: -4px;
@@ -219,7 +232,7 @@ code:not(pre code) {
 }
 
 /* Folder trigger — extend to full sidebar width */
-.fd-sidebar-nav > .fd-sidebar-folder > .fd-sidebar-folder-trigger {
+#nd-docs-layout .fd-sidebar-nav > .fd-sidebar-folder > .fd-sidebar-folder-trigger {
   margin-left: -12px;
   margin-right: -12px;
   padding-left: 12px;
@@ -227,7 +240,7 @@ code:not(pre code) {
 }
 
 /* All sidebar links — sharp corners, transparent bg */
-.fd-sidebar-link {
+#nd-docs-layout .fd-sidebar-link {
   font-size: 0.875rem;
   line-height: 1.6;
   border-radius: 0 !important;
@@ -238,89 +251,99 @@ code:not(pre code) {
   color: var(--color-fd-muted-foreground);
 }
 
-.fd-sidebar-link:hover {
+#nd-docs-layout .fd-sidebar-link:hover {
   background: transparent !important;
   background-color: transparent !important;
   color: var(--color-fd-foreground);
 }
 
-.fd-sidebar-link-active,
-.fd-sidebar-link[data-active="true"] {
+#nd-docs-layout .fd-sidebar-link-active,
+#nd-docs-layout .fd-sidebar-link[data-active="true"] {
   color: var(--color-fd-foreground) !important;
   font-weight: 600;
   background: transparent !important;
   background-color: transparent !important;
 }
 
-.fd-sidebar-link-active:hover,
-.fd-sidebar-link[data-active="true"]:hover {
+#nd-docs-layout .fd-sidebar-link-active:hover,
+#nd-docs-layout .fd-sidebar-link[data-active="true"]:hover {
   background: transparent !important;
   background-color: transparent !important;
 }
 
 /* Folder triggers — sharp corners, transparent bg */
-.fd-sidebar-folder-trigger {
+#nd-docs-layout .fd-sidebar-folder-trigger {
   font-size: 0.875rem;
   font-weight: 500;
   border-radius: 0 !important;
 }
 
-.fd-sidebar-folder-trigger:hover {
+#nd-docs-layout .fd-sidebar-folder-trigger:hover {
   background: transparent !important;
 }
 
 /* Child links — smaller, inside folder content */
-.fd-sidebar-child-link {
+#nd-docs-layout .fd-sidebar-child-link {
   font-size: 0.785rem !important;
   padding-top: 0.25rem !important;
   padding-bottom: 0.25rem !important;
 }
 
-.fd-sidebar-child-link.fd-sidebar-link-active {
+#nd-docs-layout .fd-sidebar-child-link.fd-sidebar-link-active {
   font-weight: 600 !important;
 }
 
 /* Dark mode — specific color overrides */
-.dark .fd-sidebar {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar,
+#nd-docs-layout.dark .fd-sidebar {
   background: hsl(0 0% 2%);
   border-color: hsl(0 0% 12%);
 }
 
-.dark .fd-sidebar-link {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-link,
+#nd-docs-layout.dark .fd-sidebar-link {
   color: hsl(0 0% 50%);
 }
 
-.dark .fd-sidebar-link:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-link:hover,
+#nd-docs-layout.dark .fd-sidebar-link:hover {
   color: hsl(0 0% 80%);
 }
 
-.dark .fd-sidebar-folder-trigger {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-folder-trigger,
+#nd-docs-layout.dark .fd-sidebar-folder-trigger {
   color: hsl(0 0% 90%);
 }
 
-.dark .fd-sidebar-folder-trigger:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-folder-trigger:hover,
+#nd-docs-layout.dark .fd-sidebar-folder-trigger:hover {
   color: hsl(0 0% 100%);
 }
 
-.dark .fd-sidebar-link-active,
-.dark .fd-sidebar-link[data-active="true"] {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-link-active,
+#nd-docs-layout.dark .fd-sidebar-link-active,
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-link[data-active="true"],
+#nd-docs-layout.dark .fd-sidebar-link[data-active="true"] {
   color: var(--color-fd-primary, hsl(0 0% 95%)) !important;
 }
 
-.dark .fd-sidebar-child-link {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-child-link,
+#nd-docs-layout.dark .fd-sidebar-child-link {
   color: hsl(0 0% 45%) !important;
 }
 
-.dark .fd-sidebar-child-link:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-child-link:hover,
+#nd-docs-layout.dark .fd-sidebar-child-link:hover {
   color: hsl(0 0% 75%) !important;
 }
 
-.dark .fd-sidebar-child-link.fd-sidebar-link-active {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-child-link.fd-sidebar-link-active,
+#nd-docs-layout.dark .fd-sidebar-child-link.fd-sidebar-link-active {
   color: var(--color-fd-primary, hsl(0 0% 95%)) !important;
 }
 
 /* Active indicator bar for child links */
-.fd-sidebar-folder-content .fd-sidebar-link-active::before {
+#nd-docs-layout .fd-sidebar-folder-content .fd-sidebar-link-active::before {
   content: "";
   position: absolute;
   left: -16px;
@@ -331,24 +354,25 @@ code:not(pre code) {
   border-radius: 0;
 }
 
-.dark .fd-sidebar-folder-content .fd-sidebar-link-active::before {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-folder-content .fd-sidebar-link-active::before,
+#nd-docs-layout.dark .fd-sidebar-folder-content .fd-sidebar-link-active::before {
   background: var(--color-fd-primary, hsl(0 0% 95%));
 }
 
 /* Sidebar icon */
-.fd-sidebar-icon {
+#nd-docs-layout .fd-sidebar-icon {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.fd-sidebar-link-active .fd-sidebar-icon {
+#nd-docs-layout .fd-sidebar-link-active .fd-sidebar-icon {
   opacity: 1;
 }
 
 /* Sidebar search button — full-width, border-y */
-.fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search-btn {
   background: transparent !important;
   border: none !important;
   border-top: 1px solid var(--color-fd-border) !important;
@@ -356,7 +380,7 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
-.fd-sidebar-search {
+#nd-docs-layout .fd-sidebar-search {
   padding: 0;
   margin-left: -12px;
   margin-right: -12px;
@@ -364,60 +388,65 @@ code:not(pre code) {
   padding-right: 12px;
 }
 
-.fd-sidebar-search .fd-sidebar-search-btn {
+#nd-docs-layout .fd-sidebar-search .fd-sidebar-search-btn {
   width: 100%;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
 }
 
-.fd-sidebar-search-btn:hover {
+#nd-docs-layout .fd-sidebar-search-btn:hover {
   background: var(--color-fd-accent) !important;
 }
 
-.dark .fd-sidebar-search-btn {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-search-btn,
+#nd-docs-layout.dark .fd-sidebar-search-btn {
   color: hsl(0 0% 45%);
 }
 
-.dark .fd-sidebar-search-btn:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-sidebar-search-btn:hover,
+#nd-docs-layout.dark .fd-sidebar-search-btn:hover {
   background: hsl(0 0% 4%) !important;
   color: hsl(0 0% 65%);
 }
 
 /* ─── Tables ─────────────────────────────────────────────────────── */
 
-.fd-table-wrapper {
+#nd-docs-layout .fd-table-wrapper {
   border-radius: 0 !important;
 }
 
-.dark .fd-table-wrapper {
+:is(html.dark, body.dark) #nd-docs-layout .fd-table-wrapper,
+#nd-docs-layout.dark .fd-table-wrapper {
   border-color: hsl(0 0% 15%);
 }
 
-.dark .fd-page-body table th {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-body table th,
+#nd-docs-layout.dark .fd-page-body table th {
   background: hsl(0 0% 6%);
   color: hsl(0 0% 80%);
   font-weight: 500;
   border-color: hsl(0 0% 15%);
 }
 
-.dark .fd-page-body table td {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-body table td,
+#nd-docs-layout.dark .fd-page-body table td {
   border-color: hsl(0 0% 12%);
 }
 
 /* ─── Code blocks ────────────────────────────────────────────────── */
 
-.fd-codeblock {
+#nd-docs-layout .fd-codeblock {
   border: 1px solid var(--color-fd-border);
   border-radius: 0 !important;
   box-shadow: none;
 }
 
-.fd-codeblock pre.shiki {
+#nd-docs-layout .fd-codeblock pre.shiki {
   border-radius: 0 !important;
 }
 
-.fd-codeblock-title {
+#nd-docs-layout .fd-codeblock-title {
   border-bottom: 1px solid var(--color-fd-border) !important;
   border-radius: 0 !important;
   background-color: color-mix(in srgb, var(--color-fd-secondary, hsl(0 0% 8%)) 55%, transparent) !important;
@@ -430,161 +459,166 @@ code:not(pre code) {
   ) !important;
 }
 
-.fd-codeblock-title .fd-copy-btn {
+#nd-docs-layout .fd-codeblock-title .fd-copy-btn {
   border-radius: 0 !important;
 }
 
-.fd-copy-btn {
+#nd-docs-layout .fd-copy-btn {
   border-radius: 0 !important;
 }
 
 /* ─── Tabs ───────────────────────────────────────────────────────── */
 
-.fd-tabs {
+#nd-docs-layout .fd-tabs {
   border-radius: 0 !important;
   box-shadow: none;
 }
 
 /* ─── Callouts ───────────────────────────────────────────────────── */
 
-.fd-callout {
+#nd-docs-layout .fd-callout {
   border-radius: 0 !important;
 }
 
 /* ─── Prev/Next nav cards ────────────────────────────────────────── */
 
-.fd-page-nav-card {
+#nd-docs-layout .fd-page-nav-card {
   border-radius: 0 !important;
 }
 
-.dark .fd-page-nav-card {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav-card,
+#nd-docs-layout.dark .fd-page-nav-card {
   border-color: hsl(0 0% 15%);
 }
 
-.dark .fd-page-nav-card:hover {
+:is(html.dark, body.dark) #nd-docs-layout .fd-page-nav-card:hover,
+#nd-docs-layout.dark .fd-page-nav-card:hover {
   background: hsl(0 0% 6%);
   border-color: hsl(0 0% 22%);
 }
 
 /* ─── Search dialog ──────────────────────────────────────────────── */
 
-.fd-search-overlay .fd-search-dialog {
+#nd-docs-layout .fd-search-overlay .fd-search-dialog {
   border-radius: 0;
 }
 
 /* ─── Breadcrumb (monospace, uppercase) ───────────────────────────── */
 
-.fd-breadcrumb {
+#nd-docs-layout .fd-breadcrumb {
   font-size: 0.75rem;
   letter-spacing: 0.01em;
 }
 
-.fd-breadcrumb-parent,
-.fd-breadcrumb-current {
+#nd-docs-layout .fd-breadcrumb-parent,
+#nd-docs-layout .fd-breadcrumb-current {
   font-family: ui-monospace, monospace;
   text-transform: uppercase;
 }
 
 /* ─── Selection ──────────────────────────────────────────────────── */
 
-::selection {
+#nd-docs-layout::selection,
+#nd-docs-layout *::selection {
   background: var(--color-fd-foreground);
   color: var(--color-fd-background);
 }
 
 /* ─── Scrollbar ──────────────────────────────────────────────────── */
 
-* {
+#nd-docs-layout,
+#nd-docs-layout * {
   scrollbar-width: thin;
   scrollbar-color: var(--color-fd-border) transparent;
 }
 
 /* ─── HR ─────────────────────────────────────────────────────────── */
 
-.dark hr {
+:is(html.dark, body.dark) #nd-docs-layout hr,
+#nd-docs-layout.dark hr {
   border-color: hsl(0 0% 15%);
 }
 
 /* ─── AI Chat (pixel-border — zero radius, pixel-art, monospace) ── */
 
-.fd-ai-dialog {
+#nd-docs-layout .fd-ai-dialog {
   border-radius: 0 !important;
   border-width: 1px;
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-tab-bar {
+#nd-docs-layout .fd-ai-tab-bar {
   gap: 0;
 }
 
-.fd-ai-tab {
+#nd-docs-layout .fd-ai-tab {
   border-radius: 0 !important;
   font-size: 12px;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-header-title {
+#nd-docs-layout .fd-ai-header-title {
   font-size: 13px;
 }
 
-.fd-ai-bubble-user {
+#nd-docs-layout .fd-ai-bubble-user {
   border-radius: 0 !important;
   font-size: 12px;
 }
 
-.fd-ai-bubble-ai {
+#nd-docs-layout .fd-ai-bubble-ai {
   border-radius: 0 !important;
   font-size: 12px;
 }
 
-.fd-ai-bubble-ai pre {
+#nd-docs-layout .fd-ai-bubble-ai pre {
   border-radius: 0 !important;
   border: 1px solid var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-bubble-ai code {
+#nd-docs-layout .fd-ai-bubble-ai code {
   border-radius: 0 !important;
 }
 
-.fd-ai-input-wrap {
+#nd-docs-layout .fd-ai-input-wrap {
   border-radius: 0 !important;
 }
 
-.fd-ai-input {
+#nd-docs-layout .fd-ai-input {
   font-size: 13px;
 }
 
-.fd-ai-send-btn {
+#nd-docs-layout .fd-ai-send-btn {
   border-radius: 0 !important;
 }
 
-.fd-ai-close-btn {
+#nd-docs-layout .fd-ai-close-btn {
   border-radius: 0 !important;
 }
 
-.fd-ai-floating-btn {
+#nd-docs-layout .fd-ai-floating-btn {
   border-radius: 0 !important;
   box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-floating-btn:hover {
+#nd-docs-layout .fd-ai-floating-btn:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
 /* Custom Ask AI trigger — same as fd-ai-floating-btn for theme */
-.fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger {
   font-family: var(--fd-font-sans, inherit);
   border-radius: 0 !important;
   box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%)) !important;
 }
 
-.fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-floating-trigger .ask-ai-trigger:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger {
   border-radius: 0 !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   text-transform: uppercase !important;
@@ -593,40 +627,40 @@ code:not(pre code) {
   box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%)) !important;
 }
 
-.fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
+#nd-docs-layout .fd-ai-fm-input-bar .fd-ai-floating-trigger .ask-ai-trigger:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-suggestion {
+#nd-docs-layout .fd-ai-suggestion {
   border-radius: 0 !important;
   font-size: 12px;
 }
 
-.fd-ai-result {
+#nd-docs-layout .fd-ai-result {
   border-radius: 0 !important;
 }
 
-.fd-ai-esc {
+#nd-docs-layout .fd-ai-esc {
   border-radius: 0 !important;
 }
 
-.fd-ai-clear-btn {
+#nd-docs-layout .fd-ai-clear-btn {
   border-radius: 0 !important;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-msg-label {
+#nd-docs-layout .fd-ai-msg-label {
   letter-spacing: 0.06em;
 }
 
-.fd-ai-loader-shimmer-text {
+#nd-docs-layout .fd-ai-loader-shimmer-text {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   font-size: 11px;
 }
 
-.fd-ai-loader-typing-dot {
+#nd-docs-layout .fd-ai-loader-typing-dot {
   border-radius: 0;
   width: 4px;
   height: 4px;
@@ -634,24 +668,24 @@ code:not(pre code) {
 
 /* ─── Full-Modal (pixel-border) ──────────────────────────────────── */
 
-.fd-ai-fm-input-container {
+#nd-docs-layout .fd-ai-fm-input-container {
   border-radius: 0 !important;
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-fm-send-btn {
+#nd-docs-layout .fd-ai-fm-send-btn {
   border-radius: 0 !important;
 }
 
-.fd-ai-fm-close-btn {
+#nd-docs-layout .fd-ai-fm-close-btn {
   border-radius: 0 !important;
 }
 
-.fd-ai-fm-input {
+#nd-docs-layout .fd-ai-fm-input {
   font-size: 13px;
 }
 
-.fd-ai-fm-suggestion {
+#nd-docs-layout .fd-ai-fm-suggestion {
   border-radius: 0 !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   font-size: 11px;
@@ -659,7 +693,7 @@ code:not(pre code) {
   letter-spacing: 0.04em;
 }
 
-.fd-ai-fm-trigger-btn {
+#nd-docs-layout .fd-ai-fm-trigger-btn {
   border-radius: 0 !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
@@ -668,39 +702,39 @@ code:not(pre code) {
   box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-fm-trigger-btn:hover {
+#nd-docs-layout .fd-ai-fm-trigger-btn:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%));
 }
 
-.fd-ai-fm-msg-label {
+#nd-docs-layout .fd-ai-fm-msg-label {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-size: 11px;
 }
 
-.fd-ai-fm-msg-content {
+#nd-docs-layout .fd-ai-fm-msg-content {
   font-size: 13px;
 }
 
-.fd-ai-fm-msg-content code {
+#nd-docs-layout .fd-ai-fm-msg-content code {
   border-radius: 0 !important;
 }
 
-.fd-ai-fm-suggestions-label {
+#nd-docs-layout .fd-ai-fm-suggestions-label {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-fm-clear-btn {
+#nd-docs-layout .fd-ai-fm-clear-btn {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-fm-footer-hint {
+#nd-docs-layout .fd-ai-fm-footer-hint {
   font-size: 11px;
 }
 
@@ -708,7 +742,7 @@ code:not(pre code) {
 
 /* ─── Code blocks in AI chat (pixel-border) ──────────────────────── */
 
-.fd-ai-code-block {
+#nd-docs-layout .fd-ai-code-block {
   border-radius: 0 !important;
   box-shadow: 3px 3px 0 0 var(--color-fd-border, hsl(0 0% 15%));
   background: transparent;
@@ -723,28 +757,28 @@ code:not(pre code) {
   --sh-jsxliterals: #ae81ff;
 }
 
-.fd-ai-code-header {
+#nd-docs-layout .fd-ai-code-header {
   border-bottom-color: var(--color-fd-border, hsl(0 0% 15%));
   background: transparent;
 }
 
-.fd-ai-code-lang {
+#nd-docs-layout .fd-ai-code-lang {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
-.fd-ai-code-copy {
+#nd-docs-layout .fd-ai-code-copy {
   border-radius: 0 !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.fd-ai-code-block code {
+#nd-docs-layout .fd-ai-code-block code {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
 }
 
 /* Light mode: AI code blocks — light bg + dark text + visible pixel border */
-:root:not(.dark) .fd-ai-code-block {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-block {
   background: #f4f4f5 !important;
   box-shadow: 3px 3px 0 0 hsl(0 0% 75%);
   --sh-class: #b45309;
@@ -758,32 +792,32 @@ code:not(pre code) {
   --sh-jsxliterals: #7c3aed;
 }
 
-:root:not(.dark) .fd-ai-code-header {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-header {
   border-bottom-color: hsl(0 0% 80%);
   background: color-mix(in srgb, #e4e4e7 90%, transparent);
 }
 
-:root:not(.dark) .fd-ai-code-lang {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-lang {
   color: #52525b;
 }
 
-:root:not(.dark) .fd-ai-code-copy {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-copy {
   color: #52525b;
   border-color: hsl(0 0% 75%);
 }
 
-:root:not(.dark) .fd-ai-code-copy:hover {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-copy:hover {
   color: #18181b;
   background: color-mix(in srgb, #d4d4d8 70%, transparent);
 }
 
-:root:not(.dark) .fd-ai-code-block code {
+:root:not(.dark) #nd-docs-layout .fd-ai-code-block code {
   color: #1f2937;
 }
 
 /* ─── Omni Command Palette — pixel-border theme ──────────────────── */
 
-.omni-content {
+#nd-docs-layout .omni-content {
   border-radius: 0 !important;
   border: 2px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
   box-shadow:
@@ -791,45 +825,45 @@ code:not(pre code) {
     0 24px 60px -12px rgba(0, 0, 0, 0.5) !important;
 }
 
-.omni-item {
+#nd-docs-layout .omni-item {
   border-radius: 0 !important;
 }
 
-.omni-kbd,
-.omni-kbd-sm {
+#nd-docs-layout .omni-kbd,
+#nd-docs-layout .omni-kbd-sm {
   border-radius: 0 !important;
   border: 1px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
 }
 
-.omni-close-btn {
+#nd-docs-layout .omni-close-btn {
   border-radius: 0 !important;
 }
 
-.omni-empty-icon {
+#nd-docs-layout .omni-empty-icon {
   border-radius: 0 !important;
 }
 
-.omni-search-input {
+#nd-docs-layout .omni-search-input {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.omni-group-label {
+#nd-docs-layout .omni-group-label {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   letter-spacing: 0.08em !important;
 }
 
-.omni-footer-inner {
+#nd-docs-layout .omni-footer-inner {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
 }
 
-.omni-highlight {
+#nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;
 }
 
 /* ─── Page Actions — pixel-border theme ─────────────────────────── */
 
-.fd-page-action-btn {
+#nd-docs-layout .fd-page-action-btn {
   text-transform: uppercase !important;
   box-shadow: 2px 2px 0 0 var(--color-fd-border, #262626) !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
@@ -838,18 +872,18 @@ code:not(pre code) {
   letter-spacing: 0.03em !important;
 }
 
-.fd-page-action-dropdown {
+#nd-docs-layout .fd-page-action-dropdown {
   position: relative !important;
 }
 
-.fd-page-action-menu {
+#nd-docs-layout .fd-page-action-menu {
   border-radius: 0 !important;
   border: 2px solid var(--color-fd-border, #262626) !important;
   box-shadow: 2px 2px 0 0 var(--color-fd-border, #262626), 0 4px 24px hsl(0 0% 0% / 0.5) !important;
   padding: 0 !important;
 }
 
-.fd-page-action-menu-item {
+#nd-docs-layout .fd-page-action-menu-item {
   border-radius: 0 !important;
   font-size: 0.8rem !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
@@ -859,26 +893,26 @@ code:not(pre code) {
   border-top: 1px solid var(--color-fd-border, #262626) !important;
 }
 
-.fd-page-action-menu-item:first-child {
+#nd-docs-layout .fd-page-action-menu-item:first-child {
   border-top: none !important;
 }
 
 /* ─── Prompt (pixel-border theme) ──────────────────────────────── */
 
-.fd-prompt {
+#nd-docs-layout .fd-prompt {
   border-radius: 0 !important;
   border: 1px solid var(--color-fd-border, #262626) !important;
   background: var(--color-fd-card, var(--color-fd-background)) !important;
   box-shadow: 4px 4px 0 0 var(--color-fd-border, #262626) !important;
 }
 
-.fd-prompt-body {
+#nd-docs-layout .fd-prompt-body {
   border-radius: 0 !important;
   border-top: 1px solid var(--color-fd-border, #262626) !important;
   background: var(--color-fd-background, #0c0c0c) !important;
 }
 
-.fd-prompt-action-btn {
+#nd-docs-layout .fd-prompt-action-btn {
   text-transform: uppercase !important;
   box-shadow: 2px 2px 0 0 var(--color-fd-border, #262626) !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
@@ -890,12 +924,12 @@ code:not(pre code) {
   border: 1px solid var(--color-fd-border) !important;
 }
 
-.fd-prompt-action-btn:hover {
+#nd-docs-layout .fd-prompt-action-btn:hover {
   background: var(--color-fd-muted) !important;
   color: var(--color-fd-foreground) !important;
 }
 
-.fd-prompt-menu {
+#nd-docs-layout .fd-prompt-menu {
   border-radius: 0 !important;
   box-shadow: 4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%)), 0 4px 24px hsl(0 0% 0% / 0.5) !important;
   background: var(--color-fd-popover) !important;
@@ -903,7 +937,7 @@ code:not(pre code) {
   padding: 0.375rem !important;
 }
 
-.fd-prompt-menu-item {
+#nd-docs-layout .fd-prompt-menu-item {
   border-radius: 0 !important;
   font-size: 0.8rem !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
@@ -914,28 +948,28 @@ code:not(pre code) {
   border-top: 1px solid var(--color-fd-border) !important;
 }
 
-.fd-prompt-menu-item:first-child {
+#nd-docs-layout .fd-prompt-menu-item:first-child {
   border-top: none !important;
 }
 
-.fd-prompt-menu-item:hover {
+#nd-docs-layout .fd-prompt-menu-item:hover {
   background: var(--color-fd-muted) !important;
   color: var(--color-fd-foreground) !important;
 }
 
 /* ─── Feedback (pixel-border theme) ──────────────────────────────── */
 
-.fd-feedback-input,
-.fd-feedback-submit {
+#nd-docs-layout .fd-feedback-input,
+#nd-docs-layout .fd-feedback-submit {
   border-radius: 0 !important;
   box-shadow: 3px 3px 0 0 var(--color-fd-border);
 }
 
-.fd-feedback-choice[data-selected="true"] {
+#nd-docs-layout .fd-feedback-choice[data-selected="true"] {
   background: var(--color-fd-secondary);
 }
 
-.fd-feedback-status[data-status="success"] {
+#nd-docs-layout .fd-feedback-status[data-status="success"] {
   font-family: var(--fd-font-mono, var(--font-geist-mono, ui-monospace, monospace));
   text-transform: uppercase;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scopes all docs styles and CSS variables to the `#nd-docs-layout` container (using `:has(#nd-docs-layout)` where needed) to stop hydration-time style leaks into the host app. Dark mode resolves via `:is(html.dark, body.dark) #nd-docs-layout` or `#nd-docs-layout.dark`, eliminating global overrides and flicker.

- **Bug Fixes**
  - Replaced global `:root`/`.dark` and broad selectors with `#nd-docs-layout`-scoped rules (including `docs.css` and all theme CSS).
  - Updated `DocsLayout.svelte` to emit CSS variables under the container and apply dark tokens via combined selectors with `:has()`.
  - Scoped backgrounds, scroll padding, selection, headers, and `.omni-*` UI to the container; example app sets minimal `body` styles for demo consistency.

- **Migration**
  - No changes if you use `DocsLayout` (it renders `#nd-docs-layout`).
  - If you don’t set `html/body.dark`, add `.dark` to `#nd-docs-layout` to enable dark mode.

<sup>Written for commit b962335593b67f426ba7ed22d2ab0f3d959ce558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

