### PR TITLE
fix: render docs cloud ai markdown responses

### DIFF
--- a/packages/docs/src/cloud-ask-ai.test.ts
+++ b/packages/docs/src/cloud-ask-ai.test.ts
@@ -125,6 +125,58 @@ describe("Docs Cloud Ask AI server helper", () => {
     });
   });
 
+  it("strips heading-style relevant docs footers and standalone separators", async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _init?: RequestInit) => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const content of [
+            "## Transport Details\n\n",
+            "| Property | Value |\n|----------|-------|\n",
+            "| Type | Streamable HTTP |\n\n---\n\n",
+            "## Claude Code (CLI)\n\n```bash\nclaude mcp add scholarxiv\n```\n\n",
+            "---\n\n## Relevant Docs\n\n- [MCP overview](/docs/mcp/connect)",
+          ]) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`),
+            );
+          }
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    });
+
+    const response = await createDocsCloudAskAIResponse(
+      createAskRequest({
+        messages: [{ role: "user", content: "How do I connect MCP?" }],
+      }),
+      {
+        config: {
+          ai: { enabled: true, provider: "docs-cloud" },
+          cloud: { apiKey: { env: "DOCS_CLOUD_API_KEY" } },
+        },
+        env: {
+          PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_123",
+          DOCS_CLOUD_API_KEY: "fl_key_test",
+        },
+        fetch: fetchMock as typeof fetch,
+      },
+    );
+
+    const text = await readResponseText(response);
+    expect(text).toContain("Transport Details");
+    expect(text).toContain("|----------|-------|");
+    expect(text).toContain("claude mcp add scholarxiv");
+    expect(text).not.toContain("\n---\n");
+    expect(text).not.toContain("Relevant Docs");
+    expect(text).not.toContain("MCP overview");
+  });
+
   it("reports missing Docs Cloud project configuration before calling upstream", async () => {
     const fetchMock = vi.fn();
     const response = await createDocsCloudAskAIResponse(

--- a/packages/docs/src/cloud-ask-ai.ts
+++ b/packages/docs/src/cloud-ask-ai.ts
@@ -16,7 +16,8 @@ const DOCS_CLOUD_API_BASE_URL_ENVS = [
 ] as const;
 const DOCS_CLOUD_FOOTER_GUARD_CHARS = 256;
 const docsCloudRelevantDocsPattern =
-  /\n{2,}(?:-{3,}|\*{3,}|_{3,})[ \t]*\n{1,3}(?:\*\*)?Relevant docs(?:\*\*)?[ \t]*/i;
+  /\n{2,}(?:-{3,}|\*{3,}|_{3,})[ \t]*\n{1,3}(?:#{1,6}[ \t]+)?(?:\*\*)?Relevant docs(?:\*\*)?[ \t]*/i;
+const docsCloudThematicBreakPattern = /^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$/gm;
 
 export interface DocsCloudAskAIConfig {
   ai?: Pick<AIConfig, "docsUrl" | "enabled" | "provider" | "stream">;
@@ -137,11 +138,24 @@ function stripRelevantDocsFooter(content: string): string {
     .trimEnd();
 }
 
+function stripMarkdownThematicBreaks(content: string): string {
+  return content
+    .replace(docsCloudThematicBreakPattern, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+}
+
+function cleanDocsCloudAnswer(content: string): string {
+  return stripMarkdownThematicBreaks(stripRelevantDocsFooter(content));
+}
+
 function safeDocsCloudContent(content: string, final = false): string {
   const footerStart = content.search(docsCloudRelevantDocsPattern);
-  if (footerStart >= 0) return content.slice(0, footerStart).trimEnd();
-  if (final) return stripRelevantDocsFooter(content);
-  return content.slice(0, Math.max(0, content.length - DOCS_CLOUD_FOOTER_GUARD_CHARS));
+  if (footerStart >= 0) return stripMarkdownThematicBreaks(content.slice(0, footerStart));
+  if (final) return cleanDocsCloudAnswer(content);
+  return stripMarkdownThematicBreaks(
+    content.slice(0, Math.max(0, content.length - DOCS_CLOUD_FOOTER_GUARD_CHARS)),
+  );
 }
 
 function createOpenAICompatibleSseChunk(content: string): string {
@@ -490,7 +504,7 @@ export async function createDocsCloudAskAIResponse(
     // Treat non-JSON Docs Cloud responses as the answer text.
   }
 
-  const cleanAnswer = stripRelevantDocsFooter(answer);
+  const cleanAnswer = cleanDocsCloudAnswer(answer);
   if (stream) return createOpenAICompatibleSseResponse(cleanAnswer);
 
   return Response.json(

--- a/packages/svelte-theme/src/lib/renderMarkdown.js
+++ b/packages/svelte-theme/src/lib/renderMarkdown.js
@@ -1,14 +1,36 @@
 /**
- * Markdown renderer for AI chat — exact port of the Next.js fumadocs version.
+ * Markdown renderer for AI chat.
  *
  * Uses sugar-high for syntax highlighting in code blocks.
- * Supports: fenced code blocks, tables, inline code, bold, italic,
- * links, headings, bullet lists, numbered lists.
+ * Supports fenced and streaming code blocks, loose language labels emitted by
+ * models, tables, inline code, emphasis, links, headings, and lists.
  */
 import { highlight } from "sugar-high";
 
+const codeBlockTokenBoundary = String.fromCharCode(0);
+
+const looseCodeLanguageAliases = new Map([
+  ["bash", "bash"],
+  ["shell", "bash"],
+  ["sh", "bash"],
+  ["zsh", "bash"],
+  ["curl", "bash"],
+  ["javascript", "js"],
+  ["js", "js"],
+  ["typescript", "ts"],
+  ["ts", "ts"],
+  ["json", "json"],
+  ["python", "python"],
+  ["py", "python"],
+  ["http", "http"],
+]);
+
 function escapeHtml(s) {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(s) {
+  return escapeHtml(s).replace(/"/g, "&quot;");
 }
 
 function buildCodeBlock(lang, code) {
@@ -22,6 +44,311 @@ function buildCodeBlock(lang, code) {
     `<pre><code>${highlighted}</code></pre>` +
     `</div>`
   );
+}
+
+function getCodeFenceOpening(line) {
+  const match = /^(?: {0,3})(`{3,}|~{3,})(.*)$/.exec(line);
+  if (!match) return null;
+
+  const marker = match[1];
+  const rawInfo = match[2] ?? "";
+  if (!marker) return null;
+  if (marker.startsWith("`") && rawInfo.includes("`")) return null;
+
+  return {
+    markerChar: marker[0],
+    markerLength: marker.length,
+    lang: extractCodeFenceLanguage(rawInfo),
+  };
+}
+
+function isCodeFenceClosing(line, fence) {
+  const trimmed = line.trim();
+  if (trimmed.length < fence.markerLength) return false;
+
+  for (const char of trimmed) {
+    if (char !== fence.markerChar) return false;
+  }
+
+  return true;
+}
+
+function extractCodeFenceLanguage(rawInfo) {
+  const firstToken = rawInfo.trim().split(/\s+/, 1)[0] ?? "";
+  return firstToken
+    .replace(/^\{\.?/, "")
+    .replace(/^\./, "")
+    .replace(/[},].*$/, "");
+}
+
+function normalizeLooseCodeBlocks(text) {
+  const lines = text.split("\n");
+  const output = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const lang = getLooseCodeLanguage(lines[i]);
+    if (!lang) {
+      output.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    const start = nextNonEmptyLineIndex(lines, i + 1);
+    if (start < 0 || !looksLikeLooseCodeLine(lines[start], lang)) {
+      output.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    output.push(`\`\`\`${lang}`);
+    let j = start;
+    while (j < lines.length) {
+      if (j > start && isLooseCodeBoundary(lines, j, lang)) break;
+      output.push(lines[j]);
+      j += 1;
+    }
+    output.push("```");
+    i = j;
+  }
+
+  return output.join("\n");
+}
+
+function getLooseCodeLanguage(line) {
+  const raw = line.trim().toLowerCase();
+  if (!/^[a-z][\w#+.-]*$/.test(raw)) return null;
+  return looseCodeLanguageAliases.get(raw) ?? null;
+}
+
+function nextNonEmptyLineIndex(lines, startIndex) {
+  for (let i = startIndex; i < lines.length; i += 1) {
+    if (lines[i].trim()) return i;
+  }
+  return -1;
+}
+
+function isLooseCodeBoundary(lines, index, lang) {
+  const line = lines[index];
+  const trimmed = line.trim();
+  if (getHeading(trimmed) || isHorizontalRule(trimmed)) return true;
+
+  if (!trimmed) {
+    const next = nextNonEmptyLineIndex(lines, index + 1);
+    return next < 0 || !looksLikeLooseCodeLine(lines[next], lang);
+  }
+
+  return false;
+}
+
+function looksLikeLooseCodeLine(line, lang) {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+
+  if (lang === "json") return /^[{[]/.test(trimmed);
+  if (lang === "js" || lang === "ts") {
+    return /^(?:import|export|const|let|var|function|async|await|class|type|interface|return|console\.|fetch\(|npm|pnpm|yarn|bun)\b/.test(
+      trimmed,
+    );
+  }
+  if (lang === "python") {
+    return /^(?:from|import|def|class|if|for|while|print\(|python|pip)\b/.test(trimmed);
+  }
+  if (lang === "http") return /^(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+\S+/.test(trimmed);
+
+  return /^(?:[$>#]\s*)?(?:claude|opencode|curl|npx|pnpm|npm|yarn|bun|git|node|deno|python|pip|export|cd|cat|echo|mkdir|touch|rm|cp|mv|vercel|docs)\b|^(?:--|\||&&|\\)|^[A-Z_][A-Z0-9_]*=/.test(
+    trimmed,
+  );
+}
+
+function replaceFencedCodeBlocks(text, codeBlocks) {
+  const lines = text.split("\n");
+  const output = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const fence = getCodeFenceOpening(lines[i]);
+    if (!fence) {
+      output.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    const codeLines = [];
+    i += 1;
+
+    while (i < lines.length && !isCodeFenceClosing(lines[i], fence)) {
+      codeLines.push(lines[i]);
+      i += 1;
+    }
+
+    if (i < lines.length) i += 1;
+
+    codeBlocks.push(buildCodeBlock(fence.lang, codeLines.join("\n")));
+    output.push(`${codeBlockTokenBoundary}CB${codeBlocks.length - 1}${codeBlockTokenBoundary}`);
+  }
+
+  return output.join("\n");
+}
+
+export function renderMarkdown(text) {
+  if (!text) return "";
+
+  const codeBlocks = [];
+  const processed = replaceFencedCodeBlocks(normalizeLooseCodeBlocks(text), codeBlocks);
+
+  return renderMarkdownBlocks(processed, codeBlocks);
+}
+
+function renderMarkdownBlocks(text, codeBlocks) {
+  const lines = text.split("\n");
+  const output = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      i += 1;
+      continue;
+    }
+
+    const codeBlockIndex = getCodeBlockTokenIndex(trimmed);
+    if (codeBlockIndex !== null) {
+      output.push(codeBlocks[codeBlockIndex] ?? "");
+      i += 1;
+      continue;
+    }
+
+    if (isHorizontalRule(trimmed)) {
+      output.push('<hr class="fd-ai-hr" />');
+      i += 1;
+      continue;
+    }
+
+    const heading = getHeading(trimmed);
+    if (heading) {
+      output.push(`<h${heading.level}>${renderInlineMarkdown(heading.text)}</h${heading.level}>`);
+      i += 1;
+      continue;
+    }
+
+    if (isTableRow(line) && i + 1 < lines.length && isTableSeparator(lines[i + 1])) {
+      const tableLines = [line];
+      i += 2;
+      while (i < lines.length && isTableRow(lines[i])) {
+        tableLines.push(lines[i]);
+        i += 1;
+      }
+      output.push(renderTable(tableLines));
+      continue;
+    }
+
+    const unorderedItems = collectListItems(lines, i, "unordered");
+    if (unorderedItems) {
+      output.push(
+        `<ul>${unorderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ul>`,
+      );
+      i = unorderedItems.nextIndex;
+      continue;
+    }
+
+    const orderedItems = collectListItems(lines, i, "ordered");
+    if (orderedItems) {
+      output.push(
+        `<ol>${orderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ol>`,
+      );
+      i = orderedItems.nextIndex;
+      continue;
+    }
+
+    const paragraphLines = [];
+    while (i < lines.length && lines[i].trim() && !isMarkdownBlockStart(lines, i)) {
+      paragraphLines.push(lines[i].trim());
+      i += 1;
+    }
+
+    output.push(
+      `<p>${paragraphLines.map((paragraphLine) => renderInlineMarkdown(paragraphLine)).join("<br>")}</p>`,
+    );
+  }
+
+  return output.join("");
+}
+
+function getCodeBlockTokenIndex(line) {
+  const prefix = `${codeBlockTokenBoundary}CB`;
+  if (!line.startsWith(prefix) || !line.endsWith(codeBlockTokenBoundary)) return null;
+
+  const rawIndex = line.slice(prefix.length, -codeBlockTokenBoundary.length);
+  if (!/^\d+$/.test(rawIndex)) return null;
+
+  return Number(rawIndex);
+}
+
+function getHeading(line) {
+  const match = /^(#{1,6})\s+(.+)$/.exec(line);
+  if (!match) return null;
+
+  return {
+    level: Math.min(match[1].length + 1, 4),
+    text: match[2],
+  };
+}
+
+function collectListItems(lines, startIndex, type) {
+  const pattern = type === "ordered" ? /^(?: {0,3})\d+\.\s+(.+)$/ : /^(?: {0,3})[-*+]\s+(.+)$/;
+  const items = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const match = pattern.exec(lines[i]);
+    if (!match) break;
+
+    items.push(match[1]);
+    i += 1;
+  }
+
+  return items.length > 0 ? { items, nextIndex: i } : null;
+}
+
+function isMarkdownBlockStart(lines, index) {
+  const line = lines[index];
+  const trimmed = line.trim();
+
+  return (
+    getCodeBlockTokenIndex(trimmed) !== null ||
+    isHorizontalRule(trimmed) ||
+    Boolean(getHeading(trimmed)) ||
+    (isTableRow(line) && index + 1 < lines.length && isTableSeparator(lines[index + 1])) ||
+    Boolean(collectListItems(lines, index, "unordered")) ||
+    Boolean(collectListItems(lines, index, "ordered"))
+  );
+}
+
+function renderInlineMarkdown(text) {
+  const inlineCodeTokens = [];
+  let result = escapeHtml(text).replace(/`([^`]+)`/g, (_match, code) => {
+    inlineCodeTokens.push(`<code>${code}</code>`);
+    return `${codeBlockTokenBoundary}IC${inlineCodeTokens.length - 1}${codeBlockTokenBoundary}`;
+  });
+
+  result = result
+    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
+      return `<a href="${escapeAttribute(href)}">${label}</a>`;
+    });
+
+  return result.replace(
+    new RegExp(`${codeBlockTokenBoundary}IC(\\d+)${codeBlockTokenBoundary}`, "g"),
+    (_match, idx) => inlineCodeTokens[Number(idx)] ?? "",
+  );
+}
+
+function isHorizontalRule(line) {
+  return /^(?:-{3,}|\*{3,}|_{3,})$/.test(line);
 }
 
 function isTableRow(line) {
@@ -43,83 +370,15 @@ function renderTable(rows) {
       .map((c) => c.trim());
 
   const headerCells = parseRow(rows[0]);
-  const thead = `<thead><tr>${headerCells.map((c) => `<th>${c}</th>`).join("")}</tr></thead>`;
+  const thead = `<thead><tr>${headerCells.map((c) => `<th>${renderInlineMarkdown(c)}</th>`).join("")}</tr></thead>`;
 
   const bodyRows = rows
     .slice(1)
     .map((row) => {
       const cells = parseRow(row);
-      return `<tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`;
+      return `<tr>${cells.map((c) => `<td>${renderInlineMarkdown(c)}</td>`).join("")}</tr>`;
     })
     .join("");
 
   return `<div class="fd-table-wrapper relative overflow-auto prose-no-margin my-6"><table>${thead}<tbody>${bodyRows}</tbody></table></div>`;
-}
-
-export function renderMarkdown(text) {
-  if (!text) return "";
-
-  const codeBlockTokenBoundary = String.fromCharCode(0);
-  const codeBlockTokenPattern = new RegExp(
-    `${codeBlockTokenBoundary}CB(\\d+)${codeBlockTokenBoundary}`,
-    "g",
-  );
-  const codeBlocks = [];
-
-  // Complete fences: ```lang\n...\n```
-  let processed = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, lang, code) => {
-    codeBlocks.push(buildCodeBlock(lang, code));
-    return `\x00CB${codeBlocks.length - 1}\x00`;
-  });
-
-  // Incomplete fence (streaming): opening ``` with no closing one
-  processed = processed.replace(/```(\w*)\n([\s\S]*)$/, (_match, lang, code) => {
-    codeBlocks.push(buildCodeBlock(lang, code));
-    return `\x00CB${codeBlocks.length - 1}\x00`;
-  });
-
-  const lines = processed.split("\n");
-  const output = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    if (isTableRow(lines[i]) && i + 1 < lines.length && isTableSeparator(lines[i + 1])) {
-      const tableLines = [lines[i]];
-      i++; // separator
-      i++; // move past separator
-      while (i < lines.length && isTableRow(lines[i])) {
-        tableLines.push(lines[i]);
-        i++;
-      }
-      output.push(renderTable(tableLines));
-      continue;
-    }
-    output.push(lines[i]);
-    i++;
-  }
-
-  let result = output.join("\n");
-
-  result = result
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
-    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
-    .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/^### (.*$)/gm, "<h4>$1</h4>")
-    .replace(/^## (.*$)/gm, "<h3>$1</h3>")
-    .replace(/^# (.*$)/gm, "<h2>$1</h2>")
-    .replace(
-      /^[-*] (.*$)/gm,
-      '<div style="display:flex;gap:8px;padding:2px 0"><span style="opacity:0.5">\u2022</span><span>$1</span></div>',
-    )
-    .replace(
-      /^(\d+)\. (.*$)/gm,
-      '<div style="display:flex;gap:8px;padding:2px 0"><span style="opacity:0.5">$1.</span><span>$2</span></div>',
-    )
-    .replace(/\n\n/g, '<div style="height:8px"></div>')
-    .replace(/\n/g, "<br>");
-
-  result = result.replace(codeBlockTokenPattern, (_m, idx) => codeBlocks[Number(idx)]);
-
-  return result;
 }

--- a/packages/svelte-theme/test/renderMarkdown.test.ts
+++ b/packages/svelte-theme/test/renderMarkdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/lib/renderMarkdown.js";
+
+describe("renderMarkdown", () => {
+  it("renders deeper headings and loose bash command labels from AI responses", () => {
+    const html = renderMarkdown(`#### Claude Code (CLI)
+bash
+
+claude mcp add --transport http scholarxiv https://www.scholarxiv.com/api/mcp \\
+  --header "Authorization: Bearer sxv_your_api_key_here"
+
+#### opencode
+
+Add this to your opencode config.`);
+
+    expect(html).not.toContain("####");
+    expect(html).not.toContain("<p>bash</p>");
+    expect(html).toContain("<h4>Claude Code (CLI)</h4>");
+    expect(html).toContain("<h4>opencode</h4>");
+    expect(html).toContain('fd-ai-code-lang">bash</div>');
+    expect(html).toContain("claude");
+    expect(html).toContain("mcp");
+    expect(html).toContain("add");
+    expect(html).toContain("Authorization: Bearer");
+    expect(html).toContain("<p>Add this to your opencode config.</p>");
+  });
+
+  it("keeps tables rendered as tables while preserving inline markdown", () => {
+    const html = renderMarkdown(`## Transport Details
+
+| Property | Value |
+|----------|-------|
+| Type | **Streamable HTTP** |
+| Protocol Version | \`2025-06-15\` |`);
+
+    expect(html).toContain("<h3>Transport Details</h3>");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<strong>Streamable HTTP</strong>");
+    expect(html).toContain("<code>2025-06-15</code>");
+  });
+});


### PR DESCRIPTION
## Summary

- Strip Docs Cloud Ask AI footer/separator artifacts, including `## Relevant Docs` footers, before streaming to clients.
- Replace the Svelte theme AI markdown renderer with a block parser that supports deeper headings, fenced code metadata, tables, lists, and loose language labels like `bash` before command examples.
- Add focused coverage for Docs Cloud response cleanup and Svelte AI markdown rendering.

## Root Cause

Docs Cloud could stream decorative Markdown separators and heading-style relevant-docs footers that the proxy did not fully remove. The Svelte theme renderer also only handled up to `###` headings and simple fenced code regexes, so AI responses containing `#### Claude Code (CLI)` plus a bare `bash` language line rendered as raw text.

## Validation

- `pnpm --filter @farming-labs/docs test -- --run packages/docs/src/cloud-ask-ai.test.ts`
- `pnpm --filter @farming-labs/docs exec vitest --root /Users/mac/oss/docs_ run packages/svelte-theme/test/renderMarkdown.test.ts`
- `pnpm exec oxfmt --ignore-path .oxfmtignore --check packages/docs/src/cloud-ask-ai.ts packages/docs/src/cloud-ask-ai.test.ts packages/svelte-theme/src/lib/renderMarkdown.js packages/svelte-theme/test/renderMarkdown.test.ts`
- `pnpm --filter @farming-labs/docs run build`
- `pnpm --filter @farming-labs/svelte run typecheck`
- Local ScholarXIV browser check on `http://127.0.0.1:5173/developers/docs`: MCP Ask AI answer rendered headings/code/table nodes with no raw `####`, `---`, or `Relevant Docs`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docs Cloud Ask rendering by removing footer/separator artifacts and upgrading the `@farming-labs/svelte-theme` markdown renderer to correctly display deeper headings, code blocks, tables, and lists.

- **Bug Fixes**
  - Strip `## Relevant Docs` footers (including heading-style) and standalone `---` separators from Docs Cloud streams so only the answer is sent.

- **New Features**
  - Replace the markdown renderer in `@farming-labs/svelte-theme` with a block parser that supports h1–h6, fenced code with metadata, tables, ordered/unordered lists, and loose language labels (e.g., `bash` → code fence). Adds focused tests in `@farming-labs/docs` and `@farming-labs/svelte-theme`.

<sup>Written for commit da5e5a3749761962780b194d6587d0d84fb37ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

