### PR TITLE
feat: add feedback status messages

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2160,6 +2160,10 @@ export interface FeedbackConfig {
   negativeLabel?: string;
   /** Label for the submit button. @default "Submit" */
   submitLabel?: string;
+  /** Message shown after feedback is submitted successfully. @default "Thanks for the feedback." */
+  successMessage?: string;
+  /** Message shown when feedback submission fails. @default "Could not send feedback. Please try again." */
+  errorMessage?: string;
   /**
    * Callback fired when the user submits the feedback form.
    *

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -18,6 +18,8 @@ export interface DocsFeedbackProps {
   positiveLabel?: string;
   negativeLabel?: string;
   submitLabel?: string;
+  successMessage?: string;
+  errorMessage?: string;
   onFeedback?: (data: DocsFeedbackData) => void | Promise<void>;
   analytics?: boolean;
 }
@@ -159,6 +161,8 @@ export function DocsFeedback({
   positiveLabel = "Good",
   negativeLabel = "Bad",
   submitLabel = "Submit",
+  successMessage = "Thanks for the feedback.",
+  errorMessage = "Could not send feedback. Please try again.",
   onFeedback,
   analytics = false,
 }: DocsFeedbackProps) {
@@ -306,13 +310,13 @@ export function DocsFeedback({
                 role="status"
                 aria-live="polite"
               >
-                Thanks for the feedback.
+                {successMessage}
               </p>
             )}
           </div>
           {status === "error" && (
             <p className="fd-feedback-status" data-status="error" role="status" aria-live="polite">
-              Could not send feedback. Please try again.
+              {errorMessage}
             </p>
           )}
         </div>

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -282,6 +282,26 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.feedbackRequireComment).toBe(true);
   });
 
+  it("passes feedback status messages through to DocsPageClient", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      feedback: {
+        successMessage: "Thanks, we logged this.",
+        errorMessage: "Feedback could not be recorded.",
+      },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.feedbackEnabled).toBe(true);
+    expect(props?.feedbackSuccessMessage).toBe("Thanks, we logged this.");
+    expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
+  });
+
   it("keeps reading time disabled when the config is unconfigured", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1181,6 +1181,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             feedbackPositiveLabel={feedbackConfig.positiveLabel}
             feedbackNegativeLabel={feedbackConfig.negativeLabel}
             feedbackSubmitLabel={feedbackConfig.submitLabel}
+            feedbackSuccessMessage={feedbackConfig.successMessage}
+            feedbackErrorMessage={feedbackConfig.errorMessage}
             analytics={analyticsEnabled}
           >
             {children}
@@ -1213,6 +1215,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     positiveLabel: "Good",
     negativeLabel: "Bad",
     submitLabel: "Submit",
+    successMessage: "Thanks for the feedback.",
+    errorMessage: "Could not send feedback. Please try again.",
   };
 
   if (feedback === undefined || feedback === false) return defaults;
@@ -1226,6 +1230,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     feedback.positiveLabel !== undefined ||
     feedback.negativeLabel !== undefined ||
     feedback.submitLabel !== undefined ||
+    feedback.successMessage !== undefined ||
+    feedback.errorMessage !== undefined ||
     feedback.onFeedback !== undefined;
 
   return {
@@ -1236,6 +1242,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     positiveLabel: feedback.positiveLabel ?? defaults.positiveLabel,
     negativeLabel: feedback.negativeLabel ?? defaults.negativeLabel,
     submitLabel: feedback.submitLabel ?? defaults.submitLabel,
+    successMessage: feedback.successMessage ?? defaults.successMessage,
+    errorMessage: feedback.errorMessage ?? defaults.errorMessage,
   };
 }
 

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -110,6 +110,8 @@ interface DocsPageClientProps {
   feedbackPositiveLabel?: string;
   feedbackNegativeLabel?: string;
   feedbackSubmitLabel?: string;
+  feedbackSuccessMessage?: string;
+  feedbackErrorMessage?: string;
   feedbackOnFeedback?: (data: DocsFeedbackData) => void | Promise<void>;
   analytics?: boolean;
   children: ReactNode;
@@ -528,6 +530,8 @@ export function DocsPageClient({
   feedbackPositiveLabel,
   feedbackNegativeLabel,
   feedbackSubmitLabel,
+  feedbackSuccessMessage,
+  feedbackErrorMessage,
   feedbackOnFeedback,
   analytics = false,
   children,
@@ -986,6 +990,8 @@ export function DocsPageClient({
               positiveLabel={feedbackPositiveLabel}
               negativeLabel={feedbackNegativeLabel}
               submitLabel={feedbackSubmitLabel}
+              successMessage={feedbackSuccessMessage}
+              errorMessage={feedbackErrorMessage}
               onFeedback={feedbackOnFeedback}
               analytics={analytics}
             />

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -2,6 +2,35 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { TanstackDocsLayout } from "./tanstack-layout.js";
 
+function findDocsPageClientProps(node: unknown): Record<string, unknown> | null {
+  if (!node || typeof node !== "object") return null;
+
+  const candidate = node as {
+    type?: unknown;
+    props?: Record<string, unknown> & { children?: unknown };
+  };
+
+  if (
+    candidate.type &&
+    candidate.props &&
+    "copyMarkdown" in candidate.props &&
+    "openDocs" in candidate.props
+  ) {
+    return candidate.props;
+  }
+
+  const children = candidate.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findDocsPageClientProps(child);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  return children ? findDocsPageClientProps(children) : null;
+}
+
 describe("TanstackDocsLayout", () => {
   it("does not add an extra display: contents wrapper above the docs layout root", () => {
     const tree = TanstackDocsLayout({
@@ -174,5 +203,29 @@ describe("TanstackDocsLayout", () => {
         }),
       ],
     });
+  });
+
+  it("passes feedback status messages through to DocsPageClient", () => {
+    const tree = TanstackDocsLayout({
+      config: {
+        entry: "docs",
+        feedback: {
+          successMessage: "Thanks, we logged this.",
+          errorMessage: "Feedback could not be recorded.",
+        },
+      },
+      tree: {
+        name: "Docs",
+        children: [],
+      },
+      children: React.createElement("div", null, "child"),
+    });
+
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.feedbackEnabled).toBe(true);
+    expect(props?.feedbackSuccessMessage).toBe("Thanks, we logged this.");
+    expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
   });
 });

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -291,6 +291,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     positiveLabel: "Good",
     negativeLabel: "Bad",
     submitLabel: "Submit",
+    successMessage: "Thanks for the feedback.",
+    errorMessage: "Could not send feedback. Please try again.",
   };
 
   if (feedback === undefined || feedback === false) return defaults;
@@ -304,6 +306,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     feedback.positiveLabel !== undefined ||
     feedback.negativeLabel !== undefined ||
     feedback.submitLabel !== undefined ||
+    feedback.successMessage !== undefined ||
+    feedback.errorMessage !== undefined ||
     feedback.onFeedback !== undefined;
 
   return {
@@ -314,6 +318,8 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
     positiveLabel: feedback.positiveLabel ?? defaults.positiveLabel,
     negativeLabel: feedback.negativeLabel ?? defaults.negativeLabel,
     submitLabel: feedback.submitLabel ?? defaults.submitLabel,
+    successMessage: feedback.successMessage ?? defaults.successMessage,
+    errorMessage: feedback.errorMessage ?? defaults.errorMessage,
   };
 }
 
@@ -550,6 +556,8 @@ export function TanstackDocsLayout({
           feedbackPositiveLabel={feedbackConfig.positiveLabel}
           feedbackNegativeLabel={feedbackConfig.negativeLabel}
           feedbackSubmitLabel={feedbackConfig.submitLabel}
+          feedbackSuccessMessage={feedbackConfig.successMessage}
+          feedbackErrorMessage={feedbackConfig.errorMessage}
           analytics={analyticsEnabled}
         >
           {children}


### PR DESCRIPTION
## Summary

Adds two human feedback configuration options:

- `feedback.successMessage` customizes the message shown after feedback is submitted successfully.
- `feedback.errorMessage` customizes the message shown when feedback submission fails.

The options flow through both the default docs layout and the TanStack layout into the built-in feedback component, with the existing default copy preserved when the new fields are not set.

## Tests

- `pnpm --filter @farming-labs/theme exec vitest run src/docs-layout.test.ts src/tanstack-layout.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint` (0 errors; existing warnings remain)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds customizable feedback status messages in docs. You can now set `feedback.successMessage` and `feedback.errorMessage`, with existing defaults preserved.

- **New Features**
  - Added `successMessage` and `errorMessage` to `FeedbackConfig` (defaults: "Thanks for the feedback." / "Could not send feedback. Please try again.").
  - Plumbed through default docs and TanStack layouts into `DocsPageClient` and `DocsFeedback`.

<sup>Written for commit 36637a7faf88b6553f8187c12d8e9bc90b1b20a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

