### PR TITLE
fix: complete svelte ai markdown rendering

### DIFF
--- a/packages/svelte-theme/src/lib/renderMarkdown.js
+++ b/packages/svelte-theme/src/lib/renderMarkdown.js
@@ -3,7 +3,8 @@
  *
  * Uses sugar-high for syntax highlighting in code blocks.
  * Supports fenced and streaming code blocks, loose language labels emitted by
- * models, tables, inline code, emphasis, links, headings, and lists.
+ * models, tables, inline code, emphasis, links, images, headings, blockquotes,
+ * horizontal rules, and lists.
  */
 import { highlight } from "sugar-high";
 
@@ -29,8 +30,8 @@ function escapeHtml(s) {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function escapeAttribute(s) {
-  return escapeHtml(s).replace(/"/g, "&quot;");
+function escapeEscapedAttribute(s) {
+  return s.replace(/"/g, "&quot;");
 }
 
 function buildCodeBlock(lang, code) {
@@ -227,10 +228,28 @@ function renderMarkdownBlocks(text, codeBlocks) {
       continue;
     }
 
+    const setextHeading = getSetextHeading(lines, i);
+    if (setextHeading) {
+      output.push(
+        `<h${setextHeading.level}>${renderInlineMarkdown(setextHeading.text)}</h${setextHeading.level}>`,
+      );
+      i += 2;
+      continue;
+    }
+
     const heading = getHeading(trimmed);
     if (heading) {
       output.push(`<h${heading.level}>${renderInlineMarkdown(heading.text)}</h${heading.level}>`);
       i += 1;
+      continue;
+    }
+
+    const blockquote = collectBlockquote(lines, i);
+    if (blockquote) {
+      output.push(
+        `<blockquote>${renderMarkdownBlocks(blockquote.lines.join("\n"), codeBlocks)}</blockquote>`,
+      );
+      i = blockquote.nextIndex;
       continue;
     }
 
@@ -247,18 +266,14 @@ function renderMarkdownBlocks(text, codeBlocks) {
 
     const unorderedItems = collectListItems(lines, i, "unordered");
     if (unorderedItems) {
-      output.push(
-        `<ul>${unorderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ul>`,
-      );
+      output.push(`<ul>${unorderedItems.items.map((item) => renderListItem(item)).join("")}</ul>`);
       i = unorderedItems.nextIndex;
       continue;
     }
 
     const orderedItems = collectListItems(lines, i, "ordered");
     if (orderedItems) {
-      output.push(
-        `<ol>${orderedItems.items.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ol>`,
-      );
+      output.push(`<ol>${orderedItems.items.map((item) => renderListItem(item)).join("")}</ol>`);
       i = orderedItems.nextIndex;
       continue;
     }
@@ -288,13 +303,51 @@ function getCodeBlockTokenIndex(line) {
 }
 
 function getHeading(line) {
-  const match = /^(#{1,6})\s+(.+)$/.exec(line);
+  const match = /^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+[ \t]*)?$/.exec(line);
   if (!match) return null;
 
   return {
-    level: Math.min(match[1].length + 1, 4),
+    level: match[1].length,
     text: match[2],
   };
+}
+
+function getSetextHeading(lines, index) {
+  if (index + 1 >= lines.length) return null;
+
+  const text = lines[index].trim();
+  const underline = lines[index + 1].trim();
+  if (!text || !/^(?:=+|-+)$/.test(underline)) return null;
+  if (getHeading(text) || isHorizontalRule(text) || isBlockquoteStart(text)) return null;
+  if (isTableRow(lines[index])) return null;
+  if (collectListItems(lines, index, "unordered") || collectListItems(lines, index, "ordered"))
+    return null;
+
+  return {
+    level: underline.startsWith("=") ? 1 : 2,
+    text,
+  };
+}
+
+function collectBlockquote(lines, startIndex) {
+  if (!isBlockquoteStart(lines[startIndex])) return null;
+
+  const quoteLines = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const match = /^(?: {0,3})>\s?(.*)$/.exec(lines[i]);
+    if (!match) break;
+
+    quoteLines.push(match[1]);
+    i += 1;
+  }
+
+  return quoteLines.length > 0 ? { lines: quoteLines, nextIndex: i } : null;
+}
+
+function isBlockquoteStart(line) {
+  return /^(?: {0,3})>/.test(line);
 }
 
 function collectListItems(lines, startIndex, type) {
@@ -313,6 +366,14 @@ function collectListItems(lines, startIndex, type) {
   return items.length > 0 ? { items, nextIndex: i } : null;
 }
 
+function renderListItem(item) {
+  const task = /^\[([ xX])\]\s+(.+)$/.exec(item);
+  if (!task) return `<li>${renderInlineMarkdown(item)}</li>`;
+
+  const checked = task[1].toLowerCase() === "x" ? " checked" : "";
+  return `<li class="fd-ai-task-list-item"><input class="fd-ai-task-checkbox" type="checkbox" disabled${checked}>${renderInlineMarkdown(task[2])}</li>`;
+}
+
 function isMarkdownBlockStart(lines, index) {
   const line = lines[index];
   const trimmed = line.trim();
@@ -320,7 +381,9 @@ function isMarkdownBlockStart(lines, index) {
   return (
     getCodeBlockTokenIndex(trimmed) !== null ||
     isHorizontalRule(trimmed) ||
+    Boolean(getSetextHeading(lines, index)) ||
     Boolean(getHeading(trimmed)) ||
+    isBlockquoteStart(line) ||
     (isTableRow(line) && index + 1 < lines.length && isTableSeparator(lines[index + 1])) ||
     Boolean(collectListItems(lines, index, "unordered")) ||
     Boolean(collectListItems(lines, index, "ordered"))
@@ -336,9 +399,18 @@ function renderInlineMarkdown(text) {
 
   result = result
     .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+    .replace(/__(.*?)__/g, "<strong>$1</strong>")
+    .replace(/~~(.*?)~~/g, "<del>$1</del>")
     .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>")
+    .replace(/(?<!_)_([^_]+)_(?!_)/g, "<em>$1</em>")
+    .replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+&quot;[^)]*&quot;)?\)/g, (_match, alt, src) => {
+      return `<img src="${escapeEscapedAttribute(src)}" alt="${escapeEscapedAttribute(alt)}" loading="lazy">`;
+    })
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
-      return `<a href="${escapeAttribute(href)}">${label}</a>`;
+      return `<a href="${escapeEscapedAttribute(href)}">${label}</a>`;
+    })
+    .replace(/&lt;(https?:\/\/[^<>\s]+)&gt;/g, (_match, href) => {
+      return `<a href="${escapeEscapedAttribute(href)}">${href}</a>`;
     });
 
   return result.replace(

--- a/packages/svelte-theme/styles/docs.css
+++ b/packages/svelte-theme/styles/docs.css
@@ -2656,9 +2656,24 @@ html.dark #nd-docs-layout pre.shiki {
 
 /* ─── Markdown prose inside AI bubbles (panel/modal/popover) ─────── */
 
+#nd-docs-layout .fd-ai-bubble-ai h1,
+#nd-docs-layout .fd-ai-bubble-ai h2,
+#nd-docs-layout .fd-ai-bubble-ai h3,
+#nd-docs-layout .fd-ai-bubble-ai h4,
+#nd-docs-layout .fd-ai-bubble-ai h5,
+#nd-docs-layout .fd-ai-bubble-ai h6 {
+  font-weight: 600;
+  color: var(--color-fd-foreground, #e4e4e7);
+}
+
+#nd-docs-layout .fd-ai-bubble-ai h1 {
+  font-size: 1.25rem;
+  margin: 14px 0 7px;
+  line-height: 1.25;
+}
+
 #nd-docs-layout .fd-ai-bubble-ai h2 {
   font-size: 1.125rem;
-  font-weight: 600;
   margin: 12px 0 6px;
   line-height: 1.3;
 }
@@ -2672,9 +2687,15 @@ html.dark #nd-docs-layout pre.shiki {
 
 #nd-docs-layout .fd-ai-bubble-ai h4 {
   font-size: 0.9375rem;
-  font-weight: 600;
   margin: 8px 0 4px;
   line-height: 1.4;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai h5,
+#nd-docs-layout .fd-ai-bubble-ai h6 {
+  font-size: 0.8125rem;
+  margin: 8px 0 4px;
+  line-height: 1.45;
 }
 
 #nd-docs-layout .fd-ai-bubble-ai strong {
@@ -2694,6 +2715,58 @@ html.dark #nd-docs-layout pre.shiki {
   content: "";
   display: block;
   margin-top: 2px;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai ul,
+#nd-docs-layout .fd-ai-bubble-ai ol {
+  margin: 6px 0 8px;
+  padding-left: 1.25rem;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai li {
+  margin: 3px 0;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai blockquote {
+  margin: 8px 0;
+  padding: 6px 0 6px 12px;
+  border-left: 2px solid var(--color-fd-border, rgba(255, 255, 255, 0.16));
+  color: var(--color-fd-muted-foreground, #a1a1aa);
+}
+
+#nd-docs-layout .fd-ai-bubble-ai blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai .fd-ai-hr {
+  margin: 12px 0;
+  border: none;
+  border-top: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.12));
+}
+
+#nd-docs-layout .fd-ai-bubble-ai del {
+  color: var(--color-fd-muted-foreground, #a1a1aa);
+}
+
+#nd-docs-layout .fd-ai-bubble-ai .fd-ai-task-list-item {
+  list-style: none;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai .fd-ai-task-checkbox {
+  width: 0.875rem;
+  height: 0.875rem;
+  margin: 0 0.45rem 0 -1.25rem;
+  vertical-align: -0.12em;
+  accent-color: var(--color-fd-primary, #6366f1);
+}
+
+#nd-docs-layout .fd-ai-bubble-ai img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 8px 0;
+  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius, 4px);
 }
 
 #nd-docs-layout .fd-ai-bubble-ai pre {
@@ -3122,9 +3195,24 @@ html.dark #nd-docs-layout pre.shiki {
 
 /* ─── Markdown prose inside full-modal messages ──────────────────── */
 
+#nd-docs-layout .fd-ai-fm-msg-content h1,
+#nd-docs-layout .fd-ai-fm-msg-content h2,
+#nd-docs-layout .fd-ai-fm-msg-content h3,
+#nd-docs-layout .fd-ai-fm-msg-content h4,
+#nd-docs-layout .fd-ai-fm-msg-content h5,
+#nd-docs-layout .fd-ai-fm-msg-content h6 {
+  font-weight: 600;
+  color: var(--color-fd-foreground, #e4e4e7);
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content h1 {
+  font-size: 1.375rem;
+  margin: 18px 0 9px;
+  line-height: 1.25;
+}
+
 #nd-docs-layout .fd-ai-fm-msg-content h2 {
   font-size: 1.25rem;
-  font-weight: 600;
   margin: 16px 0 8px;
   line-height: 1.3;
 }
@@ -3138,9 +3226,15 @@ html.dark #nd-docs-layout pre.shiki {
 
 #nd-docs-layout .fd-ai-fm-msg-content h4 {
   font-size: 1rem;
-  font-weight: 600;
   margin: 10px 0 4px;
   line-height: 1.4;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content h5,
+#nd-docs-layout .fd-ai-fm-msg-content h6 {
+  font-size: 0.875rem;
+  margin: 10px 0 4px;
+  line-height: 1.45;
 }
 
 #nd-docs-layout .fd-ai-fm-msg-content strong {
@@ -3160,6 +3254,58 @@ html.dark #nd-docs-layout pre.shiki {
   content: "";
   display: block;
   margin-top: 2px;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content ul,
+#nd-docs-layout .fd-ai-fm-msg-content ol {
+  margin: 8px 0 10px;
+  padding-left: 1.35rem;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content li {
+  margin: 4px 0;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content blockquote {
+  margin: 10px 0;
+  padding: 7px 0 7px 14px;
+  border-left: 2px solid var(--color-fd-border, rgba(255, 255, 255, 0.16));
+  color: var(--color-fd-muted-foreground, #a1a1aa);
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content .fd-ai-hr {
+  margin: 14px 0;
+  border: none;
+  border-top: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.12));
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content del {
+  color: var(--color-fd-muted-foreground, #a1a1aa);
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content .fd-ai-task-list-item {
+  list-style: none;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content .fd-ai-task-checkbox {
+  width: 0.9rem;
+  height: 0.9rem;
+  margin: 0 0.5rem 0 -1.35rem;
+  vertical-align: -0.12em;
+  accent-color: var(--color-fd-primary, #6366f1);
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 10px 0;
+  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius, 4px);
 }
 
 #nd-docs-layout .fd-ai-fm-msg-content pre {

--- a/packages/svelte-theme/test/renderMarkdown.test.ts
+++ b/packages/svelte-theme/test/renderMarkdown.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 import { renderMarkdown } from "../src/lib/renderMarkdown.js";
 
 describe("renderMarkdown", () => {
+  it("renders all markdown heading levels without leaking hash markers", () => {
+    const html = renderMarkdown(`# One
+## Two
+### Three
+#### Four
+##### Five
+###### Six`);
+
+    expect(html).toContain("<h1>One</h1>");
+    expect(html).toContain("<h2>Two</h2>");
+    expect(html).toContain("<h3>Three</h3>");
+    expect(html).toContain("<h4>Four</h4>");
+    expect(html).toContain("<h5>Five</h5>");
+    expect(html).toContain("<h6>Six</h6>");
+    expect(html).not.toContain("###");
+    expect(html).not.toContain("######");
+  });
+
   it("renders deeper headings and loose bash command labels from AI responses", () => {
     const html = renderMarkdown(`#### Claude Code (CLI)
 bash
@@ -33,9 +51,49 @@ Add this to your opencode config.`);
 | Type | **Streamable HTTP** |
 | Protocol Version | \`2025-06-15\` |`);
 
-    expect(html).toContain("<h3>Transport Details</h3>");
+    expect(html).toContain("<h2>Transport Details</h2>");
     expect(html).toContain("<table>");
     expect(html).toContain("<strong>Streamable HTTP</strong>");
     expect(html).toContain("<code>2025-06-15</code>");
+  });
+
+  it("renders common answer markdown blocks and inline formatting", () => {
+    const html = renderMarkdown(`Primary title
+=============
+
+Secondary title
+---------------
+
+> **Note**
+> Include the \`Bearer\` prefix.
+
+- [x] Project id configured
+- [ ] Analytics verified
+
+1. First step
+2. Second step
+
+~~old value~~
+
+![ScholarXIV](https://www.scholarxiv.com/logo.png)
+
+<https://www.scholarxiv.com/developers/docs>`);
+
+    expect(html).toContain("<h1>Primary title</h1>");
+    expect(html).toContain("<h2>Secondary title</h2>");
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<strong>Note</strong>");
+    expect(html).toContain("<code>Bearer</code>");
+    expect(html).toContain('class="fd-ai-task-list-item"');
+    expect(html).toContain('type="checkbox" disabled checked');
+    expect(html).toContain('type="checkbox" disabled>');
+    expect(html).toContain("<ol>");
+    expect(html).toContain("<del>old value</del>");
+    expect(html).toContain(
+      '<img src="https://www.scholarxiv.com/logo.png" alt="ScholarXIV" loading="lazy">',
+    );
+    expect(html).toContain(
+      '<a href="https://www.scholarxiv.com/developers/docs">https://www.scholarxiv.com/developers/docs</a>',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- render real h1-h6 and setext headings in the Svelte Ask AI markdown renderer
- add blockquote, task list, strikethrough, image, autolink, and horizontal rule support
- style the additional markdown elements in AI bubbles and the full-modal Ask AI view

## Verification
- pnpm --filter @farming-labs/docs exec vitest --root /Users/mac/oss/docs_ run packages/svelte-theme/test/renderMarkdown.test.ts
- pnpm --filter @farming-labs/docs run build
- pnpm --filter @farming-labs/svelte-theme run typecheck
- git diff --check
- live localhost ScholarXIV Ask AI modal DOM check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complete Markdown rendering for Ask AI in the Svelte theme, adding missing elements and styles across chat bubbles and the full modal. Improves heading parsing and link/image handling so answers render cleanly.

- **New Features**
  - Render H1–H6 (including setext), blockquotes, task lists with disabled checkboxes, strikethrough, images (lazy), autolinks, and horizontal rules.
  - Styled these elements in `@farming-labs/svelte-theme` for `.fd-ai-bubble-ai` and `.fd-ai-fm-msg-content`.

- **Bug Fixes**
  - Correct ATX heading parsing (no trailing hash markers; true levels 1–6).
  - Prevent double-escaping in link/image attributes while keeping quotes safe.

<sup>Written for commit 4fabbcab344284b45c257c76e0d0f4380c63fcfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

