### PR TITLE
chore: security ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "hono": "4.12.25",
       "rollup": "^4.59.0",
       "tar": "^7.5.11",
+      "undici": "7.28.0",
       "ws": "^8.21.0",
       "readdir-glob>minimatch": "^5.1.8",
       "glob@10>minimatch": "^9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   hono: 4.12.25
   rollup: ^4.59.0
   tar: ^7.5.11
+  undici: 7.28.0
   ws: ^8.21.0
   readdir-glob>minimatch: ^5.1.8
   glob@10>minimatch: ^9.0.7
@@ -7322,8 +7323,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.3:
-    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -10844,7 +10845,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.24.3
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
       zod: 3.24.4
     transitivePeerDependencies:
@@ -11624,7 +11625,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.24.3
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -15575,7 +15576,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.3: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary
- pin transitive `undici` resolution to patched `7.28.0`
- update the lockfile entries used by `@vercel/sandbox` and `cheerio`

## Validation
- `pnpm install --frozen-lockfile`
- reproduced the CI security audit locally: scanned 1,346 package names, no high or critical vulnerabilities found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins transitive `undici` to `7.28.0` to satisfy the CI security audit and ensure dependent packages use the patched version. Updates the lockfile so `@vercel/sandbox` and `cheerio` resolve the new version.

- **Dependencies**
  - Added `undici: 7.28.0` to `overrides` in `package.json`.
  - Updated `pnpm-lock.yaml` to replace `undici@7.24.3` with `7.28.0` for consumers including `@vercel/sandbox` and `cheerio`.
  - Verified with `pnpm install --frozen-lockfile`; audit shows no high or critical vulnerabilities.

<sup>Written for commit 81575f171f36d371d8b18bffd6ce6572e8a3faee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

