### PR TITLE
feat: add svelte docs cloud ask ai proxy

### DIFF
--- a/packages/docs/src/cloud-ask-ai.test.ts
+++ b/packages/docs/src/cloud-ask-ai.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDocsCloudAskAIResponse, isDocsCloudAskAIProvider } from "./cloud-ask-ai.js";
+
+async function readResponseText(response: Response): Promise<string> {
+  return await response.text();
+}
+
+function createAskRequest(body: unknown, headers?: HeadersInit): Request {
+  return new Request("https://docs.example.com/api/docs", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Docs Cloud Ask AI server helper", () => {
+  it("detects the docs-cloud provider only when Ask AI is enabled", () => {
+    expect(isDocsCloudAskAIProvider({ enabled: true, provider: "docs-cloud" })).toBe(true);
+    expect(isDocsCloudAskAIProvider({ enabled: false, provider: "docs-cloud" })).toBe(false);
+    expect(isDocsCloudAskAIProvider({ enabled: true })).toBe(false);
+  });
+
+  it("proxies questions with server env defaults and strips streamed relevant docs footer", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ choices: [{ delta: { content: "Use Bearer tokens." } }] })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ choices: [{ delta: { content: "\n\n---\n\nRelevant docs\n/docs/auth" } }] })}\n\n`,
+            ),
+          );
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    });
+
+    const response = await createDocsCloudAskAIResponse(
+      createAskRequest({
+        messages: [{ role: "user", content: "How do I auth?" }],
+      }),
+      {
+        config: {
+          ai: { enabled: true, provider: "docs-cloud" },
+          cloud: { apiKey: { env: "DOCS_CLOUD_API_KEY" } },
+        },
+        env: {
+          PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_123",
+          DOCS_CLOUD_API_KEY: "fl_key_test",
+        },
+        fetch: fetchMock,
+        publicBaseUrl: "https://docs.example.com",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.farming-labs.dev/v1/projects/project_123/knowledge/ask");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer fl_key_test",
+      "Content-Type": "application/json",
+      "X-Docs-Cloud-Public-Base-Url": "https://docs.example.com",
+    });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      question: "How do I auth?",
+      answerStyle: "public",
+      publicBaseUrl: "https://docs.example.com",
+      stream: true,
+    });
+
+    const text = await readResponseText(response);
+    expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+    expect(text).toContain("Use Bearer tokens.");
+    expect(text).toContain("data: [DONE]");
+    expect(text).not.toContain("Relevant docs");
+  });
+
+  it("returns a clean JSON answer when streaming is disabled", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        answer: "Deploy normally.\n\n---\n\nRelevant docs\n/docs/deploy",
+        citations: ["/docs/deploy"],
+      }),
+    );
+
+    const response = await createDocsCloudAskAIResponse(
+      createAskRequest(
+        {
+          messages: [{ role: "user", content: "How do I deploy?" }],
+          stream: false,
+        },
+        { Accept: "application/json" },
+      ),
+      {
+        config: {
+          ai: { enabled: true, provider: "docs-cloud", stream: false },
+          cloud: { apiKey: { env: "DOCS_CLOUD_API_KEY" } },
+        },
+        env: {
+          DOCS_CLOUD_PROJECT_ID: "project_server",
+          DOCS_CLOUD_API_KEY: "fl_key_test",
+        },
+        fetch: fetchMock,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      answer: "Deploy normally.",
+      citations: ["/docs/deploy"],
+    });
+  });
+
+  it("reports missing Docs Cloud project configuration before calling upstream", async () => {
+    const fetchMock = vi.fn();
+    const response = await createDocsCloudAskAIResponse(
+      createAskRequest({
+        messages: [{ role: "user", content: "Can you answer?" }],
+      }),
+      {
+        config: {
+          ai: { enabled: true, provider: "docs-cloud" },
+          cloud: { apiKey: { env: "DOCS_CLOUD_API_KEY" } },
+        },
+        env: { DOCS_CLOUD_API_KEY: "fl_key_test" },
+        fetch: fetchMock,
+      },
+    );
+
+    expect(response.status).toBe(500);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("Docs Cloud Ask AI is missing"),
+    });
+  });
+});

--- a/packages/docs/src/cloud-ask-ai.test.ts
+++ b/packages/docs/src/cloud-ask-ai.test.ts
@@ -25,7 +25,7 @@ describe("Docs Cloud Ask AI server helper", () => {
   });
 
   it("proxies questions with server env defaults and strips streamed relevant docs footer", async () => {
-    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) => {
       const encoder = new TextEncoder();
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -62,7 +62,7 @@ describe("Docs Cloud Ask AI server helper", () => {
           PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_123",
           DOCS_CLOUD_API_KEY: "fl_key_test",
         },
-        fetch: fetchMock,
+        fetch: fetchMock as typeof fetch,
         publicBaseUrl: "https://docs.example.com",
       },
     );
@@ -70,12 +70,12 @@ describe("Docs Cloud Ask AI server helper", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("https://api.farming-labs.dev/v1/projects/project_123/knowledge/ask");
-    expect(init.headers).toMatchObject({
+    expect(init?.headers).toMatchObject({
       Authorization: "Bearer fl_key_test",
       "Content-Type": "application/json",
       "X-Docs-Cloud-Public-Base-Url": "https://docs.example.com",
     });
-    expect(JSON.parse(String(init.body))).toMatchObject({
+    expect(JSON.parse(String(init?.body))).toMatchObject({
       question: "How do I auth?",
       answerStyle: "public",
       publicBaseUrl: "https://docs.example.com",
@@ -114,7 +114,7 @@ describe("Docs Cloud Ask AI server helper", () => {
           DOCS_CLOUD_PROJECT_ID: "project_server",
           DOCS_CLOUD_API_KEY: "fl_key_test",
         },
-        fetch: fetchMock,
+        fetch: fetchMock as typeof fetch,
       },
     );
 
@@ -137,7 +137,7 @@ describe("Docs Cloud Ask AI server helper", () => {
           cloud: { apiKey: { env: "DOCS_CLOUD_API_KEY" } },
         },
         env: { DOCS_CLOUD_API_KEY: "fl_key_test" },
-        fetch: fetchMock,
+        fetch: fetchMock as typeof fetch,
       },
     );
 

--- a/packages/docs/src/cloud-ask-ai.ts
+++ b/packages/docs/src/cloud-ask-ai.ts
@@ -1,0 +1,499 @@
+import { emitDocsAnalyticsEvent } from "./analytics.js";
+import type { AIConfig, DocsAnalyticsConfig, DocsCloudConfig } from "./types.js";
+
+const DEFAULT_DOCS_CLOUD_API_BASE_URL = "https://api.farming-labs.dev";
+const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
+const DOCS_CLOUD_PROJECT_ID_ENVS = [
+  "PUBLIC_DOCS_CLOUD_PROJECT_ID",
+  "DOCS_CLOUD_PROJECT_ID",
+  "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+] as const;
+const DOCS_CLOUD_API_BASE_URL_ENVS = [
+  "DOCS_CLOUD_API_BASE_URL",
+  "DOCS_CLOUD_API_URL",
+  "PUBLIC_DOCS_CLOUD_URL",
+  "NEXT_PUBLIC_DOCS_CLOUD_URL",
+] as const;
+const DOCS_CLOUD_FOOTER_GUARD_CHARS = 256;
+const docsCloudRelevantDocsPattern =
+  /\n{2,}(?:-{3,}|\*{3,}|_{3,})[ \t]*\n{1,3}(?:\*\*)?Relevant docs(?:\*\*)?[ \t]*/i;
+
+export interface DocsCloudAskAIConfig {
+  ai?: Pick<AIConfig, "docsUrl" | "enabled" | "provider" | "stream">;
+  analytics?: boolean | DocsAnalyticsConfig;
+  cloud?: DocsCloudConfig;
+}
+
+export interface DocsCloudAskAIResponseOptions {
+  config?: DocsCloudAskAIConfig;
+  /**
+   * Runtime env map for frameworks that expose environment variables outside
+   * `process.env`, for example SvelteKit's `$env/dynamic/private`.
+   */
+  env?: Record<string, string | undefined>;
+  fetch?: typeof fetch;
+  publicBaseUrl?: string;
+  locale?: string;
+}
+
+interface DocsChatMessage {
+  role?: unknown;
+  content?: unknown;
+}
+
+interface DocsChatBody {
+  messages?: DocsChatMessage[];
+  model?: unknown;
+  question?: unknown;
+  stream?: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readEnv(name: string, env?: Record<string, string | undefined>): string | undefined {
+  const value = env?.[name] ?? (typeof process !== "undefined" ? process.env?.[name] : undefined);
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readFirstEnv(
+  names: readonly string[],
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  for (const name of names) {
+    const value = readEnv(name, env);
+    if (value) return value;
+  }
+}
+
+function resolveDocsCloudApiBaseUrl(env?: Record<string, string | undefined>): string {
+  return (
+    readFirstEnv(DOCS_CLOUD_API_BASE_URL_ENVS, env) ?? DEFAULT_DOCS_CLOUD_API_BASE_URL
+  ).replace(/\/+$/, "");
+}
+
+function resolveDocsCloudProjectId(env?: Record<string, string | undefined>): string | undefined {
+  return readFirstEnv(DOCS_CLOUD_PROJECT_ID_ENVS, env);
+}
+
+function resolveDocsCloudApiKey(
+  cloudConfig: DocsCloudConfig | undefined,
+  env?: Record<string, string | undefined>,
+): { envName: string; apiKey: string | undefined } {
+  const envName = cloudConfig?.apiKey?.env?.trim() || DEFAULT_DOCS_CLOUD_API_KEY_ENV;
+  return { envName, apiKey: readEnv(envName, env) };
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function textFromMessageContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!isPlainObject(part)) return "";
+      if (typeof part.text === "string") return part.text;
+      if (typeof part.content === "string") return part.content;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function lastUserQuestion(messages: DocsChatMessage[] | undefined): string {
+  if (!Array.isArray(messages)) return "";
+
+  const lastUserMessage = [...messages].reverse().find((message) => message?.role === "user");
+  return textFromMessageContent(lastUserMessage?.content).trim();
+}
+
+function resolveQuestion(body: DocsChatBody): string {
+  return typeof body.question === "string" && body.question.trim()
+    ? body.question.trim()
+    : lastUserQuestion(body.messages);
+}
+
+function shouldStreamResponse(
+  request: Request,
+  body: DocsChatBody,
+  aiConfig?: DocsCloudAskAIConfig["ai"],
+) {
+  if (typeof body.stream === "boolean") return body.stream;
+  if (aiConfig?.stream === false) return false;
+
+  const accept = request.headers.get("accept")?.toLowerCase();
+  return !accept || accept.includes("text/event-stream") || accept.includes("*/*");
+}
+
+function stripRelevantDocsFooter(content: string): string {
+  return content
+    .replace(new RegExp(`${docsCloudRelevantDocsPattern.source}[\\s\\S]*$`, "i"), "")
+    .trimEnd();
+}
+
+function safeDocsCloudContent(content: string, final = false): string {
+  const footerStart = content.search(docsCloudRelevantDocsPattern);
+  if (footerStart >= 0) return content.slice(0, footerStart).trimEnd();
+  if (final) return stripRelevantDocsFooter(content);
+  return content.slice(0, Math.max(0, content.length - DOCS_CLOUD_FOOTER_GUARD_CHARS));
+}
+
+function createOpenAICompatibleSseChunk(content: string): string {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`;
+}
+
+function createOpenAICompatibleSseResponse(content: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (content) controller.enqueue(encoder.encode(createOpenAICompatibleSseChunk(content)));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function openAICompatibleDeltaContent(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const firstChoice = Array.isArray(value.choices) ? value.choices[0] : undefined;
+  if (!isPlainObject(firstChoice) || !isPlainObject(firstChoice.delta)) return undefined;
+  return typeof firstChoice.delta.content === "string" ? firstChoice.delta.content : undefined;
+}
+
+function docsCloudStreamContent(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!isPlainObject(value)) return undefined;
+
+  for (const key of ["content", "text", "answer", "delta"]) {
+    const content = value[key];
+    if (typeof content === "string") return content;
+  }
+
+  return undefined;
+}
+
+function docsCloudAnswerFromPayload(payload: unknown): string {
+  if (!isPlainObject(payload)) return "";
+  for (const key of ["answer", "text", "content"]) {
+    const content = payload[key];
+    if (typeof content === "string") return content;
+  }
+  return "";
+}
+
+function createCleanDocsCloudSseResponse(upstream: Response): Response {
+  if (!upstream.ok || !upstream.body) {
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: {
+        "Content-Type": upstream.headers.get("Content-Type") ?? "text/event-stream",
+        "Cache-Control": upstream.headers.get("Cache-Control") ?? "no-cache, no-transform",
+        Connection: upstream.headers.get("Connection") ?? "keep-alive",
+      },
+    });
+  }
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = upstream.body!.getReader();
+      let buffer = "";
+      let content = "";
+      let emittedLength = 0;
+
+      const enqueue = (chunk: string) => {
+        controller.enqueue(encoder.encode(chunk));
+      };
+
+      const emitSafeContent = (final = false) => {
+        const safeContent = safeDocsCloudContent(content, final);
+        if (safeContent.length <= emittedLength) return;
+
+        enqueue(createOpenAICompatibleSseChunk(safeContent.slice(emittedLength)));
+        emittedLength = safeContent.length;
+      };
+
+      const flushEvent = (event: string) => {
+        const data = event
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice("data:".length).trim())
+          .filter(Boolean)
+          .join("\n")
+          .trim();
+
+        if (!data) return;
+        if (data === "[DONE]") return;
+
+        try {
+          const parsed = JSON.parse(data) as unknown;
+          const delta = openAICompatibleDeltaContent(parsed) ?? docsCloudStreamContent(parsed);
+          if (delta) {
+            content += delta;
+            emitSafeContent();
+          }
+        } catch {
+          content += data;
+          emitSafeContent();
+        }
+      };
+
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const events = buffer.split(/\r?\n\r?\n/);
+          buffer = events.pop() ?? "";
+          for (const event of events) flushEvent(event);
+        }
+
+        buffer += decoder.decode();
+        if (buffer.trim()) flushEvent(buffer);
+      } catch {
+        // Finalize with whatever clean answer content arrived before the upstream closed.
+      }
+
+      emitSafeContent(true);
+      enqueue("data: [DONE]\n\n");
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": upstream.headers.get("Cache-Control") ?? "no-cache, no-transform",
+      Connection: upstream.headers.get("Connection") ?? "keep-alive",
+    },
+  });
+}
+
+function analyticsProperties(request: Request): Record<string, unknown> {
+  const userAgent = request.headers.get("user-agent")?.trim();
+  return userAgent ? { userAgent } : {};
+}
+
+export function isDocsCloudAskAIProvider(
+  config: Pick<AIConfig, "enabled" | "provider"> | undefined,
+) {
+  return config?.enabled === true && config.provider === "docs-cloud";
+}
+
+export async function createDocsCloudAskAIResponse(
+  request: Request,
+  options: DocsCloudAskAIResponseOptions = {},
+): Promise<Response> {
+  const config = options.config;
+  const aiConfig = config?.ai;
+  const analytics = config?.analytics;
+  const requestUrl = new URL(request.url);
+  const requestStartedAt = Date.now();
+  const requestProperties = analyticsProperties(request);
+
+  let body: DocsChatBody;
+  try {
+    body = (await request.json()) as DocsChatBody;
+  } catch {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: requestUrl.pathname,
+      locale: options.locale,
+      properties: {
+        ...requestProperties,
+        reason: "invalid_json",
+        provider: "docs-cloud",
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+    return jsonError("Invalid JSON body. Expected { messages: [...] }.", 400);
+  }
+
+  const question = resolveQuestion(body);
+  const messages = Array.isArray(body.messages) ? body.messages : undefined;
+  if (!question) {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: requestUrl.pathname,
+      locale: options.locale,
+      properties: {
+        ...requestProperties,
+        reason: "missing_user_message",
+        provider: "docs-cloud",
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+    return jsonError("At least one user message is required.", 400);
+  }
+
+  const projectId = resolveDocsCloudProjectId(options.env);
+  const { envName, apiKey } = resolveDocsCloudApiKey(config?.cloud, options.env);
+  if (!projectId || !apiKey) {
+    const reason = !projectId ? "missing_docs_cloud_project_id" : "missing_docs_cloud_api_key";
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: requestUrl.pathname,
+      locale: options.locale,
+      input: { question },
+      properties: {
+        ...requestProperties,
+        reason,
+        provider: "docs-cloud",
+        envName: !apiKey ? envName : undefined,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+
+    return jsonError(
+      !projectId
+        ? `Docs Cloud Ask AI is missing ${DOCS_CLOUD_PROJECT_ID_ENVS.join(" or ")}. Add the project id to the deployment environment.`
+        : `Docs Cloud Ask AI is missing ${envName}. Add it to the deployment environment.`,
+      500,
+    );
+  }
+
+  const stream = shouldStreamResponse(request, body, aiConfig);
+  const apiBaseUrl = resolveDocsCloudApiBaseUrl(options.env);
+  const publicBaseUrl = aiConfig?.docsUrl ?? options.publicBaseUrl ?? requestUrl.origin;
+  const requestedModel =
+    typeof body.model === "string" && body.model.trim() ? body.model.trim() : undefined;
+
+  await emitDocsAnalyticsEvent(analytics, {
+    type: "api_ai_request",
+    source: "server",
+    url: request.url,
+    path: requestUrl.pathname,
+    locale: options.locale,
+    input: { question },
+    properties: {
+      ...requestProperties,
+      provider: "docs-cloud",
+      messageCount: messages?.length,
+      questionLength: question.length,
+      model: requestedModel ?? "docs-cloud",
+    },
+  });
+
+  let upstream: Response;
+  try {
+    upstream = await (options.fetch ?? fetch)(
+      `${apiBaseUrl}/v1/projects/${encodeURIComponent(projectId)}/knowledge/ask`,
+      {
+        method: "POST",
+        headers: {
+          Accept: stream ? "text/event-stream, application/json" : "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "X-Docs-Cloud-Public-Base-Url": publicBaseUrl,
+        },
+        body: JSON.stringify({
+          messages,
+          question,
+          answerMode: "auto",
+          answerStyle: "public",
+          modelPreference: requestedModel,
+          stream,
+          publicBaseUrl,
+        }),
+      },
+    );
+  } catch {
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: requestUrl.pathname,
+      locale: options.locale,
+      input: { question },
+      properties: {
+        ...requestProperties,
+        reason: "docs_cloud_fetch_error",
+        provider: "docs-cloud",
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+    return jsonError("Docs Cloud Ask AI request failed.", 502);
+  }
+
+  if (!upstream.ok) {
+    await upstream.text().catch(() => "");
+    await emitDocsAnalyticsEvent(analytics, {
+      type: "api_ai_error",
+      source: "server",
+      url: request.url,
+      path: requestUrl.pathname,
+      locale: options.locale,
+      input: { question },
+      properties: {
+        ...requestProperties,
+        reason: "docs_cloud_error",
+        provider: "docs-cloud",
+        status: upstream.status,
+        durationMs: Math.max(0, Date.now() - requestStartedAt),
+      },
+    });
+    return jsonError(`Docs Cloud Ask AI error (${upstream.status}).`, 502);
+  }
+
+  await emitDocsAnalyticsEvent(analytics, {
+    type: "api_ai_response",
+    source: "server",
+    url: request.url,
+    path: requestUrl.pathname,
+    locale: options.locale,
+    input: { question },
+    properties: {
+      ...requestProperties,
+      provider: "docs-cloud",
+      status: upstream.status,
+      durationMs: Math.max(0, Date.now() - requestStartedAt),
+    },
+  });
+
+  const contentType = upstream.headers.get("Content-Type") ?? "";
+  if (stream && contentType.includes("text/event-stream")) {
+    return createCleanDocsCloudSseResponse(upstream);
+  }
+
+  const upstreamBody = await upstream.text();
+  let payload: unknown;
+  let answer = upstreamBody;
+  try {
+    payload = JSON.parse(upstreamBody) as unknown;
+    answer = docsCloudAnswerFromPayload(payload) || answer;
+  } catch {
+    // Treat non-JSON Docs Cloud responses as the answer text.
+  }
+
+  const cleanAnswer = stripRelevantDocsFooter(answer);
+  if (stream) return createOpenAICompatibleSseResponse(cleanAnswer);
+
+  return Response.json(
+    isPlainObject(payload) ? { ...payload, answer: cleanAnswer } : { answer: cleanAnswer },
+  );
+}

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -48,6 +48,8 @@ export {
   resolveDocsMcpConfig,
   runDocsMcpStdio,
 } from "./mcp.js";
+export { createDocsCloudAskAIResponse, isDocsCloudAskAIProvider } from "./cloud-ask-ai.js";
+export type { DocsCloudAskAIConfig, DocsCloudAskAIResponseOptions } from "./cloud-ask-ai.js";
 export {
   buildDocsSearchDocuments,
   buildDocsAskAIContext,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -91,7 +91,9 @@ import {
 import type { DocsAgentTraceEventInput, DocsAskAIMcpConfig } from "@farming-labs/docs";
 import {
   buildApiReferenceOpenApiDocumentAsync,
+  createDocsCloudAskAIResponse,
   createDocsMcpHttpHandler,
+  isDocsCloudAskAIProvider,
   readDocsSitemapManifest,
   resolveApiReferenceConfig,
   resolveDocsMcpConfig,
@@ -140,6 +142,7 @@ interface AIModelEntry {
 
 interface AIConfigObj {
   enabled?: boolean;
+  provider?: string;
   model?: string | { models?: AIModelEntry[]; defaultModel?: string };
   providers?: Record<string, AIProviderConfig>;
   systemPrompt?: string;
@@ -147,6 +150,7 @@ interface AIConfigObj {
   apiKey?: string;
   maxResults?: number;
   useMcp?: boolean | DocsAskAIMcpConfig;
+  stream?: boolean;
   suggestedQuestions?: string[];
   aiLabel?: string;
   packageName?: string;
@@ -1388,6 +1392,20 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
       await agentFeedbackConfig.onFeedback(parsed.data);
       return Response.json({ ok: true, handled: true }, { status: 201 });
+    }
+
+    if (isDocsCloudAskAIProvider(aiConfig)) {
+      const ctx = resolveContextFromRequest(event.request);
+      return createDocsCloudAskAIResponse(event.request, {
+        config: {
+          ai: aiConfig,
+          analytics,
+          cloud: config.cloud,
+        },
+        env: config._env as Record<string, string | undefined> | undefined,
+        publicBaseUrl: aiConfig.docsUrl ?? event.url.origin,
+        locale: ctx.locale,
+      });
     }
 
     const requestStartedAt = Date.now();

--- a/skills/farming-labs/ask-ai/SKILL.md
+++ b/skills/farming-labs/ask-ai/SKILL.md
@@ -242,7 +242,7 @@ ai: {
 
 - **Next.js:** Set `OPENAI_API_KEY` in `.env`; read via `process.env.OPENAI_API_KEY`.
 - **TanStack Start:** Set in `.env`; pass it through `createDocsServer` in `src/lib/docs.server.ts`: `ai: { apiKey: process.env.OPENAI_API_KEY, ...docsConfig.ai }`.
-- **SvelteKit:** Set in `.env`; pass into `createDocsServer` in `src/lib/docs.server.ts`: `ai: { apiKey: env.OPENAI_API_KEY, ...config.ai }` (use `$env/dynamic/private`).
+- **SvelteKit:** For OpenAI-compatible providers, set in `.env` and pass into `createDocsServer` in `src/lib/docs.server.ts`: `ai: { apiKey: env.OPENAI_API_KEY, ...config.ai }` (use `$env/dynamic/private`). For `ai.provider: "docs-cloud"`, `createDocsServer()` handles the local Docs Cloud proxy automatically; use `PUBLIC_DOCS_CLOUD_PROJECT_ID` for public project identity or `DOCS_CLOUD_PROJECT_ID` for server-only proxy mode.
 - **Astro:** Set in `.env`; pass in docs server: `ai: { apiKey: import.meta.env.OPENAI_API_KEY, ...config.ai }`.
 - **Nuxt:** Set in `.env`; Nitro/runtime config exposes it; `defineDocsHandler` reads `process.env.OPENAI_API_KEY` on the server.
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -804,7 +804,7 @@ project API key from your Docs Cloud project settings, then add it to `.env.loca
 
 ```bash title=".env.local"
 DOCS_CLOUD_API_KEY=fl_key_...
-NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
 ```
 
 Keep local env files out of git and set the same env names in production or CI. When ready, run:

--- a/website/app/docs/cloud/analytics/page.mdx
+++ b/website/app/docs/cloud/analytics/page.mdx
@@ -42,8 +42,9 @@ custom analytics source, copy the project ID from the Docs Cloud Analytics dashb
 the runtime environment:
 
 ```bash title=".env.local"
-NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
 # Use DOCS_CLOUD_PROJECT_ID instead when only the server runtime needs the id.
+# Next.js projects can use NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID.
 ```
 
 Keep using the dashboard-provided ID. Do not invent one locally; the ID must match an imported

--- a/website/app/docs/cloud/deploy/page.mdx
+++ b/website/app/docs/cloud/deploy/page.mdx
@@ -140,11 +140,11 @@ pnpm dlx @farming-labs/docs cloud check --deploy
 ```
 
 `--ask-ai` checks the Docs Cloud provider path end to end. Direct browser mode needs
-`NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe
-`cloud.apiKey.env`; the check also sends a browser-style CORS preflight to the hosted knowledge
-endpoint. If only the server-side project id and API key are available, the report marks the local
-docs API route as the proxy path and skips browser CORS for Ask AI because the browser only talks to
-the same-origin docs app.
+`PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe
+`cloud.apiKey.env`; Next.js projects can use the equivalent `NEXT_PUBLIC_*` names. The check also
+sends a browser-style CORS preflight to the hosted knowledge endpoint. If only the server-side
+project id and API key are available, the report marks the local docs API route as the proxy path and
+skips browser CORS for Ask AI because the browser only talks to the same-origin docs app.
 
 Example focused report:
 
@@ -160,7 +160,7 @@ ok docs.siteOrigin Public docs origin is https://docs.example.com.
 ok cloud.enabled Docs Cloud is enabled.
 ok analytics.runtime Runtime analytics is not disabled.
 ok analytics.cloud Docs Cloud analytics is enabled in cloud.analytics.
-ok project.env Docs Cloud project id is present in NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID.
+ok project.env Docs Cloud project id is present in PUBLIC_DOCS_CLOUD_PROJECT_ID.
 ok cors.analytics Analytics CORS allows https://docs.example.com.
 
 ok Docs Cloud check passed with 1 warning.

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -145,7 +145,7 @@ repository instead of running the local OpenAI-compatible RAG handler inside the
 ```ts title="docs.config.ts"
 export default defineDocs({
   cloud: {
-    apiKey: { env: "NEXT_PUBLIC_DOCS_CLOUD_API_KEY" },
+    apiKey: { env: "PUBLIC_DOCS_CLOUD_API_KEY" },
     ai: { enabled: true },
   },
   ai: {
@@ -165,8 +165,8 @@ export default defineDocs({
 Set the Docs Cloud project id and API key in environment variables:
 
 ```bash title=".env"
-NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
-NEXT_PUBLIC_DOCS_CLOUD_API_KEY=fl_key_...
+PUBLIC_DOCS_CLOUD_PROJECT_ID=docs_cloud_project_id
+PUBLIC_DOCS_CLOUD_API_KEY=fl_key_...
 ```
 
 `provider: "docs-cloud"` keeps OpenAI, Anthropic, embeddings, and retrieval credentials on the
@@ -174,7 +174,7 @@ Docs Cloud server. The Ask AI widget resolves one of two request paths:
 
 | Available runtime env | Request path | Use it when |
 | --------------------- | ------------ | ----------- |
-| `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `NEXT_PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe `cloud.apiKey.env` | The browser posts directly to `/v1/projects/{projectId}/knowledge/ask` with the project-scoped Docs Cloud API key | You want the lowest-latency Cloud path and the key is safe to expose to the browser |
+| `PUBLIC_DOCS_CLOUD_PROJECT_ID` plus `PUBLIC_DOCS_CLOUD_API_KEY` or another browser-safe `cloud.apiKey.env` | The browser posts directly to `/v1/projects/{projectId}/knowledge/ask` with the project-scoped Docs Cloud API key | You want the lowest-latency Cloud path and the key is safe to expose to the browser |
 | `DOCS_CLOUD_PROJECT_ID` plus the server env named by `cloud.apiKey.env` | The browser posts to the local docs API route and the server proxies the Docs Cloud request | You want the API key to stay server-only or you need same-origin browser requests |
 
 The local docs API route is also the fallback when the project id or API key is not available to the
@@ -182,8 +182,14 @@ browser. In both paths, Docs Cloud reads the same project knowledge index and re
 OpenAI-compatible event stream or a JSON answer. Streaming is enabled by default for Docs Cloud; set
 `stream: false` if you need a single JSON answer.
 
-For staging or self-hosted Cloud APIs, direct browser requests read `NEXT_PUBLIC_DOCS_CLOUD_URL`.
-Server-routed requests read `DOCS_CLOUD_API_URL` first, then `NEXT_PUBLIC_DOCS_CLOUD_URL`.
+Next.js projects can use the equivalent `NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID` and
+`NEXT_PUBLIC_DOCS_CLOUD_API_KEY` names. SvelteKit, Astro, and Vite users should prefer the
+`PUBLIC_DOCS_CLOUD_*` names. SvelteKit's `createDocsServer()` handles the local Docs Cloud proxy
+automatically for `ai.provider: "docs-cloud"`, so the app does not need a custom `POST` handler.
+
+For staging or self-hosted Cloud APIs, direct browser requests read `PUBLIC_DOCS_CLOUD_URL` or
+`NEXT_PUBLIC_DOCS_CLOUD_URL`. Server-routed requests read `DOCS_CLOUD_API_BASE_URL`,
+`DOCS_CLOUD_API_URL`, then the public URL envs.
 
 ## Configuration Reference
 


### PR DESCRIPTION
## What changed

- Adds a shared `createDocsCloudAskAIResponse()` helper in `@farming-labs/docs/server` for Docs Cloud Ask AI proxying.
- Wires `@farming-labs/svelte` `createDocsServer()` to use the shared proxy automatically when `ai.provider === "docs-cloud"`.
- Keeps SvelteKit apps thin: consumers no longer need a custom `POST` proxy just to call Docs Cloud Ask AI.
- Normalizes Docs Cloud public env guidance around `PUBLIC_DOCS_CLOUD_*`, while keeping `NEXT_PUBLIC_*` documented as the Next.js equivalent/fallback.

## Why

SvelteKit consumers were carrying app-specific Docs Cloud proxy code in `src/lib/docs.server.ts`. That implementation belongs in the framework adapter so projects can rely on package defaults and only provide config/env values.

## Validation

- `pnpm --filter @farming-labs/docs test -- --run packages/docs/src/cloud-ask-ai.test.ts`
- `pnpm --filter @farming-labs/docs run build`
- `pnpm --filter @farming-labs/svelte run typecheck`
- `pnpm --filter @farming-labs/svelte run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared Docs Cloud Ask AI proxy and wires it into SvelteKit so projects can use Docs Cloud without custom server code. Cleans streamed and JSON answers and standardizes env names for consistent setup.

- **New Features**
  - `@farming-labs/docs`: `createDocsCloudAskAIResponse()` for Docs Cloud Ask AI; outputs OpenAI-compatible SSE, strips the “Relevant docs” footer, supports JSON responses; also exports `isDocsCloudAskAIProvider`.
  - `@farming-labs/svelte`: `createDocsServer()` auto-proxies when `ai.provider: "docs-cloud"`, using package defaults and analytics.
  - Env guidance unified around `PUBLIC_DOCS_CLOUD_*` (Next.js can use `NEXT_PUBLIC_*`), with server-only fallbacks and API base URL envs (`DOCS_CLOUD_API_BASE_URL`, `DOCS_CLOUD_API_URL`, and public URL envs).
  - Tests cover proxy behavior, streaming cleanup, JSON mode, and error cases; minor type fixes included.

- **Migration**
  - SvelteKit: remove custom Ask AI `POST` handlers; set `ai.provider: "docs-cloud"` and pass `cloud` config to `createDocsServer()`.
  - Set `PUBLIC_DOCS_CLOUD_PROJECT_ID` (or `DOCS_CLOUD_PROJECT_ID` for server-only) and the key via `cloud.apiKey.env` (e.g., `DOCS_CLOUD_API_KEY` or a public key env).
  - Streaming is on by default; set `ai.stream: false` for single JSON answers.

<sup>Written for commit dd1ee14afde8285eb8e94ef8fd3567fba9f3d8f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

