### PR TITLE
feat: add doctor agent fix mode

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -84,6 +84,13 @@ describe("parseDoctorArgs", () => {
     });
   });
 
+  it("parses agent fix mode", () => {
+    expect(parseDoctorArgs(["--agent", "--fix"])).toEqual({
+      mode: "agent",
+      fix: true,
+    });
+  });
+
   it("parses explicit fail-on thresholds", () => {
     expect(parseDoctorArgs(["--fail-on", "warn"])).toEqual({
       mode: "agent",
@@ -996,6 +1003,176 @@ Updated body.
     expect(report.coverage.compaction.modifiedGeneratedPages).toBe(1);
     expect(report.coverage.compaction.unknownGeneratedPages).toBe(1);
     expect(report.coverage.compaction.tokenBudgetMissingPages).toBe(1);
+  });
+
+  it("fixes stale generated agent docs and token-budget missing outputs", async () => {
+    writePackageJson(tmpDir, "doctor-fix", { next: "16.0.0" });
+
+    const seenInputs: string[] = [];
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as { input: string };
+      seenInputs.push(payload.input);
+
+      let output = "Generic compacted";
+      if (payload.input.includes("/docs/installation")) {
+        output = payload.input.includes("Updated body.")
+          ? "Installation refreshed"
+          : "Installation initial";
+      } else if (payload.input.includes("/docs/page-actions")) {
+        output = "Page actions initial";
+      } else if (payload.input.includes("/docs/budgeted")) {
+        output = "Budgeted compacted";
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          output,
+          original_input_tokens: 100,
+          output_tokens: 25,
+        }),
+      );
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      writeFileSync(
+        path.join(tmpDir, "docs.config.ts"),
+        `export default {
+  entry: "docs",
+  agent: {
+    compact: {
+      apiKey: "test-key",
+      baseUrl: "http://127.0.0.1:${port}",
+    },
+  },
+};`,
+        "utf-8",
+      );
+
+      for (const slug of ["installation", "page-actions", "budgeted"]) {
+        mkdirSync(path.join(tmpDir, "app", "docs", slug), { recursive: true });
+      }
+
+      writeFileSync(
+        path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+        `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Original body.
+`,
+        "utf-8",
+      );
+
+      writeFileSync(
+        path.join(tmpDir, "app", "docs", "page-actions", "page.mdx"),
+        `---
+title: "Page Actions"
+description: "Customize page actions"
+---
+
+# Page Actions
+
+Original page actions body.
+`,
+        "utf-8",
+      );
+
+      writeFileSync(
+        path.join(tmpDir, "app", "docs", "budgeted", "page.mdx"),
+        `---
+title: "Budgeted"
+description: "Needs compaction output"
+agent:
+  tokenBudget: 250
+---
+
+# Budgeted
+
+Budgeted body.
+`,
+        "utf-8",
+      );
+
+      process.chdir(tmpDir);
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      try {
+        await compactAgentDocs({
+          pages: ["installation", "page-actions"],
+        });
+        seenInputs.length = 0;
+
+        writeFileSync(
+          path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+          `---
+title: "Installation"
+description: "Install the framework"
+---
+
+# Installation
+
+Updated body.
+`,
+          "utf-8",
+        );
+
+        writeFileSync(
+          path.join(tmpDir, "app", "docs", "page-actions", "agent.md"),
+          readFileSync(
+            path.join(tmpDir, "app", "docs", "page-actions", "agent.md"),
+            "utf-8",
+          ).replace("Page actions initial", "Manual page actions edit"),
+          "utf-8",
+        );
+
+        const report = await runDoctor({ mode: "agent", fix: true });
+        expect(report.mode).toBe("agent");
+        if (report.mode !== "agent") throw new Error("Expected an agent doctor report.");
+
+        expect(report.fixes).toEqual([
+          expect.objectContaining({
+            id: "agent-compact",
+            status: "applied",
+          }),
+        ]);
+        expect(report.coverage.compaction.staleGeneratedPages).toBe(0);
+        expect(report.coverage.compaction.tokenBudgetMissingPages).toBe(0);
+        expect(report.coverage.compaction.modifiedGeneratedPages).toBe(1);
+      } finally {
+        logSpy.mockRestore();
+      }
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    expect(seenInputs).toHaveLength(2);
+    expect(seenInputs.some((input) => input.includes("/docs/installation"))).toBe(true);
+    expect(seenInputs.some((input) => input.includes("/docs/budgeted"))).toBe(true);
+    expect(seenInputs.some((input) => input.includes("/docs/page-actions"))).toBe(false);
+    expect(
+      readFileSync(path.join(tmpDir, "app", "docs", "installation", "agent.md"), "utf-8"),
+    ).toContain("Installation refreshed");
+    expect(
+      readFileSync(path.join(tmpDir, "app", "docs", "budgeted", "agent.md"), "utf-8"),
+    ).toContain("Budgeted compacted");
+    expect(
+      readFileSync(path.join(tmpDir, "app", "docs", "page-actions", "agent.md"), "utf-8"),
+    ).toContain("Manual page actions edit");
   });
 
   it("returns a failing report when docs config is missing", async () => {

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -40,7 +40,7 @@ import {
   resolveDocsConfigPath,
   resolveDocsContentDir,
 } from "./config.js";
-import { inspectAgentCompactionState, scanDocsPageTargets } from "./agent.js";
+import { compactAgentDocs, inspectAgentCompactionState, scanDocsPageTargets } from "./agent.js";
 import type { AgentCompactOptions } from "./agent.js";
 import { detectFramework, type Framework } from "./utils.js";
 
@@ -57,6 +57,7 @@ export interface DoctorOptions {
   strict?: boolean;
   failOn?: DoctorFailOn;
   url?: string;
+  fix?: boolean;
 }
 
 export interface ParsedDoctorArgs extends DoctorOptions {
@@ -104,6 +105,14 @@ export interface AgentDoctorReport {
   checks: AgentDoctorCheck[];
   coverage: AgentDoctorCoverage;
   recommendations: string[];
+  fixes?: AgentDoctorFix[];
+}
+
+export interface AgentDoctorFix {
+  id: string;
+  title: string;
+  status: "applied" | "skipped";
+  detail: string;
 }
 
 export interface HumanDoctorCheck {
@@ -196,6 +205,11 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
 
     if (arg === "--strict") {
       parsed.strict = true;
+      continue;
+    }
+
+    if (arg === "--fix") {
+      parsed.fix = true;
       continue;
     }
 
@@ -300,6 +314,7 @@ ${pc.dim("Usage:")}
   pnpm exec docs doctor --site
   pnpm exec docs doctor --agent --json
   pnpm exec docs doctor --agent --strict
+  pnpm exec docs doctor --agent --fix
   pnpm exec docs doctor --agent --fail-on fail
   pnpm exec docs doctor --only agent
   pnpm exec docs doctor --only site
@@ -313,6 +328,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--only <mode>")}      Run only one doctor suite: ${pc.cyan("agent")} or ${pc.cyan("site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
+  ${pc.cyan("--fix")}              Refresh stale generated agent.md files and token-budget missing outputs
   ${pc.cyan("--fail-on <level>")}  Exit with failure on ${pc.cyan("warn")} or only on ${pc.cyan("fail")}
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}
   ${pc.cyan("--config <path>")}    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
@@ -2937,6 +2953,15 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
   console.log(
     `${pc.bold("Generated agent.md freshness:")} ${report.coverage.compaction.freshGeneratedPages} fresh ${pc.dim("•")} ${report.coverage.compaction.staleGeneratedPages} stale ${pc.dim("•")} ${report.coverage.compaction.modifiedGeneratedPages} modified ${pc.dim("•")} ${report.coverage.compaction.tokenBudgetMissingPages} token-budget missing`,
   );
+
+  if (report.fixes && report.fixes.length > 0) {
+    console.log(
+      `${pc.bold("Fixes:")} ${report.fixes
+        .map((fix) => `${fix.status === "applied" ? "applied" : "skipped"} ${fix.title}`)
+        .join(pc.dim(" • "))}`,
+    );
+  }
+
   console.log();
 
   for (const check of report.checks) {
@@ -3030,8 +3055,69 @@ function applyDoctorExitCode(
   }
 }
 
+async function runAgentDoctorFixes(
+  report: AgentDoctorReport,
+  options: DoctorOptions,
+): Promise<AgentDoctorFix[]> {
+  const fixes: AgentDoctorFix[] = [];
+  const compaction = report.coverage.compaction;
+  const shouldRunCompaction =
+    compaction.staleGeneratedPages > 0 || compaction.tokenBudgetMissingPages > 0;
+
+  if (!shouldRunCompaction) {
+    if (compaction.modifiedGeneratedPages > 0 || compaction.unknownGeneratedPages > 0) {
+      fixes.push({
+        id: "agent-compact",
+        title: "agent compact",
+        status: "skipped",
+        detail:
+          "Only modified or unknown generated agent.md files need attention; doctor --fix leaves those for manual review.",
+      });
+    }
+
+    return fixes;
+  }
+
+  const runCompaction = () =>
+    compactAgentDocs({
+      configPath: options.configPath,
+      stale: true,
+      includeMissing: compaction.tokenBudgetMissingPages > 0,
+    });
+
+  if (options.json) {
+    const originalLog = console.log;
+    console.log = () => undefined;
+    try {
+      await runCompaction();
+    } finally {
+      console.log = originalLog;
+    }
+  } else {
+    console.log();
+    console.log(pc.bold("Applying doctor --fix"));
+    await runCompaction();
+  }
+
+  fixes.push({
+    id: "agent-compact",
+    title: "agent compact",
+    status: "applied",
+    detail:
+      compaction.tokenBudgetMissingPages > 0
+        ? "Ran docs agent compact --stale --include-missing to refresh stale generated agent.md files and create token-budget missing outputs."
+        : "Ran docs agent compact --stale to refresh stale generated agent.md files.",
+  });
+
+  return fixes;
+}
+
 export async function runDoctor(options: DoctorOptions = {}) {
   if (options.mode === "human") {
+    if (options.fix) {
+      throw new Error("doctor --fix is currently only supported with --agent.");
+    }
+
     const report = await inspectHumanReadiness(options);
     applyDoctorExitCode(report, options);
     if (options.json) {
@@ -3042,7 +3128,17 @@ export async function runDoctor(options: DoctorOptions = {}) {
     return report;
   }
 
-  const report = await inspectAgentReadiness(options);
+  let report = await inspectAgentReadiness(options);
+  let fixes: AgentDoctorFix[] | undefined;
+
+  if (options.fix) {
+    fixes = await runAgentDoctorFixes(report, options);
+    report = {
+      ...(await inspectAgentReadiness(options)),
+      fixes,
+    };
+  }
+
   applyDoctorExitCode(report, options);
   if (options.json) {
     printDoctorJsonReport(report);

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -395,6 +395,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --human")}                      Alias for ${pc.cyan("doctor --site")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
   ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
+  ${pc.cyan("doctor --agent --fix")}                Refresh stale generated ${pc.dim("agent.md")} files and token-budget missing outputs
   ${pc.cyan("doctor --fail-on warn|fail")}          Choose whether warnings or only failures fail CI
   ${pc.cyan("doctor agent")}                        Subcommand alias for agent scoring
   ${pc.cyan("doctor site")}                         Subcommand alias for reader-facing scoring


### PR DESCRIPTION
## Summary

- add `docs doctor --agent --fix` parsing, help text, and reporting
- refresh stale generated `agent.md` files through the existing compaction path
- create token-budget missing generated outputs while leaving modified or unknown generated files for manual review
- add regression coverage for the fix behavior

No documentation files changed.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/cli/doctor.test.ts`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm --filter @farming-labs/docs run test`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs doctor --agent --fix` to auto-refresh stale generated `agent.md` files and create missing token-budget outputs, while leaving modified or unknown generated files for manual review. The agent report now lists applied or skipped fixes and behaves cleanly in `--json` mode.

- **New Features**
  - Parse `--fix` and update CLI help in `@farming-labs/docs`.
  - Run compaction for stale pages and optionally include missing outputs; skip modified/unknown files.
  - Suppress compaction logs in `--json` mode and print a concise "Fixes" summary in the agent report.
  - Add regression tests for flag parsing and fix behavior.

<sup>Written for commit a7b5cc9692bf9594e9b27bb4695f7fa68d5ce8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

