### PR TITLE
feat: use docs-cloud compression for agent compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,17 @@ pnpm exec docs agent compact --stale
 pnpm exec docs agent compact --stale --include-missing
 ```
 
-Optional defaults live in `docs.config.ts`:
+The API key comes from the root Docs Cloud config. Optional compression defaults live under
+`agent.compact`:
 
 ```ts
+cloud: {
+  apiKey: { env: "DOCS_CLOUD_API_KEY" },
+},
 agent: {
   compact: {
-    apiKeyEnv: "DOCS_CLOUD_API_KEY",
+    model: "docs-cloud-compress-v1",
+    aggressiveness: 0.3,
   },
 },
 ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Optional defaults live in `docs.config.ts`:
 ```ts
 agent: {
   compact: {
-    apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+    apiKeyEnv: "DOCS_CLOUD_API_KEY",
   },
 },
 ```

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -123,8 +123,8 @@ export default defineDocs({
   },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.3,
     },
   },

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -501,16 +501,18 @@ Body.
     expect(logs.some((line) => line.includes("Dry run complete: 1 page processed."))).toBe(true);
   });
 
-  it("reads compact defaults including apiKeyEnv from docs.config.ts", async () => {
+  it("reads the root cloud API key env with compact defaults from docs.config.ts", async () => {
     process.env.CUSTOM_COMPRESSION_KEY = "config-key";
 
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default defineDocs({
         entry: "docs",
+        cloud: {
+          apiKey: { env: "CUSTOM_COMPRESSION_KEY" },
+        },
         agent: {
           compact: {
-            apiKeyEnv: "CUSTOM_COMPRESSION_KEY",
             baseUrl: "http://127.0.0.1:0",
             model: "docs-cloud-compress-test",
             aggressiveness: 0.55,
@@ -564,9 +566,11 @@ Body.
       path.join(tmpDir, "docs.config.ts"),
       `export default defineDocs({
         entry: "docs",
+        cloud: {
+          apiKey: { env: "CUSTOM_COMPRESSION_KEY" },
+        },
         agent: {
           compact: {
-            apiKeyEnv: "CUSTOM_COMPRESSION_KEY",
             baseUrl: "http://127.0.0.1:${port}",
             model: "docs-cloud-compress-test",
             aggressiveness: 0.55,
@@ -694,9 +698,11 @@ Body.
       path.join(tmpDir, "docs.config.ts"),
       `export default defineDocs({
         entry: "docs",
+        cloud: {
+          apiKey: { env: "DOCS_CLOUD_API_KEY" },
+        },
         agent: {
           compact: {
-            apiKeyEnv: "DOCS_CLOUD_API_KEY",
             baseUrl: "http://127.0.0.1:0",
             model: "docs-cloud-compress-v1",
           },
@@ -747,9 +753,11 @@ Body.
       path.join(tmpDir, "docs.config.ts"),
       `export default defineDocs({
         entry: "docs",
+        cloud: {
+          apiKey: { env: "DOCS_CLOUD_API_KEY" },
+        },
         agent: {
           compact: {
-            apiKeyEnv: "DOCS_CLOUD_API_KEY",
             baseUrl: "http://127.0.0.1:${port}",
             model: "docs-cloud-compress-v1",
           },
@@ -778,7 +786,7 @@ Body.
     );
   });
 
-  it("requires the compression key to be declared in root compact config or CLI options", async () => {
+  it("requires the compression key to be declared in root cloud config or CLI options", async () => {
     process.env.DOCS_CLOUD_API_KEY = "ambient-key";
 
     writeFileSync(
@@ -805,7 +813,42 @@ Body.
     process.chdir(tmpDir);
 
     await expect(compactAgentDocs({ pages: ["installation"] })).rejects.toThrow(
-      "Set agent.compact.apiKey/apiKeyEnv in docs config or pass --api-key",
+      "Configure cloud.apiKey.env in your root docs config",
+    );
+  });
+
+  it("explains when the configured root cloud API key env is missing", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+        entry: "docs",
+        cloud: {
+          apiKey: { env: "DOCS_CLOUD_API_KEY" },
+        },
+      };`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install it"
+---
+
+# Installation
+
+Body.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    delete process.env.DOCS_CLOUD_API_KEY;
+
+    await expect(compactAgentDocs({ pages: ["installation"] })).rejects.toThrow(
+      'The configured API key env "DOCS_CLOUD_API_KEY" was not found in your shell or project .env/.env.local files',
     );
   });
 

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -248,7 +248,7 @@ Keep this focused.
     expect(seenInputs[0]).toContain("URL: /docs/installation");
     expect(seenInputs[0]).toContain("Description: Install the framework");
     expect(seenInputs[0]).toContain("Related: /docs/configuration");
-    expect(seenInputs[0]).toContain("<ttc_safe>```bash");
+    expect(seenInputs[0]).toContain("<docs_safe>```bash");
 
     expect(seenInputs[1]).toContain("URL: /docs/configuration");
     expect(seenInputs[1]).toContain("Hidden agent notes should appear in the resolved markdown.");
@@ -809,7 +809,7 @@ Body.
     );
   });
 
-  it("strips protected safe tags from compressed output before writing agent.md", async () => {
+  it("strips docs_safe tags from compressed output before writing agent.md", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default { entry: "docs" };`,
@@ -835,7 +835,7 @@ Body.
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          output: "<ttc_safe>Clean output</ttc_safe><docs_safe> Legacy</docs_safe>",
+          output: "<docs_safe>Clean output</docs_safe>",
           original_input_tokens: 10,
           output_tokens: 5,
         }),
@@ -860,7 +860,7 @@ Body.
 
     expectGeneratedAgentFile(
       path.join(tmpDir, "app", "docs", "installation", "agent.md"),
-      "Clean output Legacy",
+      "Clean output",
       "resolved-page",
     );
   });

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -778,6 +778,37 @@ Body.
     );
   });
 
+  it("requires the compression key to be declared in root compact config or CLI options", async () => {
+    process.env.DOCS_CLOUD_API_KEY = "ambient-key";
+
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs" };`,
+      "utf-8",
+    );
+
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "installation", "page.mdx"),
+      `---
+title: "Installation"
+description: "Install it"
+---
+
+# Installation
+
+Body.
+`,
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+
+    await expect(compactAgentDocs({ pages: ["installation"] })).rejects.toThrow(
+      "Set agent.compact.apiKey/apiKeyEnv in docs config or pass --api-key",
+    );
+  });
+
   it("strips docs_safe tags from compressed output before writing agent.md", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -37,10 +37,10 @@ describe("parseAgentCompactArgs", () => {
         "--api-key",
         "secret",
         "--api-key-env",
-        "MY_CUSTOM_TTC_KEY",
+        "MY_CUSTOM_COMPRESSION_KEY",
         "--base-url=http://127.0.0.1:4321",
         "--model",
-        "bear-1.1",
+        "docs-cloud-compress-test",
         "--aggressiveness",
         "0.6",
         "--max-output-tokens",
@@ -52,9 +52,9 @@ describe("parseAgentCompactArgs", () => {
     ).toEqual({
       all: true,
       apiKey: "secret",
-      apiKeyEnv: "MY_CUSTOM_TTC_KEY",
+      apiKeyEnv: "MY_CUSTOM_COMPRESSION_KEY",
       baseUrl: "http://127.0.0.1:4321",
-      model: "bear-1.1",
+      model: "docs-cloud-compress-test",
       aggressiveness: 0.6,
       maxOutputTokens: 500,
       minOutputTokens: 120,
@@ -248,7 +248,7 @@ Keep this focused.
     expect(seenInputs[0]).toContain("URL: /docs/installation");
     expect(seenInputs[0]).toContain("Description: Install the framework");
     expect(seenInputs[0]).toContain("Related: /docs/configuration");
-    expect(seenInputs[0]).toContain("<ttc_safe>```bash");
+    expect(seenInputs[0]).toContain("<docs_safe>```bash");
 
     expect(seenInputs[1]).toContain("URL: /docs/configuration");
     expect(seenInputs[1]).toContain("Hidden agent notes should appear in the resolved markdown.");
@@ -502,7 +502,7 @@ Body.
   });
 
   it("reads compact defaults including apiKeyEnv from docs.config.ts", async () => {
-    process.env.CUSTOM_TTC_KEY = "config-key";
+    process.env.CUSTOM_COMPRESSION_KEY = "config-key";
 
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
@@ -510,9 +510,9 @@ Body.
         entry: "docs",
         agent: {
           compact: {
-            apiKeyEnv: "CUSTOM_TTC_KEY",
+            apiKeyEnv: "CUSTOM_COMPRESSION_KEY",
             baseUrl: "http://127.0.0.1:0",
-            model: "bear-1.1",
+            model: "docs-cloud-compress-test",
             aggressiveness: 0.55,
             protectJson: false,
           },
@@ -566,9 +566,9 @@ Body.
         entry: "docs",
         agent: {
           compact: {
-            apiKeyEnv: "CUSTOM_TTC_KEY",
+            apiKeyEnv: "CUSTOM_COMPRESSION_KEY",
             baseUrl: "http://127.0.0.1:${port}",
-            model: "bear-1.1",
+            model: "docs-cloud-compress-test",
             aggressiveness: 0.55,
             protectJson: false,
           },
@@ -590,7 +590,7 @@ Body.
 
     expect(seenAuthHeader).toBe("Bearer config-key");
     expect(seenPayload).toMatchObject({
-      model: "bear-1.1",
+      model: "docs-cloud-compress-test",
       compression_settings: {
         aggressiveness: 0.55,
         protect_json: false,
@@ -604,7 +604,7 @@ Body.
   });
 
   it("loads docs.config.tsx and resolves apiKey from process.env expressions", async () => {
-    process.env.CUSTOM_TTC_KEY = "tsx-env-key";
+    process.env.CUSTOM_COMPRESSION_KEY = "tsx-env-key";
 
     mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
     writeFileSync(
@@ -654,9 +654,9 @@ Body.
   },
   agent: {
     compact: {
-      apiKey: process.env.CUSTOM_TTC_KEY,
+      apiKey: process.env.CUSTOM_COMPRESSION_KEY,
       baseUrl: "http://127.0.0.1:${port}",
-      model: "bear-1.2",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.2,
     },
   },
@@ -677,7 +677,7 @@ Body.
 
     expect(seenAuthHeader).toBe("Bearer tsx-env-key");
     expect(seenPayload).toMatchObject({
-      model: "bear-1.2",
+      model: "docs-cloud-compress-v1",
       compression_settings: {
         aggressiveness: 0.2,
       },
@@ -689,23 +689,23 @@ Body.
     );
   });
 
-  it("loads TOKEN_COMPANY_API_KEY from project .env files", async () => {
+  it("loads DOCS_CLOUD_API_KEY from project .env files", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default defineDocs({
         entry: "docs",
         agent: {
           compact: {
-            apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+            apiKeyEnv: "DOCS_CLOUD_API_KEY",
             baseUrl: "http://127.0.0.1:0",
-            model: "bear-1.2",
+            model: "docs-cloud-compress-v1",
           },
         },
       });`,
       "utf-8",
     );
 
-    writeFileSync(path.join(tmpDir, ".env"), `TOKEN_COMPANY_API_KEY=dotenv-key\n`, "utf-8");
+    writeFileSync(path.join(tmpDir, ".env"), `DOCS_CLOUD_API_KEY=dotenv-key\n`, "utf-8");
 
     mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
     writeFileSync(
@@ -749,9 +749,9 @@ Body.
         entry: "docs",
         agent: {
           compact: {
-            apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+            apiKeyEnv: "DOCS_CLOUD_API_KEY",
             baseUrl: "http://127.0.0.1:${port}",
-            model: "bear-1.2",
+            model: "docs-cloud-compress-v1",
           },
         },
       });`,
@@ -760,7 +760,7 @@ Body.
 
     try {
       process.chdir(tmpDir);
-      delete process.env.TOKEN_COMPANY_API_KEY;
+      delete process.env.DOCS_CLOUD_API_KEY;
       await compactAgentDocs({
         pages: ["installation"],
       });
@@ -778,7 +778,7 @@ Body.
     );
   });
 
-  it("strips ttc_safe tags from compressed output before writing agent.md", async () => {
+  it("strips docs_safe tags from compressed output before writing agent.md", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default { entry: "docs" };`,
@@ -804,7 +804,7 @@ Body.
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          output: "<ttc_safe>Clean output</ttc_safe>",
+          output: "<docs_safe>Clean output</docs_safe>",
           original_input_tokens: 10,
           output_tokens: 5,
         }),

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -248,7 +248,7 @@ Keep this focused.
     expect(seenInputs[0]).toContain("URL: /docs/installation");
     expect(seenInputs[0]).toContain("Description: Install the framework");
     expect(seenInputs[0]).toContain("Related: /docs/configuration");
-    expect(seenInputs[0]).toContain("<docs_safe>```bash");
+    expect(seenInputs[0]).toContain("<ttc_safe>```bash");
 
     expect(seenInputs[1]).toContain("URL: /docs/configuration");
     expect(seenInputs[1]).toContain("Hidden agent notes should appear in the resolved markdown.");
@@ -809,7 +809,7 @@ Body.
     );
   });
 
-  it("strips docs_safe tags from compressed output before writing agent.md", async () => {
+  it("strips protected safe tags from compressed output before writing agent.md", async () => {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
       `export default { entry: "docs" };`,
@@ -835,7 +835,7 @@ Body.
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          output: "<docs_safe>Clean output</docs_safe>",
+          output: "<ttc_safe>Clean output</ttc_safe><docs_safe> Legacy</docs_safe>",
           original_input_tokens: 10,
           output_tokens: 5,
         }),
@@ -860,7 +860,7 @@ Body.
 
     expectGeneratedAgentFile(
       path.join(tmpDir, "app", "docs", "installation", "agent.md"),
-      "Clean output",
+      "Clean output Legacy",
       "resolved-page",
     );
   });

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -32,6 +32,7 @@ import type { DocsConfig, PageFrontmatter } from "../types.js";
 const DEFAULT_COMPRESSION_BASE_URL = "https://api.farming-labs.dev";
 const DEFAULT_COMPRESSION_MODEL = "docs-cloud-compress-v1";
 const DEFAULT_COMPRESSION_AGGRESSIVENESS = 0.3;
+const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const INDEX_PAGE_BASENAMES = new Set(["index", "page", "+page"]);
 
 export interface AgentCompactOptions {
@@ -383,12 +384,30 @@ function resolveCompressionApiKey(explicitApiKey?: string, explicitApiKeyEnv?: s
       : undefined);
 
   if (!apiKey) {
+    if (explicitApiKeyEnv && explicitApiKeyEnv.length > 0) {
+      throw new Error(
+        `Missing Docs Cloud API key. The configured API key env "${explicitApiKeyEnv}" was not found in your shell or project .env/.env.local files. Add ${explicitApiKeyEnv}=fl_key_... to .env.local, configure cloud.apiKey.env in your root docs config, or pass --api-key.`,
+      );
+    }
+
     throw new Error(
-      "Missing Docs Cloud API key. Set agent.compact.apiKey/apiKeyEnv in docs config or pass --api-key.",
+      "Missing Docs Cloud API key. Configure cloud.apiKey.env in your root docs config and set DOCS_CLOUD_API_KEY=fl_key_... in .env/.env.local, or pass --api-key.",
     );
   }
 
   return apiKey;
+}
+
+function readCloudApiKeyConfig(content: string): AgentCompactOptions {
+  const cloudBlock = extractNestedObjectLiteral(content, ["cloud"]);
+  if (!cloudBlock) return {};
+
+  const apiKeyBlock = extractNestedObjectLiteral(content, ["cloud", "apiKey"]);
+  return {
+    apiKeyEnv: apiKeyBlock
+      ? (readStringProperty(apiKeyBlock, "env") ?? DEFAULT_DOCS_CLOUD_API_KEY_ENV)
+      : DEFAULT_DOCS_CLOUD_API_KEY_ENV,
+  };
 }
 
 function readAgentCompactConfig(content: string): AgentCompactOptions {
@@ -409,6 +428,14 @@ function readAgentCompactConfig(content: string): AgentCompactOptions {
     maxOutputTokens: readNumberProperty(compactBlock, "maxOutputTokens"),
     minOutputTokens: readNumberProperty(compactBlock, "minOutputTokens"),
     protectJson: readBooleanProperty(compactBlock, "protectJson"),
+  };
+}
+
+function readCloudApiKeyConfigFromModule(config: DocsConfig): AgentCompactOptions {
+  if (!config.cloud) return {};
+
+  return {
+    apiKeyEnv: config.cloud.apiKey?.env?.trim() || DEFAULT_DOCS_CLOUD_API_KEY_ENV,
   };
 }
 
@@ -633,10 +660,7 @@ function protectForCompression(input: string): string {
   result = result.replace(/https?:\/\/[^\s)]+/g, stash);
 
   for (let index = 0; index < segments.length; index += 1) {
-    result = result.replace(
-      `__DOCS_SAFE_${index}__`,
-      `<docs_safe>${segments[index]}</docs_safe>`,
-    );
+    result = result.replace(`__DOCS_SAFE_${index}__`, `<docs_safe>${segments[index]}</docs_safe>`);
   }
 
   return result;
@@ -776,10 +800,15 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   const loadedConfigModule = await loadDocsConfigModule(rootDir, options.configPath);
   const configPath = loadedConfigModule?.path ?? resolveDocsConfigPath(rootDir, options.configPath);
   const configContent = readFileSync(configPath, "utf-8");
-  const configDefaults = mergeAgentCompactOptions(
+  const cloudApiKeyDefaults = mergeAgentCompactOptions(
+    readCloudApiKeyConfig(configContent),
+    loadedConfigModule?.config ? readCloudApiKeyConfigFromModule(loadedConfigModule.config) : {},
+  );
+  const compactDefaults = mergeAgentCompactOptions(
     readAgentCompactConfig(configContent),
     loadedConfigModule?.config ? readAgentCompactConfigFromModule(loadedConfigModule.config) : {},
   );
+  const configDefaults = mergeAgentCompactOptions(cloudApiKeyDefaults, compactDefaults);
   const resolvedOptions = mergeAgentCompactOptions(configDefaults, options);
   const entry =
     normalizePathSegment(
@@ -973,8 +1002,8 @@ ${pc.dim("Options:")}
   ${pc.cyan("--stale")}                  Re-compact only stale generated agent.md files
   ${pc.cyan("--include-missing")}        With ${pc.cyan("--stale")}, also create missing agent.md files for explicit pages or pages that define ${pc.cyan("agent.tokenBudget")}
   ${pc.cyan("--config <path>")}          Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
-  ${pc.cyan("--api-key <key>")}          Docs Cloud API key; ${pc.dim("agent.compact.apiKey")} is preferred
-  ${pc.cyan("--api-key-env <name>")}     Env var name for the Docs Cloud API key; ${pc.dim("agent.compact.apiKeyEnv")} is preferred
+  ${pc.cyan("--api-key <key>")}          Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--api-key-env <name>")}     Env var name for the Docs Cloud API key; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--base-url <url>")}         Override the compression API base URL (useful for tests)
   ${pc.cyan("--model <name>")}           Compression model (${pc.dim("docs-cloud-compress-v1")} by default)
   ${pc.cyan("--aggressiveness <0-1>")}   Compression intensity (${pc.dim("0.3")} by default)

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -376,18 +376,15 @@ function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
 }
 
 function resolveCompressionApiKey(explicitApiKey?: string, explicitApiKeyEnv?: string): string {
-  const candidateKeys = [
-    explicitApiKeyEnv,
-    "DOCS_CLOUD_API_KEY",
-    "FARMING_LABS_DOCS_API_KEY",
-    "FARMING_LABS_API_KEY",
-  ].filter((value): value is string => typeof value === "string" && value.length > 0);
-
-  const apiKey = explicitApiKey ?? candidateKeys.map((key) => process.env[key]).find(Boolean);
+  const apiKey =
+    explicitApiKey ??
+    (explicitApiKeyEnv && explicitApiKeyEnv.length > 0
+      ? process.env[explicitApiKeyEnv]
+      : undefined);
 
   if (!apiKey) {
     throw new Error(
-      "Missing Docs Cloud API key. Pass --api-key, set agent.compact.apiKey/apiKeyEnv, or set DOCS_CLOUD_API_KEY.",
+      "Missing Docs Cloud API key. Set agent.compact.apiKey/apiKeyEnv in docs config or pass --api-key.",
     );
   }
 
@@ -976,8 +973,8 @@ ${pc.dim("Options:")}
   ${pc.cyan("--stale")}                  Re-compact only stale generated agent.md files
   ${pc.cyan("--include-missing")}        With ${pc.cyan("--stale")}, also create missing agent.md files for explicit pages or pages that define ${pc.cyan("agent.tokenBudget")}
   ${pc.cyan("--config <path>")}          Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
-  ${pc.cyan("--api-key <key>")}          Docs Cloud API key (or set ${pc.dim("DOCS_CLOUD_API_KEY")})
-  ${pc.cyan("--api-key-env <name>")}     Custom env var name for the Docs Cloud API key
+  ${pc.cyan("--api-key <key>")}          Docs Cloud API key; ${pc.dim("agent.compact.apiKey")} is preferred
+  ${pc.cyan("--api-key-env <name>")}     Env var name for the Docs Cloud API key; ${pc.dim("agent.compact.apiKeyEnv")} is preferred
   ${pc.cyan("--base-url <url>")}         Override the compression API base URL (useful for tests)
   ${pc.cyan("--model <name>")}           Compression model (${pc.dim("docs-cloud-compress-v1")} by default)
   ${pc.cyan("--aggressiveness <0-1>")}   Compression intensity (${pc.dim("0.3")} by default)

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -620,7 +620,7 @@ export function inspectAgentCompactionState(
 function protectForCompression(input: string): string {
   const segments: string[] = [];
   const stash = (value: string) => {
-    const token = `__TTC_SAFE_${segments.length}__`;
+    const token = `__DOCS_SAFE_${segments.length}__`;
     segments.push(value);
     return token;
   };
@@ -634,8 +634,8 @@ function protectForCompression(input: string): string {
 
   for (let index = 0; index < segments.length; index += 1) {
     result = result.replace(
-      `__TTC_SAFE_${index}__`,
-      `<ttc_safe>${segments[index]}</ttc_safe>`,
+      `__DOCS_SAFE_${index}__`,
+      `<docs_safe>${segments[index]}</docs_safe>`,
     );
   }
 
@@ -643,7 +643,7 @@ function protectForCompression(input: string): string {
 }
 
 function sanitizeCompressedOutput(output: string): string {
-  return output.replace(/<\/?(?:ttc_safe|docs_safe)>/g, "");
+  return output.replace(/<\/?docs_safe>/g, "");
 }
 
 async function compressDocument(

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -29,9 +29,9 @@ import {
 } from "./config.js";
 import type { DocsConfig, PageFrontmatter } from "../types.js";
 
-const DEFAULT_TTC_BASE_URL = "https://api.thetokencompany.com";
-const DEFAULT_TTC_MODEL = "bear-1.2";
-const DEFAULT_TTC_AGGRESSIVENESS = 0.3;
+const DEFAULT_COMPRESSION_BASE_URL = "https://api.farming-labs.dev";
+const DEFAULT_COMPRESSION_MODEL = "docs-cloud-compress-v1";
+const DEFAULT_COMPRESSION_AGGRESSIVENESS = 0.3;
 const INDEX_PAGE_BASENAMES = new Set(["index", "page", "+page"]);
 
 export interface AgentCompactOptions {
@@ -304,11 +304,12 @@ export function scanDocsPageTargets(
 function resolveCompressionEndpoint(rawBaseUrl?: string): string {
   const baseUrl =
     rawBaseUrl ??
-    process.env.TOKEN_COMPANY_BASE_URL ??
-    process.env.THE_TOKEN_COMPANY_BASE_URL ??
-    DEFAULT_TTC_BASE_URL;
+    process.env.DOCS_CLOUD_COMPRESSION_BASE_URL ??
+    process.env.DOCS_CLOUD_API_BASE_URL ??
+    process.env.FARMING_LABS_DOCS_API_BASE_URL ??
+    DEFAULT_COMPRESSION_BASE_URL;
 
-  if (/\/v1\/compress\/?$/i.test(baseUrl)) {
+  if (/\/v1\/(?:compress|agent\/compact)\/?$/i.test(baseUrl)) {
     return baseUrl.replace(/\/+$/, "");
   }
 
@@ -377,16 +378,16 @@ function listGitChangedFiles(rootDir: string, contentDir: string): Set<string> {
 function resolveCompressionApiKey(explicitApiKey?: string, explicitApiKeyEnv?: string): string {
   const candidateKeys = [
     explicitApiKeyEnv,
-    "TOKEN_COMPANY_API_KEY",
-    "THE_TOKEN_COMPANY_API_KEY",
-    "TTC_API_KEY",
+    "DOCS_CLOUD_API_KEY",
+    "FARMING_LABS_DOCS_API_KEY",
+    "FARMING_LABS_API_KEY",
   ].filter((value): value is string => typeof value === "string" && value.length > 0);
 
   const apiKey = explicitApiKey ?? candidateKeys.map((key) => process.env[key]).find(Boolean);
 
   if (!apiKey) {
     throw new Error(
-      "Missing Token Company API key. Pass --api-key, set agent.compact.apiKey/apiKeyEnv, or set TOKEN_COMPANY_API_KEY.",
+      "Missing Docs Cloud API key. Pass --api-key, set agent.compact.apiKey/apiKeyEnv, or set DOCS_CLOUD_API_KEY.",
     );
   }
 
@@ -454,8 +455,8 @@ export function readPageTokenBudget(pagePath: string): number | undefined {
 function buildCompactionSettingsHash(options: AgentCompactOptions): string {
   return hashGeneratedAgentContent(
     JSON.stringify({
-      model: options.model ?? DEFAULT_TTC_MODEL,
-      aggressiveness: options.aggressiveness ?? DEFAULT_TTC_AGGRESSIVENESS,
+      model: options.model ?? DEFAULT_COMPRESSION_MODEL,
+      aggressiveness: options.aggressiveness ?? DEFAULT_COMPRESSION_AGGRESSIVENESS,
       maxOutputTokens: options.maxOutputTokens ?? null,
       minOutputTokens: options.minOutputTokens ?? null,
       protectJson: options.protectJson ?? null,
@@ -622,7 +623,7 @@ export function inspectAgentCompactionState(
 function protectForCompression(input: string): string {
   const segments: string[] = [];
   const stash = (value: string) => {
-    const token = `__TTC_SAFE_${segments.length}__`;
+    const token = `__DOCS_SAFE_${segments.length}__`;
     segments.push(value);
     return token;
   };
@@ -635,14 +636,17 @@ function protectForCompression(input: string): string {
   result = result.replace(/https?:\/\/[^\s)]+/g, stash);
 
   for (let index = 0; index < segments.length; index += 1) {
-    result = result.replace(`__TTC_SAFE_${index}__`, `<ttc_safe>${segments[index]}</ttc_safe>`);
+    result = result.replace(
+      `__DOCS_SAFE_${index}__`,
+      `<docs_safe>${segments[index]}</docs_safe>`,
+    );
   }
 
   return result;
 }
 
 function sanitizeCompressedOutput(output: string): string {
-  return output.replace(/<\/?ttc_safe>/g, "");
+  return output.replace(/<\/?docs_safe>/g, "");
 }
 
 async function compressDocument(
@@ -651,14 +655,14 @@ async function compressDocument(
 ): Promise<CompressResponse> {
   const apiKey = resolveCompressionApiKey(options.apiKey, options.apiKeyEnv);
   const endpoint = resolveCompressionEndpoint(options.baseUrl);
-  const aggressiveness = options.aggressiveness ?? DEFAULT_TTC_AGGRESSIVENESS;
+  const aggressiveness = options.aggressiveness ?? DEFAULT_COMPRESSION_AGGRESSIVENESS;
 
   if (aggressiveness < 0 || aggressiveness > 1) {
     throw new Error("Aggressiveness must be between 0.0 and 1.0.");
   }
 
   const payload = {
-    model: options.model ?? DEFAULT_TTC_MODEL,
+    model: options.model ?? DEFAULT_COMPRESSION_MODEL,
     input: protectForCompression(input),
     compression_settings: {
       aggressiveness,
@@ -684,7 +688,7 @@ async function compressDocument(
   if (!response.ok) {
     const body = await response.text();
     throw new Error(
-      `Token Company request failed (${response.status}): ${body || response.statusText}`,
+      `Docs Cloud compression request failed (${response.status}): ${body || response.statusText}`,
     );
   }
 
@@ -693,7 +697,7 @@ async function compressDocument(
     typeof result.output === "string" ? sanitizeCompressedOutput(result.output) : result.output;
 
   if (typeof sanitizedOutput !== "string" || sanitizedOutput.trim().length === 0) {
-    throw new Error("Token Company response did not include a compressed output.");
+    throw new Error("Docs Cloud compression response did not include a compressed output.");
   }
 
   return {
@@ -972,13 +976,13 @@ ${pc.dim("Options:")}
   ${pc.cyan("--stale")}                  Re-compact only stale generated agent.md files
   ${pc.cyan("--include-missing")}        With ${pc.cyan("--stale")}, also create missing agent.md files for explicit pages or pages that define ${pc.cyan("agent.tokenBudget")}
   ${pc.cyan("--config <path>")}          Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
-  ${pc.cyan("--api-key <key>")}          Token Company API key (or set ${pc.dim("TOKEN_COMPANY_API_KEY")})
-  ${pc.cyan("--api-key-env <name>")}     Custom env var name for the Token Company API key
-  ${pc.cyan("--base-url <url>")}         Override the Token Company API base URL (useful for tests)
-  ${pc.cyan("--model <name>")}           Compression model (${pc.dim("bear-1.2")} by default)
+  ${pc.cyan("--api-key <key>")}          Docs Cloud API key (or set ${pc.dim("DOCS_CLOUD_API_KEY")})
+  ${pc.cyan("--api-key-env <name>")}     Custom env var name for the Docs Cloud API key
+  ${pc.cyan("--base-url <url>")}         Override the compression API base URL (useful for tests)
+  ${pc.cyan("--model <name>")}           Compression model (${pc.dim("docs-cloud-compress-v1")} by default)
   ${pc.cyan("--aggressiveness <0-1>")}   Compression intensity (${pc.dim("0.3")} by default)
-  ${pc.cyan("--max-output-tokens <n>")}  Pass through to Token Company compression settings
-  ${pc.cyan("--min-output-tokens <n>")}  Pass through to Token Company compression settings
+  ${pc.cyan("--max-output-tokens <n>")}  Pass through to compression settings
+  ${pc.cyan("--min-output-tokens <n>")}  Pass through to compression settings
   ${pc.cyan("--protect-json <bool>")}    Preserve JSON objects during compression
   ${pc.cyan("--dry-run")}                Resolve pages and call the compressor without writing files
 `);

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -620,7 +620,7 @@ export function inspectAgentCompactionState(
 function protectForCompression(input: string): string {
   const segments: string[] = [];
   const stash = (value: string) => {
-    const token = `__DOCS_SAFE_${segments.length}__`;
+    const token = `__TTC_SAFE_${segments.length}__`;
     segments.push(value);
     return token;
   };
@@ -634,8 +634,8 @@ function protectForCompression(input: string): string {
 
   for (let index = 0; index < segments.length; index += 1) {
     result = result.replace(
-      `__DOCS_SAFE_${index}__`,
-      `<docs_safe>${segments[index]}</docs_safe>`,
+      `__TTC_SAFE_${index}__`,
+      `<ttc_safe>${segments[index]}</ttc_safe>`,
     );
   }
 
@@ -643,7 +643,7 @@ function protectForCompression(input: string): string {
 }
 
 function sanitizeCompressedOutput(output: string): string {
-  return output.replace(/<\/?docs_safe>/g, "");
+  return output.replace(/<\/?(?:ttc_safe|docs_safe)>/g, "");
 }
 
 async function compressDocument(

--- a/packages/docs/src/cli/config.test.ts
+++ b/packages/docs/src/cli/config.test.ts
@@ -124,13 +124,13 @@ describe("property readers", () => {
       export default defineDocs({
         agent: {
           compact: {
-            apiKey: process.env.TOKEN_COMPANY_API_KEY,
+            apiKey: process.env.DOCS_CLOUD_API_KEY,
           },
         },
       });
     `;
 
-    expect(readEnvReferenceProperty(content, "apiKey")).toBe("TOKEN_COMPANY_API_KEY");
+    expect(readEnvReferenceProperty(content, "apiKey")).toBe("DOCS_CLOUD_API_KEY");
   });
 
   it("reads bracketed import.meta.env property references", () => {
@@ -138,13 +138,13 @@ describe("property readers", () => {
       export default defineDocs({
         agent: {
           compact: {
-            apiKey: import.meta.env["PUBLIC_TTC_KEY"],
+            apiKey: import.meta.env["PUBLIC_DOCS_CLOUD_KEY"],
           },
         },
       });
     `;
 
-    expect(readEnvReferenceProperty(content, "apiKey")).toBe("PUBLIC_TTC_KEY");
+    expect(readEnvReferenceProperty(content, "apiKey")).toBe("PUBLIC_DOCS_CLOUD_KEY");
   });
 
   it("ignores braces inside strings when extracting config blocks", () => {
@@ -182,7 +182,7 @@ describe("property readers", () => {
         // Keep these readable for automation.
         agent: {
           compact: {
-            apiKeyEnv: "TOKEN_COMPANY_API_KEY",
+            apiKeyEnv: "DOCS_CLOUD_API_KEY",
           },
         },
         /*
@@ -195,7 +195,7 @@ describe("property readers", () => {
     `;
 
     expect(extractNestedObjectLiteral(content, ["agent", "compact"])).toContain(
-      'apiKeyEnv: "TOKEN_COMPANY_API_KEY"',
+      'apiKeyEnv: "DOCS_CLOUD_API_KEY"',
     );
     expect(extractNestedObjectLiteral(content, ["sitemap"])).toContain("enabled: true");
   });

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -209,8 +209,8 @@ describe("inspectAgentReadiness", () => {
   },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
     },
   },
 };`,
@@ -417,8 +417,8 @@ Allow: /
   },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
     },
   },
 };`,
@@ -727,8 +727,8 @@ Allow: /
   },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
     },
   },
 };`,
@@ -820,8 +820,8 @@ Use this docs site through markdown routes and MCP.
   mcp: { enabled: true },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
     },
   },
 };`,

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -1161,7 +1161,9 @@ Updated body.
           expect.objectContaining({
             id: "agent-compact",
             status: "skipped",
-            detail: expect.stringContaining("Dry run: would run docs agent compact --stale --include-missing"),
+            detail: expect.stringContaining(
+              "Dry run: would run docs agent compact --stale --include-missing",
+            ),
           }),
         ]);
         expect(dryRunReport.coverage.compaction.staleGeneratedPages).toBe(1);

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1075,7 +1075,7 @@ function compactionFreshnessScore(
     status: "warn",
     score: 0,
     recommendation:
-      "Add agent.compact defaults if you want docs agent compact and stale detection to run without repeating model and key settings.",
+      "Add agent.compact defaults if you want docs agent compact and stale detection to run without repeating model and compression settings.",
   };
 }
 
@@ -3095,9 +3095,8 @@ async function runAgentDoctorFixes(
   const command = `docs agent compact --stale${compaction.tokenBudgetMissingPages > 0 ? " --include-missing" : ""}`;
 
   if (options.dryRun) {
-    const missingOutputDetail = compaction.tokenBudgetMissingPages > 0
-      ? " and create token-budget missing outputs"
-      : "";
+    const missingOutputDetail =
+      compaction.tokenBudgetMissingPages > 0 ? " and create token-budget missing outputs" : "";
 
     fixes.push({
       id: "agent-compact",

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -382,9 +382,9 @@ ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact --stale")}               Refresh only stale generated ${pc.dim("agent.md")} files
   ${pc.cyan("--page <slug|path>")}                  Repeatable explicit page flag; positional page args work too
   ${pc.cyan("--include-missing")}                   With ${pc.cyan("--stale")}, also create explicit or token-budget pages missing ${pc.dim("agent.md")}
-  ${pc.cyan("--api-key <key>")}                     Token Company API key (or use ${pc.dim("TOKEN_COMPANY_API_KEY")})
-  ${pc.cyan("--api-key-env <name>")}                Custom env var name for the Token Company API key
-  ${pc.cyan("--base-url <url>")}                    Override the Token Company API base URL
+  ${pc.cyan("--api-key <key>")}                     Docs Cloud API key (or use ${pc.dim("DOCS_CLOUD_API_KEY")})
+  ${pc.cyan("--api-key-env <name>")}                Custom env var name for the Docs Cloud API key
+  ${pc.cyan("--base-url <url>")}                    Override the compression API base URL
   ${pc.cyan("--aggressiveness <0-1>")}              Compression intensity for compacted output
   ${pc.cyan("--dry-run")}                           Resolve and compress pages without writing files
 

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -382,8 +382,8 @@ ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact --stale")}               Refresh only stale generated ${pc.dim("agent.md")} files
   ${pc.cyan("--page <slug|path>")}                  Repeatable explicit page flag; positional page args work too
   ${pc.cyan("--include-missing")}                   With ${pc.cyan("--stale")}, also create explicit or token-budget pages missing ${pc.dim("agent.md")}
-  ${pc.cyan("--api-key <key>")}                     Docs Cloud API key; ${pc.dim("agent.compact.apiKey")} is preferred
-  ${pc.cyan("--api-key-env <name>")}                Env var name for the Docs Cloud API key; ${pc.dim("agent.compact.apiKeyEnv")} is preferred
+  ${pc.cyan("--api-key <key>")}                     Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
+  ${pc.cyan("--api-key-env <name>")}                Env var name for the Docs Cloud API key; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--base-url <url>")}                    Override the compression API base URL
   ${pc.cyan("--aggressiveness <0-1>")}              Compression intensity for compacted output
   ${pc.cyan("--dry-run")}                           Resolve and compress pages without writing files

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -382,8 +382,8 @@ ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact --stale")}               Refresh only stale generated ${pc.dim("agent.md")} files
   ${pc.cyan("--page <slug|path>")}                  Repeatable explicit page flag; positional page args work too
   ${pc.cyan("--include-missing")}                   With ${pc.cyan("--stale")}, also create explicit or token-budget pages missing ${pc.dim("agent.md")}
-  ${pc.cyan("--api-key <key>")}                     Docs Cloud API key (or use ${pc.dim("DOCS_CLOUD_API_KEY")})
-  ${pc.cyan("--api-key-env <name>")}                Custom env var name for the Docs Cloud API key
+  ${pc.cyan("--api-key <key>")}                     Docs Cloud API key; ${pc.dim("agent.compact.apiKey")} is preferred
+  ${pc.cyan("--api-key-env <name>")}                Env var name for the Docs Cloud API key; ${pc.dim("agent.compact.apiKeyEnv")} is preferred
   ${pc.cyan("--base-url <url>")}                    Override the compression API base URL
   ${pc.cyan("--aggressiveness <0-1>")}              Compression intensity for compacted output
   ${pc.cyan("--dry-run")}                           Resolve and compress pages without writing files

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -301,8 +301,8 @@ function createDocsTelemetryEvent(
   const properties =
     context.properties || input.properties
       ? {
-          ...(input.properties ?? {}),
-          ...(context.properties ?? {}),
+          ...input.properties,
+          ...context.properties,
         }
       : undefined;
 

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2422,13 +2422,18 @@ export interface ApiReferenceConfig {
 
 export interface DocsAgentCompactConfig {
   /**
-   * Direct API key for the Docs Cloud compression API.
+   * Direct API key for the Docs Cloud compression API. Prefer `cloud.apiKey.env`
+   * so all Docs Cloud CLI commands share the same root API key configuration.
    *
-   * Prefer `apiKeyEnv` for checked-in config files so secrets stay in the environment.
+   * @deprecated Configure `cloud.apiKey.env` instead.
    */
   apiKey?: string;
   /**
-   * Environment variable name that stores the Docs Cloud API key.
+   * Environment variable name that stores the Docs Cloud API key. Prefer
+   * `cloud.apiKey.env` so all Docs Cloud CLI commands share the same root API
+   * key configuration.
+   *
+   * @deprecated Configure `cloud.apiKey.env` instead.
    */
   apiKeyEnv?: string;
   /**

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -2422,22 +2422,22 @@ export interface ApiReferenceConfig {
 
 export interface DocsAgentCompactConfig {
   /**
-   * Direct API key for the Token Company compression API.
+   * Direct API key for the Docs Cloud compression API.
    *
    * Prefer `apiKeyEnv` for checked-in config files so secrets stay in the environment.
    */
   apiKey?: string;
   /**
-   * Environment variable name that stores the Token Company API key.
+   * Environment variable name that stores the Docs Cloud API key.
    */
   apiKeyEnv?: string;
   /**
-   * Base URL for the Token Company API.
+   * Base URL for the compression API.
    */
   baseUrl?: string;
   /**
    * Compression model name.
-   * @default "bear-1.2"
+   * @default "docs-cloud-compress-v1"
    */
   model?: string;
   /**

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -467,7 +467,9 @@ Behavior:
 - page identifiers can be a slug, docs path, `.md` path, full docs URL, or `.` for the root docs
   page
 - the command loads `.env` and `.env.local`
-- defaults can come from `agent.compact` in `docs.config.ts` or `docs.config.tsx`
+- the Docs Cloud API key comes from root `cloud.apiKey.env`; `--api-key` and `--api-key-env` are
+  one-off overrides
+- compression defaults can come from `agent.compact` in `docs.config.ts` or `docs.config.tsx`
 - `--changed` compacts only docs pages changed in the current git working tree, including staged,
   unstaged, and untracked docs changes plus handwritten `agent.md` sources
 - `--stale` refreshes only generated `agent.md` files whose page source or compaction settings
@@ -487,22 +489,14 @@ Behavior:
 Recommended config:
 
 ```ts
+cloud: {
+  apiKey: { env: "DOCS_CLOUD_API_KEY" },
+},
 agent: {
   compact: {
-    apiKeyEnv: "DOCS_CLOUD_API_KEY",
     model: "docs-cloud-compress-v1",
     aggressiveness: 0.3,
     protectJson: true,
-  },
-}
-```
-
-Alternative `docs.config.tsx` form:
-
-```tsx
-agent: {
-  compact: {
-    apiKey: process.env.DOCS_CLOUD_API_KEY,
   },
 }
 ```

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -489,8 +489,8 @@ Recommended config:
 ```ts
 agent: {
   compact: {
-    apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-    model: "bear-1.2",
+    apiKeyEnv: "DOCS_CLOUD_API_KEY",
+    model: "docs-cloud-compress-v1",
     aggressiveness: 0.3,
     protectJson: true,
   },
@@ -502,7 +502,7 @@ Alternative `docs.config.tsx` form:
 ```tsx
 agent: {
   compact: {
-    apiKey: process.env.TOKEN_COMPANY_API_KEY,
+    apiKey: process.env.DOCS_CLOUD_API_KEY,
   },
 }
 ```

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -401,8 +401,8 @@ files from resolved docs pages.
 ```ts
 agent: {
   compact: {
-    apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-    model: "bear-1.2",
+    apiKeyEnv: "DOCS_CLOUD_API_KEY",
+    model: "docs-cloud-compress-v1",
     aggressiveness: 0.3,
     protectJson: true,
   },
@@ -423,7 +423,7 @@ Supported fields:
 Notes:
 
 - `.env` and `.env.local` are loaded before the CLI resolves the key
-- `apiKey: process.env.TOKEN_COMPANY_API_KEY` is supported in `docs.config.tsx`
+- `apiKey: process.env.DOCS_CLOUD_API_KEY` is supported in `docs.config.tsx`
 - the command creates missing `agent.md` files and overwrites existing ones
 - generated `agent.md` becomes the machine-readable source for `.md` routes,
   `GET /api/docs?format=markdown&path=...`, and MCP `read_page()`

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -310,7 +310,7 @@ What it does:
 
 - resolves the same machine-readable page the runtime already uses: `agent.md`, then `Agent`
   blocks, then normal page markdown
-- compresses that document with the Token Company API
+- compresses that document with the Docs Cloud compression API
 - creates missing sibling `agent.md` files and overwrites existing ones
 - makes the written `agent.md` the new source for `.md` routes, docs API markdown output, and MCP
   `read_page()`
@@ -352,8 +352,8 @@ export default defineDocs({
   entry: "docs",
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.3,
       protectJson: true,
     },
@@ -368,14 +368,14 @@ export default defineDocs({
   entry: "docs",
   agent: {
     compact: {
-      apiKey: process.env.TOKEN_COMPANY_API_KEY,
+      apiKey: process.env.DOCS_CLOUD_API_KEY,
     },
   },
 });
 ```
 
 The command loads `.env` and `.env.local` from the current project before it resolves the key, so
-the default `TOKEN_COMPANY_API_KEY` env var works without exporting it manually.
+the default `DOCS_CLOUD_API_KEY` env var works without exporting it manually.
 
 Per-page budget overrides live in frontmatter:
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -374,8 +374,10 @@ export default defineDocs({
 });
 ```
 
-The command loads `.env` and `.env.local` from the current project before it resolves the key, so
-the default `DOCS_CLOUD_API_KEY` env var works without exporting it manually.
+The command loads `.env` and `.env.local` from the current project before it resolves the root
+`agent.compact` config, so `apiKeyEnv: "DOCS_CLOUD_API_KEY"` works without exporting the key
+manually. Keep the key in `agent.compact.apiKey` or `agent.compact.apiKeyEnv`; `--api-key` is
+available for one-off runs.
 
 Per-page budget overrides live in frontmatter:
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1484,8 +1484,9 @@ Handwritten `agent.md` files are also valid. They count as explicit machine cont
 `docs doctor --agent`, but their freshness is reported as `unknown` because there is no generated
 provenance block to compare against the page source.
 
-The CLI loads `.env` and `.env.local` before resolving the key, so `DOCS_CLOUD_API_KEY` works
-out of the box. Use positional page args by default:
+The CLI loads `.env` and `.env.local` before resolving the root `agent.compact` config, so
+`apiKeyEnv: "DOCS_CLOUD_API_KEY"` works without exporting the key manually. Keep compression keys in
+`agent.compact.apiKey` or `agent.compact.apiKeyEnv`; use positional page args by default:
 
 ```bash title="terminal"
 pnpm exec docs agent compact installation configuration

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1440,8 +1440,8 @@ export default defineDocs({
   entry: "docs",
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.3,
       protectJson: true,
     },
@@ -1456,7 +1456,7 @@ export default defineDocs({
   entry: "docs",
   agent: {
     compact: {
-      apiKey: process.env.TOKEN_COMPANY_API_KEY,
+      apiKey: process.env.DOCS_CLOUD_API_KEY,
     },
   },
 });
@@ -1484,7 +1484,7 @@ Handwritten `agent.md` files are also valid. They count as explicit machine cont
 `docs doctor --agent`, but their freshness is reported as `unknown` because there is no generated
 provenance block to compare against the page source.
 
-The CLI loads `.env` and `.env.local` before resolving the key, so `TOKEN_COMPANY_API_KEY` works
+The CLI loads `.env` and `.env.local` before resolving the key, so `DOCS_CLOUD_API_KEY` works
 out of the box. Use positional page args by default:
 
 ```bash title="terminal"

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -163,7 +163,7 @@ The command resolves the same page contract the runtime already uses:
 - embedded `Agent` blocks
 - normal page markdown
 
-Then it sends that resolved document to the Token Company compression API and writes a sibling
+Then it sends that resolved document to the Docs Cloud compression API and writes a sibling
 `agent.md` file for the page.
 
 <Callout type="info" title="Compaction only changes the machine-readable layer">
@@ -177,8 +177,8 @@ export default defineDocs({
   entry: "docs",
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.3,
       protectJson: true,
     },
@@ -191,7 +191,7 @@ pnpm exec docs agent compact installation configuration
 pnpm exec docs agent compact --all
 ```
 
-The CLI also loads `.env` and `.env.local`, so `TOKEN_COMPANY_API_KEY` can stay out of checked-in
+The CLI also loads `.env` and `.env.local`, so `DOCS_CLOUD_API_KEY` can stay out of checked-in
 config. Use `--dry-run` when you want to preview the compression call without writing files. For the
 full command surface, see the [CLI page](/docs/cli). For the `agent.compact` config shape, see
 [Configuration](/docs/configuration).

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -192,7 +192,8 @@ pnpm exec docs agent compact --all
 ```
 
 The CLI also loads `.env` and `.env.local`, so `DOCS_CLOUD_API_KEY` can stay out of checked-in
-config. Use `--dry-run` when you want to preview the compression call without writing files. For the
+config while `agent.compact.apiKeyEnv` remains the root source of truth. Use `--dry-run` when you
+want to preview the compression call without writing files. For the
 full command surface, see the [CLI page](/docs/cli). For the `agent.compact` config shape, see
 [Configuration](/docs/configuration).
 

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -252,8 +252,8 @@ export default defineDocs({
   },
   agent: {
     compact: {
-      apiKeyEnv: "TOKEN_COMPANY_API_KEY",
-      model: "bear-1.2",
+      apiKeyEnv: "DOCS_CLOUD_API_KEY",
+      model: "docs-cloud-compress-v1",
       aggressiveness: 0.3,
       protectJson: true,
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches agent compact to the Docs Cloud compression API by default, replacing the Token Company integration. The API key now comes from root `cloud.apiKey` (or CLI flags), with strict validation and clearer errors.

- **Refactors**
  - Default endpoint `https://api.farming-labs.dev` (accepts `/v1/compress` or `/v1/agent/compact`)
  - Default model `docs-cloud-compress-v1`
  - Keys resolve from root `cloud.apiKey.env` or `cloud.apiKey`; `.env` is loaded; `agent.compact.apiKey`/`apiKeyEnv` are still read but deprecated; ambient `DOCS_CLOUD_API_KEY` without root config is ignored; clearer errors when the configured env is missing
  - CLI flags now prefer `cloud.apiKey.env`; `--api-key` and `--api-key-env` are one-off overrides
  - Base URL overrides via `DOCS_CLOUD_COMPRESSION_BASE_URL`, `DOCS_CLOUD_API_BASE_URL`, `FARMING_LABS_DOCS_API_BASE_URL`
  - Uses `<docs_safe>` wrappers for protected content and strips `<docs_safe>` tags from outputs

- **Migration**
  - In `docs.config.ts[x]`, set `cloud.apiKey: { env: "DOCS_CLOUD_API_KEY" }` (or inline `cloud.apiKey`)
  - Add `DOCS_CLOUD_API_KEY` to `.env`/`.env.local` if using `cloud.apiKey.env` (use `--api-key` for one-offs)
  - Replace any `process.env.TOKEN_COMPANY_API_KEY` with `process.env.DOCS_CLOUD_API_KEY`
  - Optional: set `agent.compact.model: "docs-cloud-compress-v1"` or rely on the new default; update any base URL overrides; run `docs agent compact`

<sup>Written for commit 521210dadeb9a6290fbf1111315ba65136b8a4a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

