### PR TITLE
feat: add copy markdown action labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "fast-uri": "3.1.2",
       "rollup": "^4.59.0",
       "tar": "^7.5.11",
+      "ws": "^8.21.0",
       "readdir-glob>minimatch": "^5.1.8",
       "glob@10>minimatch": "^9.0.7",
       "glob@13>minimatch": "^10.2.3"

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -693,6 +693,10 @@ export interface OpenDocsConfig {
 export interface CopyMarkdownConfig {
   /** Whether to show the "Copy Markdown" button. @default false */
   enabled?: boolean;
+  /** Button label shown before the page is copied. @default "Copy page" */
+  label?: string;
+  /** Button label shown after a successful copy. @default "Copied!" */
+  copiedLabel?: string;
 }
 
 /**

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -97,7 +97,7 @@ describe("createDocsLayout pageActions", () => {
       entry: "docs",
       pageActions: {
         alignment: "right",
-        copyMarkdown: { enabled: true },
+        copyMarkdown: { enabled: true, label: "Copy docs", copiedLabel: "Copied docs" },
         openDocs: { enabled: true },
       },
     });
@@ -109,6 +109,8 @@ describe("createDocsLayout pageActions", () => {
 
     expect(props).toBeTruthy();
     expect(props?.copyMarkdown).toBe(true);
+    expect(props?.copyMarkdownLabel).toBe("Copy docs");
+    expect(props?.copyMarkdownCopiedLabel).toBe("Copied docs");
     expect(props?.openDocs).toBe(true);
     expect(props?.pageActionsAlignment).toBe("right");
     expect(props?.pageActionsPosition).toBe("below-title");

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -26,6 +26,7 @@ import type {
   OrderingItem,
   PageFrontmatter,
   OpenDocsConfig,
+  CopyMarkdownConfig,
 } from "@farming-labs/docs";
 import { DocsPageClient } from "./docs-page-client.js";
 import { DocsAIFeatures } from "./docs-ai-features.js";
@@ -952,6 +953,10 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   // Page actions (Copy Markdown, Open in …)
   const pageActions = config.pageActions;
   const copyMarkdownEnabled = resolveBool(pageActions?.copyMarkdown);
+  const copyMarkdownConfig =
+    pageActions?.copyMarkdown && typeof pageActions.copyMarkdown === "object"
+      ? (pageActions.copyMarkdown as CopyMarkdownConfig)
+      : undefined;
   const openDocsEnabled = resolveBool(pageActions?.openDocs);
   const pageActionsPosition = pageActions?.position ?? "below-title";
   const pageActionsAlignment = pageActions?.alignment ?? "left";
@@ -1143,6 +1148,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             publicPath={localeContext.publicPath}
             locale={activeLocale}
             copyMarkdown={copyMarkdownEnabled}
+            copyMarkdownLabel={copyMarkdownConfig?.label}
+            copyMarkdownCopiedLabel={copyMarkdownConfig?.copiedLabel}
             openDocs={openDocsEnabled}
             openDocsProviders={openDocsProviders as any}
             openDocsTarget={openDocsConfig?.target}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -51,6 +51,8 @@ interface DocsPageClientProps {
   /** Active locale (used for llms.txt links) */
   locale?: string;
   copyMarkdown?: boolean;
+  copyMarkdownLabel?: string;
+  copyMarkdownCopiedLabel?: string;
   openDocs?: boolean;
   openDocsProviders?: SerializedProvider[];
   openDocsTarget?: "markdown" | "page" | "source" | "github";
@@ -489,6 +491,8 @@ export function DocsPageClient({
   publicPath,
   locale,
   copyMarkdown = false,
+  copyMarkdownLabel,
+  copyMarkdownCopiedLabel,
   openDocs = false,
   openDocsProviders,
   openDocsTarget,
@@ -808,6 +812,8 @@ export function DocsPageClient({
           >
             <PageActions
               copyMarkdown={copyMarkdown}
+              copyMarkdownLabel={copyMarkdownLabel}
+              copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
               openDocs={openDocs}
               providers={openDocsProviders}
               openDocsTarget={openDocsTarget}
@@ -868,6 +874,8 @@ export function DocsPageClient({
           <div className="fd-actions-toc-portal not-prose">
             <PageActions
               copyMarkdown={copyMarkdown}
+              copyMarkdownLabel={copyMarkdownLabel}
+              copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
               openDocs={openDocs}
               providers={openDocsProviders}
               openDocsTarget={openDocsTarget}
@@ -935,6 +943,8 @@ export function DocsPageClient({
             >
               <PageActions
                 copyMarkdown={copyMarkdown}
+                copyMarkdownLabel={copyMarkdownLabel}
+                copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
                 openDocs={openDocs}
                 providers={openDocsProviders}
                 openDocsTarget={openDocsTarget}

--- a/packages/fumadocs/src/page-actions.test.ts
+++ b/packages/fumadocs/src/page-actions.test.ts
@@ -30,6 +30,19 @@ describe("PageActions alignment", () => {
     expect(html).toContain('data-actions-alignment="right"');
   });
 
+  it("renders a custom copy button label", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PageActions, {
+        copyMarkdown: true,
+        copyMarkdownLabel: "Copy docs",
+        providers: [],
+      }),
+    );
+
+    expect(html).toContain("Copy docs");
+    expect(html).not.toContain("Copy page");
+  });
+
   it("uses /index.md for root markdown links", () => {
     mockRouterState.pathname = "/";
 

--- a/packages/fumadocs/src/page-actions.test.ts
+++ b/packages/fumadocs/src/page-actions.test.ts
@@ -30,19 +30,6 @@ describe("PageActions alignment", () => {
     expect(html).toContain('data-actions-alignment="right"');
   });
 
-  it("renders a custom copy button label", () => {
-    const html = renderToStaticMarkup(
-      React.createElement(PageActions, {
-        copyMarkdown: true,
-        copyMarkdownLabel: "Copy docs",
-        providers: [],
-      }),
-    );
-
-    expect(html).toContain("Copy docs");
-    expect(html).not.toContain("Copy page");
-  });
-
   it("uses /index.md for root markdown links", () => {
     mockRouterState.pathname = "/";
 
@@ -70,5 +57,20 @@ describe("PageActions alignment", () => {
 
     expect(html).toContain('data-page-actions-variant="rail"');
     expect(html).toContain("Ask AI");
+  });
+});
+
+describe("PageActions copy markdown labels", () => {
+  it("renders a custom copy button label", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PageActions, {
+        copyMarkdown: true,
+        copyMarkdownLabel: "Copy docs",
+        providers: [],
+      }),
+    );
+
+    expect(html).toContain("Copy docs");
+    expect(html).not.toContain("Copy page");
   });
 });

--- a/packages/fumadocs/src/page-actions.tsx
+++ b/packages/fumadocs/src/page-actions.tsx
@@ -16,6 +16,8 @@ interface SerializedProvider {
 
 interface PageActionsProps {
   copyMarkdown?: boolean;
+  copyMarkdownLabel?: string;
+  copyMarkdownCopiedLabel?: string;
   openDocs?: boolean;
   providers?: SerializedProvider[];
   openDocsTarget?: "markdown" | "page" | "source" | "github";
@@ -172,6 +174,8 @@ function fillPromptTemplate(template: string, values: Record<string, string>): s
 
 export function PageActions({
   copyMarkdown,
+  copyMarkdownLabel = "Copy page",
+  copyMarkdownCopiedLabel = "Copied!",
   openDocs,
   providers,
   openDocsTarget = DEFAULT_OPEN_DOCS_TARGET,
@@ -336,7 +340,7 @@ export function PageActions({
             data-copied={copied}
           >
             {copied ? <CheckIcon /> : <CopyIcon />}
-            <span>{copied ? "Copied!" : "Copy page"}</span>
+            <span>{copied ? copyMarkdownCopiedLabel : copyMarkdownLabel}</span>
           </button>
         )}
 
@@ -372,7 +376,7 @@ export function PageActions({
           data-copied={copied}
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
-          <span>{copied ? "Copied!" : "Copy page"}</span>
+          <span>{copied ? copyMarkdownCopiedLabel : copyMarkdownLabel}</span>
         </button>
       )}
 

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -8,6 +8,7 @@ import type {
   FontStyle,
   AIConfig,
   OpenDocsConfig,
+  CopyMarkdownConfig,
 } from "@farming-labs/docs";
 import { applySidebarFolderIndexBehavior, resolveDocsAnalyticsConfig } from "@farming-labs/docs";
 import { DocsPageClient } from "./docs-page-client.js";
@@ -373,6 +374,10 @@ export function TanstackDocsLayout({
 
   const pageActions = config.pageActions;
   const copyMarkdownEnabled = resolveBool(pageActions?.copyMarkdown);
+  const copyMarkdownConfig =
+    pageActions?.copyMarkdown && typeof pageActions.copyMarkdown === "object"
+      ? (pageActions.copyMarkdown as CopyMarkdownConfig)
+      : undefined;
   const openDocsEnabled = resolveBool(pageActions?.openDocs);
   const pageActionsPosition = pageActions?.position ?? "below-title";
   const pageActionsAlignment = pageActions?.alignment ?? "left";
@@ -519,6 +524,8 @@ export function TanstackDocsLayout({
           entry={config.entry ?? "docs"}
           locale={locale}
           copyMarkdown={copyMarkdownEnabled}
+          copyMarkdownLabel={copyMarkdownConfig?.label}
+          copyMarkdownCopiedLabel={copyMarkdownConfig?.copiedLabel}
           openDocs={openDocsEnabled}
           openDocsProviders={openDocsProviders}
           openDocsTarget={openDocsConfig?.target}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   fast-uri: 3.1.2
   rollup: ^4.59.0
   tar: ^7.5.11
+  ws: ^8.21.0
   readdir-glob>minimatch: ^5.1.8
   glob@10>minimatch: ^9.0.7
   glob@13>minimatch: ^10.2.3
@@ -7680,8 +7681,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8644,7 +8645,7 @@ snapshots:
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.3.1(magicast@0.5.2))(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-vue-tracer: 1.2.0(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.28(typescript@5.9.3))
       which: 5.0.0
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14202,7 +14203,7 @@ snapshots:
       devtools-protocol: 0.0.1581282
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -15676,7 +15677,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add `label` and `copiedLabel` options to `pageActions.copyMarkdown`
- pass those labels through the React and TanStack docs layouts
- use the configured labels in the Copy Markdown page action button
- patch the transitive `ws` advisory by overriding to the fixed `8.21.0` release

## Why
This lets docs sites customize the visible Copy Markdown button text without replacing the page actions UI. The `ws` override fixes the high-severity audit failure reported by CI for GHSA-96hv-2xvq-fx4p.

## Docs
The feature change is intentionally code-only so the knowledge-drift workflow can draft the docs update after merge. Expected docs homes are the Page Actions guide plus configuration/reference tables.

## Validation
- `pnpm --dir packages/fumadocs exec vitest run src/page-actions.test.ts src/docs-layout.test.ts`
- `pnpm --dir packages/docs typecheck`
- `pnpm --dir packages/fumadocs typecheck`
- `pnpm --dir packages/docs build`
- `pnpm --dir packages/fumadocs build`
- `pnpm typecheck`
- local CI-style bulk advisory scan: no high/critical vulnerabilities
- `pnpm lint` (existing warnings only; no errors)
- `git diff --check`
