### PR TITLE
feat: add `siteOrigin` for telemetry

### DIFF
--- a/packages/docs/src/telemetry.test.ts
+++ b/packages/docs/src/telemetry.test.ts
@@ -16,7 +16,14 @@ function resetEnv() {
   delete process.env.DOCS_TELEMETRY_DISABLED;
   delete process.env.DOCS_TELEMETRY_ENDPOINT;
   delete process.env.DOCS_TELEMETRY_INGEST_KEY;
+  delete process.env.DOCS_SITE_URL;
+  delete process.env.NEXT_PUBLIC_BASE_URL;
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+  delete process.env.SITE_URL;
+  delete process.env.URL;
   delete process.env.VERCEL_ENV;
+  delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  delete process.env.VERCEL_URL;
   delete process.env.NETLIFY;
   delete process.env.CONTEXT;
   delete process.env.CF_PAGES;
@@ -36,7 +43,7 @@ function telemetryEvent(overrides: Partial<DocsTelemetryEvent> = {}): DocsTeleme
     timestamp: "2026-06-17T00:00:00.000Z",
     package: {
       name: "@farming-labs/docs",
-      version: "0.2.24",
+      version: "0.2.25",
     },
     ...overrides,
   };
@@ -99,7 +106,39 @@ describe("telemetry", () => {
         framework: "next",
         package: {
           name: "@farming-labs/docs",
-          version: "0.2.24",
+          version: "0.2.25",
+        },
+      },
+    });
+  });
+
+  it("uses configured site origin for project events", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitDocsTelemetryProjectEvent(
+      {
+        entry: "docs",
+        telemetry: {
+          siteOrigin: "docs.example.com/path",
+        },
+      },
+      {
+        framework: "next",
+        request: new Request("https://preview.example.com/api/docs"),
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      event: {
+        site: {
+          origin: "https://docs.example.com",
         },
       },
     });

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -20,7 +20,7 @@ import type {
 } from "./types.js";
 
 const DOCS_PACKAGE_NAME = "@farming-labs/docs";
-const DOCS_PACKAGE_VERSION = "0.2.24";
+const DOCS_PACKAGE_VERSION = "0.2.25";
 const DEFAULT_DOCS_TELEMETRY_ENDPOINT = "https://docs.farming-labs.dev/api/telemetry/events";
 const PROJECT_TELEMETRY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const PROJECT_TELEMETRY_CACHE_MAX_KEYS = 256;
@@ -131,9 +131,21 @@ function readRequestOrigin(request: Request | undefined): string | undefined {
   }
 }
 
+function normalizeTelemetryOrigin(candidate: string | undefined): string | undefined {
+  if (!candidate) return undefined;
+
+  try {
+    const withProtocol = /^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`;
+    return new URL(withProtocol).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 function readDeploymentOrigin(): string | undefined {
   const candidates = [
     readRuntimeEnv("DOCS_SITE_URL"),
+    readRuntimeEnv("NEXT_PUBLIC_BASE_URL"),
     readRuntimeEnv("NEXT_PUBLIC_SITE_URL"),
     readRuntimeEnv("SITE_URL"),
     readRuntimeEnv("URL"),
@@ -144,14 +156,8 @@ function readDeploymentOrigin(): string | undefined {
   ];
 
   for (const candidate of candidates) {
-    if (!candidate) continue;
-
-    try {
-      const withProtocol = /^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`;
-      return new URL(withProtocol).origin;
-    } catch {
-      // Try the next candidate.
-    }
+    const origin = normalizeTelemetryOrigin(candidate);
+    if (origin) return origin;
   }
 
   return undefined;
@@ -283,9 +289,12 @@ function createDocsTelemetryEvent(
   input: DocsTelemetryEventInput,
   context: DocsTelemetryContext = {},
 ): DocsTelemetryEvent {
+  const telemetryConfig =
+    config.telemetry && typeof config.telemetry === "object" ? config.telemetry : undefined;
   const siteOrigin =
     context.siteOrigin ??
     input.site?.origin ??
+    normalizeTelemetryOrigin(telemetryConfig?.siteOrigin) ??
     readRequestOrigin(context.request) ??
     readDeploymentOrigin();
   const deployment = input.deployment ?? detectDeployment();

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -923,6 +923,12 @@ export interface DocsTelemetryConfig {
   /** Enable Farming Labs maintainer telemetry. Defaults to production-only enabled. */
   enabled?: boolean;
   /**
+   * Public site origin to include in telemetry events.
+   *
+   * When omitted, the runtime request origin or deployment URL is used when available.
+   */
+  siteOrigin?: string;
+  /**
    * Override the telemetry ingestion endpoint.
    *
    * This is mostly useful for self-hosting, development verification, or tests.

--- a/website/app/docs/customization/telemetry/page.mdx
+++ b/website/app/docs/customization/telemetry/page.mdx
@@ -81,10 +81,21 @@ export default defineDocs({
 });
 ```
 
-| Option     | Type      | Default                  |
-| ---------- | --------- | ------------------------ |
-| `enabled`  | `boolean` | production-only enabled  |
-| `endpoint` | `string`  | Farming Labs ingestion endpoint |
+| Option       | Type      | Default                   |
+| ------------ | --------- | ------------------------- |
+| `enabled`    | `boolean` | production-only enabled   |
+| `siteOrigin` | `string`  | request/deployment origin |
+| `endpoint`   | `string`  | Farming Labs ingestion endpoint |
+
+Use `siteOrigin` when production requests should be grouped under a stable custom domain:
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  telemetry: {
+    siteOrigin: "https://docs.example.com",
+  },
+});
+```
 
 Use `endpoint` only for self-hosting, local verification, or tests:
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -135,10 +135,11 @@ or:
 telemetry: false,
 ```
 
-| Option     | Type      | Default | Description                                  |
-| ---------- | --------- | ------- | -------------------------------------------- |
-| `enabled`  | `boolean` | production-only enabled | Enable or disable maintainer telemetry       |
-| `endpoint` | `string`  | Farming Labs endpoint | Override the ingestion endpoint for self-hosting or tests |
+| Option       | Type      | Default                   | Description                                                     |
+| ------------ | --------- | ------------------------- | --------------------------------------------------------------- |
+| `enabled`    | `boolean` | production-only enabled   | Enable or disable maintainer telemetry                          |
+| `siteOrigin` | `string`  | request/deployment origin | Stable public origin to include in telemetry events             |
+| `endpoint`   | `string`  | Farming Labs endpoint     | Override the ingestion endpoint for self-hosting or tests       |
 
 Set `DOCS_TELEMETRY_INGEST_KEY` in both the docs runtime and self-hosted ingestion app when the
 endpoint should require a shared `x-docs-telemetry-key` header.

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -48,6 +48,7 @@ const algoliaSearchApiKey = process.env.ALGOLIA_SEARCH_API_KEY;
 const algoliaAdminApiKey = process.env.ALGOLIA_ADMIN_API_KEY;
 const docsSearchProvider =
   process.env.DOCS_SEARCH_PROVIDER ?? (algoliaAppId && algoliaSearchApiKey ? "algolia" : "mcp");
+const docsSiteOrigin = process.env.NEXT_PUBLIC_BASE_URL ?? "https://docs.farming-labs.dev";
 
 const searchConfig =
   docsSearchProvider === "algolia" && algoliaAppId && algoliaSearchApiKey
@@ -77,6 +78,9 @@ export default defineDocs({
   search: searchConfig,
   observability: {
     console: "info",
+  },
+  telemetry: {
+    siteOrigin: docsSiteOrigin,
   },
   codeBlocks: {
     validate: {


### PR DESCRIPTION
## Summary
- add `telemetry.siteOrigin` so docs sites can report a stable public origin
- configure the docs website to dogfood telemetry with `NEXT_PUBLIC_BASE_URL` and a production-domain fallback
- document and test the new telemetry origin behavior

## Verification
- pnpm --filter @farming-labs/docs test
- pnpm --filter './packages/*' run typecheck\n- pnpm --dir website exec tsc --noEmit\n- pnpm build\n- pnpm --dir website build\n\n## Telemetry storage\n- telemetry ingestion writes through Prisma to the `DocsTelemetryEvent` model\n- the Prisma datasource is PostgreSQL via `DATABASE_URL` in `website/prisma/schema.prisma`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `telemetry.siteOrigin` to `@farming-labs/docs` and dogfood it in the docs site so telemetry groups events under a stable public origin. The docs site reads `NEXT_PUBLIC_BASE_URL` with a production fallback for consistent event grouping.

- **New Features**
  - Added `telemetry.siteOrigin` config (normalized to an https origin); falls back to request/deployment origin when unset.
  - Deployment origin detection now includes `NEXT_PUBLIC_BASE_URL`.
  - Docs site sets `telemetry.siteOrigin` from `NEXT_PUBLIC_BASE_URL` with a fallback to `https://docs.farming-labs.dev`.
  - Updated docs and tests; package version bump to `0.2.25`.

<sup>Written for commit 8ba76873963896882d61a2645664b464ec829991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

