### PR TITLE
fix: widen usage metrics identity hashes

### DIFF
--- a/website/app/telemetry/page.tsx
+++ b/website/app/telemetry/page.tsx
@@ -345,31 +345,44 @@ function GroupTable({
   title,
   groups,
   keyLabel = "Name",
+  className = "",
+  truncateKey = false,
 }: {
   title: string;
   groups: GroupCount[];
   keyLabel?: string;
+  className?: string;
+  truncateKey?: boolean;
 }) {
   return (
-    <section className="border border-neutral-200 bg-white dark:border-white/10 dark:bg-black">
+    <section
+      className={`border border-neutral-200 bg-white dark:border-white/10 dark:bg-black ${className}`}
+    >
       <div className="border-b border-neutral-200 px-4 py-3 dark:border-white/10">
         <h2 className="text-sm font-semibold text-neutral-950 dark:text-white">{title}</h2>
       </div>
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[420px] text-left text-sm">
+        <table className="w-full min-w-[420px] table-fixed text-left text-sm">
           <thead className="bg-neutral-50 text-[10px] uppercase tracking-wider text-neutral-500 dark:bg-white/[0.03] dark:text-white/40">
             <tr>
               <th className="px-4 py-2 font-medium">{keyLabel}</th>
-              <th className="px-4 py-2 text-right font-medium">Events</th>
-              <th className="px-4 py-2 text-right font-medium">Last seen</th>
+              <th className="w-24 px-4 py-2 text-right font-medium">Events</th>
+              <th className="w-40 px-4 py-2 text-right font-medium">Last seen</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-100 dark:divide-white/10">
             {groups.length > 0 ? (
               groups.map((group) => (
                 <tr key={group.key}>
-                  <td className="max-w-[260px] px-4 py-2 font-mono text-xs text-neutral-700 dark:text-white/70">
-                    {shortText(group.key, 84)}
+                  <td
+                    className="px-4 py-2 font-mono text-xs text-neutral-700 dark:text-white/70"
+                    title={group.key}
+                  >
+                    {truncateKey ? (
+                      <span className="block truncate">{group.key}</span>
+                    ) : (
+                      shortText(group.key, 84)
+                    )}
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-xs text-neutral-950 dark:text-white">
                     {formatNumber(group.count)}
@@ -487,6 +500,8 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
             title="Top identity hashes"
             groups={data.topIdentities}
             keyLabel="Identity hash"
+            className="xl:col-span-2 2xl:col-span-3"
+            truncateKey
           />
         </section>
 


### PR DESCRIPTION
## Summary
- make the Top identity hashes table span the full summary grid width
- truncate long identity hash values with ellipsis while preserving the full value in the title attribute
- keep the count and last-seen columns fixed so hashes get the available width

## Validation
- `pnpm exec oxfmt --ignore-path .oxfmtignore --check website/app/telemetry/page.tsx`
- `pnpm --dir website exec tsc --noEmit`
- verified locally at `/telemetry?token=local-preview` that the section spans the full grid width and hashes truncate cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the Telemetry “Top identity hashes” table to use the full grid width and made long hashes truncate with an ellipsis. Fixed column widths so counts and last-seen stay readable while the hash column uses the extra space.

- **Bug Fixes**
  - Set table to fixed layout and added widths for Events (w-24) and Last seen (w-40).
  - Truncate long hashes with `truncateKey`, keeping the full value in the `title` attribute.
  - Exposed `className` on `GroupTable` and applied `xl:col-span-2 2xl:col-span-3` to span the summary grid.

<sup>Written for commit 3e6149bc9197da484c4ab4697a5034db17f455d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

