### PR TITLE
fix: support public Docs Cloud env names

### DIFF
--- a/packages/docs/src/analytics.test.ts
+++ b/packages/docs/src/analytics.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DOCS_AGENT_TRACE_EVENT_TYPES,
   emitDocsAgentTraceEvent,
@@ -52,8 +52,11 @@ const ALL_ANALYTICS_EVENTS = [
 ] as const satisfies readonly DocsAnalyticsEventType[];
 
 describe("analytics", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  function clearDocsCloudAnalyticsEnv() {
+    delete process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
+    delete process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+    delete process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    delete process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_KEY;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
@@ -62,6 +65,12 @@ describe("analytics", () => {
     delete process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT;
     delete process.env.DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_ANALYTICS_KEY;
+  }
+
+  beforeEach(clearDocsCloudAnalyticsEnv);
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearDocsCloudAnalyticsEnv();
   });
 
   it("emits every built-in analytics event type through the shared hook", async () => {
@@ -520,8 +529,8 @@ describe("analytics", () => {
   });
 
   it("posts Docs Cloud analytics from plain config when public env is present", async () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT =
       "https://docs-cloud.example.com/api/analytics/events";
 
     const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -132,7 +132,7 @@ export default defineDocs({
 
     expect(result).toMatchObject({
       apiKeyEnv: "DOCS_CLOUD_API_KEY",
-      analyticsProjectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+      analyticsProjectIdEnv: "PUBLIC_DOCS_CLOUD_PROJECT_ID",
       configCreated: false,
       configUpdated: true,
       docsJsonCreated: true,
@@ -276,8 +276,8 @@ void missing;
     writeFileSync(
       path.join(tmpDir, ".env.local"),
       [
-        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+        "PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -291,7 +291,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "PUBLIC_DOCS_CLOUD_API_KEY" },
     deploy: { enabled: true },
     analytics: {
       enabled: true,
@@ -323,7 +323,7 @@ void missing;
     });
 
     expect(result.ok).toBe(true);
-    expect(result.analyticsProjectIdEnv).toBe("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID");
+    expect(result.analyticsProjectIdEnv).toBe("PUBLIC_DOCS_CLOUD_PROJECT_ID");
     expect(result.identity).toMatchObject({
       workspace: { id: "workspace_1", name: "Acme" },
       apiKey: { id: "key_1", scopes: ["project:read", "preview:write", "jobs:read"] },
@@ -384,7 +384,7 @@ void missing;
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
-      "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud\n",
+      "PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud\n",
       "utf-8",
     );
     writeFileSync(
@@ -422,8 +422,8 @@ void missing;
     writeFileSync(
       path.join(tmpDir, ".env.local"),
       [
-        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+        "PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -436,7 +436,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "PUBLIC_DOCS_CLOUD_API_KEY" },
     analytics: { enabled: true },
   },
 };
@@ -459,8 +459,8 @@ void missing;
           name: "askAi.direct",
           status: "pass",
           details: {
-            apiKeyEnv: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY",
-            projectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+            apiKeyEnv: "PUBLIC_DOCS_CLOUD_API_KEY",
+            projectIdEnv: "PUBLIC_DOCS_CLOUD_PROJECT_ID",
           },
         }),
       ]),
@@ -472,8 +472,8 @@ void missing;
     writeFileSync(
       path.join(tmpDir, ".env.local"),
       [
-        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+        "PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -486,7 +486,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "PUBLIC_DOCS_CLOUD_API_KEY" },
     analytics: { enabled: true },
   },
   sitemap: {
@@ -549,10 +549,9 @@ void missing;
     writePackageJson();
     writeFileSync(
       path.join(tmpDir, ".env.local"),
-      [
-        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "DOCS_CLOUD_API_KEY=docs_cloud_test_key",
-      ].join("\n"),
+      ["PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud", "DOCS_CLOUD_API_KEY=docs_cloud_test_key"].join(
+        "\n",
+      ),
       "utf-8",
     );
     writeFileSync(
@@ -606,8 +605,8 @@ void missing;
     writeFileSync(
       path.join(tmpDir, ".env.local"),
       [
-        "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
-        "NEXT_PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
+        "PUBLIC_DOCS_CLOUD_PROJECT_ID=project_cloud",
+        "PUBLIC_DOCS_CLOUD_API_KEY=docs_cloud_public_key",
       ].join("\n"),
       "utf-8",
     );
@@ -620,7 +619,7 @@ void missing;
     provider: "docs-cloud",
   },
   cloud: {
-    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "PUBLIC_DOCS_CLOUD_API_KEY" },
   },
   site: {
     url: "https://docs.example.com",

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -20,7 +20,7 @@ import { detectFramework, type Framework } from "./utils.js";
 const DOCS_JSON_FILE = "docs.json";
 const DOCS_CLOUD_SCHEMA_URL = "https://docs.farming-labs.dev/schema/docs.json";
 const DOCS_CLOUD_DEFAULT_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
-const DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
+const DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV = "PUBLIC_DOCS_CLOUD_PROJECT_ID";
 const DOCS_CLOUD_MISSING_API_KEY_DOCS_URL =
   "https://docs.farming-labs.dev/docs/cloud/deploy#missing-api-key";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
@@ -28,10 +28,11 @@ const DEFAULT_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PREVIEW_POLL_INTERVAL_MS = 2000;
 const REQUIRED_PREVIEW_API_KEY_SCOPES = ["project:read", "preview:write", "jobs:read"] as const;
 const DOCS_CLOUD_PROJECT_ID_ENVS = [
+  "PUBLIC_DOCS_CLOUD_PROJECT_ID",
   "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
   "DOCS_CLOUD_PROJECT_ID",
 ] as const;
-const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
+const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "PUBLIC_DOCS_CLOUD_API_KEY";
 const CLOUD_CHECK_TARGETS = ["deploy", "analytics", "ask-ai"] as const;
 
 type JsonPrimitive = string | number | boolean | null;
@@ -1106,7 +1107,7 @@ function createCheck(
 }
 
 function isBrowserSafeEnvName(name: string): boolean {
-  return name.startsWith("NEXT_PUBLIC_");
+  return name.startsWith("PUBLIC_") || name.startsWith("NEXT_PUBLIC_");
 }
 
 function summarizeIdentity(identity: unknown): JsonRecord | undefined {
@@ -1168,7 +1169,11 @@ function resolveApiBaseUrl(
   }
 
   const projectEnv = loadProjectEnv(rootDir);
-  for (const envName of ["DOCS_CLOUD_API_URL", "NEXT_PUBLIC_DOCS_CLOUD_URL"] as const) {
+  for (const envName of [
+    "DOCS_CLOUD_API_URL",
+    "PUBLIC_DOCS_CLOUD_URL",
+    "NEXT_PUBLIC_DOCS_CLOUD_URL",
+  ] as const) {
     const value = process.env[envName]?.trim() ?? projectEnv[envName]?.trim();
     if (value) {
       return {
@@ -1224,7 +1229,13 @@ function readDocsSiteOrigin(
   snapshot: DocsConfigSnapshot,
   env: Record<string, string>,
 ): { origin: string; source: string } | undefined {
-  const envSite = readFirstEnv(env, ["NEXT_PUBLIC_BASE_URL", "NEXT_PUBLIC_SITE_URL", "SITE_URL"]);
+  const envSite = readFirstEnv(env, [
+    "PUBLIC_BASE_URL",
+    "PUBLIC_SITE_URL",
+    "NEXT_PUBLIC_BASE_URL",
+    "NEXT_PUBLIC_SITE_URL",
+    "SITE_URL",
+  ]);
   const sitemapBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["sitemap"]);
   const llmsTxtBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["llmsTxt"]);
   const robotsBlock = extractNestedObjectLiteral(snapshot.content ?? "", ["robots"]);
@@ -1718,7 +1729,7 @@ export async function checkCloudConfig(
         siteOrigin ? "pass" : "warn",
         siteOrigin
           ? `Public docs origin is ${siteOrigin.origin}.`
-          : "Could not infer the public docs origin for CORS checks. Set NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_SITE_URL, SITE_URL, or a docs config baseUrl.",
+          : "Could not infer the public docs origin for CORS checks. Set PUBLIC_BASE_URL, PUBLIC_SITE_URL, NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_SITE_URL, SITE_URL, or a docs config baseUrl.",
         siteOrigin
           ? {
               origin: siteOrigin.origin,
@@ -1913,7 +1924,7 @@ export async function checkCloudConfig(
         createCheck(
           "cloud.cors",
           "warn",
-          "Could not infer the docs site origin for CORS checks. Set NEXT_PUBLIC_BASE_URL or a docs config baseUrl.",
+          "Could not infer the docs site origin for CORS checks. Set PUBLIC_BASE_URL, NEXT_PUBLIC_BASE_URL, or a docs config baseUrl.",
         ),
       );
     } else {

--- a/packages/docs/src/cli/init.test.ts
+++ b/packages/docs/src/cli/init.test.ts
@@ -322,7 +322,7 @@ describe("init", () => {
         configPath: `${process.cwd()}/docs.config.ts`,
         docsJsonPath: `${process.cwd()}/docs.json`,
         apiKeyEnv: "DOCS_CLOUD_API_KEY",
-        analyticsProjectIdEnv: "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+        analyticsProjectIdEnv: "PUBLIC_DOCS_CLOUD_PROJECT_ID",
         configCreated: false,
         configUpdated: true,
         docsJsonCreated: true,

--- a/packages/docs/src/cloud-analytics.ts
+++ b/packages/docs/src/cloud-analytics.ts
@@ -19,18 +19,26 @@ function readRuntimeEnv(name: string): string | undefined {
   }
 
   switch (name) {
+    case "PUBLIC_DOCS_CLOUD_PROJECT_ID":
+      return normalizeRuntimeEnvValue(process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID);
     case "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID":
       return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID);
     case "DOCS_CLOUD_PROJECT_ID":
       return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_PROJECT_ID);
+    case "PUBLIC_DOCS_CLOUD_ANALYTICS_KEY":
+      return normalizeRuntimeEnvValue(process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_KEY);
     case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY":
       return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY);
     case "DOCS_CLOUD_ANALYTICS_KEY":
       return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_KEY);
+    case "PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED":
+      return normalizeRuntimeEnvValue(process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED);
     case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED":
       return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED);
     case "DOCS_CLOUD_ANALYTICS_ENABLED":
       return normalizeRuntimeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);
+    case "PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT":
+      return normalizeRuntimeEnvValue(process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT);
     case "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT":
       return normalizeRuntimeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT);
     case "DOCS_CLOUD_ANALYTICS_ENDPOINT":
@@ -59,14 +67,19 @@ export function resolveDocsCloudAnalyticsOptions(
   }
 
   const projectId =
-    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
+    readRuntimeEnv("DOCS_CLOUD_PROJECT_ID");
   const apiKey =
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_ANALYTICS_KEY") ??
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_KEY") ??
     readRuntimeEnv("DOCS_CLOUD_ANALYTICS_KEY");
   const enabled =
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED") ??
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED") ??
     readRuntimeEnv("DOCS_CLOUD_ANALYTICS_ENABLED");
   const endpoint =
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT") ??
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT") ??
     readRuntimeEnv("DOCS_CLOUD_ANALYTICS_ENDPOINT") ??
     DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1785,8 +1785,8 @@ export interface AIConfig {
    * Server-side answer provider used by Ask AI.
    *
    * - `"docs-cloud"` — send questions to the configured Docs Cloud project
-   *   using `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` and a browser-safe
-   *   Docs Cloud API key env such as `NEXT_PUBLIC_DOCS_CLOUD_API_KEY`.
+   *   using `PUBLIC_DOCS_CLOUD_PROJECT_ID` and a browser-safe
+   *   Docs Cloud API key env such as `PUBLIC_DOCS_CLOUD_API_KEY`.
    *   If only a server-side key is configured, framework integrations may
    *   proxy through the local docs API route.
    * - Omit this option to use the built-in OpenAI-compatible RAG handler.

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1624,11 +1624,13 @@ Install the framework with pnpm.
     );
 
     const originalFetch = globalThis.fetch;
-    const originalProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalProjectId = process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalNextProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     const originalServerProjectId = process.env.DOCS_CLOUD_PROJECT_ID;
     const originalApiKey = process.env.CUSTOM_DOCS_CLOUD_KEY;
 
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_PROJECT_ID;
     process.env.CUSTOM_DOCS_CLOUD_KEY = "cloud-key";
     globalThis.fetch = vi.fn().mockResolvedValue(
@@ -1682,8 +1684,10 @@ Install the framework with pnpm.
       });
     } finally {
       globalThis.fetch = originalFetch;
-      if (originalProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
-      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalProjectId === undefined) delete process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalNextProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalNextProjectId;
       if (originalServerProjectId === undefined) delete process.env.DOCS_CLOUD_PROJECT_ID;
       else process.env.DOCS_CLOUD_PROJECT_ID = originalServerProjectId;
       if (originalApiKey === undefined) delete process.env.CUSTOM_DOCS_CLOUD_KEY;
@@ -1726,17 +1730,21 @@ export default defineDocs({
     );
 
     const originalFetch = globalThis.fetch;
-    const originalProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalProjectId = process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
+    const originalNextProjectId = process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     const originalServerProjectId = process.env.DOCS_CLOUD_PROJECT_ID;
     const originalDefaultApiKey = process.env.DOCS_CLOUD_API_KEY;
     const originalApiKey = process.env.CONFIG_DOCS_CLOUD_KEY;
     const originalApiUrl = process.env.DOCS_CLOUD_API_URL;
-    const originalPublicApiUrl = process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
+    const originalPublicApiUrl = process.env.PUBLIC_DOCS_CLOUD_URL;
+    const originalNextPublicApiUrl = process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
 
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_config";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_config";
+    delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_API_KEY;
     delete process.env.DOCS_CLOUD_API_URL;
+    delete process.env.PUBLIC_DOCS_CLOUD_URL;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
     process.env.CONFIG_DOCS_CLOUD_KEY = "config-cloud-key";
     globalThis.fetch = vi.fn().mockResolvedValue(
@@ -1778,8 +1786,10 @@ export default defineDocs({
       });
     } finally {
       globalThis.fetch = originalFetch;
-      if (originalProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
-      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalProjectId === undefined) delete process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = originalProjectId;
+      if (originalNextProjectId === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = originalNextProjectId;
       if (originalServerProjectId === undefined) delete process.env.DOCS_CLOUD_PROJECT_ID;
       else process.env.DOCS_CLOUD_PROJECT_ID = originalServerProjectId;
       if (originalDefaultApiKey === undefined) delete process.env.DOCS_CLOUD_API_KEY;
@@ -1788,8 +1798,10 @@ export default defineDocs({
       else process.env.CONFIG_DOCS_CLOUD_KEY = originalApiKey;
       if (originalApiUrl === undefined) delete process.env.DOCS_CLOUD_API_URL;
       else process.env.DOCS_CLOUD_API_URL = originalApiUrl;
-      if (originalPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
-      else process.env.NEXT_PUBLIC_DOCS_CLOUD_URL = originalPublicApiUrl;
+      if (originalPublicApiUrl === undefined) delete process.env.PUBLIC_DOCS_CLOUD_URL;
+      else process.env.PUBLIC_DOCS_CLOUD_URL = originalPublicApiUrl;
+      if (originalNextPublicApiUrl === undefined) delete process.env.NEXT_PUBLIC_DOCS_CLOUD_URL;
+      else process.env.NEXT_PUBLIC_DOCS_CLOUD_URL = originalNextPublicApiUrl;
       vi.restoreAllMocks();
     }
   });

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2338,6 +2338,7 @@ function readRuntimeEnv(name: string): string | undefined {
 function resolveDocsCloudApiBaseUrl(): string {
   return (
     readRuntimeEnv("DOCS_CLOUD_API_URL") ??
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_URL") ??
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_URL") ??
     DEFAULT_DOCS_CLOUD_API_BASE_URL
   ).replace(/\/+$/, "");
@@ -2345,7 +2346,9 @@ function resolveDocsCloudApiBaseUrl(): string {
 
 function resolveDocsCloudProjectId(): string | undefined {
   return (
-    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ?? readRuntimeEnv("DOCS_CLOUD_PROJECT_ID")
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
+    readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID") ??
+    readRuntimeEnv("DOCS_CLOUD_PROJECT_ID")
   );
 }
 
@@ -2720,7 +2723,7 @@ async function handleAskAI(
       return Response.json(
         {
           error: !projectId
-            ? "AI provider docs-cloud requires NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID or DOCS_CLOUD_PROJECT_ID."
+            ? "AI provider docs-cloud requires PUBLIC_DOCS_CLOUD_PROJECT_ID or DOCS_CLOUD_PROJECT_ID."
             : `AI provider docs-cloud requires ${envName} to be set on the server.`,
         },
         { status: 500 },

--- a/packages/fumadocs/src/docs-client-hooks.test.ts
+++ b/packages/fumadocs/src/docs-client-hooks.test.ts
@@ -1,29 +1,34 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isDocsClientAnalyticsEnabled } from "./docs-client-hooks.js";
 
 describe("DocsClientHooks analytics resolution", () => {
-  afterEach(() => {
+  function clearDocsCloudEnv() {
+    delete process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID;
     delete process.env.DOCS_CLOUD_PROJECT_ID;
+    delete process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
     delete process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED;
     delete process.env.DOCS_CLOUD_ANALYTICS_ENABLED;
-  });
+  }
+
+  beforeEach(clearDocsCloudEnv);
+  afterEach(clearDocsCloudEnv);
 
   it("enables the client analytics hook from the Docs Cloud project id env", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
 
     expect(isDocsClientAnalyticsEnabled()).toBe(true);
   });
 
   it("keeps the client analytics hook disabled when Cloud analytics is opted out", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "false";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED = "false";
 
     expect(isDocsClientAnalyticsEnabled()).toBe(false);
   });
 
   it("respects an explicit analytics false config even when a Cloud project id exists", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_cloud";
 
     expect(isDocsClientAnalyticsEnabled({ enabled: false })).toBe(false);
   });

--- a/packages/fumadocs/src/docs-cloud-ai-client.test.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.test.ts
@@ -3,12 +3,16 @@ import type { DocsConfig } from "@farming-labs/docs";
 import { resolveDocsCloudAIClientRequest } from "./docs-cloud-ai-client.js";
 
 const ENV_KEYS = [
+  "PUBLIC_DOCS_CLOUD_API_KEY",
+  "PUBLIC_DOCS_CLOUD_PROJECT_ID",
+  "PUBLIC_DOCS_CLOUD_URL",
   "NEXT_PUBLIC_DOCS_CLOUD_API_KEY",
   "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
   "NEXT_PUBLIC_DOCS_CLOUD_URL",
   "DOCS_CLOUD_API_URL",
   "DOCS_CLOUD_API_KEY",
   "SERVER_DOCS_CLOUD_KEY",
+  "PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY",
   "NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY",
 ] as const;
 
@@ -41,8 +45,8 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("uses the default public Docs Cloud API key env when no config override is set", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
 
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
       api: "https://api.farming-labs.dev/v1/projects/project_public/knowledge/ask",
@@ -55,14 +59,14 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("uses a configured browser-safe Docs Cloud API key env for direct requests", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
-    process.env.NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY = "custom-public-key";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY = "custom-public-key";
 
     expect(
       resolveDocsCloudAIClientRequest(
         createDocsCloudConfig({
-          apiKey: { env: "NEXT_PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY" },
+          apiKey: { env: "PUBLIC_CUSTOM_DOCS_CLOUD_API_KEY" },
         }),
       ),
     ).toEqual({
@@ -76,7 +80,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("falls back to the docs API route when the configured API key env is server-only", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
     process.env.SERVER_DOCS_CLOUD_KEY = "server-key";
 
     expect(
@@ -106,7 +110,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("falls back to the docs API route when the public API key is missing", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
 
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
       api: "/api/docs",
@@ -115,7 +119,7 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("falls back to the docs API route when the public project id is missing", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
 
     expect(resolveDocsCloudAIClientRequest(createDocsCloudConfig())).toEqual({
       api: "/api/docs",
@@ -124,8 +128,8 @@ describe("resolveDocsCloudAIClientRequest", () => {
   });
 
   it("allows Docs Cloud streaming to be disabled from ai.stream", () => {
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
-    process.env.NEXT_PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
+    process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID = "project_public";
+    process.env.PUBLIC_DOCS_CLOUD_API_KEY = "public-key";
 
     expect(
       resolveDocsCloudAIClientRequest({

--- a/packages/fumadocs/src/docs-cloud-ai-client.ts
+++ b/packages/fumadocs/src/docs-cloud-ai-client.ts
@@ -2,8 +2,10 @@ import type { DocsConfig } from "@farming-labs/docs";
 
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
-const DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
-const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
+const DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV = "PUBLIC_DOCS_CLOUD_PROJECT_ID";
+const FALLBACK_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV = "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID";
+const DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "PUBLIC_DOCS_CLOUD_API_KEY";
+const FALLBACK_PUBLIC_DOCS_CLOUD_API_KEY_ENV = "NEXT_PUBLIC_DOCS_CLOUD_API_KEY";
 
 export interface DocsCloudAIClientRequest {
   api: string;
@@ -19,6 +21,7 @@ function readRuntimeEnv(name: string): string | undefined {
 
 function resolveDocsCloudApiBaseUrl(): string {
   return (
+    readRuntimeEnv("PUBLIC_DOCS_CLOUD_URL") ??
     readRuntimeEnv("NEXT_PUBLIC_DOCS_CLOUD_URL") ??
     readRuntimeEnv("DOCS_CLOUD_API_URL") ??
     DEFAULT_DOCS_CLOUD_API_BASE_URL
@@ -26,7 +29,10 @@ function resolveDocsCloudApiBaseUrl(): string {
 }
 
 function resolveDocsCloudProjectId(): string | undefined {
-  return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV);
+  return (
+    readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV) ??
+    readRuntimeEnv(FALLBACK_PUBLIC_DOCS_CLOUD_PROJECT_ID_ENV)
+  );
 }
 
 function resolveDocsCloudApiKey(config: DocsConfig): string | undefined {
@@ -36,11 +42,14 @@ function resolveDocsCloudApiKey(config: DocsConfig): string | undefined {
     return readRuntimeEnv(configuredEnv);
   }
 
-  return readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV);
+  return (
+    readRuntimeEnv(DEFAULT_PUBLIC_DOCS_CLOUD_API_KEY_ENV) ??
+    readRuntimeEnv(FALLBACK_PUBLIC_DOCS_CLOUD_API_KEY_ENV)
+  );
 }
 
 function isPublicRuntimeEnvName(name: string): boolean {
-  return name.startsWith("NEXT_PUBLIC_");
+  return name.startsWith("PUBLIC_") || name.startsWith("NEXT_PUBLIC_");
 }
 
 function resolveDocsCloudAIStream(config: DocsConfig): boolean {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -287,14 +287,17 @@ function normalizeEnvValue(value: string | undefined): string | undefined {
 function createPublicDocsCloudAnalyticsEnv() {
   const projectId =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID) ??
+    normalizeEnvValue(process.env.PUBLIC_DOCS_CLOUD_PROJECT_ID) ??
     normalizeEnvValue(process.env.DOCS_CLOUD_PROJECT_ID);
   const configuredEndpoint =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
+    normalizeEnvValue(process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT) ??
     normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENDPOINT);
   const endpoint =
     configuredEndpoint ?? (projectId ? DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT : undefined);
   const enabled =
     normalizeEnvValue(process.env.NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED) ??
+    normalizeEnvValue(process.env.PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED) ??
     normalizeEnvValue(process.env.DOCS_CLOUD_ANALYTICS_ENABLED);
   const env: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary
- accept PUBLIC_DOCS_CLOUD_* runtime env vars for analytics and browser/direct Docs Cloud flows
- make Docs Cloud CLI/check defaults use PUBLIC_DOCS_CLOUD_PROJECT_ID and PUBLIC_DOCS_CLOUD_API_KEY
- keep NEXT_PUBLIC_* compatibility and keep the Next adapter emitting NEXT_PUBLIC_* bundle env

## Checks
- pnpm --filter @farming-labs/docs test -- --runInBand
- pnpm --filter @farming-labs/docs build
- pnpm --filter @farming-labs/theme exec vitest run src/docs-cloud-ai-client.test.ts src/docs-client-hooks.test.ts src/docs-api.test.ts -- --runInBand
- pnpm --filter @farming-labs/theme typecheck
- pnpm --filter @farming-labs/next test -- --runInBand
- pnpm --filter @farming-labs/docs typecheck
- pnpm --filter @farming-labs/next typecheck

Note: the full @farming-labs/theme test suite still has existing reading-time assertion failures unrelated to this env change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first‑class support for `PUBLIC_DOCS_CLOUD_*` env vars across analytics, CLI, docs API/AI, and the Next adapter. `PUBLIC_*` is now the default for browser-safe values, with `NEXT_PUBLIC_*` kept as fallback; `@farming-labs/next` still emits `NEXT_PUBLIC_*` to bundles.

- **New Features**
  - Analytics and client hooks read `PUBLIC_DOCS_CLOUD_PROJECT_ID` and `PUBLIC_DOCS_CLOUD_ANALYTICS_*` (enabled, key, endpoint).
  - CLI defaults/checks use `PUBLIC_DOCS_CLOUD_PROJECT_ID`/`PUBLIC_DOCS_CLOUD_API_KEY`; treats `PUBLIC_*` as browser-safe; resolves API base from `PUBLIC_DOCS_CLOUD_URL`; CORS/site-origin checks include `PUBLIC_BASE_URL`/`PUBLIC_SITE_URL`.
  - Docs API and Ask AI prefer `PUBLIC_DOCS_CLOUD_PROJECT_ID` and `PUBLIC_DOCS_CLOUD_URL`, with `NEXT_PUBLIC_*` fallback; errors mention `PUBLIC_*` where relevant.
  - `@farming-labs/next` reads `PUBLIC_DOCS_CLOUD_ANALYTICS_*` alongside `NEXT_PUBLIC_*` and continues emitting `NEXT_PUBLIC_*` to the client.

- **Migration**
  - Prefer `PUBLIC_DOCS_CLOUD_PROJECT_ID` and `PUBLIC_DOCS_CLOUD_API_KEY`; existing `NEXT_PUBLIC_*` envs still work.
  - Optional: set `PUBLIC_DOCS_CLOUD_URL` and `PUBLIC_DOCS_CLOUD_ANALYTICS_*`.
  - No changes required for Next.js apps relying on `NEXT_PUBLIC_*`.

<sup>Written for commit 3cb222a6d55d696aea4a2f5c4af5ce2f7b3f0aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

