### PR TITLE
feat: add doctor fix dry run

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "node:http";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AddressInfo } from "node:net";
@@ -88,6 +96,11 @@ describe("parseDoctorArgs", () => {
     expect(parseDoctorArgs(["--agent", "--fix"])).toEqual({
       mode: "agent",
       fix: true,
+    });
+    expect(parseDoctorArgs(["--agent", "--fix", "--dry-run"])).toEqual({
+      mode: "agent",
+      fix: true,
+      dryRun: true,
     });
   });
 
@@ -1137,6 +1150,27 @@ Updated body.
           ).replace("Page actions initial", "Manual page actions edit"),
           "utf-8",
         );
+
+        const dryRunReport = await runDoctor({ mode: "agent", fix: true, dryRun: true });
+        expect(dryRunReport.mode).toBe("agent");
+        if (dryRunReport.mode !== "agent") {
+          throw new Error("Expected an agent doctor report.");
+        }
+
+        expect(dryRunReport.fixes).toEqual([
+          expect.objectContaining({
+            id: "agent-compact",
+            status: "skipped",
+            detail: expect.stringContaining("Dry run: would run docs agent compact --stale --include-missing"),
+          }),
+        ]);
+        expect(dryRunReport.coverage.compaction.staleGeneratedPages).toBe(1);
+        expect(dryRunReport.coverage.compaction.tokenBudgetMissingPages).toBe(1);
+        expect(seenInputs).toHaveLength(0);
+        expect(
+          readFileSync(path.join(tmpDir, "app", "docs", "installation", "agent.md"), "utf-8"),
+        ).toContain("Installation initial");
+        expect(existsSync(path.join(tmpDir, "app", "docs", "budgeted", "agent.md"))).toBe(false);
 
         const report = await runDoctor({ mode: "agent", fix: true });
         expect(report.mode).toBe("agent");

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -58,6 +58,7 @@ export interface DoctorOptions {
   failOn?: DoctorFailOn;
   url?: string;
   fix?: boolean;
+  dryRun?: boolean;
 }
 
 export interface ParsedDoctorArgs extends DoctorOptions {
@@ -213,6 +214,11 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+      continue;
+    }
+
     if (arg.startsWith("--fail-on=")) {
       const value = parseInlineFlag(arg).value;
       if (!value) {
@@ -315,6 +321,7 @@ ${pc.dim("Usage:")}
   pnpm exec docs doctor --agent --json
   pnpm exec docs doctor --agent --strict
   pnpm exec docs doctor --agent --fix
+  pnpm exec docs doctor --agent --fix --dry-run
   pnpm exec docs doctor --agent --fail-on fail
   pnpm exec docs doctor --only agent
   pnpm exec docs doctor --only site
@@ -329,6 +336,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
   ${pc.cyan("--fix")}              Refresh stale generated agent.md files and token-budget missing outputs
+  ${pc.cyan("--dry-run")}          With ${pc.cyan("--fix")}, report the compaction command without writing files
   ${pc.cyan("--fail-on <level>")}  Exit with failure on ${pc.cyan("warn")} or only on ${pc.cyan("fail")}
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}
   ${pc.cyan("--config <path>")}    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
@@ -3084,6 +3092,22 @@ async function runAgentDoctorFixes(
       stale: true,
       includeMissing: compaction.tokenBudgetMissingPages > 0,
     });
+  const command = `docs agent compact --stale${compaction.tokenBudgetMissingPages > 0 ? " --include-missing" : ""}`;
+
+  if (options.dryRun) {
+    const missingOutputDetail = compaction.tokenBudgetMissingPages > 0
+      ? " and create token-budget missing outputs"
+      : "";
+
+    fixes.push({
+      id: "agent-compact",
+      title: "agent compact",
+      status: "skipped",
+      detail: `Dry run: would run ${command} to refresh stale generated agent.md files${missingOutputDetail}.`,
+    });
+
+    return fixes;
+  }
 
   if (options.json) {
     const originalLog = console.log;

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -396,6 +396,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
   ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
   ${pc.cyan("doctor --agent --fix")}                Refresh stale generated ${pc.dim("agent.md")} files and token-budget missing outputs
+  ${pc.cyan("doctor --agent --fix --dry-run")}      Report the fix command without writing generated ${pc.dim("agent.md")} files
   ${pc.cyan("doctor --fail-on warn|fail")}          Choose whether warnings or only failures fail CI
   ${pc.cyan("doctor agent")}                        Subcommand alias for agent scoring
   ${pc.cyan("doctor site")}                         Subcommand alias for reader-facing scoring


### PR DESCRIPTION
## Summary

- add `--dry-run` support to `docs doctor --agent --fix`
- report the compaction command that would run without writing generated `agent.md` files
- cover the parser and no-write dry-run behavior in doctor tests

Docs pages were intentionally left unchanged so the drift flow can evaluate this CLI change after merge.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/cli/doctor.test.ts`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm --filter @farming-labs/docs run test`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--dry-run` to `docs doctor --agent --fix` in `@farming-labs/docs`, letting you preview the exact `docs agent compact` command without writing generated `agent.md` files. Updates CLI help/usage and adds tests for arg parsing and dry-run no-write behavior.

<sup>Written for commit 7ea3bbc7459edacb71f054c5ae4334041a21d403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

