### PR TITLE
chore: auto drift webhook smoke test

### DIFF
--- a/benchmark/codex/test-fixtures/fake-codex.mjs
+++ b/benchmark/codex/test-fixtures/fake-codex.mjs
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
+// Used as a stable non-doc path for Docs Cloud webhook smoke tests.
 function argValue(flag) {
   const index = process.argv.indexOf(flag);
   return index >= 0 ? process.argv[index + 1] : null;


### PR DESCRIPTION
Smoke test for Docs Cloud knowledge drift AUTO mode. This touches a non-doc benchmark fixture so a merge to main should emit a push webhook and queue an auto knowledge-drift run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable non-doc marker in benchmark/codex/test-fixtures/fake-codex.mjs to smoke test Docs Cloud auto knowledge-drift webhooks. Merging to main will emit the push webhook and queue an auto drift run.

<sup>Written for commit 1e95b9d3f9a947bc4f389bba297a7e4291087e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

