### PR TITLE
fix: emit Svelte docs page analytics

### DIFF
--- a/packages/svelte-theme/src/components/DocsLayout.svelte
+++ b/packages/svelte-theme/src/components/DocsLayout.svelte
@@ -3,8 +3,14 @@
   import SearchDialog from "./SearchDialog.svelte";
   import AskAIDialog from "./AskAIDialog.svelte";
   import FloatingAIChat from "./FloatingAIChat.svelte";
+  import { afterNavigate } from "$app/navigation";
   import { page } from "$app/stores";
+  import { env as publicEnv } from "$env/dynamic/public";
   import { onMount } from "svelte";
+  import {
+    emitSvelteDocsClientAnalyticsEvent,
+    installSvelteDocsAnalytics,
+  } from "../lib/clientAnalytics.js";
 
   let {
     tree,
@@ -79,11 +85,55 @@
     ].join("");
   });
 
+  let lastAnalyticsPageKey = "";
+
+  function emitPageView(url) {
+    if (typeof window === "undefined") return;
+    if (!url) return;
+
+    window.setTimeout(() => {
+      const pathname = url.pathname.replace(/\/$/, "") || "/";
+      const search = url.search;
+      const locale =
+        url.searchParams.get("lang") ?? url.searchParams.get("locale") ?? activeLocale ?? null;
+      const pageKey = `${pathname}${search}|${locale ?? ""}`;
+      if (pageKey === lastAnalyticsPageKey) return;
+
+      lastAnalyticsPageKey = pageKey;
+      emitSvelteDocsClientAnalyticsEvent({
+        type: "page_view",
+        locale,
+        path: pathname,
+        url: url.href,
+        properties: {
+          entry: config?.entry,
+          framework: "sveltekit",
+          pathname,
+          ...(search ? { search } : {}),
+          ...(document.title ? { title: document.title } : {}),
+        },
+      });
+    }, 0);
+  }
+
+  afterNavigate(({ to }) => {
+    emitPageView(to?.url ?? $page.url);
+  });
+
   onMount(() => {
+    const cleanupAnalytics = installSvelteDocsAnalytics({
+      analytics: config?.analytics,
+      env: publicEnv,
+    });
+
     if (forcedTheme) {
       document.documentElement.classList.remove("light", "dark");
       document.documentElement.classList.add(forcedTheme);
     }
+
+    return () => {
+      cleanupAnalytics();
+    };
   });
 
   let sidebarOpen = $state(false);

--- a/packages/svelte-theme/src/lib/clientAnalytics.js
+++ b/packages/svelte-theme/src/lib/clientAnalytics.js
@@ -1,0 +1,314 @@
+const DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT = "https://api.farming-labs.dev/v1/analytics/events";
+const VISITOR_ID_STORAGE_KEY = "fd:analytics:visitor-id";
+const SESSION_ID_STORAGE_KEY = "fd:analytics:session-id";
+
+function createAnalyticsId(prefix) {
+  const random =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
+
+  return `${prefix}_${random}`;
+}
+
+function normalizeValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isFalsyEnv(value) {
+  return /^(0|false|no|off)$/i.test(normalizeValue(value) ?? "");
+}
+
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function getRuntimeEnvValue(env, ...names) {
+  for (const name of names) {
+    const value = normalizeValue(env?.[name]) ?? normalizeValue(globalThis.process?.env?.[name]);
+    if (value) return value;
+  }
+
+  return undefined;
+}
+
+function readStorage(storage, key) {
+  try {
+    return normalizeValue(storage?.getItem(key));
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStorage(storage, key, value) {
+  try {
+    storage?.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down embeds.
+  }
+}
+
+function getBrowserStorage(target, key) {
+  try {
+    return target[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function getOrCreateClientId({ cachedValue, create, storage, storageKey }) {
+  const stored = readStorage(storage, storageKey);
+  const value = stored ?? cachedValue ?? create();
+
+  if (!stored) {
+    writeStorage(storage, storageKey, value);
+  }
+
+  return value;
+}
+
+export function getSvelteDocsClientAnalyticsIdentity() {
+  if (typeof window === "undefined") return null;
+
+  const target = window;
+  const visitorId = getOrCreateClientId({
+    cachedValue: target.__fdAnalyticsVisitorId__,
+    create: () => createAnalyticsId("visitor"),
+    storage: getBrowserStorage(target, "localStorage"),
+    storageKey: VISITOR_ID_STORAGE_KEY,
+  });
+  const sessionId = getOrCreateClientId({
+    cachedValue: target.__fdAnalyticsSessionId__,
+    create: () => createAnalyticsId("session"),
+    storage: getBrowserStorage(target, "sessionStorage"),
+    storageKey: SESSION_ID_STORAGE_KEY,
+  });
+
+  target.__fdAnalyticsVisitorId__ = visitorId;
+  target.__fdAnalyticsSessionId__ = sessionId;
+
+  return {
+    anonymousId: visitorId,
+    visitorId,
+    sessionId,
+    visitor: {
+      id: visitorId,
+    },
+    session: {
+      id: sessionId,
+    },
+  };
+}
+
+function normalizeClientAnalyticsProperties(identity, properties) {
+  const provided = properties ?? {};
+  const visitorId =
+    normalizeValue(provided.visitorId) ??
+    normalizeValue(asRecord(provided.visitor).id) ??
+    normalizeValue(provided.anonymousId) ??
+    identity?.visitorId;
+  const sessionId =
+    normalizeValue(provided.sessionId) ??
+    normalizeValue(asRecord(provided.session).id) ??
+    identity?.sessionId;
+  const merged = {
+    ...identity,
+    ...provided,
+  };
+
+  return {
+    ...merged,
+    ...(visitorId
+      ? {
+          anonymousId: normalizeValue(provided.anonymousId) ?? visitorId,
+          visitorId,
+          visitor: {
+            ...asRecord(merged.visitor),
+            id: visitorId,
+          },
+        }
+      : {}),
+    ...(sessionId
+      ? {
+          sessionId,
+          session: {
+            ...asRecord(merged.session),
+            id: sessionId,
+          },
+        }
+      : {}),
+  };
+}
+
+export function emitSvelteDocsClientAnalyticsEvent(event) {
+  if (typeof window === "undefined") return;
+
+  const identity = getSvelteDocsClientAnalyticsIdentity();
+  const normalized = {
+    ...event,
+    source: "client",
+    path: event.path ?? window.location.pathname,
+    url: event.url ?? window.location.href,
+    referrer: event.referrer ?? (document.referrer || undefined),
+    timestamp: new Date().toISOString(),
+    properties: normalizeClientAnalyticsProperties(identity, event.properties),
+  };
+
+  const target = window;
+  try {
+    if (target.__fdAnalytics__) {
+      Promise.resolve(target.__fdAnalytics__(normalized)).catch(() => {
+        // Analytics should never break the docs UI.
+      });
+    } else {
+      target.__fdAnalyticsQueue__ = [...(target.__fdAnalyticsQueue__ ?? []), normalized].slice(-50);
+    }
+
+    window.dispatchEvent(new CustomEvent("fd:analytics", { detail: normalized }));
+  } catch {
+    // Analytics should never break the docs UI.
+  }
+}
+
+function resolveConsoleLevel(analytics, hasEventHandler) {
+  if (!analytics || analytics === true) return analytics === true ? "info" : false;
+  if (analytics.console === false) return false;
+  if (analytics.console === true) return "info";
+  if (["log", "info", "debug"].includes(analytics.console)) return analytics.console;
+  return hasEventHandler ? false : "info";
+}
+
+function resolveSvelteDocsAnalyticsOptions({ analytics, env }) {
+  if (
+    analytics === false ||
+    (analytics && typeof analytics === "object" && analytics.enabled === false)
+  ) {
+    return null;
+  }
+
+  const enabled = getRuntimeEnvValue(
+    env,
+    "PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED",
+    "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENABLED",
+    "DOCS_CLOUD_ANALYTICS_ENABLED",
+  );
+
+  if (isFalsyEnv(enabled)) {
+    return null;
+  }
+
+  const projectId = getRuntimeEnvValue(
+    env,
+    "PUBLIC_DOCS_CLOUD_PROJECT_ID",
+    "NEXT_PUBLIC_DOCS_CLOUD_PROJECT_ID",
+    "DOCS_CLOUD_PROJECT_ID",
+  );
+  const endpoint =
+    getRuntimeEnvValue(
+      env,
+      "PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT",
+      "NEXT_PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT",
+      "DOCS_CLOUD_ANALYTICS_ENDPOINT",
+    ) ?? DEFAULT_DOCS_CLOUD_ANALYTICS_ENDPOINT;
+  const userOnEvent =
+    analytics && typeof analytics === "object" && typeof analytics.onEvent === "function"
+      ? analytics.onEvent
+      : undefined;
+  const hasEventHandler = typeof userOnEvent === "function" || Boolean(projectId);
+
+  if (!analytics && !hasEventHandler) {
+    return null;
+  }
+
+  return {
+    console: resolveConsoleLevel(analytics, hasEventHandler),
+    endpoint,
+    includeInputs: analytics && typeof analytics === "object" && analytics.includeInputs === true,
+    onEvent: userOnEvent,
+    projectId,
+  };
+}
+
+function normalizeAnalyticsEvent(event, options) {
+  const normalized = {
+    ...event,
+    source: event.source ?? "client",
+    timestamp: event.timestamp ?? new Date().toISOString(),
+  };
+
+  if (!options.includeInputs && normalized.input) {
+    delete normalized.input;
+  }
+
+  return normalized;
+}
+
+async function sendDocsCloudAnalyticsEvent(options, event) {
+  if (typeof fetch !== "function") return;
+  if (!options.projectId) return;
+
+  try {
+    await fetch(options.endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        projectId: options.projectId,
+        event,
+      }),
+      credentials: "omit",
+      keepalive: true,
+    });
+  } catch {
+    // Docs Cloud delivery should never interfere with the docs runtime.
+  }
+}
+
+async function emitAnalyticsEvent(options, event) {
+  const normalized = normalizeAnalyticsEvent(event, options);
+
+  if (options.console) {
+    const logger = console[options.console] ?? console.info;
+    logger.call(console, "[@farming-labs/docs:analytics]", normalized);
+  }
+
+  if (typeof options.onEvent === "function") {
+    try {
+      await options.onEvent(normalized);
+    } catch {
+      // User analytics hooks should never break the docs UI.
+    }
+  }
+
+  await sendDocsCloudAnalyticsEvent(options, normalized);
+}
+
+export function installSvelteDocsAnalytics({ analytics, env } = {}) {
+  if (typeof window === "undefined") return () => {};
+
+  const options = resolveSvelteDocsAnalyticsOptions({ analytics, env });
+  if (!options) return () => {};
+
+  const target = window;
+  const previous = target.__fdAnalytics__;
+  const handler = (event) => {
+    void emitAnalyticsEvent(options, event);
+  };
+
+  target.__fdAnalytics__ = handler;
+
+  const queued = target.__fdAnalyticsQueue__ ?? [];
+  delete target.__fdAnalyticsQueue__;
+  for (const event of queued) handler(event);
+
+  return () => {
+    if (target.__fdAnalytics__ === handler) {
+      if (typeof previous === "function") {
+        target.__fdAnalytics__ = previous;
+      } else {
+        delete target.__fdAnalytics__;
+      }
+    }
+  };
+}

--- a/packages/svelte-theme/test/clientAnalytics.test.js
+++ b/packages/svelte-theme/test/clientAnalytics.test.js
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  emitSvelteDocsClientAnalyticsEvent,
+  installSvelteDocsAnalytics,
+} from "../src/lib/clientAnalytics.js";
+
+function createStorage() {
+  const values = new Map();
+
+  return {
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    setItem(key, value) {
+      values.set(key, value);
+    },
+  };
+}
+
+function installBrowserGlobals() {
+  const target = {
+    dispatchEvent: vi.fn(),
+    localStorage: createStorage(),
+    location: {
+      href: "https://www.scholarxiv.com/developers/docs",
+      pathname: "/developers/docs",
+    },
+    sessionStorage: createStorage(),
+  };
+
+  globalThis.window = target;
+  globalThis.document = {
+    referrer: "https://www.scholarxiv.com/",
+  };
+  globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  };
+  globalThis.fetch = vi.fn(async () => ({ ok: true }));
+
+  return target;
+}
+
+async function flushAnalytics() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.CustomEvent;
+  delete globalThis.fetch;
+  vi.restoreAllMocks();
+});
+
+describe("Svelte client analytics", () => {
+  it("sends browser page views to Docs Cloud with only the public project id", async () => {
+    installBrowserGlobals();
+    const cleanup = installSvelteDocsAnalytics({
+      env: {
+        PUBLIC_DOCS_CLOUD_ANALYTICS_ENDPOINT: "https://analytics.example.test/events",
+        PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_123",
+      },
+    });
+
+    emitSvelteDocsClientAnalyticsEvent({
+      type: "page_view",
+      input: {
+        question: "private input",
+      },
+      path: "/developers/docs/papers-api/examples",
+      properties: {
+        framework: "sveltekit",
+      },
+    });
+    await flushAnalytics();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://analytics.example.test/events",
+      expect.objectContaining({
+        credentials: "omit",
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    const payload = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(payload.projectId).toBe("project_123");
+    expect(payload.event).toMatchObject({
+      path: "/developers/docs/papers-api/examples",
+      source: "client",
+      type: "page_view",
+      url: "https://www.scholarxiv.com/developers/docs",
+      properties: {
+        framework: "sveltekit",
+      },
+    });
+    expect(payload.event.input).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("drains queued client events when the Svelte analytics hook installs", async () => {
+    installBrowserGlobals();
+
+    emitSvelteDocsClientAnalyticsEvent({
+      type: "page_view",
+      path: "/queued",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+
+    installSvelteDocsAnalytics({
+      env: {
+        PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_queued",
+      },
+    });
+    await flushAnalytics();
+
+    const payload = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(payload.projectId).toBe("project_queued");
+    expect(payload.event.path).toBe("/queued");
+  });
+
+  it("does not install cloud analytics when analytics is explicitly disabled", async () => {
+    installBrowserGlobals();
+
+    installSvelteDocsAnalytics({
+      analytics: false,
+      env: {
+        PUBLIC_DOCS_CLOUD_PROJECT_ID: "project_disabled",
+      },
+    });
+    emitSvelteDocsClientAnalyticsEvent({
+      type: "page_view",
+      path: "/disabled",
+    });
+    await flushAnalytics();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Svelte client analytics transport that reads the public Docs Cloud project id from SvelteKit public env
- emit page_view events from the Svelte docs layout on initial load and client navigation
- send browser analytics without Authorization/API-key credentials

## Validation
- pnpm format:check
- ./packages/docs/node_modules/.bin/vitest run packages/svelte-theme/test/clientAnalytics.test.js packages/svelte-theme/test/renderMarkdown.test.ts
- pnpm --filter @farming-labs/svelte-theme typecheck
- pnpm --filter @farming-labs/svelte-theme build
- pnpm --filter @farming-labs/docs test
- pnpm lint (existing warnings only)
- verified ScholarXIV locally posts page_view events for /developers/docs and /developers/docs/dashboard with only projectId

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit page_view analytics from Svelte docs without credentials by adding a client-side transport and wiring it into the docs layout. Tracks initial load and client navigation using the public Docs Cloud project id.

- **New Features**
  - Added `clientAnalytics.js` in `@farming-labs/svelte-theme` with visitor/session IDs, event queueing, and a handler that posts to Docs Cloud using only `PUBLIC_DOCS_CLOUD_PROJECT_ID`.
  - Hooked `DocsLayout.svelte` to install analytics from `config.analytics` and public env, and emit page_view on mount and afterNavigate with simple dedupe.
  - Sends with `fetch` (no Authorization, credentials omitted, keepalive); strips `input` by default unless `includeInputs` is true.
  - Added `clientAnalytics.test.js` to verify cloud delivery, queue draining, and explicit disable behavior.

<sup>Written for commit 070582e103491c021ea18e0904a4d1bb126b8a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

