### PR TITLE
fix: detect package managers from monorepo app dirs

### DIFF
--- a/packages/docs/src/cli/dev.ts
+++ b/packages/docs/src/cli/dev.ts
@@ -13,7 +13,7 @@ import {
   tsconfigTemplate,
   type TemplateConfig,
 } from "./templates.js";
-import { detectPackageManagerFromLockfile, type PackageManager } from "./utils.js";
+import { detectPackageManagerFromProject, type PackageManager } from "./utils.js";
 
 const PRIMARY_MANAGED_CONFIG_FILE = "docs.json";
 const LEGACY_MANAGED_CONFIG_FILE = "docs.cloud.json";
@@ -649,14 +649,7 @@ function findLocalFrameworkRoot(startDir: string): string | null {
 }
 
 function detectNearestPackageManager(startDir: string): PackageManager {
-  let current = path.resolve(startDir);
-  while (true) {
-    const detected = detectPackageManagerFromLockfile(current);
-    if (detected) return detected;
-    const parent = path.dirname(current);
-    if (parent === current) return "npm";
-    current = parent;
-  }
+  return detectPackageManagerFromProject(startDir)?.packageManager ?? "npm";
 }
 
 function resolveManagedConfigPath(projectRoot: string): {

--- a/packages/docs/src/cli/downgrade.flow.test.ts
+++ b/packages/docs/src/cli/downgrade.flow.test.ts
@@ -25,6 +25,7 @@ vi.mock("./utils.js", async () => {
   return {
     ...actual,
     detectFramework: vi.fn(),
+    detectPackageManagerFromProject: vi.fn(),
     detectPackageManagerFromLockfile: vi.fn(),
     exec: vi.fn(),
     execOutput: vi.fn(),
@@ -33,6 +34,18 @@ vi.mock("./utils.js", async () => {
 });
 
 import { downgrade } from "./downgrade.js";
+
+function packageManagerDetection(packageManager: "npm" | "pnpm" | "yarn" | "bun") {
+  return {
+    packageManager,
+    directory: process.cwd(),
+    filePath: join(
+      process.cwd(),
+      `${packageManager === "pnpm" ? "pnpm-lock.yaml" : "package.json"}`,
+    ),
+    source: "lockfile" as const,
+  };
+}
 
 function writePackageJson(project: string, version: string) {
   writeFileSync(
@@ -82,13 +95,16 @@ describe("downgrade", () => {
 
     vi.mocked(utils.fileExists).mockReset();
     vi.mocked(utils.detectFramework).mockReset();
+    vi.mocked(utils.detectPackageManagerFromProject).mockReset();
     vi.mocked(utils.detectPackageManagerFromLockfile).mockReset();
     vi.mocked(utils.exec).mockReset();
     vi.mocked(utils.execOutput).mockReset();
 
     vi.mocked(utils.fileExists).mockImplementation((filePath: string) => existsSync(filePath));
     vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
     vi.mocked(utils.execOutput).mockReturnValue('["0.1.103","0.1.104","0.1.105"]');
 
     exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -149,7 +165,7 @@ describe("downgrade", () => {
     const prompts = await import("@clack/prompts");
     const utils = await import("./utils.js");
 
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue(null);
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(null);
     vi.mocked(prompts.select).mockResolvedValueOnce("bun" as never);
 
     await downgrade({ version: "0.1.104" });

--- a/packages/docs/src/cli/init.test.ts
+++ b/packages/docs/src/cli/init.test.ts
@@ -21,6 +21,7 @@ vi.mock("./utils.js", async () => {
   return {
     ...actual,
     detectFramework: vi.fn(actual.detectFramework),
+    detectPackageManagerFromProject: vi.fn(actual.detectPackageManagerFromProject),
     detectPackageManagerFromLockfile: vi.fn(actual.detectPackageManagerFromLockfile),
     exec: vi.fn(),
   };
@@ -46,6 +47,15 @@ vi.mock("node:fs", () => {
   };
 });
 
+function packageManagerDetection(packageManager: "npm" | "pnpm" | "yarn" | "bun") {
+  return {
+    packageManager,
+    directory: process.cwd(),
+    filePath: `${packageManager === "pnpm" ? "pnpm-lock.yaml" : "package.json"}`,
+    source: "lockfile" as const,
+  };
+}
+
 describe("init", () => {
   describe("VALID_TEMPLATES", () => {
     it("includes next, nuxt, sveltekit, astro, tanstack-start", () => {
@@ -70,6 +80,7 @@ describe("init", () => {
       vi.mocked(prompts.log.error).mockReset();
       vi.mocked(prompts.isCancel).mockImplementation((value: unknown) => value === cancelSymbol);
       vi.mocked(utils.detectFramework).mockReset();
+      vi.mocked(utils.detectPackageManagerFromProject).mockReset();
       vi.mocked(utils.detectPackageManagerFromLockfile).mockReset();
       vi.mocked(utils.exec).mockReset();
       vi.mocked(cloud.initCloudConfig).mockReset();
@@ -135,7 +146,9 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
 
       vi.mocked(prompts.select)
         .mockResolvedValueOnce("existing" as never)
@@ -164,7 +177,7 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue(null);
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(null);
 
       vi.mocked(prompts.select)
         .mockResolvedValueOnce("existing" as never)
@@ -193,7 +206,9 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
 
       vi.mocked(prompts.select)
         .mockResolvedValueOnce("existing" as never)
@@ -234,7 +249,9 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
 
       vi.mocked(prompts.select)
         .mockResolvedValueOnce("existing" as never)
@@ -264,7 +281,9 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
 
       vi.mocked(prompts.select)
         .mockResolvedValueOnce("existing" as never)
@@ -296,7 +315,9 @@ describe("init", () => {
       const cloud = await import("./cloud.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
       vi.mocked(cloud.initCloudConfig).mockResolvedValueOnce({
         configPath: `${process.cwd()}/docs.config.ts`,
         docsJsonPath: `${process.cwd()}/docs.json`,
@@ -339,7 +360,9 @@ describe("init", () => {
       const utils = await import("./utils.js");
 
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
       vi.mocked(utils.exec).mockImplementationOnce(() => {
         throw new Error("install failed");
       });

--- a/packages/docs/src/cli/init.ts
+++ b/packages/docs/src/cli/init.ts
@@ -6,9 +6,10 @@ import {
   type Framework,
   type PackageManager,
   detectFramework,
-  detectPackageManagerFromLockfile,
+  detectPackageManagerFromProject,
   detectGlobalCssFiles,
   detectNextAppDir,
+  formatPackageManagerDetection,
   installCommand,
   devInstallCommand,
   writeFileSafe,
@@ -1110,9 +1111,12 @@ export async function init(options: InitOptions = {}) {
   // Step 9: Choose package manager (existing project)
   // -----------------------------------------------------------------------
 
-  let pm = detectPackageManagerFromLockfile(cwd);
-  if (pm) {
-    p.log.info(`Detected ${pc.cyan(pm)}`);
+  const detectedPackageManager = detectPackageManagerFromProject(cwd);
+  let pm = detectedPackageManager?.packageManager ?? null;
+  if (detectedPackageManager) {
+    p.log.info(
+      `Detected ${pc.cyan(detectedPackageManager.packageManager)} from ${formatPackageManagerDetection(cwd, detectedPackageManager)}`,
+    );
   }
 
   const pmAnswerExisting = await p.select({

--- a/packages/docs/src/cli/package-version.ts
+++ b/packages/docs/src/cli/package-version.ts
@@ -4,7 +4,8 @@ import {
   type Framework,
   type PackageManager,
   detectFramework,
-  detectPackageManagerFromLockfile,
+  detectPackageManagerFromProject,
+  formatPackageManagerDetection,
   installCommand,
 } from "./utils.js";
 
@@ -97,10 +98,12 @@ export async function resolveDocsPackageManager(
   cwd: string,
   command: "upgrade" | "downgrade",
 ): Promise<PackageManager> {
-  const detected = detectPackageManagerFromLockfile(cwd);
+  const detected = detectPackageManagerFromProject(cwd);
   if (detected) {
-    p.log.info(`Detected ${pc.cyan(detected)} from lockfile`);
-    return detected;
+    p.log.info(
+      `Detected ${pc.cyan(detected.packageManager)} from ${formatPackageManagerDetection(cwd, detected)}`,
+    );
+    return detected.packageManager;
   }
 
   const pmAnswer = await p.select({

--- a/packages/docs/src/cli/upgrade.flow.test.ts
+++ b/packages/docs/src/cli/upgrade.flow.test.ts
@@ -25,6 +25,7 @@ vi.mock("./utils.js", async () => {
   return {
     ...actual,
     detectFramework: vi.fn(),
+    detectPackageManagerFromProject: vi.fn(),
     detectPackageManagerFromLockfile: vi.fn(),
     exec: vi.fn(),
     fileExists: vi.fn(),
@@ -32,6 +33,18 @@ vi.mock("./utils.js", async () => {
 });
 
 import { upgrade } from "./upgrade.js";
+
+function packageManagerDetection(packageManager: "npm" | "pnpm" | "yarn" | "bun") {
+  return {
+    packageManager,
+    directory: process.cwd(),
+    filePath: join(
+      process.cwd(),
+      `${packageManager === "pnpm" ? "pnpm-lock.yaml" : "package.json"}`,
+    ),
+    source: "lockfile" as const,
+  };
+}
 
 describe("upgrade package manager selection", () => {
   let exitMock: { mockRestore: () => void };
@@ -48,6 +61,7 @@ describe("upgrade package manager selection", () => {
 
     vi.mocked(utils.fileExists).mockReset();
     vi.mocked(utils.detectFramework).mockReset();
+    vi.mocked(utils.detectPackageManagerFromProject).mockReset();
     vi.mocked(utils.detectPackageManagerFromLockfile).mockReset();
     vi.mocked(utils.exec).mockReset();
 
@@ -68,7 +82,9 @@ describe("upgrade package manager selection", () => {
     const prompts = await import("@clack/prompts");
     const utils = await import("./utils.js");
 
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
 
     await upgrade({ tag: "latest" });
 
@@ -83,7 +99,7 @@ describe("upgrade package manager selection", () => {
     const prompts = await import("@clack/prompts");
     const utils = await import("./utils.js");
 
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue(null);
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(null);
     vi.mocked(prompts.select).mockResolvedValueOnce("bun" as never);
 
     await upgrade({ tag: "latest" });
@@ -109,7 +125,9 @@ describe("upgrade package manager selection", () => {
     const utils = await import("./utils.js");
 
     vi.mocked(utils.detectFramework).mockReturnValue("tanstack-start");
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
 
     await upgrade({ tag: "latest" });
 
@@ -122,7 +140,9 @@ describe("upgrade package manager selection", () => {
   it("upgrades to an exact version when requested", async () => {
     const utils = await import("./utils.js");
 
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
 
     await upgrade({ version: "0.1.104" });
 
@@ -135,7 +155,9 @@ describe("upgrade package manager selection", () => {
   it("rejects invalid exact versions", async () => {
     const utils = await import("./utils.js");
 
-    vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
 
     await expect(upgrade({ version: "latest" })).rejects.toThrow("process.exit");
 
@@ -167,7 +189,9 @@ describe("upgrade package manager selection", () => {
 
       vi.mocked(utils.fileExists).mockImplementation((filePath: string) => existsSync(filePath));
       vi.mocked(utils.detectFramework).mockReturnValue("nextjs");
-      vi.mocked(utils.detectPackageManagerFromLockfile).mockReturnValue("pnpm");
+      vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+        packageManagerDetection("pnpm"),
+      );
 
       await upgrade({ tag: "latest" });
 

--- a/packages/docs/src/cli/utils.test.ts
+++ b/packages/docs/src/cli/utils.test.ts
@@ -6,6 +6,7 @@ import {
   detectFramework,
   detectPackageManager,
   detectPackageManagerFromLockfile,
+  detectPackageManagerFromProject,
   installCommand,
   devInstallCommand,
   runCommand,
@@ -94,7 +95,7 @@ describe("utils", () => {
   });
 
   describe("detectPackageManager", () => {
-    it("returns null from lockfile-only detection when no lockfile exists", () => {
+    it("returns null when no package manager signal exists", () => {
       fs.writeFileSync(path.join(tmpDir, "package.json"), "{}");
       expect(detectPackageManagerFromLockfile(tmpDir)).toBeNull();
     });
@@ -125,6 +126,44 @@ describe("utils", () => {
       fs.writeFileSync(path.join(tmpDir, "package-lock.json"), "");
       expect(detectPackageManagerFromLockfile(tmpDir)).toBe("npm");
       expect(detectPackageManager(tmpDir)).toBe("npm");
+    });
+
+    it("walks up to detect a monorepo root lockfile", () => {
+      const appDir = path.join(tmpDir, "apps", "web");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(appDir, "package.json"), "{}");
+      fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+
+      const detected = detectPackageManagerFromProject(appDir);
+
+      expect(detectPackageManagerFromLockfile(appDir)).toBe("pnpm");
+      expect(detected).toMatchObject({
+        packageManager: "pnpm",
+        directory: tmpDir,
+        filePath: path.join(tmpDir, "pnpm-lock.yaml"),
+        source: "lockfile",
+      });
+      expect(detectPackageManager(appDir)).toBe("pnpm");
+    });
+
+    it("walks up to detect packageManager in a monorepo root package.json", () => {
+      const appDir = path.join(tmpDir, "apps", "web");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(appDir, "package.json"), "{}");
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ packageManager: "bun@1.2.0" }),
+      );
+
+      const detected = detectPackageManagerFromProject(appDir);
+
+      expect(detected).toMatchObject({
+        packageManager: "bun",
+        directory: tmpDir,
+        filePath: path.join(tmpDir, "package.json"),
+        source: "packageManager",
+      });
+      expect(detectPackageManager(appDir)).toBe("bun");
     });
 
     it("returns npm when no lock file (default)", () => {

--- a/packages/docs/src/cli/utils.ts
+++ b/packages/docs/src/cli/utils.ts
@@ -33,18 +33,120 @@ export function detectFramework(cwd: string): Framework | null {
 
 export type PackageManager = "pnpm" | "yarn" | "npm" | "bun";
 
-export function detectPackageManagerFromLockfile(cwd: string): PackageManager | null {
-  if (fs.existsSync(path.join(cwd, "pnpm-lock.yaml"))) return "pnpm";
-  if (fs.existsSync(path.join(cwd, "bun.lockb")) || fs.existsSync(path.join(cwd, "bun.lock")))
-    return "bun";
-  if (fs.existsSync(path.join(cwd, "yarn.lock"))) return "yarn";
-  if (fs.existsSync(path.join(cwd, "package-lock.json"))) return "npm";
+export type PackageManagerDetectionSource = "lockfile" | "packageManager";
+
+export interface PackageManagerDetection {
+  packageManager: PackageManager;
+  directory: string;
+  filePath: string;
+  source: PackageManagerDetectionSource;
+}
+
+const PACKAGE_MANAGER_LOCKFILES: Array<{ fileName: string; packageManager: PackageManager }> = [
+  { fileName: "pnpm-lock.yaml", packageManager: "pnpm" },
+  { fileName: "bun.lockb", packageManager: "bun" },
+  { fileName: "bun.lock", packageManager: "bun" },
+  { fileName: "yarn.lock", packageManager: "yarn" },
+  { fileName: "package-lock.json", packageManager: "npm" },
+];
+
+function readPackageManagerName(value: unknown): PackageManager | null {
+  if (typeof value !== "string") return null;
+
+  const name = value.trim().split("@")[0];
+  if (name === "pnpm" || name === "yarn" || name === "npm" || name === "bun") {
+    return name;
+  }
+
   return null;
 }
 
+function detectPackageManagerLockfileInDirectory(
+  directory: string,
+): PackageManagerDetection | null {
+  for (const { fileName, packageManager } of PACKAGE_MANAGER_LOCKFILES) {
+    const filePath = path.join(directory, fileName);
+    if (fs.existsSync(filePath)) {
+      return {
+        packageManager,
+        directory,
+        filePath,
+        source: "lockfile",
+      };
+    }
+  }
+
+  return null;
+}
+
+function detectPackageManagerInDirectory(directory: string): PackageManagerDetection | null {
+  const lockfile = detectPackageManagerLockfileInDirectory(directory);
+  if (lockfile) return lockfile;
+
+  const packageJsonPath = path.join(directory, "package.json");
+  if (!fs.existsSync(packageJsonPath)) return null;
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      packageManager?: unknown;
+    };
+    const packageManager = readPackageManagerName(packageJson.packageManager);
+    if (!packageManager) return null;
+
+    return {
+      packageManager,
+      directory,
+      filePath: packageJsonPath,
+      source: "packageManager",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function detectPackageManagerFromProject(cwd: string): PackageManagerDetection | null {
+  let current = path.resolve(cwd);
+
+  while (true) {
+    const detected = detectPackageManagerInDirectory(current);
+    if (detected) return detected;
+
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+export function formatPackageManagerDetection(
+  cwd: string,
+  detection: PackageManagerDetection,
+): string {
+  const relativePath = path.relative(path.resolve(cwd), detection.filePath);
+  const displayPath = relativePath || path.basename(detection.filePath);
+
+  if (detection.source === "packageManager") {
+    return `packageManager in ${displayPath}`;
+  }
+
+  return displayPath;
+}
+
+export function detectPackageManagerFromLockfile(cwd: string): PackageManager | null {
+  let current = path.resolve(cwd);
+
+  while (true) {
+    const detected = detectPackageManagerLockfileInDirectory(current);
+    if (detected) return detected.packageManager;
+
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 export function detectPackageManager(cwd: string): PackageManager {
-  const detected = detectPackageManagerFromLockfile(cwd);
-  if (detected) return detected;
+  const detected = detectPackageManagerFromProject(cwd);
+  if (detected) return detected.packageManager;
   return "npm";
 }
 

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -91,9 +91,9 @@ The raw key is never written to `docs.config.ts` or `docs.json`.
 
 ## Upgrade
 
-Upgrade all `@farming-labs/*` docs packages to the latest version. Run from the **project root**. The CLI auto-detects the framework from `package.json` and upgrades the correct packages.
+Upgrade all `@farming-labs/*` docs packages to the latest version. Run from the app/package directory that contains the framework `package.json` (for monorepos, for example `apps/web`). The CLI auto-detects the framework from that `package.json` and upgrades the correct packages.
 
-For the package manager, the CLI first checks lockfiles in the current directory (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `package-lock.json`). If no lockfile is found, it prompts the user to choose instead of defaulting to npm.
+For the package manager, the CLI checks the current directory and then walks up parent directories looking for lockfiles (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `package-lock.json`) or `package.json#packageManager`. If no package manager signal is found, it prompts the user to choose instead of defaulting to npm.
 
 ```bash
 # npm
@@ -146,7 +146,7 @@ Use `--version <version>` when the user needs an exact release instead of an npm
 
 ## Downgrade
 
-Downgrade all `@farming-labs/*` docs packages to a lower version. Run from the **project root**. The CLI auto-detects the framework and package manager like `upgrade`.
+Downgrade all `@farming-labs/*` docs packages to a lower version. Run from the app/package directory that contains the framework `package.json`. The CLI auto-detects the framework and package manager like `upgrade`.
 
 Without `--version`, `downgrade` fetches published `@farming-labs/docs` versions and installs the highest version lower than the current installed version.
 


### PR DESCRIPTION
## Summary
- add recursive package-manager detection from app/package directories up to monorepo roots
- support ancestor lockfiles and package.json#packageManager for upgrade, downgrade, init, and dev flows
- document monorepo app-directory usage and add focused CLI coverage

## Tests
- pnpm exec oxfmt --ignore-path .oxfmtignore --check packages/docs/src/cli/utils.ts packages/docs/src/cli/package-version.ts packages/docs/src/cli/init.ts packages/docs/src/cli/dev.ts packages/docs/src/cli/utils.test.ts packages/docs/src/cli/upgrade.flow.test.ts packages/docs/src/cli/downgrade.flow.test.ts packages/docs/src/cli/init.test.ts skills/farming-labs/cli/SKILL.md
- pnpm --filter @farming-labs/docs test -- src/cli/utils.test.ts src/cli/upgrade.flow.test.ts src/cli/downgrade.flow.test.ts src/cli/init.test.ts
- pnpm --filter @farming-labs/docs run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes package manager detection in monorepos when running CLI commands from app/package directories. The CLI now walks up to the repo root and uses lockfiles or `package.json#packageManager` to select `pnpm`, `yarn`, `npm`, or `bun`.

- **Bug Fixes**
  - Added `detectPackageManagerFromProject` to recursively detect from lockfiles or `package.json#packageManager`; prompt only if none found.
  - Applied detection to `init`, `upgrade`, `downgrade`, and `dev`; improved logs via `formatPackageManagerDetection`.
  - Updated docs to run commands from the app directory in monorepos and clarified detection behavior.

<sup>Written for commit f5964462c3dcabad620ace32f3f4baadf6067c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

