### PR TITLE
feat: add production telemetry

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -41,6 +41,8 @@ import {
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryProjectEvent,
   formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   getDocsLlmsTxtMaxCharsIssue,
@@ -77,6 +79,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsAgentsFormat,
   resolveDocsSkillFormat,
+  inferDocsTelemetryAgentSurface,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
   validateDocsAgentFeedbackPayload,
@@ -891,6 +894,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
+  function trackTelemetryRequest(request: Request) {
+    emitDocsTelemetryProjectEvent(config, {
+      framework: "astro",
+      request,
+    });
+
+    const surface = inferDocsTelemetryAgentSurface(request, {
+      entry,
+      llmsTxt: config.llmsTxt,
+      feedback: config.feedback,
+    });
+
+    if (!surface) return;
+
+    emitDocsTelemetryAgentSurfaceEvent(config, {
+      framework: "astro",
+      request,
+      surface,
+    });
+  }
+
   function getLlmsContent(ctx: ReturnType<typeof resolveContextFromPath>) {
     const key = ctx.locale ?? "__default__";
     const cached = llmsCache.get(key);
@@ -925,6 +949,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(context: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(context.request);
     const ctx = resolveContextFromRequest(context.request);
     const url = new URL(context.request.url);
 
@@ -1288,6 +1313,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(context: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(context.request);
     const requestUrl = new URL(context.request.url);
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
@@ -1852,6 +1878,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     analytics,
+    telemetry: config.telemetry,
+    telemetryFramework: "astro",
     observability,
     defaultName: mcpSiteTitle,
   });

--- a/packages/docs/src/define-docs.test.ts
+++ b/packages/docs/src/define-docs.test.ts
@@ -76,6 +76,10 @@ describe("defineDocs", () => {
         console: "info",
         onEvent: onAnalyticsEvent,
       },
+      telemetry: {
+        enabled: true,
+        endpoint: "https://telemetry.example.com/events",
+      },
       observability: {
         console: "debug",
         onEvent: onObservabilityEvent,
@@ -85,6 +89,10 @@ describe("defineDocs", () => {
     expect(config.analytics).toEqual({
       console: "info",
       onEvent: onAnalyticsEvent,
+    });
+    expect(config.telemetry).toEqual({
+      enabled: true,
+      endpoint: "https://telemetry.example.com/events",
     });
     expect(config.observability).toEqual({
       console: "debug",

--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -17,6 +17,7 @@ export function defineDocs(config: DocsConfig): DocsConfig {
     sidebar: config.sidebar,
     components: config.components,
     analytics: config.analytics,
+    telemetry: config.telemetry,
     cloud: config.cloud,
     observability: config.observability,
     onCopyClick: config.onCopyClick,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -21,6 +21,15 @@ export {
   resolveDocsAnalyticsConfig,
   resolveDocsObservabilityConfig,
 } from "./analytics.js";
+export {
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryEvent,
+  emitDocsTelemetryMcpToolEvent,
+  emitDocsTelemetryProjectEvent,
+  getDocsTelemetryFeatures,
+  inferDocsTelemetryAgentSurface,
+  resolveDocsTelemetryConfig,
+} from "./telemetry.js";
 export { resolveChangelogConfig } from "./changelog.js";
 export { deepMerge } from "./utils.js";
 export { createTheme, extendTheme } from "./create-theme.js";
@@ -297,6 +306,13 @@ export type {
   DocsAnalyticsEventType,
   DocsAnalyticsInput,
   DocsAnalyticsSource,
+  DocsTelemetryAgentSurface,
+  DocsTelemetryConfig,
+  DocsTelemetryEvent,
+  DocsTelemetryEventInput,
+  DocsTelemetryEventType,
+  DocsTelemetryFeatures,
+  DocsTelemetryFramework,
   DocsCloudApiKeyConfig,
   DocsCloudConfig,
   DocsCloudFeatureConfig,
@@ -322,6 +338,12 @@ export type {
   ResolvedDocsAnalyticsConfig,
   ResolvedDocsObservabilityConfig,
 } from "./analytics.js";
+export type {
+  DocsTelemetryAgentSurfaceRequestOptions,
+  DocsTelemetryContext,
+  DocsTelemetryAgentSurfaceContext,
+  ResolvedDocsTelemetryConfig,
+} from "./telemetry.js";
 export type { ChangelogEntrySummary, ResolvedChangelogConfig } from "./changelog.js";
 export type { ResolvedDocsI18n, DocsPathMatch } from "./i18n.js";
 export type { DocsPageStructuredDataInput, DocsStructuredDataBreadcrumb } from "./metadata.js";

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -16,12 +16,19 @@ import {
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
 } from "./analytics.js";
+import {
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryMcpToolEvent,
+  emitDocsTelemetryProjectEvent,
+} from "./telemetry.js";
 import type {
   DocsAnalyticsConfig,
   DocsMcpConfig,
   DocsObservabilityConfig,
   DocsSearchConfig,
   DocsSearchSourcePage,
+  DocsTelemetryConfig,
+  DocsTelemetryFramework,
   McpDocsSearchConfig,
   OrderingItem,
 } from "./types.js";
@@ -176,6 +183,8 @@ interface CreateDocsMcpServerOptions {
   mcp?: boolean | DocsMcpConfig;
   search?: boolean | DocsSearchConfig;
   analytics?: boolean | DocsAnalyticsConfig;
+  telemetry?: boolean | DocsTelemetryConfig;
+  telemetryFramework?: DocsTelemetryFramework;
   observability?: boolean | DocsObservabilityConfig;
   defaultName?: string;
   defaultVersion?: string;
@@ -885,6 +894,21 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
     name: resolved.name,
     version: resolved.version,
   });
+  const telemetryConfig = {
+    telemetry: options.telemetry,
+    mcp: options.mcp,
+    search: options.search,
+  };
+  const telemetryFramework = options.telemetryFramework ?? "mcp";
+
+  function trackMcpTool(tool: string, values?: { locale?: string; resultCount?: number }) {
+    emitDocsTelemetryMcpToolEvent(telemetryConfig, {
+      framework: telemetryFramework,
+      tool,
+      locale: values?.locale,
+      resultCount: values?.resultCount,
+    });
+  }
 
   const defaultPages = dedupePages(await options.source.getPages());
   const defaultTree = await options.source.getNavigation();
@@ -969,6 +993,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("list_pages", { locale, resultCount: pages.length });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1058,6 +1083,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("list_docs", { locale, resultCount: docs.resultCount });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1141,6 +1167,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("get_navigation", { locale });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1226,6 +1253,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("get_config_schema", { resultCount: schema.resultCount });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1319,6 +1347,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("search_docs", { locale, resultCount: results.length });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1444,6 +1473,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("get_code_examples", { locale, resultCount: examples.length });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1543,6 +1573,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
                 durationMs: elapsed,
               },
             });
+            trackMcpTool("read_page", { locale, resultCount: 0 });
             await emitDocsAgentTraceEvent(options.observability, {
               type: "tool.error",
               source: "mcp",
@@ -1606,6 +1637,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               durationMs: elapsed,
             },
           });
+          trackMcpTool("read_page", { locale, resultCount: 1 });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",
@@ -1660,6 +1692,12 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     defaultName: options.defaultName ?? options.source.siteTitle ?? DEFAULT_MCP_NAME,
     defaultVersion: options.defaultVersion,
   });
+  const telemetryConfig = {
+    telemetry: options.telemetry,
+    mcp: options.mcp,
+    search: options.search,
+  };
+  const telemetryFramework = options.telemetryFramework ?? "mcp";
 
   const disabledMessage =
     "MCP is disabled. Remove `mcp: false` or set `mcp: { enabled: true }` in docs.config to enable it again.";
@@ -1707,6 +1745,20 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     }
 
     const initializeRequest = method === "POST" && parsedBody && isInitializeRequest(parsedBody);
+
+    emitDocsTelemetryProjectEvent(telemetryConfig, {
+      framework: telemetryFramework,
+      request,
+    });
+    emitDocsTelemetryAgentSurfaceEvent(telemetryConfig, {
+      framework: telemetryFramework,
+      request,
+      surface: "mcp",
+      properties: {
+        method,
+        initialize: Boolean(initializeRequest),
+      },
+    });
 
     await emitDocsAnalyticsEvent(options.analytics, {
       type: "mcp_request",

--- a/packages/docs/src/telemetry.test.ts
+++ b/packages/docs/src/telemetry.test.ts
@@ -15,10 +15,19 @@ function resetEnv() {
   delete process.env.DOCS_TELEMETRY;
   delete process.env.DOCS_TELEMETRY_DISABLED;
   delete process.env.DOCS_TELEMETRY_ENDPOINT;
+  delete process.env.DOCS_TELEMETRY_INGEST_KEY;
   delete process.env.VERCEL_ENV;
   delete process.env.NETLIFY;
   delete process.env.CONTEXT;
   delete process.env.CF_PAGES;
+}
+
+function resetTelemetryGlobals() {
+  const globalValue = globalThis as typeof globalThis & {
+    __farmingLabsDocsTelemetryProjectKeys__?: Map<string, number>;
+  };
+
+  delete globalValue.__farmingLabsDocsTelemetryProjectKeys__;
 }
 
 function telemetryEvent(overrides: Partial<DocsTelemetryEvent> = {}): DocsTelemetryEvent {
@@ -36,11 +45,13 @@ function telemetryEvent(overrides: Partial<DocsTelemetryEvent> = {}): DocsTeleme
 describe("telemetry", () => {
   beforeEach(() => {
     resetEnv();
+    resetTelemetryGlobals();
     vi.unstubAllGlobals();
   });
 
   afterEach(() => {
     resetEnv();
+    resetTelemetryGlobals();
     vi.unstubAllGlobals();
   });
 
@@ -94,6 +105,24 @@ describe("telemetry", () => {
     });
   });
 
+  it("sends an ingest key header when configured", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.DOCS_TELEMETRY_INGEST_KEY = "secret-key";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsTelemetryEvent(undefined, telemetryEvent());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init?.headers).toMatchObject({
+      "content-type": "application/json",
+      "x-docs-telemetry-key": "secret-key",
+    });
+  });
+
   it("deduplicates project detected events per runtime key", async () => {
     process.env.NODE_ENV = "production";
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
@@ -107,6 +136,29 @@ describe("telemetry", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the project detected dedupe cache", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (let index = 0; index < 300; index += 1) {
+      emitDocsTelemetryProjectEvent(
+        { entry: "docs" },
+        { framework: "next", siteOrigin: `https://site-${index}.example.com` },
+      );
+    }
+
+    emitDocsTelemetryProjectEvent(
+      { entry: "docs" },
+      { framework: "next", siteOrigin: "https://site-0.example.com" },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledTimes(301);
   });
 
   it("summarizes enabled docs features without raw user content", () => {

--- a/packages/docs/src/telemetry.test.ts
+++ b/packages/docs/src/telemetry.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  emitDocsTelemetryEvent,
+  emitDocsTelemetryProjectEvent,
+  getDocsTelemetryFeatures,
+  inferDocsTelemetryAgentSurface,
+  resolveDocsTelemetryConfig,
+} from "./telemetry.js";
+import type { DocsTelemetryEvent } from "./types.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.DOCS_TELEMETRY;
+  delete process.env.DOCS_TELEMETRY_DISABLED;
+  delete process.env.DOCS_TELEMETRY_ENDPOINT;
+  delete process.env.VERCEL_ENV;
+  delete process.env.NETLIFY;
+  delete process.env.CONTEXT;
+  delete process.env.CF_PAGES;
+}
+
+function telemetryEvent(overrides: Partial<DocsTelemetryEvent> = {}): DocsTelemetryEvent {
+  return {
+    type: "project_detected",
+    timestamp: "2026-06-17T00:00:00.000Z",
+    package: {
+      name: "@farming-labs/docs",
+      version: "0.2.24",
+    },
+    ...overrides,
+  };
+}
+
+describe("telemetry", () => {
+  beforeEach(() => {
+    resetEnv();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    resetEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it("enables telemetry by default in production", () => {
+    process.env.NODE_ENV = "production";
+
+    expect(resolveDocsTelemetryConfig()).toMatchObject({
+      enabled: true,
+      endpoint: "https://docs.farming-labs.dev/api/telemetry/events",
+    });
+  });
+
+  it("lets env opt-out win over config", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.DOCS_TELEMETRY = "false";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(resolveDocsTelemetryConfig(true)).toMatchObject({ enabled: false });
+
+    await emitDocsTelemetryEvent(true, telemetryEvent());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts telemetry events to the configured endpoint", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.DOCS_TELEMETRY_ENDPOINT = "https://telemetry.example.com/events";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsTelemetryEvent(undefined, telemetryEvent({ framework: "next" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://telemetry.example.com/events");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      event: {
+        type: "project_detected",
+        framework: "next",
+        package: {
+          name: "@farming-labs/docs",
+          version: "0.2.24",
+        },
+      },
+    });
+  });
+
+  it("deduplicates project detected events per runtime key", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("https://example.com/api/docs");
+    emitDocsTelemetryProjectEvent({ entry: "docs" }, { framework: "next", request });
+    emitDocsTelemetryProjectEvent({ entry: "docs" }, { framework: "next", request });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("summarizes enabled docs features without raw user content", () => {
+    expect(
+      getDocsTelemetryFeatures({
+        search: { provider: "typesense", collection: "docs", apiKey: "secret" } as any,
+        ai: { enabled: true, apiKey: "secret" } as any,
+        mcp: { enabled: true },
+        pageActions: { copyMarkdown: true },
+        feedback: { agent: { enabled: true } } as any,
+        staticExport: true,
+        apiReference: { enabled: true } as any,
+        codeBlocks: { validate: true } as any,
+      }),
+    ).toMatchObject({
+      search: true,
+      ai: true,
+      mcp: true,
+      pageActions: true,
+      agentFeedback: true,
+      staticExport: true,
+      apiReference: true,
+      codeBlocksValidate: true,
+    });
+  });
+
+  it("classifies agent-facing request surfaces", () => {
+    expect(
+      inferDocsTelemetryAgentSurface(new Request("https://example.com/api/docs?format=skill"), {
+        entry: "docs",
+      }),
+    ).toBe("skill");
+
+    expect(
+      inferDocsTelemetryAgentSurface(new Request("https://example.com/docs/getting-started.md"), {
+        entry: "docs",
+      }),
+    ).toBe("markdown");
+
+    expect(
+      inferDocsTelemetryAgentSurface(
+        new Request("https://example.com/api/docs?feedback=agent", { method: "POST" }),
+        {
+          entry: "docs",
+        },
+      ),
+    ).toBe("agent_feedback_submit");
+
+    expect(
+      inferDocsTelemetryAgentSurface(
+        new Request("https://example.com/api/docs", { method: "POST" }),
+        {
+          entry: "docs",
+        },
+      ),
+    ).toBe("ask_ai");
+  });
+});

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -22,6 +22,8 @@ import type {
 const DOCS_PACKAGE_NAME = "@farming-labs/docs";
 const DOCS_PACKAGE_VERSION = "0.2.24";
 const DEFAULT_DOCS_TELEMETRY_ENDPOINT = "https://docs.farming-labs.dev/api/telemetry/events";
+const PROJECT_TELEMETRY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const PROJECT_TELEMETRY_CACHE_MAX_KEYS = 256;
 
 export interface ResolvedDocsTelemetryConfig {
   enabled: boolean;
@@ -324,13 +326,27 @@ function projectEventKey(event: DocsTelemetryEvent): string {
   ].join("|");
 }
 
-function getSentProjectKeys(): Set<string> {
+function getSentProjectKeys(): Map<string, number> {
   const globalValue = globalThis as typeof globalThis & {
-    __farmingLabsDocsTelemetryProjectKeys__?: Set<string>;
+    __farmingLabsDocsTelemetryProjectKeys__?: Map<string, number>;
   };
 
-  globalValue.__farmingLabsDocsTelemetryProjectKeys__ ??= new Set<string>();
+  globalValue.__farmingLabsDocsTelemetryProjectKeys__ ??= new Map();
   return globalValue.__farmingLabsDocsTelemetryProjectKeys__;
+}
+
+function pruneSentProjectKeys(sent: Map<string, number>, now: number): void {
+  for (const [key, expiresAt] of sent) {
+    if (expiresAt <= now) {
+      sent.delete(key);
+    }
+  }
+
+  while (sent.size >= PROJECT_TELEMETRY_CACHE_MAX_KEYS) {
+    const oldestKey = sent.keys().next().value;
+    if (!oldestKey) return;
+    sent.delete(oldestKey);
+  }
 }
 
 export async function emitDocsTelemetryEvent(
@@ -341,11 +357,18 @@ export async function emitDocsTelemetryEvent(
   if (!resolved.enabled || !resolved.endpoint || typeof fetch !== "function") return;
 
   try {
+    const ingestKey = readRuntimeEnv("DOCS_TELEMETRY_INGEST_KEY");
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+
+    if (ingestKey) {
+      headers["x-docs-telemetry-key"] = ingestKey;
+    }
+
     await fetch(resolved.endpoint, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
+      headers,
       body: JSON.stringify({ event }),
       keepalive: true,
     });
@@ -367,9 +390,16 @@ export function emitDocsTelemetryProjectEvent(
   );
   const key = projectEventKey(event);
   const sent = getSentProjectKeys();
+  const now = Date.now();
+  const expiresAt = sent.get(key);
 
-  if (sent.has(key)) return;
-  sent.add(key);
+  if (expiresAt && expiresAt > now) return;
+  if (typeof expiresAt === "number") {
+    sent.delete(key);
+  }
+
+  pruneSentProjectKeys(sent, now);
+  sent.set(key, now + PROJECT_TELEMETRY_CACHE_TTL_MS);
 
   void emitDocsTelemetryEvent(config.telemetry, event);
 }

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -1,0 +1,459 @@
+import {
+  isDocsAgentDiscoveryRequest,
+  isDocsAgentsRequest,
+  isDocsSkillRequest,
+  resolveDocsAgentFeedbackConfig,
+  resolveDocsAgentFeedbackRequest,
+  resolveDocsAgentsFormat,
+  resolveDocsLlmsTxtRequest,
+  resolveDocsMarkdownRequest,
+  resolveDocsSkillFormat,
+} from "./agent.js";
+import type {
+  DocsConfig,
+  DocsTelemetryAgentSurface,
+  DocsTelemetryConfig,
+  DocsTelemetryEvent,
+  DocsTelemetryEventInput,
+  DocsTelemetryFeatures,
+  DocsTelemetryFramework,
+} from "./types.js";
+
+const DOCS_PACKAGE_NAME = "@farming-labs/docs";
+const DOCS_PACKAGE_VERSION = "0.2.24";
+const DEFAULT_DOCS_TELEMETRY_ENDPOINT = "https://docs.farming-labs.dev/api/telemetry/events";
+
+export interface ResolvedDocsTelemetryConfig {
+  enabled: boolean;
+  endpoint?: string;
+}
+
+export interface DocsTelemetryContext {
+  framework?: DocsTelemetryFramework;
+  request?: Request;
+  siteOrigin?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface DocsTelemetryAgentSurfaceContext extends DocsTelemetryContext {
+  surface: DocsTelemetryAgentSurface;
+}
+
+export interface DocsTelemetryAgentSurfaceRequestOptions {
+  entry: string;
+  llmsTxt?: DocsConfig["llmsTxt"];
+  feedback?: DocsConfig["feedback"];
+}
+
+type RuntimeEnv = Record<string, string | undefined>;
+
+function getRuntimeEnv(): RuntimeEnv | undefined {
+  if (typeof process === "undefined" || !process.env) {
+    return undefined;
+  }
+
+  return process.env;
+}
+
+function readRuntimeEnv(name: string): string | undefined {
+  const value = getRuntimeEnv()?.[name]?.trim();
+  return value ? value : undefined;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test(value ?? "");
+}
+
+function isFalsyEnv(value: string | undefined): boolean {
+  return /^(0|false|no|off)$/i.test(value ?? "");
+}
+
+function isBrowserRuntime(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
+function isProductionTelemetryRuntime(): boolean {
+  if (isBrowserRuntime()) return false;
+
+  const env = getRuntimeEnv();
+  if (!env) {
+    return true;
+  }
+
+  if (env.NODE_ENV === "test") return false;
+  if (env.VERCEL_ENV === "production") return true;
+  if (env.CONTEXT === "production" && isTruthyEnv(env.NETLIFY)) return true;
+  if (isTruthyEnv(env.CF_PAGES)) return true;
+  if (env.RENDER_SERVICE_ID || env.FLY_APP_NAME || env.RAILWAY_ENVIRONMENT) return true;
+
+  return env.NODE_ENV === "production";
+}
+
+export function resolveDocsTelemetryConfig(
+  telemetry?: boolean | DocsTelemetryConfig,
+): ResolvedDocsTelemetryConfig {
+  const envToggle = readRuntimeEnv("DOCS_TELEMETRY");
+  const envDisabled = readRuntimeEnv("DOCS_TELEMETRY_DISABLED");
+
+  if (isFalsyEnv(envToggle) || isTruthyEnv(envDisabled) || telemetry === false) {
+    return { enabled: false };
+  }
+
+  const objectConfig =
+    telemetry && typeof telemetry === "object" ? (telemetry as DocsTelemetryConfig) : undefined;
+
+  if (objectConfig?.enabled === false) {
+    return { enabled: false };
+  }
+
+  const explicitEnabled =
+    telemetry === true || objectConfig?.enabled === true || isTruthyEnv(envToggle);
+  const enabled = explicitEnabled || isProductionTelemetryRuntime();
+
+  return {
+    enabled,
+    endpoint:
+      objectConfig?.endpoint?.trim() ||
+      readRuntimeEnv("DOCS_TELEMETRY_ENDPOINT") ||
+      DEFAULT_DOCS_TELEMETRY_ENDPOINT,
+  };
+}
+
+function readRequestOrigin(request: Request | undefined): string | undefined {
+  if (!request?.url) return undefined;
+
+  try {
+    return new URL(request.url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function readDeploymentOrigin(): string | undefined {
+  const candidates = [
+    readRuntimeEnv("DOCS_SITE_URL"),
+    readRuntimeEnv("NEXT_PUBLIC_SITE_URL"),
+    readRuntimeEnv("SITE_URL"),
+    readRuntimeEnv("URL"),
+    readRuntimeEnv("CF_PAGES_URL"),
+    readRuntimeEnv("VERCEL_PROJECT_PRODUCTION_URL"),
+    readRuntimeEnv("VERCEL_URL"),
+    readRuntimeEnv("DEPLOY_PRIME_URL"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+
+    try {
+      const withProtocol = /^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`;
+      return new URL(withProtocol).origin;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return undefined;
+}
+
+function detectDeployment(): DocsTelemetryEvent["deployment"] | undefined {
+  const env = getRuntimeEnv();
+  if (!env) return undefined;
+
+  if (env.VERCEL || env.VERCEL_ENV) {
+    return {
+      provider: "vercel",
+      environment: env.VERCEL_ENV,
+      id: env.VERCEL_DEPLOYMENT_ID ?? env.VERCEL_GIT_COMMIT_SHA,
+      region: env.VERCEL_REGION,
+    };
+  }
+
+  if (env.NETLIFY) {
+    return {
+      provider: "netlify",
+      environment: env.CONTEXT,
+      id: env.DEPLOY_ID ?? env.COMMIT_REF,
+    };
+  }
+
+  if (env.CF_PAGES) {
+    return {
+      provider: "cloudflare-pages",
+      environment: env.CF_PAGES_BRANCH,
+      id: env.CF_PAGES_COMMIT_SHA,
+    };
+  }
+
+  if (env.RENDER_SERVICE_ID) {
+    return {
+      provider: "render",
+      environment: env.RENDER_ENV,
+      id: env.RENDER_SERVICE_ID,
+    };
+  }
+
+  if (env.FLY_APP_NAME) {
+    return {
+      provider: "fly",
+      environment: env.FLY_APP_NAME,
+      id: env.FLY_ALLOC_ID,
+      region: env.FLY_REGION,
+    };
+  }
+
+  if (env.RAILWAY_ENVIRONMENT) {
+    return {
+      provider: "railway",
+      environment: env.RAILWAY_ENVIRONMENT,
+      id: env.RAILWAY_DEPLOYMENT_ID,
+    };
+  }
+
+  return env.NODE_ENV === "production" ? { environment: "production" } : undefined;
+}
+
+function detectRuntime(): DocsTelemetryEvent["runtime"] | undefined {
+  if (typeof process !== "undefined" && process.versions?.node) {
+    return {
+      name: "node",
+      version: process.versions.node,
+    };
+  }
+
+  if (typeof navigator !== "undefined" && navigator.userAgent) {
+    return {
+      name: "web-standard",
+    };
+  }
+
+  return undefined;
+}
+
+function isObjectConfigEnabled(value: unknown, defaultEnabled: boolean): boolean {
+  if (value === false) return false;
+  if (value === true) return true;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const enabled = (value as { enabled?: unknown }).enabled;
+    return enabled === false ? false : defaultEnabled || enabled === true;
+  }
+
+  return defaultEnabled;
+}
+
+function hasObjectConfig(value: unknown): boolean {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function getDocsTelemetryFeatures(config: Partial<DocsConfig>): DocsTelemetryFeatures {
+  const pageActions = config.pageActions;
+  const feedback = config.feedback;
+
+  return {
+    search: isObjectConfigEnabled(config.search, true),
+    ai: isObjectConfigEnabled(config.ai, false),
+    mcp: isObjectConfigEnabled(config.mcp, true),
+    llmsTxt: isObjectConfigEnabled(config.llmsTxt, true),
+    pageActions: hasObjectConfig(pageActions),
+    feedback:
+      feedback === true || (hasObjectConfig(feedback) && (feedback as any).enabled !== false),
+    agentFeedback:
+      feedback !== false &&
+      !(hasObjectConfig(feedback) && (feedback as any).agent === false) &&
+      !(
+        hasObjectConfig(feedback) &&
+        hasObjectConfig((feedback as any).agent) &&
+        (feedback as any).agent.enabled === false
+      ),
+    sitemap: isObjectConfigEnabled(config.sitemap, true),
+    robots: isObjectConfigEnabled(config.robots, true),
+    apiReference: isObjectConfigEnabled(config.apiReference, false),
+    staticExport: config.staticExport === true,
+    changelog: isObjectConfigEnabled(config.changelog, false),
+    cloud: typeof config.cloud !== "undefined" && isObjectConfigEnabled(config.cloud, true),
+    review: isObjectConfigEnabled(config.review, true),
+    codeBlocksValidate:
+      hasObjectConfig(config.codeBlocks) && Boolean((config.codeBlocks as any).validate),
+  };
+}
+
+function createDocsTelemetryEvent(
+  config: Partial<DocsConfig>,
+  input: DocsTelemetryEventInput,
+  context: DocsTelemetryContext = {},
+): DocsTelemetryEvent {
+  const siteOrigin =
+    context.siteOrigin ??
+    input.site?.origin ??
+    readRequestOrigin(context.request) ??
+    readDeploymentOrigin();
+  const deployment = input.deployment ?? detectDeployment();
+  const properties =
+    context.properties || input.properties
+      ? {
+          ...(input.properties ?? {}),
+          ...(context.properties ?? {}),
+        }
+      : undefined;
+
+  return {
+    ...input,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    package: {
+      name: DOCS_PACKAGE_NAME,
+      version: DOCS_PACKAGE_VERSION,
+      ...input.package,
+    },
+    framework: input.framework ?? context.framework,
+    runtime: input.runtime ?? detectRuntime(),
+    site: siteOrigin ? { origin: siteOrigin } : input.site,
+    deployment,
+    features: input.features ?? getDocsTelemetryFeatures(config),
+    properties,
+  };
+}
+
+function projectEventKey(event: DocsTelemetryEvent): string {
+  return [
+    event.package.name,
+    event.package.version,
+    event.framework ?? "",
+    event.site?.origin ?? "",
+    event.deployment?.provider ?? "",
+    event.deployment?.environment ?? "",
+    event.deployment?.id ?? "",
+  ].join("|");
+}
+
+function getSentProjectKeys(): Set<string> {
+  const globalValue = globalThis as typeof globalThis & {
+    __farmingLabsDocsTelemetryProjectKeys__?: Set<string>;
+  };
+
+  globalValue.__farmingLabsDocsTelemetryProjectKeys__ ??= new Set<string>();
+  return globalValue.__farmingLabsDocsTelemetryProjectKeys__;
+}
+
+export async function emitDocsTelemetryEvent(
+  telemetry: boolean | DocsTelemetryConfig | undefined,
+  event: DocsTelemetryEvent,
+): Promise<void> {
+  const resolved = resolveDocsTelemetryConfig(telemetry);
+  if (!resolved.enabled || !resolved.endpoint || typeof fetch !== "function") return;
+
+  try {
+    await fetch(resolved.endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ event }),
+      keepalive: true,
+    });
+  } catch {
+    // Telemetry should never affect docs runtime behavior.
+  }
+}
+
+export function emitDocsTelemetryProjectEvent(
+  config: Partial<DocsConfig>,
+  context: DocsTelemetryContext = {},
+): void {
+  const event = createDocsTelemetryEvent(
+    config,
+    {
+      type: "project_detected",
+    },
+    context,
+  );
+  const key = projectEventKey(event);
+  const sent = getSentProjectKeys();
+
+  if (sent.has(key)) return;
+  sent.add(key);
+
+  void emitDocsTelemetryEvent(config.telemetry, event);
+}
+
+export function emitDocsTelemetryAgentSurfaceEvent(
+  config: Partial<DocsConfig>,
+  context: DocsTelemetryAgentSurfaceContext,
+): void {
+  const event = createDocsTelemetryEvent(
+    config,
+    {
+      type: context.surface === "mcp" ? "mcp_request" : "agent_surface_used",
+      properties: {
+        surface: context.surface,
+      },
+    },
+    context,
+  );
+
+  void emitDocsTelemetryEvent(config.telemetry, event);
+}
+
+export function emitDocsTelemetryMcpToolEvent(
+  config: Partial<DocsConfig>,
+  context: DocsTelemetryContext & { tool: string; locale?: string; resultCount?: number },
+): void {
+  const event = createDocsTelemetryEvent(
+    config,
+    {
+      type: "mcp_tool_used",
+      properties: {
+        tool: context.tool,
+        locale: context.locale,
+        resultCount: context.resultCount,
+      },
+    },
+    context,
+  );
+
+  void emitDocsTelemetryEvent(config.telemetry, event);
+}
+
+export function inferDocsTelemetryAgentSurface(
+  request: Request,
+  options: DocsTelemetryAgentSurfaceRequestOptions,
+): DocsTelemetryAgentSurface | undefined {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  const feedbackConfig = resolveDocsAgentFeedbackConfig(options.feedback);
+  const feedbackRequest = resolveDocsAgentFeedbackRequest(url, feedbackConfig);
+
+  if ((method === "GET" || method === "HEAD") && isDocsAgentDiscoveryRequest(url)) {
+    return "agent_spec";
+  }
+
+  if ((method === "GET" || method === "HEAD") && feedbackRequest?.kind === "schema") {
+    return "agent_feedback_schema";
+  }
+
+  if (method === "POST" && feedbackRequest?.kind === "submit") {
+    return "agent_feedback_submit";
+  }
+
+  if (method === "GET" || method === "HEAD") {
+    if (isDocsAgentsRequest(url) || resolveDocsAgentsFormat(url) === "agents") {
+      return "agents";
+    }
+
+    if (isDocsSkillRequest(url) || resolveDocsSkillFormat(url) === "skill") {
+      return "skill";
+    }
+
+    if (resolveDocsMarkdownRequest(options.entry, url, request)) {
+      return "markdown";
+    }
+
+    if (resolveDocsLlmsTxtRequest(url, options.llmsTxt, options.entry)) {
+      return "llms";
+    }
+  }
+
+  if (method === "POST") {
+    return "ask_ai";
+  }
+
+  return undefined;
+}

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -892,6 +892,92 @@ export interface DocsAnalyticsConfig {
   onEvent?: (event: DocsAnalyticsEvent) => void | Promise<void>;
 }
 
+export type DocsTelemetryFramework =
+  | "next"
+  | "tanstack-start"
+  | "sveltekit"
+  | "astro"
+  | "nuxt"
+  | "mcp"
+  | (string & {});
+
+export type DocsTelemetryEventType =
+  | "project_detected"
+  | "agent_surface_used"
+  | "mcp_request"
+  | "mcp_tool_used"
+  | (string & {});
+
+export type DocsTelemetryAgentSurface =
+  | "agent_spec"
+  | "agents"
+  | "skill"
+  | "markdown"
+  | "llms"
+  | "agent_feedback_schema"
+  | "agent_feedback_submit"
+  | "ask_ai"
+  | "mcp";
+
+export interface DocsTelemetryConfig {
+  /** Enable Farming Labs maintainer telemetry. Defaults to production-only enabled. */
+  enabled?: boolean;
+  /**
+   * Override the telemetry ingestion endpoint.
+   *
+   * This is mostly useful for self-hosting, development verification, or tests.
+   */
+  endpoint?: string;
+}
+
+export interface DocsTelemetryFeatures {
+  search: boolean;
+  ai: boolean;
+  mcp: boolean;
+  llmsTxt: boolean;
+  pageActions: boolean;
+  feedback: boolean;
+  agentFeedback: boolean;
+  sitemap: boolean;
+  robots: boolean;
+  apiReference: boolean;
+  staticExport: boolean;
+  changelog: boolean;
+  cloud: boolean;
+  review: boolean;
+  codeBlocksValidate: boolean;
+}
+
+export interface DocsTelemetryEvent {
+  type: DocsTelemetryEventType;
+  timestamp: string;
+  package: {
+    name: "@farming-labs/docs";
+    version?: string;
+  };
+  framework?: DocsTelemetryFramework;
+  runtime?: {
+    name?: string;
+    version?: string;
+  };
+  site?: {
+    origin?: string;
+  };
+  deployment?: {
+    provider?: string;
+    environment?: string;
+    id?: string;
+    region?: string;
+  };
+  features?: Partial<DocsTelemetryFeatures>;
+  properties?: Record<string, unknown>;
+}
+
+export type DocsTelemetryEventInput = Omit<DocsTelemetryEvent, "timestamp" | "package"> & {
+  timestamp?: string;
+  package?: Partial<DocsTelemetryEvent["package"]>;
+};
+
 export interface DocsCloudApiKeyConfig {
   /**
    * Environment variable that stores the Docs Cloud API key.
@@ -2645,6 +2731,16 @@ export interface DocsConfig {
    * included unless `includeInputs: true` is set.
    */
   analytics?: boolean | DocsAnalyticsConfig;
+  /**
+   * Farming Labs maintainer telemetry for production adoption and coarse
+   * agent-optimized feature usage.
+   *
+   * This is separate from project-owned `analytics`. It avoids visitor
+   * identities, page views, raw inputs, docs content, cookies, and per-user
+   * sessions. Disable with `telemetry: false`, `DOCS_TELEMETRY=false`, or
+   * `DOCS_TELEMETRY_DISABLED=1`.
+   */
+  telemetry?: boolean | DocsTelemetryConfig;
   /**
    * Docs Cloud integration settings.
    *

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -33,6 +33,9 @@ import {
   detectDocsMarkdownAgentRequest,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryProjectEvent,
+  inferDocsTelemetryAgentSurface,
   getDocsMarkdownVaryHeader,
   hasDocsMarkdownSignatureAgent,
   getDocsLlmsTxtMaxCharsIssue,
@@ -61,6 +64,7 @@ import type {
   DocsI18nConfig,
   LlmsTxtConfig,
   DocsObservabilityConfig,
+  DocsTelemetryConfig,
   FeedbackConfig,
 } from "@farming-labs/docs";
 import {
@@ -149,6 +153,8 @@ interface DocsAPIOptions {
   search?: boolean | DocsSearchConfig;
   /** Analytics configuration */
   analytics?: boolean | DocsAnalyticsConfig;
+  /** Farming Labs maintainer telemetry configuration. */
+  telemetry?: boolean | DocsTelemetryConfig;
   /** Observability configuration for logs, traces, and metrics callbacks. */
   observability?: boolean | DocsObservabilityConfig;
   /** Feedback configuration */
@@ -176,6 +182,7 @@ interface DocsMCPAPIOptions {
   mcp?: boolean | DocsMcpConfig;
   search?: boolean | DocsSearchConfig;
   analytics?: boolean | DocsAnalyticsConfig;
+  telemetry?: boolean | DocsTelemetryConfig;
   observability?: boolean | DocsObservabilityConfig;
 }
 
@@ -3595,9 +3602,48 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     apiReference: apiReferenceConfig,
   } as DocsConfig;
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(apiReferenceConfig);
-  const mcpConfig = resolveDocsMcpConfig(options?.mcp ?? readMcpConfig(root), {
+  const rawMcpConfig = options?.mcp ?? readMcpConfig(root);
+  const mcpConfig = resolveDocsMcpConfig(rawMcpConfig, {
     defaultName: llmsConfig.siteTitle ?? "Documentation",
   });
+  const telemetryConfig: Partial<DocsConfig> = {
+    entry,
+    docsPath,
+    contentDir,
+    telemetry: options?.telemetry,
+    search: searchConfig,
+    ai: aiConfig as DocsConfig["ai"],
+    cloud: cloudConfig,
+    i18n: i18nConfig ?? undefined,
+    feedback: options?.feedback,
+    mcp: rawMcpConfig,
+    llmsTxt: llmsConfig as DocsConfig["llmsTxt"],
+    sitemap: sitemapConfig,
+    robots: robotsConfig,
+    apiReference: apiReferenceConfig,
+    metadata: options?.metadata,
+  };
+
+  function trackTelemetryRequest(request: Request) {
+    emitDocsTelemetryProjectEvent(telemetryConfig, {
+      framework: "next",
+      request,
+    });
+
+    const surface = inferDocsTelemetryAgentSurface(request, {
+      entry,
+      llmsTxt: llmsConfig,
+      feedback: options?.feedback,
+    });
+
+    if (!surface) return;
+
+    emitDocsTelemetryAgentSurfaceEvent(telemetryConfig, {
+      framework: "next",
+      request,
+      surface,
+    });
+  }
 
   function resolveDocsDirCandidates(locale?: string): string[] {
     const relativeCandidates = new Set<string>();
@@ -3812,6 +3858,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
      * GET handler — search, markdown, llms.txt, llms-full.txt, or skill.md.
      */
     async GET(request: Request) {
+      trackTelemetryRequest(request);
       const ctx = resolveContextFromRequest(request);
       const url = new URL(request.url);
       const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
@@ -4228,6 +4275,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
      * Response: SSE stream of chat completion chunks.
      */
     async POST(request: Request): Promise<Response> {
+      trackTelemetryRequest(request);
       const url = new URL(request.url);
       const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
       const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
@@ -4387,6 +4435,8 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
     mcp: options.mcp ?? readMcpConfig(rootDir),
     search: options.search,
     analytics: options.analytics,
+    telemetry: options.telemetry,
+    telemetryFramework: "next",
     observability: options.observability,
     defaultName: navTitle,
   });

--- a/packages/next/src/layout.tsx
+++ b/packages/next/src/layout.tsx
@@ -1,4 +1,5 @@
 import { createDocsLayout, createDocsMetadata } from "@farming-labs/theme";
+import { emitDocsTelemetryProjectEvent } from "@farming-labs/docs";
 import type { DocsConfig } from "@farming-labs/docs";
 import { withNextApiReferenceBanner } from "./api-reference.js";
 import DocsClientCallbacks from "./client-callbacks.js";
@@ -8,6 +9,10 @@ export function createNextDocsMetadata(config: DocsConfig) {
 }
 
 export function createNextDocsLayout(config: DocsConfig) {
+  emitDocsTelemetryProjectEvent(config, {
+    framework: "next",
+  });
+
   const DocsLayout = createDocsLayout(withNextApiReferenceBanner(config));
 
   return function NextDocsLayout({ children }: { children: React.ReactNode }) {

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -28,6 +28,8 @@ import {
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryProjectEvent,
   formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   getDocsLlmsTxtMaxCharsIssue,
@@ -67,6 +69,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsAgentsFormat,
   resolveDocsSkillFormat,
+  inferDocsTelemetryAgentSurface,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
   validateDocsAgentFeedbackPayload,
@@ -881,6 +884,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
+  function trackTelemetryRequest(request: Request) {
+    emitDocsTelemetryProjectEvent(config, {
+      framework: "nuxt",
+      request,
+    });
+
+    const surface = inferDocsTelemetryAgentSurface(request, {
+      entry,
+      llmsTxt: config.llmsTxt,
+      feedback: config.feedback,
+    });
+
+    if (!surface) return;
+
+    emitDocsTelemetryAgentSurfaceEvent(config, {
+      framework: "nuxt",
+      request,
+      surface,
+    });
+  }
+
   function getLlmsContent(ctx: ReturnType<typeof resolveContextFromPath>) {
     const key = ctx.locale ?? "__default__";
     const cached = llmsCache.get(key);
@@ -915,6 +939,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(context: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(context.request);
     const ctx = resolveContextFromRequest(context.request);
     const url = new URL(context.request.url);
 
@@ -1278,6 +1303,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(context: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(context.request);
     const requestUrl = new URL(context.request.url);
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
@@ -1840,6 +1866,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     analytics,
+    telemetry: config.telemetry,
+    telemetryFramework: "nuxt",
     observability,
     defaultName: mcpSiteTitle,
   });

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -41,6 +41,8 @@ import {
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryProjectEvent,
   formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   getDocsLlmsTxtMaxCharsIssue,
@@ -77,6 +79,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsAgentsFormat,
   resolveDocsSkillFormat,
+  inferDocsTelemetryAgentSurface,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
   validateDocsAgentFeedbackPayload,
@@ -900,6 +903,27 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
+  function trackTelemetryRequest(request: Request) {
+    emitDocsTelemetryProjectEvent(config, {
+      framework: "sveltekit",
+      request,
+    });
+
+    const surface = inferDocsTelemetryAgentSurface(request, {
+      entry,
+      llmsTxt: config.llmsTxt,
+      feedback: config.feedback,
+    });
+
+    if (!surface) return;
+
+    emitDocsTelemetryAgentSurfaceEvent(config, {
+      framework: "sveltekit",
+      request,
+      surface,
+    });
+  }
+
   function getLlmsContent(ctx: ReturnType<typeof resolveContextFromPath>) {
     const key = ctx.locale ?? "__default__";
     const cached = llmsCache.get(key);
@@ -934,6 +958,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(event: RequestEvent): Promise<Response> {
+    trackTelemetryRequest(event.request);
     const ctx = resolveContextFromRequest(event.request);
 
     if (isDocsAgentDiscoveryRequest(event.url)) {
@@ -1296,6 +1321,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   }
 
   async function POST(event: RequestEvent): Promise<Response> {
+    trackTelemetryRequest(event.request);
     const requestUrl = new URL(event.request.url);
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
@@ -1860,6 +1886,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
     analytics,
+    telemetry: config.telemetry,
+    telemetryFramework: "sveltekit",
     observability,
     defaultName: mcpSiteTitle,
   });

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -11,6 +11,8 @@ import {
   createDocsAgentTraceId,
   emitDocsAgentTraceEvent,
   emitDocsAnalyticsEvent,
+  emitDocsTelemetryAgentSurfaceEvent,
+  emitDocsTelemetryProjectEvent,
   formatDocsAskAIPackageHints,
   findDocsMarkdownPage,
   getDocsLlmsTxtMaxCharsIssue,
@@ -47,6 +49,7 @@ import {
   resolveDocsSitemapPageLastmod,
   resolveDocsAgentsFormat,
   resolveDocsSkillFormat,
+  inferDocsTelemetryAgentSurface,
   renderDocsPageStructuredDataJson,
   selectDocsLlmsTxtContent,
   validateDocsAgentFeedbackPayload,
@@ -852,6 +855,27 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
   const llmsCache = new Map<string, ReturnType<typeof renderDocsLlmsTxt>>();
 
+  function trackTelemetryRequest(request: Request) {
+    emitDocsTelemetryProjectEvent(config, {
+      framework: "tanstack-start",
+      request,
+    });
+
+    const surface = inferDocsTelemetryAgentSurface(request, {
+      entry,
+      llmsTxt: config.llmsTxt,
+      feedback: config.feedback,
+    });
+
+    if (!surface) return;
+
+    emitDocsTelemetryAgentSurfaceEvent(config, {
+      framework: "tanstack-start",
+      request,
+      surface,
+    });
+  }
+
   function getLlmsContent(ctx: ReturnType<typeof resolveContextFromPath>) {
     const key = ctx.locale ?? "__default__";
     const cached = llmsCache.get(key);
@@ -885,6 +909,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   }
 
   async function GET(event: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(event.request);
     const ctx = resolveContextFromRequest(event.request);
     const url = new URL(event.request.url);
 
@@ -1243,6 +1268,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   }
 
   async function POST(event: { request: Request }): Promise<Response> {
+    trackTelemetryRequest(event.request);
     const requestUrl = new URL(event.request.url);
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
@@ -1802,6 +1828,8 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     },
     mcp: config.mcp,
     analytics,
+    telemetry: config.telemetry,
+    telemetryFramework: "tanstack-start",
     observability,
     defaultName: mcpSiteTitle,
   });

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -43,6 +43,7 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `onCopyClick` | `(data: CodeBlockCopyData) => void` | — | Callback when user copies a code block (title, content, url, language) |
 | `codeBlocks` | `DocsCodeBlocksConfig` | — | Validate fenced MDX code blocks with metadata planning and optional sandbox execution |
 | `feedback` | `boolean \| FeedbackConfig` | `false` for UI | Human page feedback UI; agent feedback endpoints are default-on unless opted out |
+| `telemetry` | `boolean \| DocsTelemetryConfig` | production-only enabled | Farming Labs maintainer telemetry for package adoption and coarse agent-surface usage |
 | `readingTime` | `boolean \| ReadingTimeConfig` | `false` | Opt-in estimated read-time label with per-page overrides |
 | `agent` | `DocsAgentConfig` | — | Defaults for `docs agent compact` |
 | `review` | `boolean \| DocsReviewConfig` | `true` | Docs Review scoring, GitHub Actions workflow generation, and rule severities |

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configuration
-description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, readingTime, agent.compact, metadata, og, apiReference, MCP, llmsTxt, sitemap, robots, codeBlocks.validate, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
+description: docs.config.ts options for @farming-labs/docs. Use when configuring entry, contentDir, theme, staticExport, nav, github, themeToggle, breadcrumb, sidebar, icons, components, search, changelog, feedback, telemetry, readingTime, agent.compact, metadata, og, apiReference, MCP, llmsTxt, sitemap, robots, codeBlocks.validate, onCopyClick, pageActions, or ai. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt config file location.
 ---
 
 # @farming-labs/docs — Configuration

--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -7,7 +7,8 @@ export const dynamic = "force-dynamic";
 
 const MAX_TELEMETRY_BODY_BYTES = 32_768;
 const TELEMETRY_RATE_LIMIT_WINDOW_MS = 60_000;
-const TELEMETRY_RATE_LIMIT_MAX_REQUESTS = 120;
+const TELEMETRY_GLOBAL_RATE_LIMIT_MAX_REQUESTS = 2_000;
+const TELEMETRY_IDENTITY_RATE_LIMIT_MAX_REQUESTS = 120;
 const TELEMETRY_RATE_LIMIT_MAX_KEYS = 4_096;
 
 interface TelemetryRateLimitEntry {
@@ -77,17 +78,6 @@ function hasValidTelemetryIngestKey(request: Request) {
   return readTelemetryIngestKey(request) === requiredKey;
 }
 
-function readClientIp(request: Request) {
-  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0];
-
-  return (
-    readString(request.headers.get("cf-connecting-ip"), { max: 100 }) ??
-    readString(request.headers.get("x-real-ip"), { max: 100 }) ??
-    readString(forwardedFor, { max: 100 }) ??
-    "unknown"
-  );
-}
-
 function pruneExpiredRateLimitEntries(store: Map<string, TelemetryRateLimitEntry>, now: number) {
   for (const [key, entry] of store) {
     if (entry.resetAt <= now) {
@@ -104,12 +94,11 @@ function trimRateLimitStore(store: Map<string, TelemetryRateLimitEntry>) {
   }
 }
 
-function isTelemetryRateLimited(request: Request) {
+function isTelemetryRateLimited(key: string, maxRequests: number) {
   const now = Date.now();
   const store = getRateLimitStore();
   pruneExpiredRateLimitEntries(store, now);
 
-  const key = readClientIp(request);
   const current = store.get(key);
 
   if (!current || current.resetAt <= now) {
@@ -126,10 +115,39 @@ function isTelemetryRateLimited(request: Request) {
     return false;
   }
 
-  if (current.count >= TELEMETRY_RATE_LIMIT_MAX_REQUESTS) return true;
+  if (current.count >= maxRequests) return true;
 
   current.count += 1;
   return false;
+}
+
+function createTelemetryIdentityRateLimitKey(
+  eventBody: Record<string, unknown>,
+  eventType: string,
+) {
+  const packageInfo = readNestedRecord(eventBody, "package");
+  const site = readNestedRecord(eventBody, "site");
+  const deployment = readNestedRecord(eventBody, "deployment");
+
+  const packageName = readString(packageInfo?.name, { max: 120 });
+  const packageVersion = readString(packageInfo?.version, { max: 80 });
+  const framework = readString(eventBody.framework, { max: 80 });
+  const siteOrigin = readString(site?.origin, { max: 512 });
+  const deploymentId = readString(deployment?.id, { max: 160 });
+  const deploymentProvider = readString(deployment?.provider, { max: 80 });
+  const deploymentEnvironment = readString(deployment?.environment, { max: 120 });
+  const deploymentKey =
+    deploymentId ??
+    (deploymentProvider || deploymentEnvironment
+      ? `${deploymentProvider ?? ""}:${deploymentEnvironment ?? ""}`
+      : undefined);
+  const stableIdentity = siteOrigin ?? deploymentKey;
+
+  if (!packageName || !packageVersion || !stableIdentity) return undefined;
+
+  return ["identity", packageName, packageVersion, eventType, framework ?? "", stableIdentity].join(
+    "|",
+  );
 }
 
 export async function POST(request: Request) {
@@ -143,7 +161,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Telemetry ingest key is invalid" }, { status: 401 });
     }
 
-    if (isTelemetryRateLimited(request)) {
+    if (isTelemetryRateLimited("global", TELEMETRY_GLOBAL_RATE_LIMIT_MAX_REQUESTS)) {
       return NextResponse.json({ error: "Telemetry rate limit exceeded" }, { status: 429 });
     }
 
@@ -174,6 +192,14 @@ export async function POST(request: Request) {
     const eventType = readString(eventBody.type, { max: 80 });
     if (!eventType) {
       return NextResponse.json({ error: "Telemetry event type is required" }, { status: 400 });
+    }
+
+    const identityRateLimitKey = createTelemetryIdentityRateLimitKey(eventBody, eventType);
+    if (
+      identityRateLimitKey &&
+      isTelemetryRateLimited(identityRateLimitKey, TELEMETRY_IDENTITY_RATE_LIMIT_MAX_REQUESTS)
+    ) {
+      return NextResponse.json({ error: "Telemetry rate limit exceeded" }, { status: 429 });
     }
 
     const packageInfo = readNestedRecord(eventBody, "package");

--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -1,0 +1,143 @@
+import type { DocsTelemetryEvent } from "@farming-labs/docs";
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+const MAX_TELEMETRY_BODY_BYTES = 32_768;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readString(value: unknown, { max }: { max: number }) {
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.slice(0, max);
+}
+
+function readNestedRecord(value: unknown, key: string) {
+  if (!isRecord(value)) return undefined;
+  const next = value[key];
+  return isRecord(next) ? next : undefined;
+}
+
+function isPrismaSchemaMissing(error: unknown) {
+  return (
+    (error instanceof Prisma.PrismaClientKnownRequestError &&
+      (error.code === "P2021" || error.code === "P2022")) ||
+    error instanceof Prisma.PrismaClientValidationError
+  );
+}
+
+function isPrismaUnavailable(error: unknown) {
+  return error instanceof Prisma.PrismaClientInitializationError;
+}
+
+export async function POST(request: Request) {
+  try {
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (Number.isFinite(contentLength) && contentLength > MAX_TELEMETRY_BODY_BYTES) {
+      return NextResponse.json({ error: "Telemetry body is too large" }, { status: 413 });
+    }
+
+    if (!process.env.DATABASE_URL) {
+      return NextResponse.json(
+        {
+          ok: true,
+          stored: false,
+          warning: "Telemetry database not configured",
+        },
+        { status: 202 },
+      );
+    }
+
+    let body: unknown;
+
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Telemetry body must be valid JSON" }, { status: 400 });
+    }
+
+    const eventBody = isRecord(body) && isRecord(body.event) ? body.event : body;
+    if (!isRecord(eventBody)) {
+      return NextResponse.json({ error: "Telemetry event must be an object" }, { status: 400 });
+    }
+
+    const eventType = readString(eventBody.type, { max: 80 });
+    if (!eventType) {
+      return NextResponse.json({ error: "Telemetry event type is required" }, { status: 400 });
+    }
+
+    const packageInfo = readNestedRecord(eventBody, "package");
+    const runtime = readNestedRecord(eventBody, "runtime");
+    const site = readNestedRecord(eventBody, "site");
+    const deployment = readNestedRecord(eventBody, "deployment");
+    const features = readNestedRecord(eventBody, "features");
+    const properties = readNestedRecord(eventBody, "properties");
+
+    const event = eventBody as unknown as DocsTelemetryEvent;
+
+    try {
+      const entry = await prisma.docsTelemetryEvent.create({
+        data: {
+          eventType,
+          packageName: readString(packageInfo?.name, { max: 120 }),
+          packageVersion: readString(packageInfo?.version, { max: 80 }),
+          framework: readString(event.framework, { max: 80 }),
+          runtimeName: readString(runtime?.name, { max: 80 }),
+          siteOrigin: readString(site?.origin, { max: 512 }),
+          deploymentProvider: readString(deployment?.provider, { max: 80 }),
+          deploymentEnvironment: readString(deployment?.environment, { max: 120 }),
+          deploymentId: readString(deployment?.id, { max: 160 }),
+          features: features as unknown as Prisma.InputJsonValue,
+          properties: properties as unknown as Prisma.InputJsonValue,
+          payload: event as unknown as Prisma.InputJsonValue,
+        },
+      });
+
+      return NextResponse.json({ ok: true, stored: true, id: entry.id }, { status: 201 });
+    } catch (error) {
+      if (isPrismaSchemaMissing(error)) {
+        console.warn(
+          "[telemetry POST] DocsTelemetryEvent schema or Prisma client is out of date. Run `pnpm --dir website exec prisma generate` and `pnpm --dir website exec prisma db push` to sync it.",
+        );
+
+        return NextResponse.json(
+          {
+            ok: true,
+            stored: false,
+            warning: "Telemetry schema or Prisma client is out of date",
+          },
+          { status: 202 },
+        );
+      }
+
+      if (isPrismaUnavailable(error)) {
+        console.warn(
+          "[telemetry POST] Telemetry database is currently unreachable. Returning a non-blocking response.",
+        );
+
+        return NextResponse.json(
+          {
+            ok: true,
+            stored: false,
+            warning: "Telemetry database unreachable",
+          },
+          { status: 202 },
+        );
+      }
+
+      throw error;
+    }
+  } catch (error) {
+    console.error("[telemetry POST]", error);
+
+    return NextResponse.json({ error: "Failed to store docs telemetry" }, { status: 500 });
+  }
+}

--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -6,6 +6,14 @@ import { prisma } from "@/lib/prisma";
 export const dynamic = "force-dynamic";
 
 const MAX_TELEMETRY_BODY_BYTES = 32_768;
+const TELEMETRY_RATE_LIMIT_WINDOW_MS = 60_000;
+const TELEMETRY_RATE_LIMIT_MAX_REQUESTS = 120;
+const TELEMETRY_RATE_LIMIT_MAX_KEYS = 4_096;
+
+interface TelemetryRateLimitEntry {
+  count: number;
+  resetAt: number;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -28,9 +36,8 @@ function readNestedRecord(value: unknown, key: string) {
 
 function isPrismaSchemaMissing(error: unknown) {
   return (
-    (error instanceof Prisma.PrismaClientKnownRequestError &&
-      (error.code === "P2021" || error.code === "P2022")) ||
-    error instanceof Prisma.PrismaClientValidationError
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    (error.code === "P2021" || error.code === "P2022")
   );
 }
 
@@ -38,11 +45,106 @@ function isPrismaUnavailable(error: unknown) {
   return error instanceof Prisma.PrismaClientInitializationError;
 }
 
+function getRateLimitStore() {
+  const globalValue = globalThis as typeof globalThis & {
+    __farmingLabsDocsTelemetryRateLimit__?: Map<string, TelemetryRateLimitEntry>;
+  };
+
+  globalValue.__farmingLabsDocsTelemetryRateLimit__ ??= new Map();
+  return globalValue.__farmingLabsDocsTelemetryRateLimit__;
+}
+
+function readBearerToken(value: string | null) {
+  if (!value) return undefined;
+
+  const [scheme, token] = value.split(/\s+/, 2);
+  if (!scheme || scheme.toLowerCase() !== "bearer") return undefined;
+
+  return readString(token, { max: 512 });
+}
+
+function readTelemetryIngestKey(request: Request) {
+  return (
+    readString(request.headers.get("x-docs-telemetry-key"), { max: 512 }) ??
+    readBearerToken(request.headers.get("authorization"))
+  );
+}
+
+function hasValidTelemetryIngestKey(request: Request) {
+  const requiredKey = readString(process.env.DOCS_TELEMETRY_INGEST_KEY, { max: 512 });
+  if (!requiredKey) return true;
+
+  return readTelemetryIngestKey(request) === requiredKey;
+}
+
+function readClientIp(request: Request) {
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0];
+
+  return (
+    readString(request.headers.get("cf-connecting-ip"), { max: 100 }) ??
+    readString(request.headers.get("x-real-ip"), { max: 100 }) ??
+    readString(forwardedFor, { max: 100 }) ??
+    "unknown"
+  );
+}
+
+function pruneExpiredRateLimitEntries(store: Map<string, TelemetryRateLimitEntry>, now: number) {
+  for (const [key, entry] of store) {
+    if (entry.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+function trimRateLimitStore(store: Map<string, TelemetryRateLimitEntry>) {
+  while (store.size >= TELEMETRY_RATE_LIMIT_MAX_KEYS) {
+    const oldestKey = store.keys().next().value;
+    if (!oldestKey) return;
+    store.delete(oldestKey);
+  }
+}
+
+function isTelemetryRateLimited(request: Request) {
+  const now = Date.now();
+  const store = getRateLimitStore();
+  pruneExpiredRateLimitEntries(store, now);
+
+  const key = readClientIp(request);
+  const current = store.get(key);
+
+  if (!current || current.resetAt <= now) {
+    if (current) {
+      store.delete(key);
+    }
+
+    trimRateLimitStore(store);
+
+    store.set(key, {
+      count: 1,
+      resetAt: now + TELEMETRY_RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  if (current.count >= TELEMETRY_RATE_LIMIT_MAX_REQUESTS) return true;
+
+  current.count += 1;
+  return false;
+}
+
 export async function POST(request: Request) {
   try {
     const contentLength = Number(request.headers.get("content-length") ?? "0");
     if (Number.isFinite(contentLength) && contentLength > MAX_TELEMETRY_BODY_BYTES) {
       return NextResponse.json({ error: "Telemetry body is too large" }, { status: 413 });
+    }
+
+    if (!hasValidTelemetryIngestKey(request)) {
+      return NextResponse.json({ error: "Telemetry ingest key is invalid" }, { status: 401 });
+    }
+
+    if (isTelemetryRateLimited(request)) {
+      return NextResponse.json({ error: "Telemetry rate limit exceeded" }, { status: 429 });
     }
 
     if (!process.env.DATABASE_URL) {

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customization"
-description: "Colors, typography, sidebar, components, analytics, observability, agent primitives, robots.txt, OG images, AI chat, and page actions"
+description: "Colors, typography, sidebar, components, analytics, telemetry, observability, agent primitives, robots.txt, OG images, AI chat, and page actions"
 icon: "settings"
 order: 5
 ---
@@ -8,7 +8,7 @@ order: 5
 # Customization
 
 <Agent>
-Use this page when the user asks about this topic: Colors, typography, sidebar, components, analytics, observability, agent primitives, robots.txt, OG images, AI chat, and page actions.
+Use this page when the user asks about this topic: Colors, typography, sidebar, components, analytics, telemetry, observability, agent primitives, robots.txt, OG images, AI chat, and page actions.
 Keep answers grounded in the exact options, routes, commands, and examples documented here.
 If the request moves beyond this page, point to the closest related docs instead of inventing config.
 </Agent>
@@ -26,6 +26,7 @@ Everything is customizable from `docs.config.ts`. No CSS files to edit, no layou
 - **[Ask AI](/docs/customization/ai-chat)** — RAG-powered AI chat with configurable LLM, floating/search modes, and more
 - **[Page Actions](/docs/customization/page-actions)** — "Copy Markdown" and "Open in LLM" buttons on doc pages
 - **[Analytics](/docs/customization/analytics)** — Track page views, search, AI, feedback, page actions, agent reads, and MCP usage
+- **[Telemetry](/docs/customization/telemetry)** — Farming Labs maintainer telemetry for package adoption and coarse agent-surface usage
 - **[Observability](/docs/customization/observability)** — Trace Ask AI and MCP runs with span IDs, timing, status, previews, and errors
 - **[MCP Server](/docs/customization/mcp)** — Built-in MCP tools/resources over stdio, `/mcp`, and `/.well-known/mcp`
 - **[llms.txt](/docs/customization/llms-txt)** — Auto-generate `llms.txt` and `llms-full.txt` for LLM-friendly documentation

--- a/website/app/docs/customization/telemetry/page.mdx
+++ b/website/app/docs/customization/telemetry/page.mdx
@@ -95,3 +95,13 @@ export default defineDocs({
   },
 });
 ```
+
+If a self-hosted ingestion endpoint requires a shared key, set the same environment variable in
+the docs runtime and the ingestion app:
+
+```bash title=".env"
+DOCS_TELEMETRY_INGEST_KEY=your-shared-ingest-key
+```
+
+When present, telemetry requests include the key as `x-docs-telemetry-key`. Failed telemetry
+requests are still ignored by the docs runtime.

--- a/website/app/docs/customization/telemetry/page.mdx
+++ b/website/app/docs/customization/telemetry/page.mdx
@@ -1,0 +1,97 @@
+---
+title: "Telemetry"
+description: "Production maintainer telemetry for @farming-labs/docs adoption and agent-surface usage"
+icon: "activity"
+order: 5.65
+related:
+  - /docs/reference
+  - /docs/customization/analytics
+  - /docs/customization/mcp
+  - /docs/customization/llms-txt
+---
+
+# Telemetry
+
+<Agent>
+Use this page when the user asks about this topic: Farming Labs maintainer telemetry, production
+package adoption, opt-out configuration, DOCS_TELEMETRY, and coarse agent-surface usage. Keep this
+separate from project-owned analytics.
+</Agent>
+
+`@farming-labs/docs` includes limited production telemetry so Farming Labs can understand which
+frameworks, deployments, and agent-optimized features are used in real projects.
+
+Telemetry is separate from [Analytics](/docs/customization/analytics). Analytics is a project-owned
+event stream for page views, search, Ask AI, feedback, and MCP usage. Telemetry is a low-volume
+maintainer signal for package adoption and coarse feature usage.
+
+## Opt Out
+
+Disable telemetry with an environment variable:
+
+```bash title=".env.local"
+DOCS_TELEMETRY=false
+# or
+DOCS_TELEMETRY_DISABLED=1
+```
+
+Or disable it in `docs.config.ts`:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  telemetry: false,
+});
+```
+
+Environment opt-out wins over config. Telemetry delivery failures are ignored and never affect
+rendering, builds, routing, search, Ask AI, or MCP behavior.
+
+## What Telemetry Includes
+
+Telemetry may include:
+
+- package name and version
+- framework adapter, such as Next.js, TanStack Start, SvelteKit, Astro, or Nuxt
+- production/runtime and deployment provider signals
+- public site origin or deployment URL when available
+- enabled feature flags such as search, Ask AI, MCP, llms.txt, page actions, feedback, sitemap,
+  robots, API reference, static export, changelog, Docs Cloud, and Docs Review
+- coarse agent-surface usage such as `markdown`, `llms`, `agents`, `skill`, `agent_spec`,
+  `agent_feedback_submit`, `ask_ai`, `mcp`, and MCP tool names
+
+Telemetry does not collect:
+
+- visitor identities
+- end-user page views
+- search queries
+- Ask AI questions
+- feedback comments
+- copied code or markdown content
+- documentation source content
+- cookies or cross-site tracking identifiers
+- per-user sessions
+
+## Options
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  telemetry: {
+    enabled: true,
+  },
+});
+```
+
+| Option     | Type      | Default                  |
+| ---------- | --------- | ------------------------ |
+| `enabled`  | `boolean` | production-only enabled  |
+| `endpoint` | `string`  | Farming Labs ingestion endpoint |
+
+Use `endpoint` only for self-hosting, local verification, or tests:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  telemetry: {
+    endpoint: "https://telemetry.example.com/events",
+  },
+});
+```

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -51,6 +51,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `icons`       | `Record<string, unknown>`                       | —                | Shared icon registry for frontmatter `icon` fields and built-ins like `Prompt`       |
 | `components`  | `Record<string, unknown>`                       | —                | Custom MDX component overrides, including built-ins like `HoverLink` and `Prompt`    |
 | `analytics`    | `boolean \| DocsAnalyticsConfig`              | `false`          | Product/usage event stream for docs UI, search, AI, feedback, agent reads, and MCP usage |
+| `telemetry`    | `boolean \| DocsTelemetryConfig`              | production-only enabled | Farming Labs maintainer telemetry for package adoption and coarse agent-surface usage |
 | `observability` | `boolean \| DocsObservabilityConfig`          | `false`          | Trace event stream for Ask AI and MCP runs, including spans, timing, status, and errors |
 | `onCopyClick` | `(data: CodeBlockCopyData) => void`              | —                | Callback when the user clicks the copy button on a code block (runs in addition to copy) |
 | `feedback`    | `boolean \| FeedbackConfig`                     | `false` for UI   | Human page feedback UI; agent feedback endpoints are default-on unless opted out     |
@@ -111,6 +112,38 @@ That keeps the files under `app/docs` and serves them from the public root:
 ---
 
 `components` is merged into the default MDX component map, so you can both add your own components and replace built-ins such as `Callout`, `Tabs`, `HoverLink`, or `Prompt`. For built-in defaults like `theme.ui.components.HoverLink` and `theme.ui.components.Prompt`, see [Creating themes](/docs/themes/creating-themes). For usage examples and a live demo, see [Components](/docs/customization/components).
+
+---
+
+## `telemetry` and `DocsTelemetryConfig`
+
+Farming Labs maintainer telemetry for production adoption and coarse agent-optimized feature usage.
+It is separate from `analytics`: telemetry is for framework/package insight, while analytics is for
+project-owned product events.
+
+Telemetry can be disabled with either:
+
+```bash title=".env.local"
+DOCS_TELEMETRY=false
+# or
+DOCS_TELEMETRY_DISABLED=1
+```
+
+or:
+
+```ts title="docs.config.ts"
+telemetry: false,
+```
+
+| Option     | Type      | Default | Description                                  |
+| ---------- | --------- | ------- | -------------------------------------------- |
+| `enabled`  | `boolean` | production-only enabled | Enable or disable maintainer telemetry       |
+| `endpoint` | `string`  | Farming Labs endpoint | Override the ingestion endpoint for self-hosting or tests |
+
+Telemetry may include package/framework versions, deployment provider signals, site origin, enabled
+docs features, and coarse agent-surface events such as `llms`, `markdown`, `mcp`, or `skill`.
+It does not collect visitor identities, page views, search queries, Ask AI questions, feedback
+comments, copied content, docs source content, cookies, or per-user sessions.
 
 ---
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -140,6 +140,9 @@ telemetry: false,
 | `enabled`  | `boolean` | production-only enabled | Enable or disable maintainer telemetry       |
 | `endpoint` | `string`  | Farming Labs endpoint | Override the ingestion endpoint for self-hosting or tests |
 
+Set `DOCS_TELEMETRY_INGEST_KEY` in both the docs runtime and self-hosted ingestion app when the
+endpoint should require a shared `x-docs-telemetry-key` header.
+
 Telemetry may include package/framework versions, deployment provider signals, site origin, enabled
 docs features, and coarse agent-surface events such as `llms`, `markdown`, `mcp`, or `skill`.
 It does not collect visitor identities, page views, search queries, Ask AI questions, feedback

--- a/website/prisma/schema.prisma
+++ b/website/prisma/schema.prisma
@@ -48,6 +48,29 @@ model DocsFeedback {
   @@index([slug])
 }
 
+model DocsTelemetryEvent {
+  id                    String   @id @default(cuid())
+  eventType             String
+  packageName           String?
+  packageVersion        String?
+  framework             String?
+  runtimeName           String?
+  siteOrigin            String?
+  deploymentProvider    String?
+  deploymentEnvironment String?
+  deploymentId          String?
+  features              Json?
+  properties            Json?
+  payload               Json
+  createdAt             DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([eventType])
+  @@index([framework])
+  @@index([siteOrigin])
+  @@index([packageName, packageVersion])
+}
+
 model CloudWaitlistEntry {
   id         String   @id @default(cuid())
   email      String   @unique

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "pnpm install --frozen-lockfile",
   "crons": [
     {
       "path": "/api/enterprise-support/email/process",


### PR DESCRIPTION
## Summary

Adds production-only maintainer telemetry for @farming-labs/docs adoption and coarse agent-surface usage, separate from project-owned analytics.

## Changes

- adds telemetry config, runtime resolution, opt-out envs, and fire-and-forget event delivery
- wires project, agent-surface, and MCP tool telemetry across supported adapters
- adds a website ingestion endpoint backed by a Prisma/Postgres telemetry event model
- documents telemetry behavior, opt-out controls, and collection boundaries

## Validation

- pnpm --filter @farming-labs/docs test
- pnpm --filter ./packages/* run typecheck
- pnpm --dir website exec prisma generate
- pnpm --dir website exec tsc --noEmit
- pnpm build

## Deployment Notes

- apply the Prisma schema in production before relying on stored telemetry events

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-only maintainer telemetry to `@farming-labs/docs` to track package adoption and coarse agent-surface usage with easy opt-out. Also switches the website to pnpm-based deployments for consistent installs.

- New Features
  - Telemetry module: config via `DOCS_TELEMETRY`, `DOCS_TELEMETRY_DISABLED`, `DOCS_TELEMETRY_ENDPOINT`, and optional `DOCS_TELEMETRY_INGEST_KEY`; defaults to production with safe, fire-and-forget POSTs.
  - Emits project, agent-surface, and MCP tool events; infers surfaces like `markdown`, `llms`, `agents`, `skill`, `agent_spec`, `agent_feedback_*`, `ask_ai`, and `mcp`; dedupes project-detected per runtime key.
  - Integrated across `next` (API and layout), `sveltekit`, `astro`, `nuxt`, `tanstack-start`, and MCP server/HTTP handler; frameworks pass `telemetryFramework`.
  - Adds `POST /api/telemetry/events` with body size limits, global and per-identity rate limiting, and optional shared ingest key via `x-docs-telemetry-key` or Bearer; stores to Prisma `DocsTelemetryEvent`, returns 201 on store and graceful 202s when schema or DB is unavailable; docs added for behavior and opt-out.
  - Website deployments use pnpm (`vercel.json` installCommand) to avoid mismatched installs.

- Migration
  - Apply the Prisma schema before relying on stored events: run `pnpm --dir website exec prisma generate` and `pnpm --dir website exec prisma db push`.
  - Set `DOCS_TELEMETRY=false` or `DOCS_TELEMETRY_DISABLED=1` to opt out; when self-hosting ingestion, set `DOCS_TELEMETRY_INGEST_KEY` in both the runtime and ingestion app.

<sup>Written for commit 877a4ff20eab1d03999d08bae13cff3f1096e8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

