### PR TITLE
chore: refine auto drift smoke marker

### DIFF
--- a/benchmark/codex/test-fixtures/fake-codex.mjs
+++ b/benchmark/codex/test-fixtures/fake-codex.mjs
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-// Used as a stable non-doc path for Docs Cloud webhook smoke tests.
+// Used as a stable non-doc path for Docs Cloud auto-drift smoke tests.
 function argValue(flag) {
   const index = process.argv.indexOf(flag);
   return index >= 0 ? process.argv[index + 1] : null;


### PR DESCRIPTION
Second smoke test for Docs Cloud knowledge drift AUTO mode after wiring the repository push webhook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the fixture comment to reference Docs Cloud auto-drift smoke tests. Ensures the stable non-doc path marker matches the webhook-driven flow.

<sup>Written for commit c148d66f19906f68e0447901197865663675e739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

