### PR TITLE
feat: add docs doctor --fail-on flag

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -84,6 +84,17 @@ describe("parseDoctorArgs", () => {
     });
   });
 
+  it("parses explicit fail-on thresholds", () => {
+    expect(parseDoctorArgs(["--fail-on", "warn"])).toEqual({
+      mode: "agent",
+      failOn: "warn",
+    });
+    expect(parseDoctorArgs(["--site", "--fail-on=fail"])).toEqual({
+      mode: "human",
+      failOn: "fail",
+    });
+  });
+
   it("parses explicit only mode", () => {
     expect(parseDoctorArgs(["--only", "agent"])).toEqual({
       mode: "agent",
@@ -133,6 +144,14 @@ describe("parseDoctorArgs", () => {
     expect(() => parseDoctorArgs(["--only="])).toThrow("Missing value for --only.");
     expect(() => parseDoctorArgs(["--only", "human"])).toThrow(
       "Invalid value for --only. Expected agent or site.",
+    );
+  });
+
+  it("rejects invalid fail-on values", () => {
+    expect(() => parseDoctorArgs(["--fail-on"])).toThrow("Missing value for --fail-on.");
+    expect(() => parseDoctorArgs(["--fail-on="])).toThrow("Missing value for --fail-on.");
+    expect(() => parseDoctorArgs(["--fail-on", "error"])).toThrow(
+      "Invalid value for --fail-on. Expected warn or fail.",
     );
   });
 });
@@ -1406,6 +1425,34 @@ describe("inspectHumanReadiness", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  function writeWarningSiteFixture(name: string) {
+    writePackageJson(tmpDir, name, { next: "16.0.0" });
+
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "docs",
+};`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "docs", "page.mdx"),
+      `---
+title: "Overview"
+description: "Docs home"
+---
+
+# Overview
+
+Welcome to the docs.
+`,
+      "utf-8",
+    );
+  }
+
   it("scores a healthy docs app as reader-ready", async () => {
     writePackageJson(tmpDir, "doctor-human", { next: "16.0.0" });
 
@@ -1637,31 +1684,7 @@ description: "Docs home"
   });
 
   it("sets a failing exit code in strict mode when checks warn", async () => {
-    writePackageJson(tmpDir, "doctor-site-strict-warnings", { next: "16.0.0" });
-
-    writeFileSync(
-      path.join(tmpDir, "docs.config.ts"),
-      `export default {
-  entry: "docs",
-  contentDir: "docs",
-};`,
-      "utf-8",
-    );
-
-    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
-    writeFileSync(
-      path.join(tmpDir, "docs", "page.mdx"),
-      `---
-title: "Overview"
-description: "Docs home"
----
-
-# Overview
-
-Welcome to the docs.
-`,
-      "utf-8",
-    );
+    writeWarningSiteFixture("doctor-site-strict-warnings");
 
     process.chdir(tmpDir);
 
@@ -1673,6 +1696,67 @@ Welcome to the docs.
       const report = await runDoctor({ mode: "human", json: true, strict: true });
 
       expect(report.checks.some((check) => check.status === "warn")).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+      logSpy.mockRestore();
+    }
+  });
+
+  it("sets a failing exit code with fail-on warn when checks warn", async () => {
+    writeWarningSiteFixture("doctor-site-fail-on-warn");
+
+    process.chdir(tmpDir);
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      const report = await runDoctor({ mode: "human", json: true, failOn: "warn" });
+
+      expect(report.checks.some((check) => check.status === "warn")).toBe(true);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+      logSpy.mockRestore();
+    }
+  });
+
+  it("keeps exit code passing with fail-on fail when checks only warn", async () => {
+    writeWarningSiteFixture("doctor-site-fail-on-fail-warnings");
+
+    process.chdir(tmpDir);
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      const report = await runDoctor({ mode: "human", json: true, failOn: "fail" });
+
+      expect(report.checks.some((check) => check.status === "warn")).toBe(true);
+      expect(report.checks.every((check) => check.status !== "fail")).toBe(true);
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      process.exitCode = previousExitCode;
+      logSpy.mockRestore();
+    }
+  });
+
+  it("sets a failing exit code with fail-on fail when checks fail", async () => {
+    writePackageJson(tmpDir, "doctor-agent-fail-on-fail", { next: "16.0.0" });
+
+    process.chdir(tmpDir);
+
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      const report = await runDoctor({ mode: "agent", json: true, failOn: "fail" });
+
+      expect(report.checks.some((check) => check.status === "fail")).toBe(true);
       expect(process.exitCode).toBe(1);
     } finally {
       process.exitCode = previousExitCode;

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -3022,9 +3022,8 @@ function applyDoctorExitCode(
     return;
   }
 
-  const shouldFail = failOn === "warn"
-    ? hasNonPassingDoctorCheck(report)
-    : hasFailingDoctorCheck(report);
+  const shouldFail =
+    failOn === "warn" ? hasNonPassingDoctorCheck(report) : hasFailingDoctorCheck(report);
 
   if (shouldFail) {
     process.exitCode = 1;

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -48,12 +48,14 @@ type DoctorStatus = "pass" | "warn" | "fail";
 type AgentDoctorGrade = "Agent-optimized" | "Agent-ready" | "Promising" | "Needs work";
 type HumanDoctorGrade = "Human-optimized" | "Reader-ready" | "Promising" | "Needs work";
 type DoctorMode = "agent" | "human";
+type DoctorFailOn = "warn" | "fail";
 
 export interface DoctorOptions {
   configPath?: string;
   mode?: DoctorMode;
   json?: boolean;
   strict?: boolean;
+  failOn?: DoctorFailOn;
   url?: string;
 }
 
@@ -166,6 +168,11 @@ function parseDoctorOnlyMode(value: string): DoctorMode {
   throw new Error("Invalid value for --only. Expected agent or site.");
 }
 
+function parseDoctorFailOn(value: string): DoctorFailOn {
+  if (value === "warn" || value === "fail") return value;
+  throw new Error("Invalid value for --fail-on. Expected warn or fail.");
+}
+
 export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
   const parsed: ParsedDoctorArgs = {};
 
@@ -189,6 +196,25 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
 
     if (arg === "--strict") {
       parsed.strict = true;
+      continue;
+    }
+
+    if (arg.startsWith("--fail-on=")) {
+      const value = parseInlineFlag(arg).value;
+      if (!value) {
+        throw new Error("Missing value for --fail-on.");
+      }
+      parsed.failOn = parseDoctorFailOn(value);
+      continue;
+    }
+
+    if (arg === "--fail-on") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("Missing value for --fail-on.");
+      }
+      parsed.failOn = parseDoctorFailOn(value);
+      index += 1;
       continue;
     }
 
@@ -274,6 +300,7 @@ ${pc.dim("Usage:")}
   pnpm exec docs doctor --site
   pnpm exec docs doctor --agent --json
   pnpm exec docs doctor --agent --strict
+  pnpm exec docs doctor --agent --fail-on fail
   pnpm exec docs doctor --only agent
   pnpm exec docs doctor --only site
   pnpm exec docs doctor agent
@@ -286,6 +313,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--only <mode>")}      Run only one doctor suite: ${pc.cyan("agent")} or ${pc.cyan("site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
+  ${pc.cyan("--fail-on <level>")}  Exit with failure on ${pc.cyan("warn")} or only on ${pc.cyan("fail")}
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}
   ${pc.cyan("--config <path>")}    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
   ${pc.cyan("-h, --help")}         Show this help message
@@ -2981,11 +3009,24 @@ function hasNonPassingDoctorCheck(report: AgentDoctorReport | HumanDoctorReport)
   return report.checks.some((check) => check.status !== "pass");
 }
 
-function applyStrictExitCode(
+function hasFailingDoctorCheck(report: AgentDoctorReport | HumanDoctorReport) {
+  return report.checks.some((check) => check.status === "fail");
+}
+
+function applyDoctorExitCode(
   report: AgentDoctorReport | HumanDoctorReport,
   options: DoctorOptions,
 ) {
-  if (options.strict && hasNonPassingDoctorCheck(report)) {
+  const failOn = options.failOn ?? (options.strict ? "warn" : undefined);
+  if (!failOn) {
+    return;
+  }
+
+  const shouldFail = failOn === "warn"
+    ? hasNonPassingDoctorCheck(report)
+    : hasFailingDoctorCheck(report);
+
+  if (shouldFail) {
     process.exitCode = 1;
   }
 }
@@ -2993,7 +3034,7 @@ function applyStrictExitCode(
 export async function runDoctor(options: DoctorOptions = {}) {
   if (options.mode === "human") {
     const report = await inspectHumanReadiness(options);
-    applyStrictExitCode(report, options);
+    applyDoctorExitCode(report, options);
     if (options.json) {
       printDoctorJsonReport(report);
       return report;
@@ -3003,7 +3044,7 @@ export async function runDoctor(options: DoctorOptions = {}) {
   }
 
   const report = await inspectAgentReadiness(options);
-  applyStrictExitCode(report, options);
+  applyDoctorExitCode(report, options);
   if (options.json) {
     printDoctorJsonReport(report);
     return report;

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -392,6 +392,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --human")}                      Alias for ${pc.cyan("doctor --site")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
   ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
+  ${pc.cyan("doctor --fail-on warn|fail")}          Choose whether warnings or only failures fail CI
   ${pc.cyan("doctor agent")}                        Subcommand alias for agent scoring
   ${pc.cyan("doctor site")}                         Subcommand alias for reader-facing scoring
   ${pc.cyan("doctor human")}                        Legacy alias for reader-facing scoring


### PR DESCRIPTION
Adds an explicit `docs doctor --fail-on warn|fail` threshold for CI runs.

What changed:
- Parses `--fail-on warn` and `--fail-on=fail` for doctor runs.
- Keeps `--strict` compatible as the warn-level failure behavior.

Validation:
- `pnpm --filter @farming-labs/docs test -- src/cli/doctor.test.ts`
- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm --filter @farming-labs/docs build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs doctor --fail-on warn|fail` to control CI failure thresholds. Keeps `--strict` as the warn-level behavior for backward compatibility.

- **New Features**
  - Parses `--fail-on warn` and `--fail-on=fail` with validation.
  - Updates help text in the doctor CLI (and top-level help) to document the flag.
  - Applies exit codes based on the chosen level: `warn` fails on warnings or failures; `fail` fails only on failures.
  - Adds tests for parsing, invalid values, and exit-code behavior (warnings vs failures).

- **Migration**
  - In CI, prefer `--fail-on warn` (equivalent to `--strict`), or use `--fail-on fail` to ignore warnings. Example: `pnpm exec docs doctor --human --json --fail-on fail`.

<sup>Written for commit 5075f91ef9333b7981c1209c0c52767463492220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

