### PR TITLE
fix: agent score api response

### DIFF
--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -139,6 +139,23 @@ const SCORE_LOADING_STEPS = [
   "Calculating final score",
 ] as const;
 
+function fallbackApiErrorMessage(response: Response, body: string): string {
+  const compactBody = body.trim().replace(/\s+/g, " ");
+  const status = `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+  return compactBody ? `${status}: ${compactBody.slice(0, 240)}` : status;
+}
+
+async function readApiJson<T extends object>(response: Response): Promise<T & { error?: string }> {
+  const body = await response.text();
+  if (!body.trim()) return {} as T & { error?: string };
+
+  try {
+    return JSON.parse(body) as T & { error?: string };
+  } catch {
+    return { error: fallbackApiErrorMessage(response, body) } as T & { error?: string };
+  }
+}
+
 const BREAKDOWN_HELP_ITEMS = [
   {
     title: "Discovery",
@@ -909,10 +926,10 @@ export function AgentScorePage() {
       const response = await fetch("/api/agent-score/leaderboard?limit=100", {
         cache: "no-store",
       });
-      const data = (await response.json()) as {
+      const data = await readApiJson<{
         entries?: LeaderboardEntry[];
         notConfigured?: boolean;
-      };
+      }>(response);
       setLeaderboardNotConfigured(Boolean(data.notConfigured));
       setEntries(Array.isArray(data.entries) ? data.entries : []);
     } catch {
@@ -939,7 +956,7 @@ export function AgentScorePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ url: trimmed }),
         });
-        const data = (await response.json()) as { error?: string } & AgentScoreReport;
+        const data = await readApiJson<Partial<AgentScoreReport>>(response);
         if (!response.ok) {
           setFetchState({
             status: "error",
@@ -948,11 +965,24 @@ export function AgentScorePage() {
           return;
         }
 
-        setFetchState({ status: "success", report: data });
+        if (
+          typeof data.baseUrl !== "string" ||
+          typeof data.score !== "number" ||
+          !Array.isArray(data.checks)
+        ) {
+          setFetchState({
+            status: "error",
+            message: data.error ?? "The scorer returned an unexpected response.",
+          });
+          return;
+        }
+
+        const report = data as AgentScoreReport;
+        setFetchState({ status: "success", report });
         hydratedSelectionRef.current = null;
 
         if (options.historyMode !== "none") {
-          writeScoreUrl(data.baseUrl, {
+          writeScoreUrl(report.baseUrl, {
             source: "input",
             ...(options.historyMode === "replace" ? { mode: "replace" as const } : {}),
           });
@@ -1080,14 +1110,14 @@ export function AgentScorePage() {
           url: fetchState.report.baseUrl,
         }),
       });
-      const data = (await response.json()) as {
+      const data = await readApiJson<{
         error?: string;
         warning?: string;
         stored?: boolean;
         action?: "created" | "updated";
         previousScore?: number;
         report?: AgentScoreReport;
-      };
+      }>(response);
 
       if (!response.ok) {
         setSubmitState({

--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -930,6 +930,13 @@ export function AgentScorePage() {
         entries?: LeaderboardEntry[];
         notConfigured?: boolean;
       }>(response);
+      if (
+        !response.ok ||
+        data.error ||
+        (!Array.isArray(data.entries) && data.notConfigured !== true)
+      ) {
+        throw new Error(data.error ?? "Failed to load the leaderboard.");
+      }
       setLeaderboardNotConfigured(Boolean(data.notConfigured));
       setEntries(Array.isArray(data.entries) ? data.entries : []);
     } catch {

--- a/website/app/api/agent-score/route.ts
+++ b/website/app/api/agent-score/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { inspectHostedAgentReadiness } from "@/lib/agent-score";
 
 export const dynamic = "force-dynamic";
-// Probing seven endpoints over the network needs room to breathe.
+// Public scoring performs bounded network probes and should return JSON before
+// the platform timeout can replace the response with plain text.
 export const maxDuration = 30;
 
 type AgentScoreBody = {

--- a/website/lib/agent-score.ts
+++ b/website/lib/agent-score.ts
@@ -32,10 +32,12 @@ import {
 // Kept in sync with @modelcontextprotocol/sdk; the deployed MCP server
 // negotiates any version it advertises so bumps are safe.
 const MCP_PROTOCOL_VERSION = "2025-11-25";
-const PROBE_TIMEOUT_MS = 9000;
-const AF_DOCS_MAX_LINKS_TO_TEST = 10;
-const AF_DOCS_REQUEST_DELAY_MS = 50;
-const AF_DOCS_MAX_CONCURRENCY = 6;
+const PROBE_TIMEOUT_MS = 5000;
+const AGENT_SCORE_TOTAL_BUDGET_MS = 26000;
+const AF_DOCS_MAX_LINKS_TO_TEST = 3;
+const AF_DOCS_REQUEST_DELAY_MS = 0;
+const AF_DOCS_MAX_CONCURRENCY = 8;
+const AF_DOCS_REQUEST_TIMEOUT_MS = 2500;
 const ADJACENT_MARKDOWN_MAX_SCORE = 3;
 const MAX_SAFE_REDIRECTS = 5;
 const FARMING_LABS_DOCS_UPGRADE_RECOMMENDATION =
@@ -300,6 +302,7 @@ async function fetchPublicAgentScoreUrl(
   const request = input instanceof Request ? input : undefined;
   const redirectMode = currentInit.redirect ?? request?.redirect ?? "follow";
 
+  assertPublicAgentScoreBudget();
   await assertPublicAgentScoreUrl(currentUrl);
 
   if (redirectMode === "manual") {
@@ -310,6 +313,7 @@ async function fetchPublicAgentScoreUrl(
   }
 
   for (let redirectCount = 0; redirectCount <= MAX_SAFE_REDIRECTS; redirectCount++) {
+    assertPublicAgentScoreBudget();
     await assertPublicAgentScoreUrl(currentUrl);
     const response = await fetcher(currentUrl, { ...currentInit, redirect: "manual" });
     const location = response.headers.get("location");
@@ -335,9 +339,22 @@ async function fetchPublicAgentScoreUrl(
 
 let fetchGuardDepth = 0;
 let fetchBeforeGuard: typeof fetch | undefined;
+let fetchGuardDeadline = 0;
+
+function remainingPublicAgentScoreTime(): number | undefined {
+  return fetchGuardDeadline > 0 ? Math.max(0, fetchGuardDeadline - Date.now()) : undefined;
+}
+
+function assertPublicAgentScoreBudget(): void {
+  const remaining = remainingPublicAgentScoreTime();
+  if (remaining !== undefined && remaining <= 0) {
+    throw new Error("Agent score timed out before all probes completed.");
+  }
+}
 
 async function withPublicAgentScoreFetch<T>(callback: () => Promise<T>): Promise<T> {
   if (fetchGuardDepth === 0) {
+    fetchGuardDeadline = Date.now() + AGENT_SCORE_TOTAL_BUDGET_MS;
     fetchBeforeGuard = globalThis.fetch.bind(globalThis);
     const guardedFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
       fetchPublicAgentScoreUrl(
@@ -356,6 +373,7 @@ async function withPublicAgentScoreFetch<T>(callback: () => Promise<T>): Promise
     if (fetchGuardDepth === 0 && fetchBeforeGuard) {
       globalThis.fetch = fetchBeforeGuard;
       fetchBeforeGuard = undefined;
+      fetchGuardDeadline = 0;
     }
   }
 }
@@ -388,8 +406,11 @@ async function fetchWithTimeout(
   init: RequestInit = {},
   timeoutMs = PROBE_TIMEOUT_MS,
 ): Promise<Response> {
+  const remainingBudget = remainingPublicAgentScoreTime();
+  const effectiveTimeoutMs =
+    remainingBudget === undefined ? timeoutMs : Math.max(1, Math.min(timeoutMs, remainingBudget));
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs);
 
   try {
     return await fetch(url, {
@@ -2024,11 +2045,11 @@ export async function inspectHostedAgentReadiness(rawUrl: string): Promise<Agent
   const { afdocsReport, adjacentMarkdownChecks, framework } = await withPublicAgentScoreFetch(
     async () => {
       const report = await runChecks(baseUrl, {
-        samplingStrategy: "deterministic",
+        samplingStrategy: "none",
         maxLinksToTest: AF_DOCS_MAX_LINKS_TO_TEST,
         maxConcurrency: AF_DOCS_MAX_CONCURRENCY,
         requestDelay: AF_DOCS_REQUEST_DELAY_MS,
-        requestTimeout: PROBE_TIMEOUT_MS,
+        requestTimeout: AF_DOCS_REQUEST_TIMEOUT_MS,
       });
       const adjacentMarkdownProbes = await probeAdjacentMarkdownRoutes(baseUrl, report);
       return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the Agent Score API and leaderboard respond reliably and keep the UI stable even when the platform returns plain text. Adds a global probe time budget so responses return JSON before timeouts, with clear errors when they don’t.

- **Bug Fixes**
  - Parse API responses safely and show a compact fallback HTTP error when bodies are empty or not JSON.
  - Validate `AgentScoreReport` and leaderboard data before use; show clear errors on invalid shapes.

- **Performance**
  - Add a 26s total budget for all probes; propagate remaining time to each request and stop early if exhausted.
  - Tighten probes: 5s per request, docs 2.5s, test 3 links, 0ms delay, concurrency 8.
  - Keep API route `maxDuration` at 30s to return JSON before platform timeouts.

<sup>Written for commit d405d7ad278c1fda71040948033b248eb7cd4a43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

