### PR TITLE
feat: add copyMarkdown includeTitle option

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -697,6 +697,8 @@ export interface CopyMarkdownConfig {
   enabled?: boolean;
   /** Content format copied by the button. @default "markdown" */
   format?: CopyMarkdownFormat;
+  /** Whether to prepend the current page title to copied content. @default false */
+  includeTitle?: boolean;
   /** Button label shown before the page is copied. @default "Copy page" */
   label?: string;
   /** Button label shown after a successful copy. @default "Copied!" */

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -100,6 +100,7 @@ describe("createDocsLayout pageActions", () => {
         copyMarkdown: {
           enabled: true,
           format: "text",
+          includeTitle: true,
           label: "Copy docs",
           copiedLabel: "Copied docs",
         },
@@ -115,6 +116,7 @@ describe("createDocsLayout pageActions", () => {
     expect(props).toBeTruthy();
     expect(props?.copyMarkdown).toBe(true);
     expect(props?.copyMarkdownFormat).toBe("text");
+    expect(props?.copyMarkdownIncludeTitle).toBe(true);
     expect(props?.copyMarkdownLabel).toBe("Copy docs");
     expect(props?.copyMarkdownCopiedLabel).toBe("Copied docs");
     expect(props?.openDocs).toBe(true);

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1149,6 +1149,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             locale={activeLocale}
             copyMarkdown={copyMarkdownEnabled}
             copyMarkdownFormat={copyMarkdownConfig?.format}
+            copyMarkdownIncludeTitle={copyMarkdownConfig?.includeTitle}
             copyMarkdownLabel={copyMarkdownConfig?.label}
             copyMarkdownCopiedLabel={copyMarkdownConfig?.copiedLabel}
             openDocs={openDocsEnabled}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -52,6 +52,7 @@ interface DocsPageClientProps {
   locale?: string;
   copyMarkdown?: boolean;
   copyMarkdownFormat?: CopyMarkdownFormat;
+  copyMarkdownIncludeTitle?: boolean;
   copyMarkdownLabel?: string;
   copyMarkdownCopiedLabel?: string;
   openDocs?: boolean;
@@ -493,6 +494,7 @@ export function DocsPageClient({
   locale,
   copyMarkdown = false,
   copyMarkdownFormat,
+  copyMarkdownIncludeTitle,
   copyMarkdownLabel,
   copyMarkdownCopiedLabel,
   openDocs = false,
@@ -815,6 +817,7 @@ export function DocsPageClient({
             <PageActions
               copyMarkdown={copyMarkdown}
               copyMarkdownFormat={copyMarkdownFormat}
+              copyMarkdownIncludeTitle={copyMarkdownIncludeTitle}
               copyMarkdownLabel={copyMarkdownLabel}
               copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
               openDocs={openDocs}
@@ -878,6 +881,7 @@ export function DocsPageClient({
             <PageActions
               copyMarkdown={copyMarkdown}
               copyMarkdownFormat={copyMarkdownFormat}
+              copyMarkdownIncludeTitle={copyMarkdownIncludeTitle}
               copyMarkdownLabel={copyMarkdownLabel}
               copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
               openDocs={openDocs}
@@ -948,6 +952,7 @@ export function DocsPageClient({
               <PageActions
                 copyMarkdown={copyMarkdown}
                 copyMarkdownFormat={copyMarkdownFormat}
+                copyMarkdownIncludeTitle={copyMarkdownIncludeTitle}
                 copyMarkdownLabel={copyMarkdownLabel}
                 copyMarkdownCopiedLabel={copyMarkdownCopiedLabel}
                 openDocs={openDocs}

--- a/packages/fumadocs/src/page-actions.test.ts
+++ b/packages/fumadocs/src/page-actions.test.ts
@@ -10,7 +10,7 @@ vi.mock("fumadocs-core/framework", () => ({
   usePathname: () => mockRouterState.pathname,
 }));
 
-import { PageActions } from "./page-actions.js";
+import { formatCopyMarkdownContent, PageActions } from "./page-actions.js";
 
 describe("PageActions alignment", () => {
   beforeEach(() => {
@@ -84,5 +84,61 @@ describe("PageActions copy markdown labels", () => {
     );
 
     expect(html).toContain('data-copy-markdown-format="text"');
+  });
+
+  it("marks when copied content should include the page title", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PageActions, {
+        copyMarkdown: true,
+        copyMarkdownIncludeTitle: true,
+        providers: [],
+      }),
+    );
+
+    expect(html).toContain('data-copy-markdown-include-title="true"');
+  });
+
+  it("prepends a markdown title when requested", () => {
+    expect(
+      formatCopyMarkdownContent({
+        content: "Body copy",
+        format: "markdown",
+        includeTitle: true,
+        title: "Install",
+      }),
+    ).toBe("# Install\n\nBody copy");
+  });
+
+  it("prepends a plain title for text copies", () => {
+    expect(
+      formatCopyMarkdownContent({
+        content: "Body copy",
+        format: "text",
+        includeTitle: true,
+        title: "Install",
+      }),
+    ).toBe("Install\n\nBody copy");
+  });
+
+  it("does not duplicate an existing copied title", () => {
+    expect(
+      formatCopyMarkdownContent({
+        content: "# Install\n\nBody copy",
+        format: "markdown",
+        includeTitle: true,
+        title: "Install",
+      }),
+    ).toBe("# Install\n\nBody copy");
+  });
+
+  it("does not duplicate a plain title when markdown falls back to page text", () => {
+    expect(
+      formatCopyMarkdownContent({
+        content: "Install\n\nBody copy",
+        format: "markdown",
+        includeTitle: true,
+        title: "Install",
+      }),
+    ).toBe("Install\n\nBody copy");
   });
 });

--- a/packages/fumadocs/src/page-actions.tsx
+++ b/packages/fumadocs/src/page-actions.tsx
@@ -18,6 +18,7 @@ interface SerializedProvider {
 interface PageActionsProps {
   copyMarkdown?: boolean;
   copyMarkdownFormat?: CopyMarkdownFormat;
+  copyMarkdownIncludeTitle?: boolean;
   copyMarkdownLabel?: string;
   copyMarkdownCopiedLabel?: string;
   openDocs?: boolean;
@@ -174,9 +175,54 @@ function fillPromptTemplate(template: string, values: Record<string, string>): s
     .replace(/\{url\}/g, values.url);
 }
 
+function firstContentLine(content: string) {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+}
+
+export function formatCopyMarkdownContent(params: {
+  content: string;
+  format: CopyMarkdownFormat;
+  includeTitle?: boolean;
+  title?: string | null;
+}) {
+  const title = params.title?.trim();
+  if (!params.includeTitle || !title) {
+    return params.content;
+  }
+
+  const firstLine = firstContentLine(params.content);
+  if (params.format === "markdown") {
+    const heading = `# ${title}`;
+    if (firstLine === heading || firstLine === title) {
+      return params.content;
+    }
+
+    return `${heading}\n\n${params.content.trimStart()}`;
+  }
+
+  if (firstLine === title) {
+    return params.content;
+  }
+
+  return `${title}\n\n${params.content.trimStart()}`;
+}
+
+function currentPageTitle() {
+  const title =
+    document.querySelector<HTMLElement>("#nd-page h1") ??
+    document.querySelector<HTMLElement>("article h1") ??
+    document.querySelector<HTMLElement>("h1");
+
+  return title?.innerText?.trim() || title?.textContent?.trim() || "";
+}
+
 export function PageActions({
   copyMarkdown,
   copyMarkdownFormat = "markdown",
+  copyMarkdownIncludeTitle = false,
   copyMarkdownLabel = "Copy page",
   copyMarkdownCopiedLabel = "Copied!",
   openDocs,
@@ -223,6 +269,13 @@ export function PageActions({
 
       if (!content) return;
 
+      content = formatCopyMarkdownContent({
+        content,
+        format: copyMarkdownFormat,
+        includeTitle: copyMarkdownIncludeTitle,
+        title: currentPageTitle(),
+      });
+
       await navigator.clipboard.writeText(content);
       if (analytics) {
         emitClientAnalyticsEvent({
@@ -230,6 +283,7 @@ export function PageActions({
           properties: {
             contentLength: content.length,
             format: copyMarkdownFormat,
+            includeTitle: copyMarkdownIncludeTitle,
             pathname,
           },
         });
@@ -239,7 +293,7 @@ export function PageActions({
     } catch {
       // silent
     }
-  }, [analytics, copyMarkdownFormat, markdownHref, pathname]);
+  }, [analytics, copyMarkdownFormat, copyMarkdownIncludeTitle, markdownHref, pathname]);
 
   const handleOpen = useCallback(
     (provider: SerializedProvider) => {
@@ -345,6 +399,7 @@ export function PageActions({
             className="fd-page-action-btn"
             data-copied={copied}
             data-copy-markdown-format={copyMarkdownFormat}
+            data-copy-markdown-include-title={copyMarkdownIncludeTitle || undefined}
           >
             {copied ? <CheckIcon /> : <CopyIcon />}
             <span>{copied ? copyMarkdownCopiedLabel : copyMarkdownLabel}</span>
@@ -382,6 +437,7 @@ export function PageActions({
           className="fd-page-action-btn"
           data-copied={copied}
           data-copy-markdown-format={copyMarkdownFormat}
+          data-copy-markdown-include-title={copyMarkdownIncludeTitle || undefined}
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
           <span>{copied ? copyMarkdownCopiedLabel : copyMarkdownLabel}</span>

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -524,6 +524,8 @@ export function TanstackDocsLayout({
           entry={config.entry ?? "docs"}
           locale={locale}
           copyMarkdown={copyMarkdownEnabled}
+          copyMarkdownFormat={copyMarkdownConfig?.format}
+          copyMarkdownIncludeTitle={copyMarkdownConfig?.includeTitle}
           copyMarkdownLabel={copyMarkdownConfig?.label}
           copyMarkdownCopiedLabel={copyMarkdownConfig?.copiedLabel}
           openDocs={openDocsEnabled}


### PR DESCRIPTION
## Summary
- add `pageActions.copyMarkdown.includeTitle` to prepend the current page title when copying page markdown or text
- thread the option through the docs and TanStack layouts
- cover the option with page action and layout tests

## Validation
- `pnpm --dir packages/fumadocs exec vitest run src/page-actions.test.ts src/docs-layout.test.ts`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

Docs are intentionally not changed in this feature PR so the knowledge drift workflow can draft the docs update from the merged code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an option to prepend the current page title when copying content. Works for both markdown and plain text, and is wired through the docs and TanStack layouts.

- **New Features**
  - Added `includeTitle?: boolean` to `CopyMarkdownConfig`.
  - Threaded through `createDocsLayout`, `DocsPageClient`, `TanstackDocsLayout`, and `PageActions`.
  - Added `formatCopyMarkdownContent` to prepend titles and avoid duplicates; supports `markdown` and `text`.
  - Set `data-copy-markdown-include-title` and included `includeTitle` in copy analytics.
  - Added tests for attribute rendering, markdown/text title prepending, and duplicate title avoidance.

<sup>Written for commit 1754b12b4907f3ba2cc353c0719acc30ad1203ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

