### PR TITLE
feat: add telemetry identity hash

### DIFF
--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -59,8 +59,13 @@ function isPrismaUnavailable(error: unknown) {
   return error instanceof Prisma.PrismaClientInitializationError;
 }
 
-function isPrismaColumnMissing(error: unknown) {
-  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2022";
+function isPrismaIdentityHashColumnMissing(error: unknown) {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2022") {
+    return false;
+  }
+
+  const missingColumn = String(error.meta?.column ?? "");
+  return missingColumn.includes("identityHash");
 }
 
 function getRateLimitStore() {
@@ -311,7 +316,7 @@ export async function POST(request: Request) {
 
       return NextResponse.json({ ok: true, stored: true, id: entry.id }, { status: 201 });
     } catch (error) {
-      if (identityHash && isPrismaColumnMissing(error)) {
+      if (identityHash && isPrismaIdentityHashColumnMissing(error)) {
         console.warn(
           "[telemetry POST] DocsTelemetryEvent.identityHash is missing. Storing telemetry without identityHash until the database schema is synced.",
         );

--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -1,5 +1,6 @@
 import type { DocsTelemetryEvent } from "@farming-labs/docs";
 import { Prisma } from "@prisma/client";
+import { createHash, createHmac } from "node:crypto";
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
@@ -10,6 +11,7 @@ const TELEMETRY_RATE_LIMIT_WINDOW_MS = 60_000;
 const TELEMETRY_GLOBAL_RATE_LIMIT_MAX_REQUESTS = 2_000;
 const TELEMETRY_IDENTITY_RATE_LIMIT_MAX_REQUESTS = 120;
 const TELEMETRY_RATE_LIMIT_MAX_KEYS = 4_096;
+const TELEMETRY_IDENTITY_HASH_VERSION = "v1";
 
 interface TelemetryRateLimitEntry {
   count: number;
@@ -35,6 +37,17 @@ function readNestedRecord(value: unknown, key: string) {
   return isRecord(next) ? next : undefined;
 }
 
+function normalizeOrigin(value: string | undefined) {
+  if (!value) return undefined;
+
+  try {
+    const withProtocol = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+    return new URL(withProtocol).origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
 function isPrismaSchemaMissing(error: unknown) {
   return (
     error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -44,6 +57,10 @@ function isPrismaSchemaMissing(error: unknown) {
 
 function isPrismaUnavailable(error: unknown) {
   return error instanceof Prisma.PrismaClientInitializationError;
+}
+
+function isPrismaColumnMissing(error: unknown) {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2022";
 }
 
 function getRateLimitStore() {
@@ -150,6 +167,51 @@ function createTelemetryIdentityRateLimitKey(
   );
 }
 
+function createTelemetryIdentityHash({
+  packageName,
+  framework,
+  siteOrigin,
+  deploymentProvider,
+  deploymentEnvironment,
+  deploymentId,
+}: {
+  packageName?: string;
+  framework?: string;
+  siteOrigin?: string;
+  deploymentProvider?: string;
+  deploymentEnvironment?: string;
+  deploymentId?: string;
+}) {
+  if (!packageName) return undefined;
+
+  const normalizedSiteOrigin = normalizeOrigin(siteOrigin);
+  const stableProjectIdentity = normalizedSiteOrigin
+    ? `site:${normalizedSiteOrigin}`
+    : deploymentId
+      ? [
+          "deployment",
+          deploymentProvider?.toLowerCase() ?? "",
+          deploymentEnvironment?.toLowerCase() ?? "",
+          deploymentId,
+        ].join(":")
+      : undefined;
+
+  if (!stableProjectIdentity) return undefined;
+
+  const identityInput = [
+    TELEMETRY_IDENTITY_HASH_VERSION,
+    packageName.toLowerCase(),
+    framework?.toLowerCase() ?? "",
+    stableProjectIdentity,
+  ].join("|");
+  const salt = readString(process.env.DOCS_TELEMETRY_IDENTITY_SALT, { max: 512 });
+  const hash = salt
+    ? createHmac("sha256", salt).update(identityInput).digest("hex")
+    : createHash("sha256").update(identityInput).digest("hex");
+
+  return `${TELEMETRY_IDENTITY_HASH_VERSION}:${hash}`;
+}
+
 export async function POST(request: Request) {
   try {
     const contentLength = Number(request.headers.get("content-length") ?? "0");
@@ -208,29 +270,62 @@ export async function POST(request: Request) {
     const deployment = readNestedRecord(eventBody, "deployment");
     const features = readNestedRecord(eventBody, "features");
     const properties = readNestedRecord(eventBody, "properties");
+    const packageName = readString(packageInfo?.name, { max: 120 });
+    const packageVersion = readString(packageInfo?.version, { max: 80 });
+    const framework = readString(eventBody.framework, { max: 80 });
+    const runtimeName = readString(runtime?.name, { max: 80 });
+    const siteOrigin = readString(site?.origin, { max: 512 });
+    const deploymentProvider = readString(deployment?.provider, { max: 80 });
+    const deploymentEnvironment = readString(deployment?.environment, { max: 120 });
+    const deploymentId = readString(deployment?.id, { max: 160 });
+    const identityHash = createTelemetryIdentityHash({
+      packageName,
+      framework,
+      siteOrigin,
+      deploymentProvider,
+      deploymentEnvironment,
+      deploymentId,
+    });
 
     const event = eventBody as unknown as DocsTelemetryEvent;
+    const data = {
+      eventType,
+      identityHash,
+      packageName,
+      packageVersion,
+      framework,
+      runtimeName,
+      siteOrigin,
+      deploymentProvider,
+      deploymentEnvironment,
+      deploymentId,
+      features: features as unknown as Prisma.InputJsonValue,
+      properties: properties as unknown as Prisma.InputJsonValue,
+      payload: event as unknown as Prisma.InputJsonValue,
+    };
 
     try {
       const entry = await prisma.docsTelemetryEvent.create({
-        data: {
-          eventType,
-          packageName: readString(packageInfo?.name, { max: 120 }),
-          packageVersion: readString(packageInfo?.version, { max: 80 }),
-          framework: readString(event.framework, { max: 80 }),
-          runtimeName: readString(runtime?.name, { max: 80 }),
-          siteOrigin: readString(site?.origin, { max: 512 }),
-          deploymentProvider: readString(deployment?.provider, { max: 80 }),
-          deploymentEnvironment: readString(deployment?.environment, { max: 120 }),
-          deploymentId: readString(deployment?.id, { max: 160 }),
-          features: features as unknown as Prisma.InputJsonValue,
-          properties: properties as unknown as Prisma.InputJsonValue,
-          payload: event as unknown as Prisma.InputJsonValue,
-        },
+        data,
       });
 
       return NextResponse.json({ ok: true, stored: true, id: entry.id }, { status: 201 });
     } catch (error) {
+      if (identityHash && isPrismaColumnMissing(error)) {
+        console.warn(
+          "[telemetry POST] DocsTelemetryEvent.identityHash is missing. Storing telemetry without identityHash until the database schema is synced.",
+        );
+
+        const entry = await prisma.docsTelemetryEvent.create({
+          data: {
+            ...data,
+            identityHash: undefined,
+          },
+        });
+
+        return NextResponse.json({ ok: true, stored: true, id: entry.id }, { status: 201 });
+      }
+
       if (isPrismaSchemaMissing(error)) {
         console.warn(
           "[telemetry POST] DocsTelemetryEvent schema or Prisma client is out of date. Run `pnpm --dir website exec prisma generate` and `pnpm --dir website exec prisma db push` to sync it.",

--- a/website/app/docs/customization/telemetry/page.mdx
+++ b/website/app/docs/customization/telemetry/page.mdx
@@ -50,6 +50,7 @@ rendering, builds, routing, search, Ask AI, or MCP behavior.
 
 Telemetry may include:
 
+- an anonymous project identity hash derived by the ingestion service from stable project metadata
 - package name and version
 - framework adapter, such as Next.js, TanStack Start, SvelteKit, Astro, or Nuxt
 - production/runtime and deployment provider signals
@@ -63,6 +64,7 @@ Telemetry does not collect:
 
 - visitor identities
 - end-user page views
+- device fingerprints
 - search queries
 - Ask AI questions
 - feedback comments
@@ -116,3 +118,10 @@ DOCS_TELEMETRY_INGEST_KEY=your-shared-ingest-key
 
 When present, telemetry requests include the key as `x-docs-telemetry-key`. Failed telemetry
 requests are still ignored by the docs runtime.
+
+The ingestion service computes the anonymous identity hash server-side. Clients do not send a
+device id, cookie, browser fingerprint, or session id; the hash exists only to group repeated
+telemetry events from the same docs project/site.
+
+For self-hosted ingestion, set `DOCS_TELEMETRY_IDENTITY_SALT` on the ingestion service to derive the
+identity hash with HMAC-SHA256. Without it, ingestion uses a deterministic SHA-256 hash.

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -144,10 +144,11 @@ telemetry: false,
 Set `DOCS_TELEMETRY_INGEST_KEY` in both the docs runtime and self-hosted ingestion app when the
 endpoint should require a shared `x-docs-telemetry-key` header.
 
-Telemetry may include package/framework versions, deployment provider signals, site origin, enabled
-docs features, and coarse agent-surface events such as `llms`, `markdown`, `mcp`, or `skill`.
-It does not collect visitor identities, page views, search queries, Ask AI questions, feedback
-comments, copied content, docs source content, cookies, or per-user sessions.
+Telemetry may include an anonymous project identity hash, package/framework versions, deployment
+provider signals, site origin, enabled docs features, and coarse agent-surface events such as
+`llms`, `markdown`, `mcp`, or `skill`. It does not collect visitor identities, page views, device
+fingerprints, search queries, Ask AI questions, feedback comments, copied content, docs source
+content, cookies, or per-user sessions.
 
 ---
 

--- a/website/prisma/schema.prisma
+++ b/website/prisma/schema.prisma
@@ -51,6 +51,7 @@ model DocsFeedback {
 model DocsTelemetryEvent {
   id                    String   @id @default(cuid())
   eventType             String
+  identityHash          String?
   packageName           String?
   packageVersion        String?
   framework             String?
@@ -67,6 +68,7 @@ model DocsTelemetryEvent {
   @@index([createdAt])
   @@index([eventType])
   @@index([framework])
+  @@index([identityHash])
   @@index([siteOrigin])
   @@index([packageName, packageVersion])
 }


### PR DESCRIPTION
## Summary
- add a nullable indexed `identityHash` column to docs telemetry events
- compute the hash on ingestion from stable project metadata instead of device/browser data
- document that telemetry does not use device fingerprints and note the optional identity salt

## Verification
- `pnpm --dir website exec tsc --noEmit`
- `pnpm --filter @farming-labs/docs test`
- `pnpm --dir website build`

## Deployment note
After deploy, run the website Prisma schema sync so production Postgres has the new `identityHash` column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an anonymous, versioned project identity hash to docs telemetry. It’s computed server‑side from stable project metadata and stored in a new nullable, indexed column to group events without device fingerprints.

- **New Features**
  - Compute `identityHash` from package/framework and either normalized site origin or deployment provider/env/id.
  - Versioned hash (`v1:<hex>`). Optional HMAC via `DOCS_TELEMETRY_IDENTITY_SALT`; falls back to SHA‑256.
  - Add nullable, indexed `identityHash` on `DocsTelemetryEvent`; write hash on ingest.
  - Safer rollout: only fall back when the `identityHash` column is missing; store events without the hash and log a warning.
  - Docs updated to note no device fingerprinting and how the salt works.

- **Migration**
  - After deploy, sync the schema: run `pnpm --dir website exec prisma generate` and `pnpm --dir website exec prisma db push`.
  - (Optional) Set `DOCS_TELEMETRY_IDENTITY_SALT` on the ingestion service to use HMAC.

<sup>Written for commit ea0afe287bf7d3abce061f849453524f57c6330d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

