### PR TITLE
fix: round ai markdown tables

### DIFF
--- a/packages/svelte-theme/styles/docs.css
+++ b/packages/svelte-theme/styles/docs.css
@@ -2634,18 +2634,36 @@ html.dark #nd-docs-layout pre.shiki {
   font-size: inherit;
 }
 
+#nd-docs-layout .fd-ai-bubble-ai .fd-table-wrapper {
+  margin: 8px 0;
+  overflow: auto;
+  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius, 6px);
+}
+
 #nd-docs-layout .fd-ai-bubble-ai table {
   width: 100%;
-  border-collapse: collapse;
-  margin: 8px 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 0;
   font-size: 13px;
 }
 
 #nd-docs-layout .fd-ai-bubble-ai th,
 #nd-docs-layout .fd-ai-bubble-ai td {
-  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border: 0;
+  border-right: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border-bottom: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
   padding: 6px 12px;
   text-align: left;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai tr > :last-child {
+  border-right: 0;
+}
+
+#nd-docs-layout .fd-ai-bubble-ai tbody tr:last-child td {
+  border-bottom: 0;
 }
 
 #nd-docs-layout .fd-ai-bubble-ai th {
@@ -3173,18 +3191,36 @@ html.dark #nd-docs-layout pre.shiki {
   text-decoration: underline;
 }
 
+#nd-docs-layout .fd-ai-fm-msg-content .fd-table-wrapper {
+  margin: 8px 0;
+  overflow: auto;
+  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius, 6px);
+}
+
 #nd-docs-layout .fd-ai-fm-msg-content table {
   width: 100%;
-  border-collapse: collapse;
-  margin: 8px 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 0;
   font-size: 13px;
 }
 
 #nd-docs-layout .fd-ai-fm-msg-content th,
 #nd-docs-layout .fd-ai-fm-msg-content td {
-  border: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border: 0;
+  border-right: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
+  border-bottom: 1px solid var(--color-fd-border, rgba(255, 255, 255, 0.1));
   padding: 6px 12px;
   text-align: left;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content tr > :last-child {
+  border-right: 0;
+}
+
+#nd-docs-layout .fd-ai-fm-msg-content tbody tr:last-child td {
+  border-bottom: 0;
 }
 
 #nd-docs-layout .fd-ai-fm-msg-content th {


### PR DESCRIPTION
## Summary
- add clipped borders and radius to AI markdown table wrappers
- switch AI markdown tables from collapsed to separated borders so rounded corners render cleanly
- keep the change scoped to AI bubbles and full-modal Ask AI messages

## Verification
- pnpm --filter @farming-labs/docs exec vitest --root /Users/mac/oss/docs_ run packages/svelte-theme/test/renderMarkdown.test.ts
- pnpm --filter @farming-labs/svelte-theme run typecheck
- pnpm --filter @farming-labs/docs run build
- git diff --check
- live localhost ScholarXIV Ask AI table computed-style check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounded AI markdown tables in Ask AI bubbles and full‑modal messages for cleaner corners and better horizontal scrolling. Scoped to AI views only in `@farming-labs/svelte-theme`.

- **Bug Fixes**
  - Added `.fd-table-wrapper` with border, radius, and `overflow: auto` around AI tables in `.fd-ai-bubble-ai` and `.fd-ai-fm-msg-content`.
  - Switched tables to `border-collapse: separate` with `border-spacing: 0`; applied borders on cell right/bottom; removed on last col/row.
  - Moved table margins to the wrapper to avoid clipped corners.

<sup>Written for commit 9a1ae00ad73752e81a6406e0ce70f3fdfd3f5850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

