### PR TITLE
Add docs doctor --only flag

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -84,6 +84,16 @@ describe("parseDoctorArgs", () => {
     });
   });
 
+  it("parses explicit only mode", () => {
+    expect(parseDoctorArgs(["--only", "agent"])).toEqual({
+      mode: "agent",
+    });
+    expect(parseDoctorArgs(["--only=site", "--json"])).toEqual({
+      mode: "human",
+      json: true,
+    });
+  });
+
   it("parses hosted URL probes", () => {
     expect(parseDoctorArgs(["--agent", "--url", "https://docs.example.com"])).toEqual({
       mode: "agent",
@@ -116,6 +126,14 @@ describe("parseDoctorArgs", () => {
   it("rejects missing URL values", () => {
     expect(() => parseDoctorArgs(["--url"])).toThrow("Missing value for --url.");
     expect(() => parseDoctorArgs(["--url="])).toThrow("Missing value for --url.");
+  });
+
+  it("rejects invalid only mode values", () => {
+    expect(() => parseDoctorArgs(["--only"])).toThrow("Missing value for --only.");
+    expect(() => parseDoctorArgs(["--only="])).toThrow("Missing value for --only.");
+    expect(() => parseDoctorArgs(["--only", "human"])).toThrow(
+      "Invalid value for --only. Expected agent or site.",
+    );
   });
 });
 

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -160,6 +160,12 @@ function parseInlineFlag(arg: string): { key: string; value?: string } {
   return { key: rawKey.trim(), value };
 }
 
+function parseDoctorOnlyMode(value: string): DoctorMode {
+  if (value === "agent") return "agent";
+  if (value === "site") return "human";
+  throw new Error("Invalid value for --only. Expected agent or site.");
+}
+
 export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
   const parsed: ParsedDoctorArgs = {};
 
@@ -183,6 +189,25 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
 
     if (arg === "--strict") {
       parsed.strict = true;
+      continue;
+    }
+
+    if (arg.startsWith("--only=")) {
+      const value = parseInlineFlag(arg).value;
+      if (!value) {
+        throw new Error("Missing value for --only.");
+      }
+      parsed.mode = parseDoctorOnlyMode(value);
+      continue;
+    }
+
+    if (arg === "--only") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("Missing value for --only.");
+      }
+      parsed.mode = parseDoctorOnlyMode(value);
+      index += 1;
       continue;
     }
 
@@ -249,6 +274,8 @@ ${pc.dim("Usage:")}
   pnpm exec docs doctor --site
   pnpm exec docs doctor --agent --json
   pnpm exec docs doctor --agent --strict
+  pnpm exec docs doctor --only agent
+  pnpm exec docs doctor --only site
   pnpm exec docs doctor agent
   pnpm exec docs doctor site
 
@@ -256,6 +283,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--agent")}            Score agent-readiness for the current docs app (default)
   ${pc.cyan("--site")}             Score reader-facing docs quality for the current docs app
   ${pc.cyan("--human")}            Alias for ${pc.cyan("--site")}
+  ${pc.cyan("--only <mode>")}      Run only one doctor suite: ${pc.cyan("agent")} or ${pc.cyan("site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}


### PR DESCRIPTION
## Summary
- Add `docs doctor --only <agent|site>` as an explicit selector for doctor suites.
- Map `--only agent` to the existing agent-readiness mode and `--only site` to the existing site/human mode.
- Cover inline, separate-value, missing-value, and invalid-value parsing in tests.

## Validation
- `pnpm --filter @farming-labs/docs exec vitest run src/cli/doctor.test.ts`
- `pnpm --filter @farming-labs/docs run build`
- `pnpm --filter @farming-labs/docs run typecheck`
- `git diff --check`

## Workflow test
This is intentionally a code-only CLI feature so merging it to `main` should create a real docs drift signal without adding the docs update manually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit `--only <agent|site>` flag to `docs doctor` in `@farming-labs/docs` to run a single doctor suite. This makes mode selection clearer and easier to script.

- **New Features**
  - `--only agent` maps to agent-readiness; `--only site` maps to site/human mode.
  - Supports `--only=value` and `--only value`; throws on missing/invalid values.
  - CLI help updated with examples; tests added for inline/separate values and errors.

<sup>Written for commit 5fbec6697eeaf0d2e71ce940108019d6782d4d8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

