### PR TITLE
feat: add hosted MCP setup command

### DIFF
--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -84,6 +84,15 @@ async function main() {
   };
   const mcpOptions = {
     configPath: typeof flags.config === "string" ? flags.config : undefined,
+    setup: subcommand === "setup",
+    deploymentId: typeof flags.deployment === "string" ? flags.deployment : undefined,
+    apiBaseUrl:
+      typeof flags["api-base-url"] === "string"
+        ? flags["api-base-url"]
+        : typeof flags.url === "string"
+          ? flags.url
+          : undefined,
+    json: typeof flags.json === "boolean" ? flags.json : undefined,
   };
   const devOptions = {
     verbose: typeof flags.verbose === "boolean" ? flags.verbose : undefined,
@@ -349,6 +358,9 @@ ${pc.dim("Options for init:")}
 
 ${pc.dim("Options for mcp:")}
   ${pc.cyan("--config <path>")}     Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
+  ${pc.cyan("mcp setup --deployment <id>")} Print Docs Cloud hosted MCP setup for a deployment id
+  ${pc.cyan("--api-base-url <url>")} Override the hosted Docs Cloud API base URL for ${pc.cyan("mcp setup")}
+  ${pc.cyan("--json")}              Print MCP client JSON only for ${pc.cyan("mcp setup")}
 
 ${pc.dim("Options for dev:")}
   ${pc.cyan("--port <number>")}     Run the frameworkless preview on a custom port

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import pc from "picocolors";
 import { createFilesystemDocsMcpSource, resolveDocsMcpConfig, runDocsMcpStdio } from "../server.js";
 import type { DocsMcpConfig } from "../types.js";
 import {
@@ -12,9 +13,18 @@ import {
 
 interface RunMcpOptions {
   configPath?: string;
+  setup?: boolean;
+  deploymentId?: string;
+  apiBaseUrl?: string;
+  json?: boolean;
 }
 
 export async function runMcp(options: RunMcpOptions = {}): Promise<void> {
+  if (options.setup) {
+    printHostedMcpSetup(options);
+    return;
+  }
+
   const rootDir = process.cwd();
   const configPath = resolveDocsConfigPath(rootDir, options.configPath);
   const content = readFileSync(configPath, "utf-8");
@@ -40,6 +50,56 @@ export async function runMcp(options: RunMcpOptions = {}): Promise<void> {
     mcp: resolvedMcp,
     defaultName: navTitle ?? "@farming-labs/docs",
   });
+}
+
+function normalizeApiBaseUrl(value?: string) {
+  return (value?.trim() || "https://api.farming-labs.dev").replace(/\/+$/g, "");
+}
+
+function printHostedMcpSetup(options: RunMcpOptions) {
+  const deploymentId = options.deploymentId?.trim();
+
+  if (!deploymentId) {
+    console.error(pc.red("Missing MCP deployment id."));
+    console.error();
+    console.error(
+      `Run ${pc.cyan("npx @farming-labs/docs mcp setup --deployment <deployment-id>")}.`,
+    );
+    process.exit(1);
+  }
+
+  const apiBaseUrl = normalizeApiBaseUrl(options.apiBaseUrl);
+  const endpoint = `${apiBaseUrl}/v1/mcp/${deploymentId}`;
+  const jsonConfig = {
+    mcpServers: {
+      "docs-cloud": {
+        command: "npx",
+        args: ["@farming-labs/docs", "mcp", "setup", "--deployment", deploymentId],
+      },
+    },
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(jsonConfig, null, 2));
+    return;
+  }
+
+  console.log(pc.bold("Docs Cloud MCP deployment"));
+  console.log(pc.dim(`Deployment: ${deploymentId}`));
+  console.log();
+  console.log(pc.cyan("CLI stdio"));
+  console.log(`  npx @farming-labs/docs mcp setup --deployment ${deploymentId}`);
+  console.log();
+  console.log(pc.cyan("Streamable HTTP"));
+  console.log(`  ${endpoint}`);
+  console.log();
+  console.log(pc.cyan("SSE"));
+  console.log(`  ${endpoint}/sse`);
+  console.log();
+  console.log(pc.cyan("MCP client JSON"));
+  console.log(JSON.stringify(jsonConfig, null, 2));
+  console.log();
+  console.log(pc.dim("Set DOCS_CLOUD_API_KEY in the agent environment before connecting."));
 }
 
 function readMcpConfig(content: string): boolean | DocsMcpConfig | undefined {


### PR DESCRIPTION
## Summary

- Add `mcp setup --deployment <id>` support to the docs CLI.
- Print hosted MCP setup instructions for CLI stdio, streamable HTTP, SSE, and MCP client JSON.
- Add `--api-base-url` and `--json` options for hosted MCP setup output.

## Validation

- `pnpm exec oxfmt --ignore-path .oxfmtignore --check packages/docs/src/cli/index.ts packages/docs/src/cli/mcp.ts`
- `pnpm --filter @farming-labs/docs typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hosted MCP setup to the `@farming-labs/docs` CLI with `mcp setup --deployment <id>`. Prints CLI stdio command, streamable HTTP and SSE endpoints, and MCP client JSON to simplify connecting to a Docs Cloud deployment.

- **New Features**
  - `mcp setup` requires `--deployment <id>` and exits with an error when missing.
  - `--api-base-url` overrides the API base (defaults to https://api.farming-labs.dev; trailing slashes normalized).
  - `--json` outputs MCP client JSON only.

<sup>Written for commit 2241bc7ad1a367fcfb4a9d1dc690ea406b8da196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

