### PR TITLE
feat: require comments for page feedback

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2133,6 +2133,8 @@ export interface FeedbackConfig {
   question?: string;
   /** Placeholder shown in the optional free-form feedback field. @default "Leave your feedback..." */
   placeholder?: string;
+  /** Require a non-empty comment before feedback can be submitted. @default false */
+  requireComment?: boolean;
   /** Label for the positive button. @default "Good" */
   positiveLabel?: string;
   /** Label for the negative button. @default "Bad" */

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -14,6 +14,7 @@ export interface DocsFeedbackProps {
   locale?: string;
   question?: string;
   placeholder?: string;
+  requireComment?: boolean;
   positiveLabel?: string;
   negativeLabel?: string;
   submitLabel?: string;
@@ -154,6 +155,7 @@ export function DocsFeedback({
   locale,
   question = "How is this guide?",
   placeholder = "Leave your feedback...",
+  requireComment = false,
   positiveLabel = "Good",
   negativeLabel = "Bad",
   submitLabel = "Submit",
@@ -165,6 +167,7 @@ export function DocsFeedback({
   const [status, setStatus] = useState<"idle" | "submitting" | "submitted" | "error">("idle");
   const normalizedPathname = useMemo(() => normalizePathname(pathname), [pathname]);
   const showForm = selected !== null;
+  const commentRequired = requireComment && comment.trim().length === 0;
   const submitButtonLabel = status === "submitted" ? "Submitted" : submitLabel;
 
   useEffect(() => {
@@ -199,7 +202,7 @@ export function DocsFeedback({
   }
 
   async function handleSubmit() {
-    if (!selected || status === "submitting") return;
+    if (!selected || status === "submitting" || commentRequired) return;
 
     setStatus("submitting");
     const payload = buildFeedbackPayload(selected, normalizedPathname, entry, comment, locale);
@@ -274,6 +277,8 @@ export function DocsFeedback({
             className="fd-feedback-input"
             aria-label="Additional feedback"
             placeholder={placeholder}
+            required={requireComment}
+            aria-required={requireComment}
             value={comment}
             disabled={status === "submitting"}
             onChange={(event) => {
@@ -285,7 +290,7 @@ export function DocsFeedback({
             <button
               type="button"
               className="fd-page-action-btn fd-feedback-submit"
-              disabled={status === "submitting" || status === "submitted"}
+              disabled={status === "submitting" || status === "submitted" || commentRequired}
               onClick={() => void handleSubmit()}
             >
               {status === "submitting" && (

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -254,6 +254,24 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.openDocs).toBe(false);
   });
 
+  it("passes required feedback comments through to DocsPageClient", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      feedback: {
+        requireComment: true,
+      },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.feedbackEnabled).toBe(true);
+    expect(props?.feedbackRequireComment).toBe(true);
+  });
+
   it("keeps reading time disabled when the config is unconfigured", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1165,6 +1165,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             feedbackEnabled={feedbackConfig.enabled}
             feedbackQuestion={feedbackConfig.question}
             feedbackPlaceholder={feedbackConfig.placeholder}
+            feedbackRequireComment={feedbackConfig.requireComment}
             feedbackPositiveLabel={feedbackConfig.positiveLabel}
             feedbackNegativeLabel={feedbackConfig.negativeLabel}
             feedbackSubmitLabel={feedbackConfig.submitLabel}
@@ -1196,6 +1197,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     enabled: false,
     question: "How is this guide?",
     placeholder: "Leave your feedback...",
+    requireComment: false,
     positiveLabel: "Good",
     negativeLabel: "Bad",
     submitLabel: "Submit",
@@ -1208,6 +1210,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     feedback.enabled !== undefined ||
     feedback.question !== undefined ||
     feedback.placeholder !== undefined ||
+    feedback.requireComment !== undefined ||
     feedback.positiveLabel !== undefined ||
     feedback.negativeLabel !== undefined ||
     feedback.submitLabel !== undefined ||
@@ -1217,6 +1220,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     enabled: feedback.enabled === true || (feedback.enabled !== false && hasHumanFeedbackConfig),
     question: feedback.question ?? defaults.question,
     placeholder: feedback.placeholder ?? defaults.placeholder,
+    requireComment: feedback.requireComment ?? defaults.requireComment,
     positiveLabel: feedback.positiveLabel ?? defaults.positiveLabel,
     negativeLabel: feedback.negativeLabel ?? defaults.negativeLabel,
     submitLabel: feedback.submitLabel ?? defaults.submitLabel,

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -102,6 +102,7 @@ interface DocsPageClientProps {
   feedbackEnabled?: boolean;
   feedbackQuestion?: string;
   feedbackPlaceholder?: string;
+  feedbackRequireComment?: boolean;
   feedbackPositiveLabel?: string;
   feedbackNegativeLabel?: string;
   feedbackSubmitLabel?: string;
@@ -515,6 +516,7 @@ export function DocsPageClient({
   feedbackEnabled = false,
   feedbackQuestion,
   feedbackPlaceholder,
+  feedbackRequireComment,
   feedbackPositiveLabel,
   feedbackNegativeLabel,
   feedbackSubmitLabel,
@@ -960,6 +962,7 @@ export function DocsPageClient({
               locale={activeLocale}
               question={feedbackQuestion}
               placeholder={feedbackPlaceholder}
+              requireComment={feedbackRequireComment}
               positiveLabel={feedbackPositiveLabel}
               negativeLabel={feedbackNegativeLabel}
               submitLabel={feedbackSubmitLabel}

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -286,6 +286,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     enabled: false,
     question: "How is this guide?",
     placeholder: "Leave your feedback...",
+    requireComment: false,
     positiveLabel: "Good",
     negativeLabel: "Bad",
     submitLabel: "Submit",
@@ -298,6 +299,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     feedback.enabled !== undefined ||
     feedback.question !== undefined ||
     feedback.placeholder !== undefined ||
+    feedback.requireComment !== undefined ||
     feedback.positiveLabel !== undefined ||
     feedback.negativeLabel !== undefined ||
     feedback.submitLabel !== undefined ||
@@ -307,6 +309,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     enabled: feedback.enabled === true || (feedback.enabled !== false && hasHumanFeedbackConfig),
     question: feedback.question ?? defaults.question,
     placeholder: feedback.placeholder ?? defaults.placeholder,
+    requireComment: feedback.requireComment ?? defaults.requireComment,
     positiveLabel: feedback.positiveLabel ?? defaults.positiveLabel,
     negativeLabel: feedback.negativeLabel ?? defaults.negativeLabel,
     submitLabel: feedback.submitLabel ?? defaults.submitLabel,
@@ -534,6 +537,7 @@ export function TanstackDocsLayout({
           feedbackEnabled={feedbackConfig.enabled}
           feedbackQuestion={feedbackConfig.question}
           feedbackPlaceholder={feedbackConfig.placeholder}
+          feedbackRequireComment={feedbackConfig.requireComment}
           feedbackPositiveLabel={feedbackConfig.positiveLabel}
           feedbackNegativeLabel={feedbackConfig.negativeLabel}
           feedbackSubmitLabel={feedbackConfig.submitLabel}


### PR DESCRIPTION
## Summary

Adds a `feedback.requireComment` option for the human page feedback UI.

When enabled, readers must enter a non-empty comment before submitting Good/Bad page feedback. The textarea is marked as required and the submit action is disabled until the comment has content.

## Source behavior changed

- `FeedbackConfig` now includes `requireComment?: boolean`.
- Next/Fumadocs and TanStack layout config resolution pass `feedback.requireComment` into the client page shell.
- `DocsFeedback` prevents submission while the required comment is empty.
- Agent feedback endpoints are unchanged; this only affects the human page footer feedback UI.

## Docs drift test

This PR intentionally does not edit docs content. After this source PR is merged, prod knowledge drift should detect the public config change and draft docs updates for the existing feedback/config reference pages.

Expected docs targets include:
- `website/app/docs/configuration/page.mdx`
- `website/app/docs/reference/page.mdx`

## Validation

- `pnpm typecheck`
- `pnpm --filter @farming-labs/docs test`
- `pnpm --dir packages/fumadocs exec vitest run src/docs-layout.test.ts`
- `pnpm --dir packages/fumadocs exec vitest run src/tanstack-layout.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `feedback.requireComment` to require a non-empty comment before submitting Good/Bad page feedback. Default is false; only affects the human page footer UI and makes no API changes.

- **New Features**
  - Extend `FeedbackConfig` with `requireComment?: boolean`.
  - Pass the option through `createDocsLayout` and `TanstackDocsLayout` to `DocsPageClient`, then to `DocsFeedback`.
  - In `DocsFeedback`, mark the textarea required, set `aria-required`, and disable submit until filled; tests cover config propagation.

<sup>Written for commit 4dcbe371bfd9b5dcfea18f7c82513c318b11e5a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

