### PR TITLE
feat: add lastUpdated label option

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1411,6 +1411,11 @@ export interface LastUpdatedConfig {
    */
   enabled?: boolean;
   /**
+   * Label shown before the formatted date.
+   * @default "Last updated"
+   */
+  label?: string;
+  /**
    * Where to render the "Last updated" date.
    *
    * - `"footer"` — next to the "Edit on GitHub" link at the bottom (default)

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -302,6 +302,26 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
   });
 
+  it("passes the configured last-updated label through to DocsPageClient", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      lastUpdated: {
+        label: "Updated",
+        position: "below-title",
+      },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.lastUpdatedEnabled).toBe(true);
+    expect(props?.lastUpdatedLabel).toBe("Updated");
+    expect(props?.lastUpdatedPosition).toBe("below-title");
+  });
+
   it("keeps reading time disabled when the config is unconfigured", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -967,6 +967,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
   const lastUpdatedEnabled =
     lastUpdatedRaw !== false &&
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
+  const lastUpdatedLabel =
+    typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.label ?? "Last updated") : "Last updated";
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
   const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
@@ -1167,6 +1169,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             githubDirectory={githubDirectory}
             lastModifiedMap={lastModifiedMap}
             lastUpdatedEnabled={lastUpdatedEnabled}
+            lastUpdatedLabel={lastUpdatedLabel}
             lastUpdatedPosition={lastUpdatedPosition}
             readingTimeEnabled={readingTimeEnabled}
             readingTimeFormat={readingTimeFormat}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -781,9 +781,8 @@ export function DocsPageClient({
   const showLastUpdatedBelowTitle = !!lastModified && lastUpdatedPosition === "below-title";
   const showLastUpdatedInFooter = !!lastModified && lastUpdatedPosition === "footer";
   const lastUpdatedLabelText = lastUpdatedLabel.trim();
-  const lastUpdatedText = lastUpdatedLabelText && lastModified
-    ? `${lastUpdatedLabelText} ${lastModified}`
-    : lastModified;
+  const lastUpdatedText =
+    lastUpdatedLabelText && lastModified ? `${lastUpdatedLabelText} ${lastModified}` : lastModified;
   const showFooter =
     !isChangelogRoute && (!!githubFileUrl || showLastUpdatedInFooter || llmsTxtEnabled);
   const readingTimeBlock =

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -94,6 +94,8 @@ interface DocsPageClientProps {
   readingTimeEnabled?: boolean;
   /** Whether to show "Last updated" at all */
   lastUpdatedEnabled?: boolean;
+  /** Label shown before the formatted last-updated date */
+  lastUpdatedLabel?: string;
   /** Where to show the "Last updated" date: "footer" (next to Edit on GitHub) or "below-title" */
   lastUpdatedPosition?: "footer" | "below-title";
   /** Whether llms.txt is enabled — shows links in footer */
@@ -519,6 +521,7 @@ export function DocsPageClient({
   structuredData: structuredDataProp,
   readingTimeEnabled = false,
   lastUpdatedEnabled = true,
+  lastUpdatedLabel = "Last updated",
   lastUpdatedPosition = "footer",
   llmsTxtEnabled = false,
   descriptionMap,
@@ -777,6 +780,10 @@ export function DocsPageClient({
 
   const showLastUpdatedBelowTitle = !!lastModified && lastUpdatedPosition === "below-title";
   const showLastUpdatedInFooter = !!lastModified && lastUpdatedPosition === "footer";
+  const lastUpdatedLabelText = lastUpdatedLabel.trim();
+  const lastUpdatedText = lastUpdatedLabelText && lastModified
+    ? `${lastUpdatedLabelText} ${lastModified}`
+    : lastModified;
   const showFooter =
     !isChangelogRoute && (!!githubFileUrl || showLastUpdatedInFooter || llmsTxtEnabled);
   const readingTimeBlock =
@@ -808,7 +815,7 @@ export function DocsPageClient({
       <div key="below-title" className="fd-below-title-block not-prose">
         {showLastUpdatedBelowTitle && (
           <p key="last-updated" className="fd-last-updated-inline">
-            Last updated {lastModified}
+            {lastUpdatedText}
           </p>
         )}
         <hr key="separator" className="fd-title-separator" />
@@ -1021,7 +1028,7 @@ export function DocsPageClient({
               )}
               {showLastUpdatedInFooter && lastModified && (
                 <span key="last-updated" className="fd-last-updated-footer">
-                  Last updated {lastModified}
+                  {lastUpdatedText}
                 </span>
               )}
             </div>

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -228,4 +228,28 @@ describe("TanstackDocsLayout", () => {
     expect(props?.feedbackSuccessMessage).toBe("Thanks, we logged this.");
     expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
   });
+
+  it("passes the configured last-updated label through to DocsPageClient", () => {
+    const tree = TanstackDocsLayout({
+      config: {
+        entry: "docs",
+        lastUpdated: {
+          label: "Updated",
+          position: "below-title",
+        },
+      },
+      tree: {
+        name: "Docs",
+        children: [],
+      },
+      children: React.createElement("div", null, "child"),
+    });
+
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.lastUpdatedEnabled).toBe(true);
+    expect(props?.lastUpdatedLabel).toBe("Updated");
+    expect(props?.lastUpdatedPosition).toBe("below-title");
+  });
 });

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -392,6 +392,8 @@ export function TanstackDocsLayout({
   const lastUpdatedEnabled =
     lastUpdatedRaw !== false &&
     (typeof lastUpdatedRaw !== "object" || lastUpdatedRaw.enabled !== false);
+  const lastUpdatedLabel =
+    typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.label ?? "Last updated") : "Last updated";
   const lastUpdatedPosition: "footer" | "below-title" =
     typeof lastUpdatedRaw === "object" ? (lastUpdatedRaw.position ?? "footer") : "footer";
   const readingTimeOptions = resolveReadingTimeOptions(config.readingTime);
@@ -542,6 +544,7 @@ export function TanstackDocsLayout({
           pageActionsAlignment={pageActionsAlignment}
           editOnGithubUrl={editOnGithubUrl}
           lastUpdatedEnabled={lastUpdatedEnabled}
+          lastUpdatedLabel={lastUpdatedLabel}
           lastUpdatedPosition={lastUpdatedPosition}
           lastModified={lastModified}
           readingTimeEnabled={readingTimeEnabled}


### PR DESCRIPTION
## Summary
- Add `lastUpdated.label` to `LastUpdatedConfig`.
- Pass the label through the Next/Fumadocs and TanStack layouts into `DocsPageClient`.
- Render the configured label before the formatted last-updated date in both footer and below-title positions.

## Validation
- `pnpm --filter @farming-labs/docs run build`
- `pnpm --filter @farming-labs/theme exec vitest run src/docs-layout.test.ts src/tanstack-layout.test.ts`
- `pnpm --filter @farming-labs/theme typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `lastUpdated.label` so docs can customize the text before the date (defaults to "Last updated"). The label is passed through both layouts and rendered in the footer or below the title with trimmed, clean formatting.

- **New Features**
  - `LastUpdatedConfig.label?: string` added in `packages/docs` (default: "Last updated").
  - `createDocsLayout` and `TanstackDocsLayout` pass `lastUpdatedLabel` to `DocsPageClient`.
  - `DocsPageClient` renders the label before the date in both positions, trimming the label and avoiding extra spaces; tests cover both layouts.

<sup>Written for commit 3744681032fe38a87f7b4747572ab3d4ce233811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

