### PR TITLE
feat: add docs doctor strict mode

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -72,6 +72,18 @@ describe("parseDoctorArgs", () => {
     });
   });
 
+  it("parses strict CI mode", () => {
+    expect(parseDoctorArgs(["--strict"])).toEqual({
+      mode: "agent",
+      strict: true,
+    });
+    expect(parseDoctorArgs(["--site", "--json", "--strict"])).toEqual({
+      mode: "human",
+      json: true,
+      strict: true,
+    });
+  });
+
   it("parses hosted URL probes", () => {
     expect(parseDoctorArgs(["--agent", "--url", "https://docs.example.com"])).toEqual({
       mode: "agent",
@@ -1602,6 +1614,50 @@ description: "Docs home"
       expect(payload.mode).toBe("site");
       expect(Array.isArray(payload.checks)).toBe(true);
     } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("sets a failing exit code in strict mode when checks warn", async () => {
+    writePackageJson(tmpDir, "doctor-site-strict-warnings", { next: "16.0.0" });
+
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "docs",
+};`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs", "page.mdx"),
+      `---
+title: "Overview"
+description: "Docs home"
+---
+
+# Overview
+
+Welcome to the docs.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      const report = await runDoctor({ mode: "human", json: true, strict: true });
+
+      expect(report.checks.some((check) => check.status === "warn")).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
       logSpy.mockRestore();
     }
   });

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -53,6 +53,7 @@ export interface DoctorOptions {
   configPath?: string;
   mode?: DoctorMode;
   json?: boolean;
+  strict?: boolean;
   url?: string;
 }
 
@@ -180,6 +181,11 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg === "--strict") {
+      parsed.strict = true;
+      continue;
+    }
+
     if (arg === "--human" || arg === "human" || arg === "--site" || arg === "site") {
       parsed.mode = "human";
       continue;
@@ -242,6 +248,7 @@ ${pc.dim("Usage:")}
   pnpm exec docs doctor --agent
   pnpm exec docs doctor --site
   pnpm exec docs doctor --agent --json
+  pnpm exec docs doctor --agent --strict
   pnpm exec docs doctor agent
   pnpm exec docs doctor site
 
@@ -250,6 +257,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--site")}             Score reader-facing docs quality for the current docs app
   ${pc.cyan("--human")}            Alias for ${pc.cyan("--site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
+  ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}
   ${pc.cyan("--config <path>")}    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
   ${pc.cyan("-h, --help")}         Show this help message
@@ -2941,9 +2949,23 @@ export function printDoctorJsonReport(report: AgentDoctorReport | HumanDoctorRep
   console.log(JSON.stringify(serializeDoctorJsonReport(report), null, 2));
 }
 
+function hasNonPassingDoctorCheck(report: AgentDoctorReport | HumanDoctorReport) {
+  return report.checks.some((check) => check.status !== "pass");
+}
+
+function applyStrictExitCode(
+  report: AgentDoctorReport | HumanDoctorReport,
+  options: DoctorOptions,
+) {
+  if (options.strict && hasNonPassingDoctorCheck(report)) {
+    process.exitCode = 1;
+  }
+}
+
 export async function runDoctor(options: DoctorOptions = {}) {
   if (options.mode === "human") {
     const report = await inspectHumanReadiness(options);
+    applyStrictExitCode(report, options);
     if (options.json) {
       printDoctorJsonReport(report);
       return report;
@@ -2953,6 +2975,7 @@ export async function runDoctor(options: DoctorOptions = {}) {
   }
 
   const report = await inspectAgentReadiness(options);
+  applyStrictExitCode(report, options);
   if (options.json) {
     printDoctorJsonReport(report);
     return report;

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -391,6 +391,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --site")}                       Score the current docs app for reader-facing docs quality
   ${pc.cyan("doctor --human")}                      Alias for ${pc.cyan("doctor --site")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
+  ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
   ${pc.cyan("doctor agent")}                        Subcommand alias for agent scoring
   ${pc.cyan("doctor site")}                         Subcommand alias for reader-facing scoring
   ${pc.cyan("doctor human")}                        Legacy alias for reader-facing scoring


### PR DESCRIPTION
## Summary

Adds a `--strict` flag to `docs doctor` so CI can fail when any doctor check warns or fails.

This intentionally leaves website documentation unchanged so Docs Cloud knowledge drift can detect the CLI behavior change after merge and draft the docs update.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/cli/doctor.test.ts`
- `pnpm --filter @farming-labs/docs run test`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm exec oxfmt --ignore-path .oxfmtignore --check packages/docs/src/cli/doctor.ts packages/docs/src/cli/index.ts packages/docs/src/cli/doctor.test.ts`
- `pnpm exec oxlint packages/docs/src/cli/doctor.ts packages/docs/src/cli/index.ts packages/docs/src/cli/doctor.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--strict` flag to `docs doctor` so CI fails when any check warns or fails. Works in both agent and site modes and preserves JSON output behavior.

- **New Features**
  - Added `--strict` arg to `docs doctor` (agent and site). Updates help text in `@farming-labs/docs`.
  - In strict mode, sets exit code to 1 if any check is not "pass" (warn or fail).

- **Migration**
  - Update CI to use strict mode, e.g. `pnpm exec docs doctor --agent --json --strict`.

<sup>Written for commit 8c517df00a03973ede08ad16fb40003d30c24125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

