### PR TITLE
chore: security ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "lodash": "4.18.1",
       "simple-git": "^3.36.0",
       "serialize-javascript": "^7.0.3",
+      "shell-quote@<=1.8.3": "1.8.4",
       "svgo": "^4.0.1",
       "fast-uri": "3.1.2",
       "rollup": "^4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   lodash: 4.18.1
   simple-git: ^3.36.0
   serialize-javascript: ^7.0.3
+  shell-quote@<=1.8.3: 1.8.4
   svgo: ^4.0.1
   fast-uri: 3.1.2
   rollup: ^4.59.0
@@ -6892,8 +6893,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.22.0:
@@ -12874,7 +12875,7 @@ snapshots:
   launch-editor@2.13.0:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   lazystream@1.0.1:
     dependencies:
@@ -15004,7 +15005,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.22.0:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force-upgrade transitive `shell-quote` to 1.8.4 to address a security advisory and keep CI passing.

- **Dependencies**
  - Added a `package.json` override `"shell-quote@<=1.8.3": "1.8.4"` and synced `pnpm-lock.yaml` so all consumers resolve to 1.8.4.

<sup>Written for commit bf6eef2b28d40f916ae9fcadce683f0e6620cc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

