### PR TITLE
feat: add Perplexity open docs provider

### DIFF
--- a/packages/docs/src/prompt-utils.test.ts
+++ b/packages/docs/src/prompt-utils.test.ts
@@ -59,6 +59,16 @@ describe("resolvePromptProviderChoices", () => {
     ]);
   });
 
+  it("resolves Perplexity as a built-in prompt provider", () => {
+    expect(resolvePromptProviderChoices(undefined, ["Perplexity"])).toEqual([
+      {
+        name: "Perplexity",
+        urlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+        iconHtml: undefined,
+      },
+    ]);
+  });
+
   it("falls back to a provider urlTemplate when no prompt template is configured", () => {
     expect(
       resolvePromptProviderChoices(
@@ -180,6 +190,16 @@ describe("serializeOpenDocsProviders", () => {
       urlTemplate: "cursor://anysphere.cursor-deeplink/prompt?text={prompt}",
       promptUrlTemplate: "cursor://anysphere.cursor-deeplink/prompt?text={prompt}",
       iconHtml: undefined,
+      target: undefined,
+      prompt: undefined,
+    });
+  });
+
+  it("serializes Perplexity as a built-in open docs provider", () => {
+    expect(serializeOpenDocsProvider("perplexity")).toEqual({
+      name: "Perplexity",
+      urlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+      promptUrlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
       target: undefined,
       prompt: undefined,
     });

--- a/packages/docs/src/prompt-utils.ts
+++ b/packages/docs/src/prompt-utils.ts
@@ -41,6 +41,7 @@ export const DEFAULT_PROMPT_PROVIDER_TEMPLATES: Record<string, string> = {
   cursor: "https://cursor.com/link/prompt?text={prompt}",
   gemini: "https://gemini.google.com/app?q={prompt}",
   copilot: "https://github.com/copilot?prompt={prompt}",
+  perplexity: "https://www.perplexity.ai/search/?q={prompt}",
 };
 
 export const DEFAULT_OPEN_DOCS_TARGET: OpenDocsTarget = "markdown";
@@ -74,6 +75,11 @@ const DEFAULT_OPEN_DOCS_PROVIDER_PRESETS: Record<string, OpenDocsProviderPreset>
     name: "Copilot",
     urlTemplate: "https://github.com/copilot?prompt={prompt}",
     promptUrlTemplate: DEFAULT_PROMPT_PROVIDER_TEMPLATES.copilot,
+  },
+  perplexity: {
+    name: "Perplexity",
+    urlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+    promptUrlTemplate: DEFAULT_PROMPT_PROVIDER_TEMPLATES.perplexity,
   },
   github: {
     name: "GitHub",

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -565,7 +565,14 @@ export interface SidebarConfig {
 
 export type OpenDocsTarget = "markdown" | "page" | "source" | "github";
 
-export type OpenDocsProviderId = "chatgpt" | "claude" | "cursor" | "gemini" | "copilot" | "github";
+export type OpenDocsProviderId =
+  | "chatgpt"
+  | "claude"
+  | "cursor"
+  | "gemini"
+  | "copilot"
+  | "perplexity"
+  | "github";
 
 /**
  * A single "Open in …" provider shown in the Open dropdown.
@@ -629,7 +636,7 @@ export interface OpenDocsProviderConfig {
   /**
    * Optional URL template used by the built-in `Prompt` MDX component.
    * When omitted, known providers such as ChatGPT, Claude, Cursor, Gemini,
-   * and Copilot fall back to a built-in `{prompt}` template by provider name.
+   * Copilot, and Perplexity fall back to a built-in `{prompt}` template by provider name.
    *
    * Placeholders:
    * - `{prompt}` — prompt text (encoded).

--- a/packages/fumadocs/src/open-docs-providers.test.ts
+++ b/packages/fumadocs/src/open-docs-providers.test.ts
@@ -28,4 +28,14 @@ describe("resolveOpenDocsProvider", () => {
       target: "page",
     });
   });
+
+  it("resolves Perplexity as a built-in open docs provider", () => {
+    expect(resolveOpenDocsProvider("perplexity")).toEqual({
+      name: "Perplexity",
+      urlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+      promptUrlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+      target: undefined,
+      prompt: undefined,
+    });
+  });
 });

--- a/packages/fumadocs/src/open-docs-providers.ts
+++ b/packages/fumadocs/src/open-docs-providers.ts
@@ -28,6 +28,7 @@ const PROMPT_PROVIDER_TEMPLATES: Record<string, string> = {
   cursor: "https://cursor.com/link/prompt?text={prompt}",
   gemini: "https://gemini.google.com/app?q={prompt}",
   copilot: "https://github.com/copilot?prompt={prompt}",
+  perplexity: "https://www.perplexity.ai/search/?q={prompt}",
 };
 
 const OPEN_DOCS_PROVIDER_PRESETS: Record<string, OpenDocsProviderPreset> = {
@@ -55,6 +56,11 @@ const OPEN_DOCS_PROVIDER_PRESETS: Record<string, OpenDocsProviderPreset> = {
     name: "Copilot",
     urlTemplate: "https://github.com/copilot?prompt={prompt}",
     promptUrlTemplate: PROMPT_PROVIDER_TEMPLATES.copilot,
+  },
+  perplexity: {
+    name: "Perplexity",
+    urlTemplate: "https://www.perplexity.ai/search/?q={prompt}",
+    promptUrlTemplate: PROMPT_PROVIDER_TEMPLATES.perplexity,
   },
   github: {
     name: "GitHub",

--- a/website/app/docs/customization/page-actions/page.mdx
+++ b/website/app/docs/customization/page-actions/page.mdx
@@ -145,7 +145,7 @@ pageActions: {
 }
 ```
 
-Built-in provider ids are `"chatgpt"`, `"claude"`, `"cursor"`, `"gemini"`, `"copilot"`, and `"github"`.
+Built-in provider ids are `"chatgpt"`, `"claude"`, `"cursor"`, `"gemini"`, `"copilot"`, `"perplexity"`, and `"github"`.
 
 ### `pageActions.openDocs.target`
 
@@ -174,7 +174,7 @@ pageActions: {
     enabled: true,
     target: "markdown",
     prompt: "Use this documentation while editing the codebase: {url}",
-    providers: ["chatgpt", "claude", { id: "cursor", mode: "app" }],
+    providers: ["chatgpt", "claude", "perplexity", { id: "cursor", mode: "app" }],
   },
 }
 ```

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1463,7 +1463,7 @@ Action buttons shown on each docs page. See [Page Actions](/docs/customization/p
 
 | Property            | Type        | Description                                                                       |
 | ------------------- | ----------- | --------------------------------------------------------------------------------- |
-| `id`                | `string`    | Built-in provider preset (`"chatgpt"`, `"claude"`, `"cursor"`, `"gemini"`, `"copilot"`, `"github"`) |
+| `id`                | `string`    | Built-in provider preset (`"chatgpt"`, `"claude"`, `"cursor"`, `"gemini"`, `"copilot"`, `"perplexity"`, `"github"`) |
 | `name`              | `string`    | Display name override                                                            |
 | `icon`              | `ReactNode` | Icon rendered next to the name                                                    |
 | `target`            | `"markdown" \| "page" \| "source" \| "github"` | Per-provider target override                                                      |


### PR DESCRIPTION
## Summary

- Add Perplexity as a built-in `openDocs` provider preset in `@farming-labs/docs` and `@farming-labs/theme`.
- Extend provider ID typing and focused tests for prompt/provider resolution.
- Update the Page Actions and reference docs so the docs-review workflow has a docs-path change to evaluate.

## Why

This is a small real feature intended to exercise the PR workflow end to end while keeping the product surface useful and low risk.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/prompt-utils.test.ts`
- `pnpm --filter @farming-labs/theme exec vitest run src/open-docs-providers.test.ts`
- `git diff --check`
- `pnpm format:check`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm --filter @farming-labs/theme run typecheck`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Perplexity as a built-in Open Docs and prompt provider so users can search docs via Perplexity from the docs UI. Updates types, tests, and docs; no breaking changes.

- **New Features**
  - Added `perplexity` preset in `@farming-labs/docs` and `@farming-labs/fumadocs` with URL template `https://www.perplexity.ai/search/?q={prompt}`.
  - Extended `OpenDocsProviderId` to include `"perplexity"` and added a default prompt template.
  - Added tests for provider resolution and serialization in both packages.
  - Updated docs to list `"perplexity"` and included it in config examples.

<sup>Written for commit 376c5babbf986c9c5f3186869c3fa0b1eccba0d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

