### PR TITLE
feat: update feedback placeholder copy

### DIFF
--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2155,7 +2155,7 @@ export interface FeedbackConfig {
   enabled?: boolean;
   /** Prompt shown above the feedback buttons. @default "How is this guide?" */
   question?: string;
-  /** Placeholder shown in the optional free-form feedback field. @default "Leave your feedback..." */
+  /** Placeholder shown in the optional free-form feedback field. @default "Share what could be clearer..." */
   placeholder?: string;
   /** Require a non-empty comment before feedback can be submitted. @default false */
   requireComment?: boolean;

--- a/packages/fumadocs/src/docs-feedback.tsx
+++ b/packages/fumadocs/src/docs-feedback.tsx
@@ -156,7 +156,7 @@ export function DocsFeedback({
   entry,
   locale,
   question = "How is this guide?",
-  placeholder = "Leave your feedback...",
+  placeholder = "Share what could be clearer...",
   requireComment = false,
   positiveLabel = "Good",
   negativeLabel = "Bad",

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -302,6 +302,24 @@ describe("createDocsLayout pageActions", () => {
     expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
   });
 
+  it("passes the configured feedback placeholder through to DocsPageClient", () => {
+    const Layout = createDocsLayout({
+      entry: "docs",
+      feedback: {
+        placeholder: "Tell us what felt unclear.",
+      },
+    });
+
+    const tree = Layout({
+      children: React.createElement("div", null, "child"),
+    });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.feedbackEnabled).toBe(true);
+    expect(props?.feedbackPlaceholder).toBe("Tell us what felt unclear.");
+  });
+
   it("passes the configured last-updated label through to DocsPageClient", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1213,7 +1213,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
   const defaults = {
     enabled: false,
     question: "How is this guide?",
-    placeholder: "Leave your feedback...",
+    placeholder: "Share what could be clearer...",
     requireComment: false,
     positiveLabel: "Good",
     negativeLabel: "Bad",

--- a/packages/fumadocs/src/tanstack-layout.test.ts
+++ b/packages/fumadocs/src/tanstack-layout.test.ts
@@ -229,6 +229,28 @@ describe("TanstackDocsLayout", () => {
     expect(props?.feedbackErrorMessage).toBe("Feedback could not be recorded.");
   });
 
+  it("passes the configured feedback placeholder through to DocsPageClient", () => {
+    const tree = TanstackDocsLayout({
+      config: {
+        entry: "docs",
+        feedback: {
+          placeholder: "Tell us what felt unclear.",
+        },
+      },
+      tree: {
+        name: "Docs",
+        children: [],
+      },
+      children: React.createElement("div", null, "child"),
+    });
+
+    const props = findDocsPageClientProps(tree);
+
+    expect(props).toBeTruthy();
+    expect(props?.feedbackEnabled).toBe(true);
+    expect(props?.feedbackPlaceholder).toBe("Tell us what felt unclear.");
+  });
+
   it("passes the configured last-updated label through to DocsPageClient", () => {
     const tree = TanstackDocsLayout({
       config: {

--- a/packages/fumadocs/src/tanstack-layout.tsx
+++ b/packages/fumadocs/src/tanstack-layout.tsx
@@ -286,7 +286,7 @@ function resolveFeedbackConfig(feedback: DocsConfig["feedback"]) {
   const defaults = {
     enabled: false,
     question: "How is this guide?",
-    placeholder: "Leave your feedback...",
+    placeholder: "Share what could be clearer...",
     requireComment: false,
     positiveLabel: "Good",
     negativeLabel: "Bad",


### PR DESCRIPTION
## Summary
- update the default page feedback comment placeholder to a clearer prompt
- keep the public FeedbackConfig default comment in sync
- add Next/Fumadocs and TanStack layout coverage for custom feedback.placeholder pass-through

## Validation
- pnpm --filter @farming-labs/theme exec vitest run src/docs-layout.test.ts src/tanstack-layout.test.ts
- pnpm --filter @farming-labs/docs run build
- pnpm --filter @farming-labs/theme typecheck
- pnpm format:check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the default feedback comment placeholder to "Share what could be clearer..." to make prompts clearer across docs and layouts. Added tests to ensure custom placeholder values pass through in the Fumadocs and TanStack layouts, and kept the public `FeedbackConfig` default in sync.

<sup>Written for commit dfd29e9b8547682da29a27ddfaa1f9bc8bdc0f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

