### PR TITLE
docs: knowledge drift sync

### DIFF
--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -475,11 +475,21 @@ pnpm exec docs doctor
 pnpm exec docs doctor --agent
 pnpm exec docs doctor --site
 pnpm exec docs doctor --agent --json
+pnpm exec docs doctor --agent --strict
 pnpm exec docs doctor agent
 pnpm exec docs doctor site
 pnpm exec docs doctor --agent --config docs.config.tsx
 pnpm exec docs doctor --agent --url https://docs.example.com
 pnpm exec docs doctor --agent --url https://docs.example.com --json
+```
+
+Use `--strict` in CI when warnings should fail the job. Strict mode sets a non-zero exit code when
+any doctor check reports `warn` or `fail`, and it can be combined with `--json` for
+machine-readable output.
+
+```bash title="terminal"
+pnpm exec docs doctor --agent --strict
+pnpm exec docs doctor --site --json --strict
 ```
 
 Expected output:


### PR DESCRIPTION
## Summary

Updates the existing CLI docs page for the `docs doctor --strict` addition from the recent merge.

## Docs changes

- Adds `--strict` to the existing Doctor command examples.
- Documents that strict mode exits non-zero when warnings or errors are present, which is useful for CI and automation.

## Scope

- Only updates `website/app/docs/cli/page.mdx`.
- Reuses the existing CLI docs location instead of creating new API/CLI or quickstart pages.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--strict` to the `docs doctor` CLI docs and examples. Explain that strict mode returns a non-zero exit code on warnings or failures and can be combined with `--json` for CI.

<sup>Written for commit 52742cbbfba8db687f7d153de0b7509d0cb944c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

