### PR TITLE
feat: add reading time label format

### DIFF
--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -141,7 +141,19 @@ const readingTimeValue =
   typeof data.readingTime === "number"
     ? Math.max(1, Math.ceil(data.readingTime))
     : null;
-const readingTimeLabel = readingTimeValue ? `${readingTimeValue} min read` : null;
+const readingTimeConfig = config?.readingTime;
+const readingTimeFormat =
+  data.readingTimeFormat === "short" ||
+  (readingTimeConfig &&
+    typeof readingTimeConfig === "object" &&
+    (readingTimeConfig as { format?: string }).format === "short")
+    ? "short"
+    : "long";
+const readingTimeLabel = readingTimeValue
+  ? readingTimeFormat === "short"
+    ? `${readingTimeValue} min`
+    : `${readingTimeValue} min read`
+  : null;
 const showReadingTimeAbove = !!readingTimeLabel && showActionsAbove;
 const showReadingTimeBelow =
   !!readingTimeLabel &&

--- a/packages/astro-theme/src/components/DocsContent.astro
+++ b/packages/astro-theme/src/components/DocsContent.astro
@@ -143,12 +143,13 @@ const readingTimeValue =
     : null;
 const readingTimeConfig = config?.readingTime;
 const readingTimeFormat =
-  data.readingTimeFormat === "short" ||
-  (readingTimeConfig &&
-    typeof readingTimeConfig === "object" &&
-    (readingTimeConfig as { format?: string }).format === "short")
-    ? "short"
-    : "long";
+  data.readingTimeFormat === "short" || data.readingTimeFormat === "long"
+    ? data.readingTimeFormat
+    : readingTimeConfig &&
+        typeof readingTimeConfig === "object" &&
+        (readingTimeConfig as { format?: string }).format === "short"
+      ? "short"
+      : "long";
 const readingTimeLabel = readingTimeValue
   ? readingTimeFormat === "short"
     ? `${readingTimeValue} min`

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -197,6 +197,7 @@ export interface DocsServer {
     html: string;
     rawMarkdown?: string;
     readingTime?: number | null;
+    readingTimeFormat?: "long" | "short";
     entry?: string;
     locale?: string;
     slug?: string;
@@ -811,6 +812,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       html,
       rawMarkdown: humanRawContent,
       readingTime,
+      readingTimeFormat: readingTimeOptions.format,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -265,6 +265,7 @@ export type {
   OrderingItem,
   LastUpdatedConfig,
   ReadingTimeConfig,
+  ReadingTimeFormat,
   CodeBlockCopyData,
   DocsFeedbackValue,
   DocsFeedbackData,

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -327,7 +327,7 @@ const DOCS_CONFIG_SCHEMA_OPTIONS: DocsMcpConfigSchemaOption[] = [
     name: "readingTime",
     type: "boolean | ReadingTimeConfig",
     default: false,
-    description: "Opt-in estimated reading time label with per-page overrides.",
+    description: "Opt-in estimated reading time label with per-page overrides and label format.",
   },
   {
     path: "agent",

--- a/packages/docs/src/reading-time.test.ts
+++ b/packages/docs/src/reading-time.test.ts
@@ -45,7 +45,18 @@ describe("reading time helpers", () => {
   });
 
   it("treats null config as disabled", () => {
-    expect(resolveReadingTimeOptions(null)).toEqual({ enabled: false });
+    expect(resolveReadingTimeOptions(null)).toEqual({ enabled: false, format: "long" });
+  });
+
+  it("resolves short reading-time labels from config", () => {
+    expect(resolveReadingTimeOptions({ enabled: true, format: "short" })).toMatchObject({
+      enabled: true,
+      format: "short",
+    });
+    expect(resolveReadingTimeOptions({ enabled: true, format: "verbose" as never })).toMatchObject({
+      enabled: true,
+      format: "long",
+    });
   });
 
   it("ignores four-backtick fenced code blocks", () => {

--- a/packages/docs/src/reading-time.ts
+++ b/packages/docs/src/reading-time.ts
@@ -1,9 +1,10 @@
 import matter from "gray-matter";
-import type { PageFrontmatter, ReadingTimeConfig } from "./types.js";
+import type { PageFrontmatter, ReadingTimeConfig, ReadingTimeFormat } from "./types.js";
 
 export interface ResolvedReadingTimeOptions {
   enabled: boolean;
   wordsPerMinute?: number;
+  format: ReadingTimeFormat;
 }
 
 function hasExplicitReadingTime(frontmatter: Partial<PageFrontmatter> | undefined): boolean {
@@ -38,11 +39,11 @@ export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: num
 export function resolveReadingTimeOptions(
   readingTime: boolean | ReadingTimeConfig | null | undefined,
 ): ResolvedReadingTimeOptions {
-  if (readingTime === true) return { enabled: true };
+  if (readingTime === true) return { enabled: true, format: "long" };
   if (readingTime === false || readingTime === undefined || readingTime === null) {
-    return { enabled: false };
+    return { enabled: false, format: "long" };
   }
-  if (typeof readingTime !== "object") return { enabled: false };
+  if (typeof readingTime !== "object") return { enabled: false, format: "long" };
 
   return {
     enabled: readingTime.enabled !== false,
@@ -50,6 +51,7 @@ export function resolveReadingTimeOptions(
       typeof readingTime.wordsPerMinute === "number" && Number.isFinite(readingTime.wordsPerMinute)
         ? readingTime.wordsPerMinute
         : undefined,
+    format: readingTime.format === "short" ? "short" : "long",
   };
 }
 

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1411,6 +1411,8 @@ export interface LastUpdatedConfig {
   position?: "footer" | "below-title";
 }
 
+export type ReadingTimeFormat = "long" | "short";
+
 /**
  * Configuration for estimated page reading time.
  *
@@ -1430,6 +1432,14 @@ export interface ReadingTimeConfig {
    * @default 220
    */
   wordsPerMinute?: number;
+  /**
+   * Label style used when rendering the reading-time estimate.
+   *
+   * `"long"` renders labels like `3 min read`; `"short"` renders `3 min`.
+   *
+   * @default "long"
+   */
+  format?: ReadingTimeFormat;
 }
 
 /**

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -319,6 +319,21 @@ describe("createDocsLayout pageActions", () => {
     });
   });
 
+  it("passes the configured reading-time label format through to DocsPageClient", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      readingTime: { enabled: true, format: "short" },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.readingTimeFormat).toBe("short");
+  });
+
   it("lets per-page frontmatter override a disabled global reading-time config", () => {
     mkdirSync(join(tmpDir, "app", "docs", "guide"), { recursive: true });
     writeFileSync(

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -966,6 +966,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
   const readingTimeEnabledByDefault = readingTimeOptions.enabled;
   const readingTimeWordsPerMinute = readingTimeOptions.wordsPerMinute ?? 220;
+  const readingTimeFormat = readingTimeOptions.format;
 
   // llms.txt config
   const llmsTxtEnabled = resolveEnabledByDefault(config.llmsTxt);
@@ -1156,6 +1157,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             lastUpdatedEnabled={lastUpdatedEnabled}
             lastUpdatedPosition={lastUpdatedPosition}
             readingTimeEnabled={readingTimeEnabled}
+            readingTimeFormat={readingTimeFormat}
             readingTimeMap={readingTimeMap}
             structuredDataMap={structuredDataMap}
             llmsTxtEnabled={llmsTxtEnabled}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -4,7 +4,7 @@ import { DocsBody, DocsPage, EditOnGitHub } from "fumadocs-ui/layouts/docs/page"
 import { Children, Fragment, useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { usePathname, useRouter } from "fumadocs-core/framework";
-import type { DocsFeedbackData } from "@farming-labs/docs";
+import type { DocsFeedbackData, ReadingTimeFormat } from "@farming-labs/docs";
 import { PageActions } from "./page-actions.js";
 import { useWindowSearchParams } from "./client-location.js";
 import { DocsFeedback } from "./docs-feedback.js";
@@ -77,6 +77,8 @@ interface DocsPageClientProps {
   readingTimeMap?: Record<string, number>;
   /** Direct reading-time override for the current page. */
   readingTime?: number | null;
+  /** Reading-time label style. */
+  readingTimeFormat?: ReadingTimeFormat;
   /** Map of pathname → serialized Schema.org JSON-LD. */
   structuredDataMap?: Record<string, string>;
   /** Direct serialized Schema.org JSON-LD override for the current page. */
@@ -382,9 +384,9 @@ function decodeHashTarget(hash: string): string {
   }
 }
 
-function formatReadingTimeLabel(minutes: number): string {
+function formatReadingTimeLabel(minutes: number, format: ReadingTimeFormat = "long"): string {
   const normalized = Math.max(1, Math.ceil(minutes));
-  return `${normalized} min read`;
+  return format === "short" ? `${normalized} min` : `${normalized} min read`;
 }
 
 function escapeIdSelector(value: string): string {
@@ -501,6 +503,7 @@ export function DocsPageClient({
   lastModified: lastModifiedProp,
   readingTimeMap,
   readingTime: readingTimeProp,
+  readingTimeFormat = "long",
   structuredDataMap,
   structuredData: structuredDataProp,
   readingTimeEnabled = false,
@@ -768,7 +771,9 @@ export function DocsPageClient({
         <span className="fd-page-meta-dot" aria-hidden="true">
           ·
         </span>
-        <span className="fd-page-meta-item">{formatReadingTimeLabel(resolvedReadingTime)}</span>
+        <span className="fd-page-meta-item">
+          {formatReadingTimeLabel(resolvedReadingTime, readingTimeFormat)}
+        </span>
       </div>
     ) : undefined;
 

--- a/packages/fumadocs/src/reading-time.ts
+++ b/packages/fumadocs/src/reading-time.ts
@@ -1,9 +1,10 @@
 import matter from "gray-matter";
-import type { PageFrontmatter, ReadingTimeConfig } from "@farming-labs/docs";
+import type { PageFrontmatter, ReadingTimeConfig, ReadingTimeFormat } from "@farming-labs/docs";
 
 export interface ResolvedReadingTimeOptions {
   enabled: boolean;
   wordsPerMinute?: number;
+  format: ReadingTimeFormat;
 }
 
 function hasExplicitReadingTime(frontmatter: Partial<PageFrontmatter> | undefined): boolean {
@@ -38,11 +39,11 @@ export function estimateReadingTimeMinutes(content: string, wordsPerMinute?: num
 export function resolveReadingTimeOptions(
   readingTime: boolean | ReadingTimeConfig | null | undefined,
 ): ResolvedReadingTimeOptions {
-  if (readingTime === true) return { enabled: true };
+  if (readingTime === true) return { enabled: true, format: "long" };
   if (readingTime === false || readingTime === undefined || readingTime === null) {
-    return { enabled: false };
+    return { enabled: false, format: "long" };
   }
-  if (typeof readingTime !== "object") return { enabled: false };
+  if (typeof readingTime !== "object") return { enabled: false, format: "long" };
 
   return {
     enabled: readingTime.enabled !== false,
@@ -50,6 +51,7 @@ export function resolveReadingTimeOptions(
       typeof readingTime.wordsPerMinute === "number" && Number.isFinite(readingTime.wordsPerMinute)
         ? readingTime.wordsPerMinute
         : undefined,
+    format: readingTime.format === "short" ? "short" : "long",
   };
 }
 

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -380,7 +380,8 @@ export function TanstackDocsLayout({
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
-  const readingTimeEnabled = resolveReadingTimeOptions(config.readingTime).enabled;
+  const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
+  const readingTimeEnabled = readingTimeOptions.enabled;
 
   const llmsTxtEnabled = resolveEnabledByDefault(config.llmsTxt);
   const feedbackConfig = resolveFeedbackConfig(config.feedback);
@@ -526,6 +527,7 @@ export function TanstackDocsLayout({
           lastUpdatedPosition={lastUpdatedPosition}
           lastModified={lastModified}
           readingTimeEnabled={readingTimeEnabled}
+          readingTimeFormat={readingTimeOptions.format}
           readingTime={typeof readingTime === "number" ? readingTime : undefined}
           llmsTxtEnabled={llmsTxtEnabled}
           description={description}

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
     html: string;
     rawMarkdown?: string;
     readingTime?: number | null;
+    readingTimeFormat?: "long" | "short";
     previousPage?: { name: string; url: string } | null;
     nextPage?: { name: string; url: string } | null;
     editOnGithub?: string;
@@ -55,6 +56,20 @@ type FeedbackPayload = {
   slug: string;
   locale?: string;
 };
+
+function resolveReadingTimeFormat(
+  config: Record<string, unknown> | null | undefined,
+  data: { readingTimeFormat?: "long" | "short" },
+) {
+  if (data.readingTimeFormat === "short") return "short";
+
+  const readingTime = config?.readingTime;
+  return readingTime &&
+    typeof readingTime === "object" &&
+    (readingTime as { format?: unknown }).format === "short"
+    ? "short"
+    : "long";
+}
 
 interface DocsWindowHooks extends Window {
   __fdOnFeedback__?: (payload: FeedbackPayload) => void | Promise<void>;
@@ -239,8 +254,13 @@ const readingTimeValue = computed(() =>
     ? Math.max(1, Math.ceil(props.data.readingTime))
     : null,
 );
+const readingTimeFormat = computed(() => resolveReadingTimeFormat(props.config, props.data));
 const readingTimeLabel = computed(() =>
-  readingTimeValue.value ? `${readingTimeValue.value} min read` : null,
+  readingTimeValue.value
+    ? readingTimeFormat.value === "short"
+      ? `${readingTimeValue.value} min`
+      : `${readingTimeValue.value} min read`
+    : null,
 );
 const showReadingTimeAbove = computed(() => !!readingTimeLabel.value && showActionsAbove.value);
 const showReadingTimeBelow = computed(

--- a/packages/nuxt-theme/src/components/DocsContent.vue
+++ b/packages/nuxt-theme/src/components/DocsContent.vue
@@ -61,7 +61,9 @@ function resolveReadingTimeFormat(
   config: Record<string, unknown> | null | undefined,
   data: { readingTimeFormat?: "long" | "short" },
 ) {
-  if (data.readingTimeFormat === "short") return "short";
+  if (data.readingTimeFormat === "short" || data.readingTimeFormat === "long") {
+    return data.readingTimeFormat;
+  }
 
   const readingTime = config?.readingTime;
   return readingTime &&

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -185,6 +185,7 @@ export interface DocsServer {
     description?: string;
     html: string;
     readingTime?: number | null;
+    readingTimeFormat?: "long" | "short";
     entry?: string;
     locale?: string;
     slug?: string;
@@ -801,6 +802,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       description,
       html,
       readingTime,
+      readingTimeFormat: readingTimeOptions.format,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -75,7 +75,9 @@
   }
 
   function resolveReadingTimeFormat(config, data) {
-    if (data?.readingTimeFormat === "short") return "short";
+    if (data?.readingTimeFormat === "short" || data?.readingTimeFormat === "long") {
+      return data.readingTimeFormat;
+    }
 
     const readingTime = config?.readingTime;
     return readingTime && typeof readingTime === "object" && readingTime.format === "short"

--- a/packages/svelte-theme/src/components/DocsContent.svelte
+++ b/packages/svelte-theme/src/components/DocsContent.svelte
@@ -74,6 +74,15 @@
       .replace(/\{url\}/g, values.url);
   }
 
+  function resolveReadingTimeFormat(config, data) {
+    if (data?.readingTimeFormat === "short") return "short";
+
+    const readingTime = config?.readingTime;
+    return readingTime && typeof readingTime === "object" && readingTime.format === "short"
+      ? "short"
+      : "long";
+  }
+
   let breadcrumbEnabled = $derived.by(() => {
     const bc = config?.breadcrumb;
     if (bc === undefined || bc === true) return true;
@@ -194,7 +203,14 @@
       ? Math.max(1, Math.ceil(data.readingTime))
       : null
   );
-  let readingTimeLabel = $derived(readingTimeValue ? `${readingTimeValue} min read` : null);
+  let readingTimeFormat = $derived(resolveReadingTimeFormat(config, data));
+  let readingTimeLabel = $derived(
+    readingTimeValue
+      ? readingTimeFormat === "short"
+        ? `${readingTimeValue} min`
+        : `${readingTimeValue} min read`
+      : null
+  );
   let showReadingTimeAbove = $derived(!!readingTimeLabel && showActionsAbove);
   let showReadingTimeBelow = $derived(
     !!readingTimeLabel &&

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -205,6 +205,7 @@ export interface DocsServer {
     description?: string;
     html: string;
     readingTime?: number | null;
+    readingTimeFormat?: "long" | "short";
     entry?: string;
     locale?: string;
     slug?: string;
@@ -820,6 +821,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       description,
       html,
       readingTime,
+      readingTimeFormat: readingTimeOptions.format,
       entry,
       locale: ctx.locale,
       ...(isIndex ? {} : { slug }),

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -159,6 +159,7 @@ export interface DocsServerLoadResult {
   description?: string;
   rawContent: string;
   readingTime?: number | null;
+  readingTimeFormat?: "long" | "short";
   sourcePath: string;
   entry?: string;
   locale?: string;
@@ -781,6 +782,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       description,
       rawContent: content,
       readingTime,
+      readingTimeFormat: readingTimeOptions.format,
       sourcePath: toSourcePath(ctx.contentDirRel, relPath, rootDir),
       entry,
       locale: ctx.locale,


### PR DESCRIPTION
## Summary
- add `readingTime.format` with `"long"` as the default and `"short"` for labels like `3 min`
- pass the normalized reading-time format through React, TanStack, Astro, Nuxt, and Svelte render paths
- expose the normalized format in adapter load results for custom consumers
- intentionally leave markdown docs unchanged so the knowledge drift workflow can generate the docs update after merge

## Validation
- pnpm --filter @farming-labs/docs exec vitest run src/reading-time.test.ts
- pnpm --filter @farming-labs/theme exec vitest run src/docs-layout.test.ts
- pnpm --filter @farming-labs/docs run typecheck
- pnpm --filter @farming-labs/docs run build
- pnpm --filter @farming-labs/theme run typecheck
- pnpm --filter @farming-labs/astro --filter @farming-labs/nuxt --filter @farming-labs/svelte --filter @farming-labs/tanstack-start --filter @farming-labs/astro-theme --filter @farming-labs/nuxt-theme --filter @farming-labs/svelte-theme run typecheck
- pnpm format:check

## Knowledge drift test
After this PR is merged, the drift workflow should detect the new `readingTime.format` option and target existing reading-time docs instead of creating an unrelated page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a configurable reading-time label format, including a new "short" option that renders "3 min". Default stays "long", and themes/servers now pass and prefer the normalized format to prevent mismatched labels.

- **New Features**
  - Introduced `ReadingTimeFormat` and `readingTime.format` with `"long"` (default) or `"short"`.
  - Normalized format is propagated through `@farming-labs/docs`, `fumadocs` (via `DocsPageClient`), and adapters/themes (`@farming-labs/astro`, `@farming-labs/nuxt`, `@farming-labs/svelte`, `@farming-labs/tanstack-start`), and included in server load results as `readingTimeFormat`.
  - UI components in `astro-theme`, `nuxt-theme`, `svelte-theme`, and `fumadocs` render short labels when configured.
  - Added tests for format resolution and pass-through.

- **Bug Fixes**
  - Prefer the normalized `readingTimeFormat` from load results over theme config; fall back to config, then `"long"`.

<sup>Written for commit 5d2aaad65041f9e648db88f9a18b892a1f6d7e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

