### PR TITLE
feat: add package version dry run

### DIFF
--- a/packages/docs/src/cli/downgrade.flow.test.ts
+++ b/packages/docs/src/cli/downgrade.flow.test.ts
@@ -145,6 +145,21 @@ describe("downgrade", () => {
     );
   });
 
+  it("prints the install command without executing when dry-run is enabled", async () => {
+    const prompts = await import("@clack/prompts");
+    const utils = await import("./utils.js");
+
+    await downgrade({ version: "0.1.104", dryRun: true });
+
+    expect(utils.execOutput).not.toHaveBeenCalled();
+    expect(utils.exec).not.toHaveBeenCalled();
+    expect(prompts.log.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "pnpm add @farming-labs/docs@0.1.104 @farming-labs/theme@0.1.104 @farming-labs/next@0.1.104",
+      ),
+    );
+  });
+
   it("rejects a version newer than the current version", async () => {
     const utils = await import("./utils.js");
 

--- a/packages/docs/src/cli/downgrade.ts
+++ b/packages/docs/src/cli/downgrade.ts
@@ -21,6 +21,8 @@ export interface DowngradeOptions {
   framework?: string;
   /** Exact package version to install, e.g. 0.1.104. Must be lower than the current installed version. */
   version?: string;
+  /** Print the resolved install command without running it. */
+  dryRun?: boolean;
 }
 
 interface ParsedSemver {
@@ -249,6 +251,12 @@ export async function downgrade(options: DowngradeOptions = {}) {
 
   p.log.step(`Downgrading ${preset} docs packages from ${currentVersion} to ${targetVersion}...`);
   p.log.message(pc.dim(packages.join(", ")));
+
+  if (options.dryRun) {
+    p.log.info("Dry run. Would run:\n  " + pc.cyan(cmd));
+    p.outro(pc.green("Dry run complete. No changes made."));
+    return;
+  }
 
   try {
     exec(cmd, cwd);

--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -116,6 +116,11 @@ describe("parseFlags", () => {
     expect(parseFlags(["upgrade", "--version=0.1.104-beta.1"]).version).toBe("0.1.104-beta.1");
   });
 
+  it("parses package version dry-run flag", () => {
+    expect(parseFlags(["upgrade", "--dry-run"])["dry-run"]).toBe(true);
+    expect(parseFlags(["downgrade", "--version", "0.1.104", "--dry-run"])["dry-run"]).toBe(true);
+  });
+
   it("returns empty object for empty argv", () => {
     expect(parseFlags([])).toEqual({});
   });

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -43,6 +43,7 @@ export function parseFlags(argv: string[]): Record<string, string | boolean | un
     "analytics",
     "ask-ai",
     "deploy",
+    "dry-run",
   ]);
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -274,7 +275,8 @@ async function main() {
       args.includes("--version") || args.some((arg) => arg.startsWith("--version="));
     const version =
       typeof flags.version === "string" ? flags.version : hasVersionFlag ? "" : undefined;
-    await downgrade({ framework, version });
+    const dryRun = flags["dry-run"] === true;
+    await downgrade({ framework, version, dryRun });
   } else if (parsedCommand.command === "upgrade") {
     const { upgrade } = await import("./upgrade.js");
     const framework =
@@ -292,7 +294,8 @@ async function main() {
           : args.includes("--latest")
             ? "latest"
             : (parsedCommand.tag ?? "latest");
-    await upgrade({ framework, tag, version });
+    const dryRun = flags["dry-run"] === true;
+    await upgrade({ framework, tag, version, dryRun });
   } else if (parsedCommand.command === "--help" || parsedCommand.command === "-h") {
     printHelp();
   } else if (parsedCommand.command === "--version" || parsedCommand.command === "-v") {
@@ -445,6 +448,7 @@ ${pc.dim("Options for upgrade:")}
   ${pc.cyan("--version <version>")} Install an exact version (e.g. ${pc.dim("0.1.104")})
   ${pc.cyan("--latest")}            Install latest stable (default)
   ${pc.cyan("--beta")}             Install beta versions
+  ${pc.cyan("--dry-run")}          Print the install command without changing dependencies
   ${pc.cyan("upgrade@beta")}       Shortcut for ${pc.cyan("upgrade --beta")}
   ${pc.cyan("upgrade@latest")}     Shortcut for ${pc.cyan("upgrade --latest")}
 
@@ -452,6 +456,7 @@ ${pc.dim("Options for downgrade:")}
   ${pc.cyan("downgrade")}           Install the published version immediately below the current installed version
   ${pc.cyan("--framework <name>")}  Explicit framework (${pc.dim("next")}, ${pc.dim("tanstack-start")}, ${pc.dim("nuxt")}, ${pc.dim("sveltekit")}, ${pc.dim("astro")}); omit to auto-detect
   ${pc.cyan("--version <version>")} Install an exact lower version (e.g. ${pc.dim("0.1.103")})
+  ${pc.cyan("--dry-run")}          Print the install command without changing dependencies
 
   ${pc.cyan("-h, --help")}         Show this help message
   ${pc.cyan("-v, --version")}     Show version

--- a/packages/docs/src/cli/upgrade.flow.test.ts
+++ b/packages/docs/src/cli/upgrade.flow.test.ts
@@ -152,6 +152,24 @@ describe("upgrade package manager selection", () => {
     );
   });
 
+  it("prints the install command without executing when dry-run is enabled", async () => {
+    const prompts = await import("@clack/prompts");
+    const utils = await import("./utils.js");
+
+    vi.mocked(utils.detectPackageManagerFromProject).mockReturnValue(
+      packageManagerDetection("pnpm"),
+    );
+
+    await upgrade({ tag: "latest", dryRun: true });
+
+    expect(utils.exec).not.toHaveBeenCalled();
+    expect(prompts.log.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "pnpm add @farming-labs/docs@latest @farming-labs/theme@latest @farming-labs/next@latest",
+      ),
+    );
+  });
+
   it("rejects invalid exact versions", async () => {
     const utils = await import("./utils.js");
 

--- a/packages/docs/src/cli/upgrade.ts
+++ b/packages/docs/src/cli/upgrade.ts
@@ -53,6 +53,8 @@ export interface UpgradeOptions {
   tag?: UpgradeTag;
   /** Exact package version to install, e.g. 0.1.104. Overrides tag when provided. */
   version?: string;
+  /** Print the resolved install command without running it. */
+  dryRun?: boolean;
 }
 
 export async function upgrade(options: UpgradeOptions = {}) {
@@ -82,6 +84,12 @@ export async function upgrade(options: UpgradeOptions = {}) {
 
   p.log.step(`Upgrading ${preset} docs packages to ${target}...`);
   p.log.message(pc.dim(packages.join(", ")));
+
+  if (options.dryRun) {
+    p.log.info("Dry run. Would run:\n  " + pc.cyan(cmd));
+    p.outro(pc.green("Dry run complete. No changes made."));
+    return;
+  }
 
   try {
     exec(cmd, cwd);

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -138,11 +138,14 @@ npx @farming-labs/docs@latest upgrade              # latest stable (default)
 npx @farming-labs/docs@latest upgrade --latest     # same
 npx @farming-labs/docs@latest upgrade --beta       # beta versions
 npx @farming-labs/docs@latest upgrade --version 0.1.104
+npx @farming-labs/docs@latest upgrade --dry-run    # print the install command only
 npx @farming-labs/docs@latest upgrade@beta         # shorthand for --beta
 npx @farming-labs/docs@latest upgrade@latest       # shorthand for --latest
 ```
 
 Use `--version <version>` when the user needs an exact release instead of an npm dist-tag. If someone uses `pnpx @farming-labs/docs upgrade@beta`, treat it as the supported shorthand for upgrading to the latest beta dist-tag.
+
+Use `--dry-run` to resolve the framework, package manager, target packages, and install command without changing `package.json` or lockfiles. This is useful in monorepos before running the real upgrade from an app directory like `apps/web`.
 
 ## Downgrade
 
@@ -159,6 +162,12 @@ Use `--version <version>` to choose an exact lower version:
 
 ```bash
 npx @farming-labs/docs@latest downgrade --version 0.1.103
+```
+
+Preview the downgrade command without changing dependencies:
+
+```bash
+npx @farming-labs/docs@latest downgrade --version 0.1.103 --dry-run
 ```
 
 If the requested version is equal to or newer than the current installed version, `downgrade` stops and tells the user to use `upgrade --version <version>` for newer versions.

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -825,7 +825,7 @@ The generated project gets:
 Upgrade all `@farming-labs/*` docs packages to the latest version, beta channel, or an exact version. Run from your project root; the CLI **auto-detects** your framework from `package.json` and upgrades the right packages for Next.js, TanStack Start, Nuxt, SvelteKit, and Astro.
 
 > In a monorepo, run from the app or package directory that contains your framework `package.json` (e.g. `apps/web`). The CLI will walk up to find the workspace lockfile automatically.
-The CLI also detects your package manager from the lockfile in the current directory (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, or `package-lock.json`). If no lockfile is found, it asks which package manager you want to use instead of defaulting to npm.
+The CLI also detects your package manager from lockfiles (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, or `package-lock.json`) or `package.json#packageManager` in the current directory or parent directories. If no package manager signal is found, it asks which package manager you want to use instead of defaulting to npm.
 
 > **Monorepo note:** Run `upgrade` and `downgrade` from the app or package directory that contains the framework `package.json` (e.g. `apps/web`), not the workspace root. The CLI walks up parent directories automatically to find a lockfile (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `package-lock.json`) or the `packageManager` field in `package.json`. The log message shows the relative path to the detected file, e.g. `Detected pnpm from ../pnpm-lock.yaml`.
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
@@ -903,6 +903,7 @@ Use **`--latest`** (default) to install the latest stable release, **`--beta`** 
     npx @farming-labs/docs upgrade --latest     # same
     npx @farming-labs/docs upgrade --beta       # beta versions
     npx @farming-labs/docs upgrade --version 0.1.104
+    npx @farming-labs/docs upgrade --dry-run    # print the install command only
     ```
   </Tab>
   <Tab value="pnpm">
@@ -911,6 +912,7 @@ Use **`--latest`** (default) to install the latest stable release, **`--beta`** 
     pnpm dlx @farming-labs/docs upgrade --latest     # same
     pnpm dlx @farming-labs/docs upgrade --beta       # beta versions
     pnpm dlx @farming-labs/docs upgrade --version 0.1.104
+    pnpm dlx @farming-labs/docs upgrade --dry-run    # print the install command only
     ```
   </Tab>
   <Tab value="yarn">
@@ -919,6 +921,7 @@ Use **`--latest`** (default) to install the latest stable release, **`--beta`** 
     yarn dlx @farming-labs/docs upgrade --latest     # same
     yarn dlx @farming-labs/docs upgrade --beta       # beta versions
     yarn dlx @farming-labs/docs upgrade --version 0.1.104
+    yarn dlx @farming-labs/docs upgrade --dry-run    # print the install command only
     ```
   </Tab>
   <Tab value="bun">
@@ -927,9 +930,12 @@ Use **`--latest`** (default) to install the latest stable release, **`--beta`** 
     bunx @farming-labs/docs upgrade --latest     # same
     bunx @farming-labs/docs upgrade --beta       # beta versions
     bunx @farming-labs/docs upgrade --version 0.1.104
+    bunx @farming-labs/docs upgrade --dry-run    # print the install command only
     ```
   </Tab>
 </Tabs>
+
+Use `--dry-run` when you want to preview the exact package manager command before changing `package.json` or the lockfile.
 
 If you prefer the shorter command form, the CLI also accepts `upgrade@beta` and `upgrade@latest`. For example, `pnpx @farming-labs/docs upgrade@beta` behaves like `pnpx @farming-labs/docs upgrade --beta`.
 
@@ -966,7 +972,10 @@ Pass `--version` to choose an exact lower version:
 
 ```bash title="terminal"
 npx @farming-labs/docs downgrade --version 0.1.103
+npx @farming-labs/docs downgrade --version 0.1.103 --dry-run
 ```
+
+Use `--dry-run` to preview the downgrade install command without changing dependencies. Without `--version`, dry-run still resolves the previous published version first.
 
 If the requested version is newer than the current installed version, the command stops and points you to `upgrade --version <version>` instead.
 


### PR DESCRIPTION
## Summary
- add --dry-run support to upgrade and downgrade package version commands
- print the resolved package manager install command without changing dependencies
- document dry-run usage in the CLI docs and CLI skill

## Tests
- pnpm exec oxfmt --ignore-path .oxfmtignore --check packages/docs/src/cli/upgrade.ts packages/docs/src/cli/downgrade.ts packages/docs/src/cli/index.ts packages/docs/src/cli/index.test.ts packages/docs/src/cli/upgrade.flow.test.ts packages/docs/src/cli/downgrade.flow.test.ts skills/farming-labs/cli/SKILL.md website/app/docs/cli/page.mdx
- pnpm --filter @farming-labs/docs test -- src/cli/index.test.ts src/cli/upgrade.flow.test.ts src/cli/downgrade.flow.test.ts
- pnpm --filter @farming-labs/docs run typecheck
- source dogfood: upgrade/downgrade dry-run from /Users/mac/oss/grag/apps/web and /Users/mac/oss/orms/apps/docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--dry-run` to the CLI `upgrade` and `downgrade` commands to preview the exact install command before changing dependencies. Useful for verifying framework and package manager resolution, especially in monorepos.

- **New Features**
  - `--dry-run` prints the resolved install command and exits; no changes to `package.json` or lockfiles.
  - Respects auto-detected framework and package manager (lockfiles or `package.json#packageManager`), including exact `--version` and dist-tags.
  - Updated `--help`, docs, and tests to cover dry-run usage.

<sup>Written for commit 903fb9ad00a24cf9ff9b60ab363198583e03424f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

