### PR TITLE
feat: improve docs search modal

### DIFF
--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next-build/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -86,7 +86,6 @@ const { config = null } = Astro.props;
             type="button"
             class="omni-filter-button"
             id="fd-omni-filter-button"
-            aria-haspopup="menu"
             aria-expanded="false"
           >
             <span id="fd-omni-filter-value">All</span>
@@ -97,14 +96,13 @@ const { config = null } = Astro.props;
           <div
             class="omni-filter-menu"
             id="fd-omni-filter-menu"
-            role="menu"
+            role="group"
             aria-label="Search filter"
             style="display: none;"
           >
             <button
               type="button"
-              role="menuitemradio"
-              aria-checked="true"
+              aria-pressed="true"
               class="omni-filter-option omni-filter-option-active"
               data-filter="all"
             >
@@ -112,8 +110,7 @@ const { config = null } = Astro.props;
             </button>
             <button
               type="button"
-              role="menuitemradio"
-              aria-checked="false"
+              aria-pressed="false"
               class="omni-filter-option"
               data-filter="pages"
             >
@@ -121,8 +118,7 @@ const { config = null } = Astro.props;
             </button>
             <button
               type="button"
-              role="menuitemradio"
-              aria-checked="false"
+              aria-pressed="false"
               class="omni-filter-option"
               data-filter="inside"
             >
@@ -274,9 +270,13 @@ const { config = null } = Astro.props;
     );
   }
 
-  function sortResultsForFilter(results) {
+  function getCurrentSearchQuery() {
     var input = getInput();
-    var q = input ? input.value.trim() : "";
+    return input ? input.value.trim() : "";
+  }
+
+  function sortResultsForFilter(results, searchQuery) {
+    var q = typeof searchQuery === "string" ? searchQuery : getCurrentSearchQuery();
     if (!q) return results;
 
     return results.map(function (result, index) {
@@ -306,7 +306,6 @@ const { config = null } = Astro.props;
       setFilterMenuOpen(false);
       renderFilter();
       bindListboxDelegation();
-      ensureListboxClickBound();
       setTimeout(function () {
         var input = getInput();
         if (input) { input.value = ""; input.focus(); }
@@ -344,20 +343,18 @@ const { config = null } = Astro.props;
   function highlightSnippet(text, query) {
     var q = (query || "").trim();
     if (!q) return escapeHtml(text);
-    var lower = text.toLowerCase();
-    var needle = q.toLowerCase();
-    var pos = 0;
     var html = "";
-    var idx = lower.indexOf(needle, pos);
+    var lastIndex = 0;
+    var regex = new RegExp(escapeRegExp(q), "gi");
+    var match;
 
-    while (idx !== -1) {
-      html += escapeHtml(text.slice(pos, idx));
-      html += '<mark class="omni-highlight">' + escapeHtml(text.slice(idx, idx + q.length)) + '</mark>';
-      pos = idx + q.length;
-      idx = lower.indexOf(needle, pos);
+    while ((match = regex.exec(text)) !== null) {
+      html += escapeHtml(text.slice(lastIndex, match.index));
+      html += '<mark class="omni-highlight">' + escapeHtml(match[0]) + '</mark>';
+      lastIndex = match.index + match[0].length;
     }
 
-    return html + escapeHtml(text.slice(pos));
+    return html + escapeHtml(text.slice(lastIndex));
   }
 
   function renderItem(item, active, isRecent) {
@@ -386,15 +383,37 @@ const { config = null } = Astro.props;
   var currentFilter = "all";
   var abortController = null;
   var searchCache = new Map();
+  var currentResultsVersion = 0;
+  var visibleResultsCacheKey = "";
+  var visibleResultsCacheResults = [];
+
+  function setCurrentResults(results) {
+    currentResults = results;
+    currentResultsVersion += 1;
+    visibleResultsCacheKey = "";
+    visibleResultsCacheResults = [];
+  }
 
   function visibleResults() {
+    var q = getCurrentSearchQuery();
+    var cacheKey = currentFilter + "\n" + q + "\n" + currentResultsVersion;
+    if (visibleResultsCacheKey === cacheKey) return visibleResultsCacheResults;
+
+    var results;
     if (currentFilter === "pages") {
-      return currentResults.filter(function (result) { return result.type === "page"; });
+      results = currentResults.filter(function (result) { return result.type === "page"; });
+    } else if (currentFilter === "inside") {
+      results = sortResultsForFilter(
+        currentResults.filter(function (result) { return result.type !== "page"; }),
+        q
+      );
+    } else {
+      results = sortResultsForFilter(currentResults, q);
     }
-    if (currentFilter === "inside") {
-      return sortResultsForFilter(currentResults.filter(function (result) { return result.type !== "page"; }));
-    }
-    return sortResultsForFilter(currentResults);
+
+    visibleResultsCacheKey = cacheKey;
+    visibleResultsCacheResults = results;
+    return results;
   }
 
   function allItems() {
@@ -418,7 +437,7 @@ const { config = null } = Astro.props;
     if (!menu) return;
     Array.prototype.forEach.call(menu.querySelectorAll("[data-filter]"), function (option) {
       var active = option.getAttribute("data-filter") === currentFilter;
-      option.setAttribute("aria-checked", active ? "true" : "false");
+      option.setAttribute("aria-pressed", active ? "true" : "false");
       option.classList.toggle("omni-filter-option-active", active);
     });
   }
@@ -450,7 +469,7 @@ const { config = null } = Astro.props;
     renderFilter();
 
     if (!q) {
-      currentResults = [];
+      if (currentResults.length) setCurrentResults([]);
       if (recentGroup) recentGroup.style.display = recentsList.length ? "block" : "none";
       if (recentItemsEl) {
         recentItemsEl.innerHTML = recentsList.map(function (r, i) {
@@ -508,14 +527,6 @@ const { config = null } = Astro.props;
     var withinDialog = e.target.closest && e.target.closest("#fd-search-dialog");
     if (!withinDialog) return;
 
-    var ext = e.target.closest && e.target.closest("a.omni-item-ext");
-    if (ext) {
-      e.preventDefault();
-      e.stopPropagation();
-      var url = ext.getAttribute("data-ext-url") || ext.getAttribute("href");
-      navigateToUrl(url, true);
-      return;
-    }
     var row = e.target.closest && e.target.closest(".omni-item[data-url]");
     if (row) {
       e.preventDefault();
@@ -551,35 +562,6 @@ const { config = null } = Astro.props;
     document.addEventListener("mouseover", handleOmniItemMouseOver, true);
   }
 
-  function ensureListboxClickBound() {
-    var listbox = getListbox();
-    if (!listbox || listbox._fdOmniClickBound) return;
-    listbox._fdOmniClickBound = true;
-    function onListboxClick(e) {
-      var ext = e.target.closest && e.target.closest("a.omni-item-ext");
-      if (ext) {
-        e.preventDefault();
-        e.stopPropagation();
-        var url = ext.getAttribute("data-ext-url") || ext.getAttribute("href");
-        navigateToUrl(url, true);
-        return;
-      }
-      var row = e.target.closest && e.target.closest(".omni-item[data-url]");
-      if (row) {
-        e.preventDefault();
-        e.stopPropagation();
-        var url = row.getAttribute("data-url");
-        if (!url) return;
-        var labelEl = row.querySelector(".omni-item-label");
-        var label = labelEl ? labelEl.textContent : url;
-        saveRecent({ id: url, label: label, url: url });
-        closeDialog();
-        navigateToUrl(url, url.startsWith("http"));
-      }
-    }
-    listbox.addEventListener("click", onListboxClick, true);
-  }
-
   function scrollActiveIntoView() {
     var q = getInput() && getInput().value.trim();
     var container = q ? getDocsItems() : getRecentItems();
@@ -612,7 +594,7 @@ const { config = null } = Astro.props;
     var q = (input && input.value || "").trim();
     if (getLoading()) getLoading().style.display = "none";
     if (abortController) abortController.abort();
-    currentResults = [];
+    setCurrentResults([]);
     activeIndex = 0;
     setFilterMenuOpen(false);
     if (getDocsGroup()) getDocsGroup().style.display = "none";
@@ -626,7 +608,7 @@ const { config = null } = Astro.props;
     if (!q) return;
     var requestUrl = withLang("/api/docs?query=" + encodeURIComponent(q));
     if (searchCache.has(requestUrl)) {
-      currentResults = searchCache.get(requestUrl) || [];
+      setCurrentResults(searchCache.get(requestUrl) || []);
       activeIndex = 0;
       render();
       return;
@@ -639,7 +621,7 @@ const { config = null } = Astro.props;
         .then(function (res) { return res.ok ? res.json() : []; })
         .then(function (data) {
           if (controller.signal.aborted) return;
-          currentResults = Array.isArray(data) ? data : [];
+          setCurrentResults(Array.isArray(data) ? data : []);
           if (searchCache.size >= 20) {
             var firstKey = searchCache.keys().next().value;
             if (firstKey) searchCache.delete(firstKey);

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -21,15 +21,11 @@ const { config = null } = Astro.props;
           role="combobox"
           aria-expanded="true"
           aria-controls="fd-omni-listbox"
-          placeholder="Search documentation…"
+          placeholder="Search"
           autocomplete="off"
         />
-        <kbd class="omni-kbd">⌘ K</kbd>
         <button type="button" aria-label="Close" class="omni-close-btn" id="fd-omni-close">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M18 6 6 18" />
-            <path d="m6 6 12 12" />
-          </svg>
+          ESC
         </button>
       </div>
     </div>
@@ -65,25 +61,32 @@ const { config = null } = Astro.props;
         <div class="omni-footer-hints">
           <span class="omni-footer-hint">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <polyline points="9 18 15 12 9 6" />
+              <path d="m9 10-5 5 5 5" />
+              <path d="M20 4v7a4 4 0 0 1-4 4H4" />
             </svg>
             to select
           </span>
           <span class="omni-footer-hint">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path d="M18 15l-6-6-6 6" />
+              <path d="m18 15-6-6-6 6" />
             </svg>
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path d="M6 9l6 6 6-6" />
+              <path d="m6 9 6 6 6-6" />
             </svg>
             to navigate
           </span>
           <span class="omni-footer-hint omni-footer-hint-desktop">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path d="M18 6 6 18" />
-              <path d="m6 6 12 12" />
-            </svg>
+            <span class="omni-kbd-sm">ESC</span>
             to close
+          </span>
+        </div>
+        <div class="omni-footer-filter">
+          <span class="omni-filter-label">Filter</span>
+          <span class="omni-filter-value">
+            All
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M6 9l6 6 6-6" />
+            </svg>
           </span>
         </div>
       </div>
@@ -148,6 +151,27 @@ const { config = null } = Astro.props;
     }
   }
 
+  function breadcrumbForUrl(url) {
+    try {
+      var parsed = new URL(url, window.location.origin);
+      var parts = parsed.pathname.split("/").filter(Boolean).map(function (part) {
+        return decodeURIComponent(part)
+          .replace(/[-_]+/g, " ")
+          .replace(/\b\w/g, function (char) { return char.toUpperCase(); });
+      });
+      return parts.length ? parts.join(" > ") : "Docs";
+    } catch (e) {
+      return "Docs";
+    }
+  }
+
+  function displayLabelForResult(result) {
+    if (result.section) return result.section;
+    var label = result.content || "";
+    var parts = label.split(/\s+[—–]\s+/).map(function (part) { return part.trim(); }).filter(Boolean);
+    return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
+  }
+
   function openDialog() {
     var dialog = getDialog();
     if (dialog) {
@@ -178,26 +202,20 @@ const { config = null } = Astro.props;
     return el.textContent || el.innerText || "";
   }
 
-  var fileIconSvg = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>';
-  var externalSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>';
-  var chevronSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>';
-
   function renderItem(item, active, isRecent) {
     var label = (item.label || item.content || "").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    var subtitle = (item.subtitle || item.description || (isRecent ? "Recently viewed" : "Page")).replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    var subtitle = (item.subtitle || (isRecent ? "Recently viewed" : breadcrumbForUrl(item.url || ""))).replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    var description = (item.description || "").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     var url = item.url || "#";
     var id = (item.id || url).replace(/[^a-zA-Z0-9-_]/g, "_");
-    var safeUrl = url.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
     var activeClass = active ? " omni-item-active" : "";
     return (
       '<div class="omni-item' + activeClass + '" data-id="' + id + '" data-url="' + url.replace(/"/g, "&quot;") + '" role="option" aria-selected="' + (active ? "true" : "false") + '" tabindex="-1">' +
-        '<div class="omni-item-icon">' + fileIconSvg + '</div>' +
         '<div class="omni-item-text">' +
-          '<div class="omni-item-label">' + label + '</div>' +
           '<div class="omni-item-subtitle">' + subtitle + '</div>' +
+          '<div class="omni-item-label">' + label + '</div>' +
+          (description ? '<div class="omni-item-description">' + description + '</div>' : '') +
         '</div>' +
-        '<a href="' + safeUrl + '" class="omni-item-ext" title="Open in new tab" target="_blank" rel="noopener noreferrer" data-ext-url="' + url.replace(/"/g, "&quot;") + '">' + externalSvg + '</a>' +
-        '<span class="omni-item-chevron" aria-hidden="true">' + chevronSvg + '</span>' +
       '</div>'
     );
   }
@@ -249,7 +267,7 @@ const { config = null } = Astro.props;
       if (docsItemsEl) {
         docsItemsEl.innerHTML = currentResults.map(function (r, i) {
           return renderItem(
-            { id: r.url, label: r.content, url: r.url, subtitle: r.description || "Page" },
+            { id: r.url, label: displayLabelForResult(r), url: r.url, subtitle: breadcrumbForUrl(r.url), description: r.description || "" },
             i === activeIndex,
             false
           );

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -140,6 +140,7 @@ const { config = null } = Astro.props;
   var STORAGE_KEY = "fd:omni:recents";
   var MAX_RECENTS = 8;
   var DEBOUNCE_MS = 150;
+  var BREADCRUMB_SEPARATOR = "\u00a0\u00a0>\u00a0\u00a0";
   var FILTER_LABELS = {
     all: "All",
     pages: "Pages",
@@ -208,7 +209,7 @@ const { config = null } = Astro.props;
           .replace(/[-_]+/g, " ")
           .replace(/\b\w/g, function (char) { return char.toUpperCase(); });
       });
-      return parts.length ? parts.join(" > ") : "Docs";
+      return parts.length ? parts.join(BREADCRUMB_SEPARATOR) : "Docs";
     } catch (e) {
       return "Docs";
     }

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -270,7 +270,6 @@ const { config = null } = Astro.props;
     if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
     return Math.max(
       literalMatchPriority(searchQuery, result.section),
-      literalMatchPriority(searchQuery, result.content),
       literalMatchPriority(searchQuery, result.description)
     );
   }
@@ -280,14 +279,21 @@ const { config = null } = Astro.props;
     var q = input ? input.value.trim() : "";
     if (!q) return results;
 
-    return results.slice().sort(function (a, b) {
-      var literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
+    return results.map(function (result, index) {
+      return { result: result, index: index };
+    }).sort(function (a, b) {
+      var aLiteralPriority = insideLiteralPriority(a.result, q);
+      var bLiteralPriority = insideLiteralPriority(b.result, q);
+      var literalDelta = bLiteralPriority - aLiteralPriority;
       if (literalDelta) return literalDelta;
+      if (aLiteralPriority > 0 && bLiteralPriority > 0) return a.index - b.index;
 
-      var scoreDelta = (b.score || 0) - (a.score || 0);
+      var scoreDelta = (b.result.score || 0) - (a.result.score || 0);
       if (scoreDelta) return scoreDelta;
 
-      return (a.url || "").localeCompare(b.url || "");
+      return a.index - b.index;
+    }).map(function (item) {
+      return item.result;
     });
   }
 

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -82,12 +82,53 @@ const { config = null } = Astro.props;
         </div>
         <div class="omni-footer-filter">
           <span class="omni-filter-label">Filter</span>
-          <span class="omni-filter-value">
-            All
+          <button
+            type="button"
+            class="omni-filter-button"
+            id="fd-omni-filter-button"
+            aria-haspopup="menu"
+            aria-expanded="false"
+          >
+            <span id="fd-omni-filter-value">All</span>
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="M6 9l6 6 6-6" />
             </svg>
-          </span>
+          </button>
+          <div
+            class="omni-filter-menu"
+            id="fd-omni-filter-menu"
+            role="menu"
+            aria-label="Search filter"
+            style="display: none;"
+          >
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked="true"
+              class="omni-filter-option omni-filter-option-active"
+              data-filter="all"
+            >
+              All
+            </button>
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked="false"
+              class="omni-filter-option"
+              data-filter="pages"
+            >
+              Pages
+            </button>
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked="false"
+              class="omni-filter-option"
+              data-filter="inside"
+            >
+              Inside pages
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -99,6 +140,11 @@ const { config = null } = Astro.props;
   var STORAGE_KEY = "fd:omni:recents";
   var MAX_RECENTS = 8;
   var DEBOUNCE_MS = 150;
+  var FILTER_LABELS = {
+    all: "All",
+    pages: "Pages",
+    inside: "Inside pages"
+  };
 
   function getDialog() { return document.getElementById("fd-search-dialog"); }
   function getOverlay() { return document.getElementById("fd-omni-overlay"); }
@@ -112,6 +158,9 @@ const { config = null } = Astro.props;
   function getDocsItems() { return document.getElementById("fd-omni-docs-items"); }
   function getEmpty() { return document.getElementById("fd-omni-empty"); }
   function getEmptyText() { return document.getElementById("fd-omni-empty-text"); }
+  function getFilterButton() { return document.getElementById("fd-omni-filter-button"); }
+  function getFilterValue() { return document.getElementById("fd-omni-filter-value"); }
+  function getFilterMenu() { return document.getElementById("fd-omni-filter-menu"); }
 
   function getRecents() {
     try {
@@ -177,6 +226,9 @@ const { config = null } = Astro.props;
     if (dialog) {
       dialog.style.display = "block";
       document.body.style.overflow = "hidden";
+      currentFilter = "all";
+      setFilterMenuOpen(false);
+      renderFilter();
       bindListboxDelegation();
       ensureListboxClickBound();
       setTimeout(function () {
@@ -192,6 +244,7 @@ const { config = null } = Astro.props;
     if (dialog) {
       dialog.style.display = "none";
       document.body.style.overflow = "";
+      setFilterMenuOpen(false);
     }
   }
 
@@ -224,11 +277,53 @@ const { config = null } = Astro.props;
   var currentResults = [];
   var recentsList = [];
   var activeIndex = 0;
+  var currentFilter = "all";
+  var abortController = null;
+  var searchCache = new Map();
+
+  function visibleResults() {
+    if (currentFilter === "pages") {
+      return currentResults.filter(function (result) { return result.type === "page"; });
+    }
+    if (currentFilter === "inside") {
+      return currentResults.filter(function (result) { return result.type !== "page"; });
+    }
+    return currentResults;
+  }
 
   function allItems() {
     var q = (getInput() && getInput().value || "").trim();
-    if (q && currentResults.length) return currentResults;
+    var results = visibleResults();
+    if (q && results.length) return results;
     return recentsList;
+  }
+
+  function setFilterMenuOpen(open) {
+    var menu = getFilterMenu();
+    var button = getFilterButton();
+    if (menu) menu.style.display = open ? "block" : "none";
+    if (button) button.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  function renderFilter() {
+    var value = getFilterValue();
+    var menu = getFilterMenu();
+    if (value) value.textContent = FILTER_LABELS[currentFilter] || "All";
+    if (!menu) return;
+    Array.prototype.forEach.call(menu.querySelectorAll("[data-filter]"), function (option) {
+      var active = option.getAttribute("data-filter") === currentFilter;
+      option.setAttribute("aria-checked", active ? "true" : "false");
+      option.classList.toggle("omni-filter-option-active", active);
+    });
+  }
+
+  function updateFilter(nextFilter) {
+    if (!FILTER_LABELS[nextFilter]) return;
+    currentFilter = nextFilter;
+    activeIndex = 0;
+    setFilterMenuOpen(false);
+    renderFilter();
+    render();
   }
 
   function render() {
@@ -241,9 +336,12 @@ const { config = null } = Astro.props;
     var docsItemsEl = getDocsItems();
     var emptyEl = getEmpty();
     var emptyText = getEmptyText();
+    var isLoading = !!loadingEl && loadingEl.style.display !== "none";
+    var results = visibleResults();
 
     recentsList = !q ? getRecents() : [];
     if (loadingEl && !q) loadingEl.style.display = "none";
+    renderFilter();
 
     if (!q) {
       currentResults = [];
@@ -263,9 +361,9 @@ const { config = null } = Astro.props;
       if (emptyText) emptyText.textContent = "Type to search the docs, or browse recent items.";
     } else {
       if (recentGroup) recentGroup.style.display = "none";
-      if (docsGroup) docsGroup.style.display = currentResults.length ? "block" : "none";
+      if (docsGroup) docsGroup.style.display = results.length ? "block" : "none";
       if (docsItemsEl) {
-        docsItemsEl.innerHTML = currentResults.map(function (r, i) {
+        docsItemsEl.innerHTML = results.map(function (r, i) {
           return renderItem(
             { id: r.url, label: displayLabelForResult(r), url: r.url, subtitle: breadcrumbForUrl(r.url), description: r.description || "" },
             i === activeIndex,
@@ -273,8 +371,12 @@ const { config = null } = Astro.props;
           );
         }).join("");
       }
-      if (emptyEl) emptyEl.style.display = (currentResults.length === 0 && !loadingEl.style.display) ? "none" : (currentResults.length === 0 ? "block" : "none");
-      if (emptyText) emptyText.textContent = "No results found. Try a different query.";
+      if (emptyEl) emptyEl.style.display = (results.length === 0 && !isLoading) ? "block" : "none";
+      if (emptyText) {
+        emptyText.textContent = currentResults.length > 0
+          ? "No " + (FILTER_LABELS[currentFilter] || "all").toLowerCase() + " results found."
+          : "No results found. Try a different query.";
+      }
     }
 
     scrollActiveIntoView();
@@ -403,8 +505,10 @@ const { config = null } = Astro.props;
     var input = getInput();
     var q = (input && input.value || "").trim();
     if (getLoading()) getLoading().style.display = "none";
+    if (abortController) abortController.abort();
     currentResults = [];
     activeIndex = 0;
+    setFilterMenuOpen(false);
     if (getDocsGroup()) getDocsGroup().style.display = "none";
     if (getDocsItems()) getDocsItems().innerHTML = "";
     if (getRecentGroup()) getRecentGroup().style.display = !q && getRecents().length ? "block" : "none";
@@ -414,19 +518,38 @@ const { config = null } = Astro.props;
 
     clearTimeout(debounceTimer);
     if (!q) return;
+    var requestUrl = withLang("/api/docs?query=" + encodeURIComponent(q));
+    if (searchCache.has(requestUrl)) {
+      currentResults = searchCache.get(requestUrl) || [];
+      activeIndex = 0;
+      render();
+      return;
+    }
     debounceTimer = setTimeout(function () {
+      var controller = new AbortController();
+      abortController = controller;
       if (getLoading()) getLoading().style.display = "flex";
-      fetch(withLang("/api/docs?query=" + encodeURIComponent(q)))
+      fetch(requestUrl, { signal: controller.signal })
         .then(function (res) { return res.ok ? res.json() : []; })
         .then(function (data) {
+          if (controller.signal.aborted) return;
           currentResults = Array.isArray(data) ? data : [];
+          if (searchCache.size >= 20) {
+            var firstKey = searchCache.keys().next().value;
+            if (firstKey) searchCache.delete(firstKey);
+          }
+          searchCache.set(requestUrl, currentResults);
           activeIndex = 0;
           if (getLoading()) getLoading().style.display = "none";
           render();
         })
         .catch(function () {
+          if (controller.signal.aborted) return;
           if (getLoading()) getLoading().style.display = "none";
           render();
+        })
+        .finally(function () {
+          if (abortController === controller) abortController = null;
         });
     }, DEBOUNCE_MS);
   }
@@ -437,6 +560,8 @@ const { config = null } = Astro.props;
     var content = getContent();
     var input = getInput();
     var closeBtn = document.getElementById("fd-omni-close");
+    var filterButton = getFilterButton();
+    var filterMenu = getFilterMenu();
 
     if (!dialog || !input) return;
 
@@ -451,9 +576,40 @@ const { config = null } = Astro.props;
       else if (e.key === "Enter") { e.preventDefault(); executeActive(); }
     });
 
+    if (filterButton && !filterButton.hasAttribute("data-fd-bound")) {
+      filterButton.setAttribute("data-fd-bound", "true");
+      filterButton.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var menu = getFilterMenu();
+        var isOpen = !!menu && menu.style.display !== "none";
+        setFilterMenuOpen(!isOpen);
+      });
+    }
+
+    if (filterMenu && !filterMenu.hasAttribute("data-fd-bound")) {
+      filterMenu.setAttribute("data-fd-bound", "true");
+      filterMenu.addEventListener("click", function (e) {
+        var option = e.target.closest && e.target.closest("[data-filter]");
+        if (!option) return;
+        e.preventDefault();
+        e.stopPropagation();
+        updateFilter(option.getAttribute("data-filter"));
+      });
+    }
+
     document.addEventListener("keydown", function (e) {
       if (e.key === "Escape") closeDialog();
     });
+
+    if (!document.body.hasAttribute("data-fd-omni-filter-close")) {
+      document.body.setAttribute("data-fd-omni-filter-close", "true");
+      document.addEventListener("click", function (e) {
+        var target = e.target;
+        if (target && target.closest && target.closest(".omni-footer-filter")) return;
+        setFilterMenuOpen(false);
+      });
+    }
 
     if (!document.body.hasAttribute("data-fd-cmdk-registered")) {
       document.body.setAttribute("data-fd-cmdk-registered", "true");

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -266,10 +266,6 @@ const { config = null } = Astro.props;
     });
   }
 
-  function isCodeLikeSnippet(text) {
-    return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(text);
-  }
-
   function highlightSnippet(text, query) {
     var q = (query || "").trim();
     if (!q) return escapeHtml(text);
@@ -294,7 +290,6 @@ const { config = null } = Astro.props;
     var subtitle = escapeHtml(item.subtitle || (isRecent ? "Recently viewed" : breadcrumbForUrl(item.url || "")));
     var rawDescription = item.description || "";
     var description = highlightSnippet(rawDescription, getInput() && getInput().value || "");
-    var descriptionClass = isCodeLikeSnippet(rawDescription) ? " omni-item-description-code" : "";
     var url = item.url || "#";
     var id = (item.id || url).replace(/[^a-zA-Z0-9-_]/g, "_");
     var activeClass = active ? " omni-item-active" : "";
@@ -303,7 +298,7 @@ const { config = null } = Astro.props;
         '<div class="omni-item-text">' +
           '<div class="omni-item-subtitle">' + subtitle + '</div>' +
           '<div class="omni-item-label">' + label + '</div>' +
-          (description ? '<div class="omni-item-description' + descriptionClass + '">' + description + '</div>' : '') +
+          (description ? '<div class="omni-item-description">' + description + '</div>' : '') +
         '</div>' +
       '</div>'
     );

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -222,6 +222,75 @@ const { config = null } = Astro.props;
     return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
   }
 
+  function normalizeSearchPhrase(value) {
+    return (value || "").toLowerCase().replace(/[?!.,;:]+$/g, "").replace(/\s+/g, " ").trim();
+  }
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function literalMatchPriority(searchQuery, value) {
+    var q = normalizeSearchPhrase(searchQuery);
+    var text = normalizeSearchPhrase(value);
+    if (!q || !text) return 0;
+    if (text === q) return 2;
+
+    var boundary = "[^\\p{L}\\p{N}]";
+    return new RegExp("(^|" + boundary + ")" + escapeRegExp(q) + "(?=$|" + boundary + ")", "u").test(text)
+      ? 1
+      : 0;
+  }
+
+  function tokenizeLiteralQuery(searchQuery) {
+    return Array.from(new Set(
+      searchQuery
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}@/_:.-]+/gu, " ")
+        .split(/\s+/)
+        .map(function (word) { return word.replace(/^[^\p{L}\p{N}@]+|[^\p{L}\p{N}]+$/gu, ""); })
+        .filter(function (word) { return word.length > 1; })
+    ));
+  }
+
+  function isLiteralLookupQuery(searchQuery) {
+    var q = normalizeSearchPhrase(searchQuery);
+    var words = tokenizeLiteralQuery(q);
+    return words.length > 0 && words.length <= 3 && words.join(" ") === q;
+  }
+
+  function hasDistinctSearchSection(result) {
+    if (result.type === "page") return false;
+    if (!result.section) return true;
+    var title = (result.content || "").split(/\s+[—–]\s+/)[0] || "";
+    return normalizeSearchPhrase(result.section) !== normalizeSearchPhrase(title);
+  }
+
+  function insideLiteralPriority(result, searchQuery) {
+    if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
+    return Math.max(
+      literalMatchPriority(searchQuery, result.section),
+      literalMatchPriority(searchQuery, result.content),
+      literalMatchPriority(searchQuery, result.description)
+    );
+  }
+
+  function sortResultsForFilter(results) {
+    var input = getInput();
+    var q = input ? input.value.trim() : "";
+    if (!q) return results;
+
+    return results.slice().sort(function (a, b) {
+      var literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
+      if (literalDelta) return literalDelta;
+
+      var scoreDelta = (b.score || 0) - (a.score || 0);
+      if (scoreDelta) return scoreDelta;
+
+      return (a.url || "").localeCompare(b.url || "");
+    });
+  }
+
   function openDialog() {
     var dialog = getDialog();
     if (dialog) {
@@ -317,9 +386,9 @@ const { config = null } = Astro.props;
       return currentResults.filter(function (result) { return result.type === "page"; });
     }
     if (currentFilter === "inside") {
-      return currentResults.filter(function (result) { return result.type !== "page"; });
+      return sortResultsForFilter(currentResults.filter(function (result) { return result.type !== "page"; }));
     }
-    return currentResults;
+    return sortResultsForFilter(currentResults);
   }
 
   function allItems() {

--- a/packages/astro-theme/src/components/SearchDialog.astro
+++ b/packages/astro-theme/src/components/SearchDialog.astro
@@ -256,10 +256,45 @@ const { config = null } = Astro.props;
     return el.textContent || el.innerText || "";
   }
 
+  function escapeHtml(value) {
+    return (value || "").replace(/[&<>"']/g, function (char) {
+      if (char === "&") return "&amp;";
+      if (char === "<") return "&lt;";
+      if (char === ">") return "&gt;";
+      if (char === '"') return "&quot;";
+      return "&#39;";
+    });
+  }
+
+  function isCodeLikeSnippet(text) {
+    return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(text);
+  }
+
+  function highlightSnippet(text, query) {
+    var q = (query || "").trim();
+    if (!q) return escapeHtml(text);
+    var lower = text.toLowerCase();
+    var needle = q.toLowerCase();
+    var pos = 0;
+    var html = "";
+    var idx = lower.indexOf(needle, pos);
+
+    while (idx !== -1) {
+      html += escapeHtml(text.slice(pos, idx));
+      html += '<mark class="omni-highlight">' + escapeHtml(text.slice(idx, idx + q.length)) + '</mark>';
+      pos = idx + q.length;
+      idx = lower.indexOf(needle, pos);
+    }
+
+    return html + escapeHtml(text.slice(pos));
+  }
+
   function renderItem(item, active, isRecent) {
-    var label = (item.label || item.content || "").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    var subtitle = (item.subtitle || (isRecent ? "Recently viewed" : breadcrumbForUrl(item.url || ""))).replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    var description = (item.description || "").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    var label = escapeHtml(item.label || item.content || "");
+    var subtitle = escapeHtml(item.subtitle || (isRecent ? "Recently viewed" : breadcrumbForUrl(item.url || "")));
+    var rawDescription = item.description || "";
+    var description = highlightSnippet(rawDescription, getInput() && getInput().value || "");
+    var descriptionClass = isCodeLikeSnippet(rawDescription) ? " omni-item-description-code" : "";
     var url = item.url || "#";
     var id = (item.id || url).replace(/[^a-zA-Z0-9-_]/g, "_");
     var activeClass = active ? " omni-item-active" : "";
@@ -268,7 +303,7 @@ const { config = null } = Astro.props;
         '<div class="omni-item-text">' +
           '<div class="omni-item-subtitle">' + subtitle + '</div>' +
           '<div class="omni-item-label">' + label + '</div>' +
-          (description ? '<div class="omni-item-description">' + description + '</div>' : '') +
+          (description ? '<div class="omni-item-description' + descriptionClass + '">' + description + '</div>' : '') +
         '</div>' +
       '</div>'
     );

--- a/packages/astro-theme/styles/command-grid-bundle.css
+++ b/packages/astro-theme/styles/command-grid-bundle.css
@@ -605,6 +605,7 @@ figure.shiki:has(figcaption) > div:first-child,
 }
 
 .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/astro-theme/styles/command-grid.css
+++ b/packages/astro-theme/styles/command-grid.css
@@ -605,6 +605,7 @@ figure.shiki:has(figcaption) > div:first-child,
 }
 
 .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -68,7 +68,7 @@
   top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(640px, calc(100% - 1rem));
+  width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   background: var(--color-fd-popover, #fafafa);
@@ -163,10 +163,10 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 460px;
+  max-height: 540px;
   overflow: auto;
   overscroll-behavior: contain;
-  padding: 0.25rem;
+  padding: 0.5rem;
 }
 .omni-body::-webkit-scrollbar {
   width: 6px;
@@ -199,6 +199,7 @@
 .omni-group-items {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 /* Items */
@@ -208,7 +209,7 @@
   width: 100%;
   flex-shrink: 0;
   border-radius: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.75rem 0.875rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -246,6 +247,7 @@
   white-space: nowrap;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   font-weight: 500;
+  line-height: 1.35;
 }
 .omni-item-subtitle {
   min-width: 0;
@@ -265,12 +267,14 @@
   min-width: 0;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  margin-top: 0.25rem;
+  margin-top: 0.625rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
   font-size: 0.875rem;
-  line-height: 1.35rem;
+  line-height: 1.5rem;
   font-weight: 400;
 }
 .omni-item-badge {
@@ -369,6 +373,14 @@
   white-space: nowrap;
 }
 .omni-footer-hint svg {
+  box-sizing: border-box;
+  width: 1.375rem;
+  height: 1.375rem;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 70%, transparent);
+  color: var(--color-fd-muted-foreground, #737373);
   flex-shrink: 0;
 }
 .omni-footer-hint-desktop {

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -65,7 +65,7 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: clamp(1rem, 8vh, 8rem);
+  top: clamp(1.5rem, 10vh, 6rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -63,9 +63,10 @@
 }
 
 .omni-content {
+  --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
   z-index: 51;
-  top: clamp(1.5rem, 10vh, 6rem);
+  top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -86,7 +87,8 @@
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 1rem;
+    --omni-content-top: 1rem;
+    top: var(--omni-content-top);
     width: calc(100% - 1rem);
     max-height: calc(100vh - 2rem);
   }
@@ -167,7 +169,7 @@
 .omni-body {
   flex: 1 1 auto;
   min-height: 0;
-  max-height: min(540px, calc(100vh - 10.5rem));
+  max-height: min(540px, calc(100vh - var(--omni-content-top, 7rem) - 8rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -65,9 +65,11 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: calc(50% - 250px);
+  top: clamp(1rem, 8vh, 8rem);
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
   width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
@@ -163,7 +165,9 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 540px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(540px, calc(100vh - 10.5rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;
@@ -387,6 +391,7 @@
   display: none;
 }
 .omni-footer-filter {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -406,4 +411,47 @@
   align-items: center;
   gap: 0.25rem;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+}
+.omni-filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.omni-filter-button:hover {
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+}
+.omni-filter-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 1;
+  width: 10rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  border-radius: 0.5rem;
+  background: var(--color-fd-popover, #fafafa);
+  padding: 0.25rem;
+  box-shadow: 0 16px 32px -20px rgba(0, 0, 0, 0.45);
+}
+.omni-filter-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+}
+.omni-filter-option:hover,
+.omni-filter-option-active {
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -1,6 +1,6 @@
 /* ═══════════════════════════════════════════════════════════════════
- * Omni Command Palette — core styles (clone of website/components/ui/omni-command-palette)
- * Uses same CSS variables as docs so it auto-adapts to every theme.
+ * Omni Command Palette — core styles
+ * Uses fumadocs CSS variables so it auto-adapts to every theme.
  * ═══════════════════════════════════════════════════════════════════ */
 
 @keyframes omni-fade-in {
@@ -22,7 +22,7 @@
 @keyframes omni-scale-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
   to {
     opacity: 1;
@@ -36,7 +36,7 @@
   }
   to {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
 }
 
@@ -56,39 +56,37 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
 }
 
 .omni-content {
   position: fixed;
-  z-index: 101;
-  top: 18%;
+  z-index: 51;
+  top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(720px, calc(100% - 32px));
-  border-radius: var(--radius, 0.75rem);
-  border: 1px solid var(--color-fd-border, #262626);
-  background: var(--color-fd-popover, #0c0c0c);
-  color: var(--color-fd-foreground, #fafafa);
-  box-shadow:
-    0 24px 60px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: min(640px, calc(100% - 1rem));
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
+  background: var(--color-fd-popover, #fafafa);
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-family: var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
+      ui-sans-serif, sans-serif);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
   overflow: hidden;
+  overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 10%;
-    width: calc(100% - 24px);
-    max-height: 75vh;
-  }
-  .omni-kbd {
-    display: none;
+    top: 1rem;
+    width: calc(100% - 1rem);
+    max-height: calc(100vh - 2rem);
   }
 }
 
@@ -100,51 +98,74 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  padding: 0.75rem;
 }
 .omni-search-icon {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
+.omni-search-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
 .omni-search-input {
+  width: 0;
   flex: 1;
   background: transparent;
   outline: none;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  color: var(--color-fd-foreground, #fafafa);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   border: none;
 }
 .omni-search-input::placeholder {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-kbd {
-  border-radius: 0.25rem;
-  background: var(--color-fd-muted, #262626);
-  padding: 0.125rem 0.375rem;
-  font-size: 10px;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: transparent;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-family: inherit;
-  line-height: 1.4;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  line-height: 1rem;
 }
 .omni-close-btn {
-  margin-left: 0.25rem;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 2.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  padding: 0.375rem 0.5rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  transition: background 120ms;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  transition:
+    background 120ms,
+    color 120ms;
   cursor: pointer;
-  border: none;
   background: none;
 }
 .omni-close-btn:hover {
-  background: var(--color-fd-muted, #262626);
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+  background: var(--color-fd-accent, #e5e5e5);
+}
+.omni-close-btn svg {
+  display: none;
 }
 
 /* Body / listbox */
 .omni-body {
-  max-height: 60vh;
+  max-height: 460px;
   overflow: auto;
+  overscroll-behavior: contain;
   padding: 0.25rem;
 }
 .omni-body::-webkit-scrollbar {
@@ -163,22 +184,17 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.625rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
 
 /* Groups */
 .omni-group {
-  padding: 0.25rem 0;
+  padding: 0;
 }
 .omni-group-label {
-  padding: 0.25rem 0.75rem;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-weight: 500;
+  display: none;
 }
 .omni-group-items {
   display: flex;
@@ -187,12 +203,12 @@
 
 /* Items */
 .omni-item {
-  display: flex;
+  position: relative;
+  display: block;
   width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: calc(var(--radius, 0.75rem) - 4px);
-  padding: 0.5rem 0.75rem;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.625rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -204,10 +220,10 @@
 }
 .omni-item:hover,
 .omni-item-active {
-  background: color-mix(in srgb, var(--color-fd-accent, #262626) 60%, transparent);
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }
 .omni-item-active {
-  color: var(--color-fd-accent-foreground, #fafafa);
+  color: var(--color-fd-accent-foreground, #171717);
 }
 .omni-item-disabled {
   opacity: 0.5;
@@ -215,51 +231,53 @@
 }
 
 .omni-item-icon {
-  flex-shrink: 0;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
+  display: none;
 }
 .omni-item-active .omni-item-icon {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
 .omni-item-text {
-  flex: 1;
   min-width: 0;
 }
 .omni-item-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-weight: 500;
 }
 .omni-item-subtitle {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.75rem;
+  line-height: 1rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0.8;
+  opacity: 1;
 }
 .omni-item-active .omni-item-subtitle {
-  color: var(--color-fd-accent-foreground, #fafafa);
-  opacity: 0.7;
+  color: var(--color-fd-muted-foreground, #737373);
+  opacity: 1;
+}
+.omni-item-description {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-top: 0.25rem;
+  color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35rem;
+  font-weight: 400;
 }
 .omni-item-badge {
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
+  display: none;
 }
 .omni-item-ext {
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
-  transition:
-    color 100ms,
-    background 100ms;
-  text-decoration: none;
+  display: none;
 }
 .omni-item-ext:hover {
   color: var(--color-fd-foreground, #fafafa);
@@ -281,16 +299,11 @@
   border-radius: 0.25rem;
   background: var(--color-fd-muted, #262626);
   padding: 0.125rem 0.25rem;
-  font-family: inherit;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
 }
 .omni-item-chevron {
-  width: 0.875rem;
-  height: 0.875rem;
-  margin-left: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0;
-  transition: opacity 120ms;
-  flex-shrink: 0;
+  display: none;
 }
 .omni-item:hover .omni-item-chevron {
   opacity: 1;
@@ -298,10 +311,12 @@
 
 /* Highlight */
 .omni-highlight {
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 30%, transparent);
-  padding: 0 2px;
-  color: inherit;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--color-fd-primary, #ca8a04);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Empty states */
@@ -311,7 +326,7 @@
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-empty {
-  padding: 2rem 0.75rem;
+  padding: 1.5rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
@@ -330,30 +345,53 @@
 /* Footer */
 .omni-footer {
   border-top: 1px solid var(--color-fd-border, #262626);
+  background: color-mix(in srgb, var(--color-fd-secondary, #f5f5f5) 50%, transparent);
 }
 .omni-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-footer-hints {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 .omni-footer-hint {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  white-space: nowrap;
+}
+.omni-footer-hint svg {
+  flex-shrink: 0;
 }
 .omni-footer-hint-desktop {
   display: none;
+}
+.omni-footer-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  white-space: nowrap;
 }
 @media (min-width: 640px) {
   .omni-footer-hint-desktop {
     display: flex;
   }
+}
+.omni-filter-label {
+  color: var(--color-fd-muted-foreground, #a3a3a3);
+}
+.omni-filter-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
 }

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -80,7 +80,6 @@
       ui-sans-serif, sans-serif);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
-  overflow: hidden;
   overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -315,10 +314,6 @@
 .omni-item-chevron {
   display: none;
 }
-.omni-item:hover .omni-item-chevron {
-  opacity: 1;
-}
-
 /* Highlight */
 .omni-highlight {
   border-radius: 0;

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -282,29 +282,8 @@
   font-weight: 400;
 }
 .omni-item-description-code {
-  display: block;
-  max-height: 4.75rem;
-  padding: 0.5rem 0.625rem;
-  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
-  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
-  border-radius: 0.375rem;
-  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace);
-  font-size: 0.8125rem;
-  line-height: 1.45rem;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.omni-item-active .omni-item-description-code {
-  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
-}
-.omni-item-description-code .omni-highlight {
-  border-radius: 0.1875rem;
-  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
-  padding: 0 0.125rem;
-  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
-  text-decoration: none;
 }
 .omni-item-badge {
   display: none;

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -283,10 +283,6 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
-.omni-item-description-code {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace);
-}
 .omni-item-badge {
   display: none;
 }

--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -281,6 +281,31 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
+.omni-item-description-code {
+  display: block;
+  max-height: 4.75rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.8125rem;
+  line-height: 1.45rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.omni-item-active .omni-item-description-code {
+  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
+}
+.omni-item-description-code .omni-highlight {
+  border-radius: 0.1875rem;
+  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
+  padding: 0 0.125rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  text-decoration: none;
+}
 .omni-item-badge {
   display: none;
 }

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -863,10 +863,13 @@ code:not(pre code) {
   border: 1px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
 }
 
-.omni-search-input,
 .omni-group-label,
 .omni-footer-inner {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-search-input {
+  font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif) !important;
 }
 
 .omni-group-label {

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -877,6 +877,11 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
+.omni-filter-menu,
+.omni-filter-option {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -882,6 +882,11 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
+.omni-item-description-code,
+.omni-item-description-code .omni-highlight {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -840,6 +840,45 @@ code:not(pre code) {
   color: var(--color-fd-foreground) !important;
 }
 
+/* ─── Omni Command Palette — pixel-border theme ──────────────────── */
+
+.omni-content {
+  border-radius: 0 !important;
+  border: 2px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
+  box-shadow:
+    4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%)),
+    0 24px 60px -12px rgba(0, 0, 0, 0.5) !important;
+}
+
+.omni-item,
+.omni-kbd,
+.omni-kbd-sm,
+.omni-close-btn,
+.omni-empty-icon {
+  border-radius: 0 !important;
+}
+
+.omni-kbd,
+.omni-kbd-sm {
+  border: 1px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
+}
+
+.omni-search-input,
+.omni-group-label,
+.omni-footer-inner {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  display: block !important;
+  letter-spacing: 0.08em !important;
+}
+
+.omni-highlight {
+  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
+  border-radius: 0 !important;
+}
+
 /* ─── Feedback (pixel-border theme) ──────────────────────────────── */
 
 .fd-feedback-input,

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -870,8 +870,11 @@ code:not(pre code) {
 }
 
 .omni-group-label {
-  display: block !important;
   letter-spacing: 0.08em !important;
+}
+
+.omni-footer-hint svg {
+  border-radius: 0 !important;
 }
 
 .omni-highlight {

--- a/packages/astro-theme/styles/pixel-border.css
+++ b/packages/astro-theme/styles/pixel-border.css
@@ -882,11 +882,6 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
-.omni-item-description-code,
-.omni-item-description-code .omni-highlight {
-  border-radius: 0 !important;
-}
-
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -199,6 +199,54 @@ API reference for React search.
     });
   });
 
+  it("promotes exact page matches when an external provider only returns sections", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "MCP Server",
+          url: "/docs/customization/mcp",
+          content: "Configure MCP routes for multiple frameworks.",
+          rawContent: `# MCP Server
+
+## Stdio transport
+
+Use the local MCP transport.
+
+## Custom route
+
+Configure a custom MCP route.
+`,
+        },
+      ],
+      query: "mcp",
+      search: createCustomSearchAdapter({
+        name: "external",
+        async search() {
+          return [
+            {
+              id: "external-1",
+              url: "/docs/customization/mcp#stdio-transport",
+              content: "MCP Server — Stdio transport",
+              description: "Use the local MCP transport.",
+              type: "heading",
+              section: "Stdio transport",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results[0]).toMatchObject({
+      type: "page",
+      url: "/docs/customization/mcp",
+      content: "MCP Server",
+    });
+    expect(results[1]).toMatchObject({
+      type: "heading",
+      url: "/docs/customization/mcp#stdio-transport",
+    });
+  });
+
   it("uses a custom adapter when configured", async () => {
     const search = await performDocsSearch({
       pages,

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -134,6 +134,71 @@ describe("performDocsSearch", () => {
     expect(results[0].description).toContain("Configure the route");
   });
 
+  it("prioritizes exact result labels over broader prefix matches", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "React",
+          url: "/docs/react",
+          content: "Configure React search.",
+          rawContent: `# React
+
+## Search
+
+Configure React search.
+`,
+        },
+        {
+          title: "React Search API",
+          url: "/docs/react-search-api",
+          content: "API reference for React search.",
+          rawContent: `# React Search API
+
+API reference for React search.
+`,
+        },
+      ],
+      query: "React Search",
+    });
+
+    expect(results[0]).toMatchObject({
+      url: "/docs/react#search",
+      content: "React — Search",
+      section: "Search",
+    });
+  });
+
+  it("prioritizes exact URL segment matches", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "AI Search",
+          url: "/docs/ai-search",
+          content: "Configure the AI search experience.",
+          rawContent: "# AI Search\n\nConfigure the AI search experience.",
+        },
+        {
+          title: "Search",
+          url: "/docs/search",
+          content: "Mentions ai-native as a related setup option.",
+          rawContent: "# Search\n\nMentions ai-native as a related setup option.",
+        },
+        {
+          title: "AI Native",
+          url: "/docs/getting-started/ai-native",
+          content: "Configure AI-native docs.",
+          rawContent: "# AI Native\n\nConfigure AI-native docs.",
+        },
+      ],
+      query: "ai-native",
+    });
+
+    expect(results[0]).toMatchObject({
+      url: "/docs/getting-started/ai-native",
+      content: "AI Native",
+    });
+  });
+
   it("uses a custom adapter when configured", async () => {
     const search = await performDocsSearch({
       pages,

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -199,6 +199,42 @@ API reference for React search.
     });
   });
 
+  it("prioritizes literal inside-page matches before page matches", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "MCP",
+          url: "/docs/mcp",
+          content: "Overview page.",
+          rawContent: "Overview page.",
+        },
+        {
+          title: "Customization",
+          url: "/docs/customization/transports",
+          content: "Transport options.",
+          rawContent: `# Customization
+
+## Stdio transport
+
+Use MCP locally from editor and agent clients.
+`,
+        },
+      ],
+      query: "mcp",
+    });
+
+    expect(results[0]).toMatchObject({
+      type: "heading",
+      url: "/docs/customization/transports#stdio-transport",
+      content: "Customization — Stdio transport",
+    });
+    expect(results[1]).toMatchObject({
+      type: "page",
+      url: "/docs/mcp",
+      content: "MCP",
+    });
+  });
+
   it("promotes exact page matches when an external provider only returns sections", async () => {
     const results = await performDocsSearch({
       pages: [

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -235,7 +235,7 @@ Use MCP locally from editor and agent clients.
     });
   });
 
-  it("promotes exact page matches when an external provider only returns sections", async () => {
+  it("keeps exact page matches after literal inside-page matches from an external provider", async () => {
     const results = await performDocsSearch({
       pages: [
         {
@@ -273,13 +273,57 @@ Configure a custom MCP route.
     });
 
     expect(results[0]).toMatchObject({
+      type: "heading",
+      url: "/docs/customization/mcp#stdio-transport",
+    });
+    expect(results[1]).toMatchObject({
       type: "page",
       url: "/docs/customization/mcp",
       content: "MCP Server",
     });
+  });
+
+  it("does not treat repeated page labels as literal inside-page matches", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "AI Native",
+          url: "/docs/getting-started/ai-native",
+          content: "Configure AI-native docs.",
+          rawContent: `# AI Native
+
+## Custom Loading States
+
+Customize the loading UI.
+`,
+        },
+      ],
+      query: "ai-native",
+      search: createCustomSearchAdapter({
+        name: "external",
+        async search() {
+          return [
+            {
+              id: "external-1",
+              url: "/docs/getting-started/ai-native#custom-loading-states",
+              content: "AI Native — Custom Loading States",
+              description: "Customize the loading UI.",
+              type: "heading",
+              section: "Custom Loading States",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results[0]).toMatchObject({
+      type: "page",
+      url: "/docs/getting-started/ai-native",
+      content: "AI Native",
+    });
     expect(results[1]).toMatchObject({
       type: "heading",
-      url: "/docs/customization/mcp#stdio-transport",
+      url: "/docs/getting-started/ai-native#custom-loading-states",
     });
   });
 

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -478,6 +478,21 @@ function mergeSearchResults(...groups: DocsSearchResult[][]): DocsSearchResult[]
   return results;
 }
 
+function pageToSearchDocument(page: DocsSearchSourcePage): DocsSearchDocument {
+  return {
+    id: makeDocumentId(page.url, "page"),
+    url: page.url,
+    title: page.title,
+    content: normalizeWhitespace(page.content),
+    description: page.description,
+    type: "page",
+    locale: page.locale,
+    framework: page.framework,
+    version: page.version,
+    tags: page.tags,
+  };
+}
+
 function buildExactPageSearchResults(
   query: string,
   pages: DocsSearchSourcePage[],
@@ -488,18 +503,7 @@ function buildExactPageSearchResults(
   const results: DocsSearchResult[] = [];
 
   for (const page of pages) {
-    const document: DocsSearchDocument = {
-      id: makeDocumentId(page.url, "page"),
-      url: page.url,
-      title: page.title,
-      content: normalizeWhitespace(page.content),
-      description: page.description,
-      type: "page",
-      locale: page.locale,
-      framework: page.framework,
-      version: page.version,
-      tags: page.tags,
-    };
+    const document = pageToSearchDocument(page);
     const title = normalizeSearchPhrase(page.title);
     const urlSegments = getUrlSearchSegments(page.url);
     const isExactPageMatch = title === normalizedQuery || urlSegments.includes(normalizedQuery);
@@ -655,18 +659,7 @@ export function buildDocsSearchDocuments(
   const strategy = chunking.strategy ?? "section";
 
   return pages.flatMap((page) => {
-    const base: DocsSearchDocument = {
-      id: makeDocumentId(page.url, "page"),
-      url: page.url,
-      title: page.title,
-      content: normalizeWhitespace(page.content),
-      description: page.description,
-      type: "page",
-      locale: page.locale,
-      framework: page.framework,
-      version: page.version,
-      tags: page.tags,
-    };
+    const base = pageToSearchDocument(page);
 
     if (strategy === "page") return [base];
 

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -124,6 +124,10 @@ function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function normalizeSearchPhrase(value: string): string {
+  return normalizeWhitespace(value.toLowerCase().replace(/[?!.,;:]+$/g, ""));
+}
+
 function tokenizeSearchQuery(query: string): string[] {
   return Array.from(
     new Set(
@@ -143,6 +147,37 @@ function normalizeUrlPathname(value: string): string {
   } catch {
     return value.split(/[?#]/)[0]?.replace(/\/+$/, "") || "/";
   }
+}
+
+function safeDecodeUrlSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function getUrlSearchSegments(value: string): string[] {
+  let pathname = "";
+
+  try {
+    pathname = new URL(value, "https://docs.local").pathname;
+  } catch {
+    pathname = value.split(/[?#]/)[0] ?? "";
+  }
+
+  return Array.from(
+    new Set(
+      pathname
+        .split("/")
+        .flatMap((segment) => {
+          const decoded = safeDecodeUrlSegment(segment);
+          return [decoded, decoded.replace(/[-_]+/g, " ")];
+        })
+        .map(normalizeSearchPhrase)
+        .filter(Boolean),
+    ),
+  );
 }
 
 function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
@@ -550,28 +585,40 @@ export function buildDocsSearchDocuments(
 }
 
 function scoreDocument(query: string, document: DocsSearchDocument): number {
-  const q = normalizeWhitespace(query.toLowerCase().replace(/[?!.,;:]+$/g, ""));
+  const q = normalizeSearchPhrase(query);
   if (!q) return 0;
 
   const words = tokenizeSearchQuery(q);
-  const title = document.title.toLowerCase();
-  const section = document.section?.toLowerCase() ?? "";
-  const description = document.description?.toLowerCase() ?? "";
-  const content = document.content.toLowerCase();
-  const url = document.url.toLowerCase();
+  const title = normalizeSearchPhrase(document.title);
+  const section = document.section ? normalizeSearchPhrase(document.section) : "";
+  const hasDistinctSection = Boolean(section && section !== title);
+  const titleSection = section
+    ? normalizeSearchPhrase(`${document.title} ${document.section}`)
+    : "";
+  const description = document.description ? normalizeSearchPhrase(document.description) : "";
+  const content = normalizeSearchPhrase(document.content);
+  const url = normalizeSearchPhrase(document.url);
+  const urlSegments = getUrlSearchSegments(document.url);
   const titleTokens = tokenizeSearchQuery(title);
   const sectionTokens = tokenizeSearchQuery(section);
 
   let score = 0;
 
-  if (title === q) score += 120;
+  if (title === q) score += 1_120;
   else if (title.startsWith(q)) score += 70;
   else if (title.includes(q)) score += 45;
 
-  if (section === q) score += 80;
-  else if (section.startsWith(q)) score += 55;
-  else if (section.includes(q)) score += 30;
+  if (hasDistinctSection) {
+    if (section === q) score += 1_080;
+    else if (section.startsWith(q)) score += 55;
+    else if (section.includes(q)) score += 30;
 
+    if (titleSection === q) score += 1_000;
+    else if (titleSection.startsWith(q)) score += 50;
+    else if (titleSection.includes(q)) score += 28;
+  }
+
+  if (urlSegments.includes(q)) score += 950;
   if (url.includes(q)) score += 12;
   if (description.includes(q)) score += 18;
   if (content.includes(q)) score += 12;
@@ -592,15 +639,17 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
       matched = true;
     }
 
-    if (section === word) {
-      score += 22;
-      matched = true;
-    } else if (section.startsWith(word)) {
-      score += 16;
-      matched = true;
-    } else if (section.includes(word)) {
-      score += 10;
-      matched = true;
+    if (hasDistinctSection) {
+      if (section === word) {
+        score += 22;
+        matched = true;
+      } else if (section.startsWith(word)) {
+        score += 16;
+        matched = true;
+      } else if (section.includes(word)) {
+        score += 10;
+        matched = true;
+      }
     }
 
     if (description.includes(word)) {
@@ -617,7 +666,11 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
   }
 
   if (words.length > 1) {
-    if (sectionTokens.length > 0 && words.every((word) => sectionTokens.includes(word))) {
+    if (
+      hasDistinctSection &&
+      sectionTokens.length > 0 &&
+      words.every((word) => sectionTokens.includes(word))
+    ) {
       score += 30;
     }
     if (
@@ -630,7 +683,7 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
   }
 
   if (matchedWords === words.length && words.length > 1) score += 20;
-  if (document.type === "heading") score += 6;
+  if (document.type === "heading" && hasDistinctSection) score += 6;
 
   return score;
 }

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -139,9 +139,7 @@ function literalMatchPriority(query: string, value?: string): number {
   if (text === q) return 2;
 
   const boundary = "[^\\p{L}\\p{N}]";
-  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
-    ? 1
-    : 0;
+  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text) ? 1 : 0;
 }
 
 function isLiteralLookupQuery(query: string): boolean {
@@ -547,7 +545,8 @@ function prioritizeLiteralInsideResults(
   if (!isLiteralLookupQuery(query)) return results;
 
   return [...results].sort((a, b) => {
-    const literalDelta = insideLiteralResultPriority(query, b) - insideLiteralResultPriority(query, a);
+    const literalDelta =
+      insideLiteralResultPriority(query, b) - insideLiteralResultPriority(query, a);
     if (literalDelta) return literalDelta;
     return 0;
   });

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -458,6 +458,47 @@ function mergeSearchResults(...groups: DocsSearchResult[][]): DocsSearchResult[]
   return results;
 }
 
+function buildExactPageSearchResults(
+  query: string,
+  pages: DocsSearchSourcePage[],
+): DocsSearchResult[] {
+  const normalizedQuery = normalizeSearchPhrase(query);
+  if (!normalizedQuery) return [];
+
+  const results: DocsSearchResult[] = [];
+
+  for (const page of pages) {
+    const document: DocsSearchDocument = {
+      id: makeDocumentId(page.url, "page"),
+      url: page.url,
+      title: page.title,
+      content: normalizeWhitespace(page.content),
+      description: page.description,
+      type: "page",
+      locale: page.locale,
+      framework: page.framework,
+      version: page.version,
+      tags: page.tags,
+    };
+    const title = normalizeSearchPhrase(page.title);
+    const urlSegments = getUrlSearchSegments(page.url);
+    const isExactPageMatch = title === normalizedQuery || urlSegments.includes(normalizedQuery);
+
+    if (!isExactPageMatch) continue;
+
+    results.push({
+      id: document.id,
+      url: document.url,
+      content: cleanSearchResultText(document.title) ?? document.title,
+      description: cleanSearchResultText(buildSnippet(document, query) ?? document.description),
+      type: "page",
+      score: scoreDocument(query, document) + 2_000,
+    });
+  }
+
+  return results.sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || a.url.localeCompare(b.url));
+}
+
 function shouldSupplementAskAIWithSimpleSearch(search: ResolvedDocsSearchConfig): boolean {
   return search.enabled && search.provider !== "simple";
 }
@@ -1487,7 +1528,11 @@ export async function performDocsSearch(options: {
   try {
     const adapter = await resolveSearchAdapter(search, context);
     await maybeSyncSearchIndex(adapter, search, context);
-    return await adapter.search(query, context);
+    const results = await adapter.search(query, context);
+    if (search.provider === "simple") return results;
+
+    return mergeSearchResults(buildExactPageSearchResults(options.query, options.pages), results)
+      .slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
   } catch {
     return createSimpleSearchAdapter().search(query, context);
   }

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -128,6 +128,28 @@ function normalizeSearchPhrase(value: string): string {
   return normalizeWhitespace(value.toLowerCase().replace(/[?!.,;:]+$/g, ""));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function literalMatchPriority(query: string, value?: string): number {
+  const q = normalizeSearchPhrase(query);
+  const text = normalizeSearchPhrase(value ?? "");
+  if (!q || !text) return 0;
+  if (text === q) return 2;
+
+  const boundary = "[^\\p{L}\\p{N}]";
+  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
+    ? 1
+    : 0;
+}
+
+function isLiteralLookupQuery(query: string): boolean {
+  const q = normalizeSearchPhrase(query);
+  const words = tokenizeSearchQuery(q);
+  return words.length > 0 && words.length <= 3 && words.join(" ") === q;
+}
+
 function tokenizeSearchQuery(query: string): string[] {
   return Array.from(
     new Set(
@@ -644,6 +666,18 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
   const sectionTokens = tokenizeSearchQuery(section);
 
   let score = 0;
+  const insideLiteralPriority =
+    document.type !== "page" && hasDistinctSection && isLiteralLookupQuery(q)
+      ? Math.max(
+          literalMatchPriority(q, section),
+          literalMatchPriority(q, description),
+          literalMatchPriority(q, content),
+        )
+      : 0;
+
+  if (insideLiteralPriority > 0) {
+    score += insideLiteralPriority * 2_250;
+  }
 
   if (title === q) score += 1_120;
   else if (title.startsWith(q)) score += 70;

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -521,6 +521,38 @@ function buildExactPageSearchResults(
   return results.sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || a.url.localeCompare(b.url));
 }
 
+function hasDistinctResultSection(result: DocsSearchResult): boolean {
+  if (result.type === "page") return false;
+  const section = normalizeSearchPhrase(stripHtml(result.section ?? ""));
+  if (!section) return true;
+
+  const label = normalizeSearchPhrase(stripHtml(result.content));
+  const title = label.split(/\s+[—–]\s+/)[0] ?? "";
+  return section !== normalizeSearchPhrase(title);
+}
+
+function insideLiteralResultPriority(query: string, result: DocsSearchResult): number {
+  if (!hasDistinctResultSection(result) || !isLiteralLookupQuery(query)) return 0;
+
+  return Math.max(
+    literalMatchPriority(query, stripHtml(result.section ?? "")),
+    literalMatchPriority(query, stripHtml(result.description ?? "")),
+  );
+}
+
+function prioritizeLiteralInsideResults(
+  query: string,
+  results: DocsSearchResult[],
+): DocsSearchResult[] {
+  if (!isLiteralLookupQuery(query)) return results;
+
+  return [...results].sort((a, b) => {
+    const literalDelta = insideLiteralResultPriority(query, b) - insideLiteralResultPriority(query, a);
+    if (literalDelta) return literalDelta;
+    return 0;
+  });
+}
+
 function shouldSupplementAskAIWithSimpleSearch(search: ResolvedDocsSearchConfig): boolean {
   return search.enabled && search.provider !== "simple";
 }
@@ -1565,8 +1597,10 @@ export async function performDocsSearch(options: {
     const results = await adapter.search(query, context);
     if (search.provider === "simple") return results;
 
-    return mergeSearchResults(buildExactPageSearchResults(options.query, options.pages), results)
-      .slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
+    return prioritizeLiteralInsideResults(
+      options.query,
+      mergeSearchResults(buildExactPageSearchResults(options.query, options.pages), results),
+    ).slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
   } catch {
     return createSimpleSearchAdapter().search(query, context);
   }

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -81,6 +81,48 @@ function normalizeSearchPhrase(value: string): string {
     .trim();
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function literalMatchPriority(query: string, value?: string): number {
+  const q = normalizeSearchPhrase(query);
+  const text = normalizeSearchPhrase(value ?? "");
+  if (!q || !text) return 0;
+  if (text === q) return 2;
+
+  const boundary = "[^\\p{L}\\p{N}]";
+  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
+    ? 1
+    : 0;
+}
+
+function tokenizeLiteralQuery(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}@/_:.-]+/gu, " ")
+        .split(/\s+/)
+        .map((word) => word.replace(/^[^\p{L}\p{N}@]+|[^\p{L}\p{N}]+$/gu, ""))
+        .filter((word) => word.length > 1),
+    ),
+  );
+}
+
+function isLiteralLookupQuery(query: string): boolean {
+  const q = normalizeSearchPhrase(query);
+  const words = tokenizeLiteralQuery(q);
+  return words.length > 0 && words.length <= 3 && words.join(" ") === q;
+}
+
+function hasDistinctSearchSection(result: SearchResult, label: string): boolean {
+  if (result.type === "page") return false;
+  if (!result.section) return true;
+  const title = label.split(/\s+[—–]\s+/)[0] ?? "";
+  return normalizeSearchPhrase(result.section) !== normalizeSearchPhrase(title);
+}
+
 function getUrlSearchSegments(url: string): string[] {
   try {
     const parsed = new URL(url, "https://docs.local");
@@ -305,6 +347,7 @@ interface ResultItem {
   type: SearchResult["type"];
   score: number;
   exactPriority: number;
+  insideLiteralPriority: number;
   sourceIndex: number;
   indices: number[];
   descriptionIndices: number[];
@@ -453,6 +496,14 @@ export function DocsCommandSearch({
             type: r.type,
             score,
             exactPriority: exactMatchPriority(debouncedQuery, sourceLabel, r.url),
+            insideLiteralPriority:
+              hasDistinctSearchSection(r, sourceLabel) && isLiteralLookupQuery(debouncedQuery)
+                ? Math.max(
+                    literalMatchPriority(debouncedQuery, sourceLabel),
+                    literalMatchPriority(debouncedQuery, label),
+                    literalMatchPriority(debouncedQuery, description),
+                  )
+                : 0,
             sourceIndex,
             indices,
             descriptionIndices: descriptionMatch.indices,
@@ -460,9 +511,10 @@ export function DocsCommandSearch({
         });
         items.sort(
           (a, b) =>
+            b.insideLiteralPriority - a.insideLiteralPriority ||
             b.exactPriority - a.exactPriority ||
-            a.sourceIndex - b.sourceIndex ||
             b.score - a.score ||
+            a.sourceIndex - b.sourceIndex ||
             a.label.localeCompare(b.label),
         );
         if (!cancelled) {
@@ -608,6 +660,7 @@ export function DocsCommandSearch({
       type: "page",
       score: 0,
       exactPriority: 0,
+      insideLiteralPriority: 0,
       sourceIndex: 0,
       indices: [],
       descriptionIndices: [],

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -92,9 +92,7 @@ function literalMatchPriority(query: string, value?: string): number {
   if (text === q) return 2;
 
   const boundary = "[^\\p{L}\\p{N}]";
-  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
-    ? 1
-    : 0;
+  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text) ? 1 : 0;
 }
 
 function tokenizeLiteralQuery(query: string): string[] {
@@ -823,8 +821,8 @@ export function DocsCommandSearch({
               {debouncedQuery && results.length > 0
                 ? `No ${FILTER_LABELS[filter].toLowerCase()} results found.`
                 : debouncedQuery
-                ? "No results found. Try a different query."
-                : "Type to search the docs, or browse recent items."}
+                  ? "No results found. Try a different query."
+                  : "Type to search the docs, or browse recent items."}
             </div>
           )}
         </div>

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -846,7 +846,6 @@ export function DocsCommandSearch({
               <button
                 type="button"
                 className="omni-filter-button"
-                aria-haspopup="menu"
                 aria-expanded={filterOpen}
                 onClick={() => setFilterOpen((value) => !value)}
               >
@@ -854,13 +853,12 @@ export function DocsCommandSearch({
                 <ArrowDownIcon />
               </button>
               {filterOpen && (
-                <div className="omni-filter-menu" role="menu" aria-label="Search filter">
+                <div className="omni-filter-menu" role="group" aria-label="Search filter">
                   {(["all", "pages", "inside"] as const).map((mode) => (
                     <button
                       key={mode}
                       type="button"
-                      role="menuitemradio"
-                      aria-checked={filter === mode}
+                      aria-pressed={filter === mode}
                       className={cn(
                         "omni-filter-option",
                         filter === mode && "omni-filter-option-active",

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -164,12 +164,6 @@ function fuzzyScore(query: string, text: string) {
   return { score, indices: Array.from(new Set(indices)).sort((a, b) => a - b) };
 }
 
-function isCodeLikeSnippet(text: string): boolean {
-  return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
-    text,
-  );
-}
-
 function HighlightedLabel({ label, indices = [] }: { label: string; indices?: number[] }) {
   if (!indices.length) return <>{label}</>;
   const out: ReactNode[] = [];
@@ -314,7 +308,6 @@ interface ResultItem {
   sourceIndex: number;
   indices: number[];
   descriptionIndices: number[];
-  descriptionCodeLike: boolean;
 }
 
 /**
@@ -463,7 +456,6 @@ export function DocsCommandSearch({
             sourceIndex,
             indices,
             descriptionIndices: descriptionMatch.indices,
-            descriptionCodeLike: description ? isCodeLikeSnippet(description) : false,
           };
         });
         items.sort(
@@ -619,7 +611,6 @@ export function DocsCommandSearch({
       sourceIndex: 0,
       indices: [],
       descriptionIndices: [],
-      descriptionCodeLike: false,
     }));
   }, [query, results, recents]);
 
@@ -751,12 +742,7 @@ export function DocsCommandSearch({
                           <HighlightedLabel label={item.label} indices={item.indices} />
                         </div>
                         {item.description && (
-                          <div
-                            className={cn(
-                              "omni-item-description",
-                              item.descriptionCodeLike && "omni-item-description-code",
-                            )}
-                          >
+                          <div className="omni-item-description">
                             <HighlightedLabel
                               label={item.description}
                               indices={item.descriptionIndices}

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -17,6 +17,7 @@ interface SearchResult {
   type: "page" | "heading" | "text";
   content: string;
   description?: string;
+  section?: string;
 }
 
 type RecentEntry = { id: string; label: string; url: string };
@@ -45,6 +46,75 @@ function stripSearchPreview(text: string): string {
     .replace(/`+/g, "")
     .replace(/\s{2,}/g, " ")
     .trim();
+}
+
+function breadcrumbForUrl(url: string): string {
+  try {
+    const parsed = new URL(url, "https://docs.local");
+    const parts = parsed.pathname
+      .split("/")
+      .filter(Boolean)
+      .map((part) =>
+        decodeURIComponent(part)
+          .replace(/[-_]+/g, " ")
+          .replace(/\b\w/g, (char) => char.toUpperCase()),
+      );
+    return parts.length > 0 ? parts.join(" > ") : "Docs";
+  } catch {
+    return "Docs";
+  }
+}
+
+function normalizeSearchPhrase(value: string): string {
+  return value.toLowerCase().replace(/[?!.,;:]+$/g, "").replace(/\s+/g, " ").trim();
+}
+
+function getUrlSearchSegments(url: string): string[] {
+  try {
+    const parsed = new URL(url, "https://docs.local");
+    return Array.from(
+      new Set(
+        parsed.pathname
+          .split("/")
+          .flatMap((segment) => {
+            const decoded = decodeURIComponent(segment);
+            return [decoded, decoded.replace(/[-_]+/g, " ")];
+          })
+          .map(normalizeSearchPhrase)
+          .filter(Boolean),
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function exactMatchPriority(query: string, label: string, url: string): number {
+  const q = normalizeSearchPhrase(query);
+  if (!q) return 0;
+
+  const normalizedLabel = normalizeSearchPhrase(label);
+  const joinedLabel = normalizeSearchPhrase(label.replace(/\s+[—–-]\s+/g, " "));
+  const labelParts = normalizedLabel
+    .split(/\s+[—–-]\s+/)
+    .map(normalizeSearchPhrase)
+    .filter(Boolean);
+
+  if (normalizedLabel === q || joinedLabel === q) return 4;
+  if (labelParts.includes(q)) return 3;
+  if (getUrlSearchSegments(url).includes(q)) return 2;
+  if (normalizedLabel.startsWith(q) || joinedLabel.startsWith(q)) return 1;
+  return 0;
+}
+
+function resultDisplayLabel(result: SearchResult): string {
+  const section = result.section ? stripSearchPreview(stripHtml(result.section)) : "";
+  if (section) return section;
+
+  const label = stripSearchPreview(stripHtml(result.content));
+  const parts = label.split(/\s+[—–]\s+/).map((part) => part.trim()).filter(Boolean);
+  if (result.type === "heading" && parts.length > 1) return parts[parts.length - 1] ?? label;
+  return label;
 }
 
 function fuzzyScore(query: string, text: string) {
@@ -121,82 +191,7 @@ function SearchIcon() {
   );
 }
 
-function FileIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
-      <path d="M14 2v4a2 2 0 0 0 2 2h4" />
-    </svg>
-  );
-}
-
-function HashIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="4" x2="20" y1="9" y2="9" />
-      <line x1="4" x2="20" y1="15" y2="15" />
-      <line x1="10" x2="8" y1="3" y2="21" />
-      <line x1="16" x2="14" y1="3" y2="21" />
-    </svg>
-  );
-}
-
-function TypeIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polyline points="4 7 4 4 20 4 20 7" />
-      <line x1="9" x2="15" y1="20" y2="20" />
-      <line x1="12" x2="12" y1="4" y2="20" />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
-  );
-}
-
-function EnterIcon() {
+function ArrowDownIcon() {
   return (
     <svg
       width="12"
@@ -208,8 +203,7 @@ function EnterIcon() {
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <polyline points="9 10 4 15 9 20" />
-      <path d="M20 4v7a4 4 0 0 1-4 4H4" />
+      <path d="m6 9 6 6 6-6" />
     </svg>
   );
 }
@@ -231,7 +225,7 @@ function ArrowUpIcon() {
   );
 }
 
-function ArrowDownIcon() {
+function CornerDownLeftIcon() {
   return (
     <svg
       width="12"
@@ -243,43 +237,8 @@ function ArrowDownIcon() {
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <path d="m6 9 6 6 6-6" />
-    </svg>
-  );
-}
-
-function ExternalLinkIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M15 3h6v6" />
-      <path d="M10 14 21 3" />
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-    </svg>
-  );
-}
-
-function ChevronRightIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="m9 18 6-6-6-6" />
+      <path d="m9 10-5 5 5 5" />
+      <path d="M20 4v7a4 4 0 0 1-4 4H4" />
     </svg>
   );
 }
@@ -321,37 +280,15 @@ function HistoryIcon() {
   );
 }
 
-function iconForType(type: string) {
-  switch (type) {
-    case "heading":
-      return <HashIcon />;
-    case "text":
-      return <TypeIcon />;
-    default:
-      return <FileIcon />;
-  }
-}
-
-function labelForType(type: string) {
-  switch (type) {
-    case "page":
-      return "Page";
-    case "heading":
-      return "Section";
-    case "text":
-      return "Content";
-    default:
-      return "Result";
-  }
-}
-
 interface ResultItem {
   id: string;
   label: string;
   subtitle: string;
+  description?: string;
   url: string;
-  icon: ReactNode;
   score: number;
+  exactPriority: number;
+  sourceIndex: number;
   indices: number[];
 }
 
@@ -466,22 +403,33 @@ export function DocsCommandSearch({
         const res = await fetch(requestUrl.toString());
         if (!res.ok || cancelled) return;
         const data: SearchResult[] = await res.json();
-        const items: ResultItem[] = data.map((r) => {
-          const label = stripSearchPreview(stripHtml(r.content));
+        const items: ResultItem[] = data.map((r, sourceIndex) => {
+          const sourceLabel = stripSearchPreview(stripHtml(r.content));
+          const label = resultDisplayLabel(r);
+          const description = r.description
+            ? stripSearchPreview(stripHtml(r.description)).slice(0, 220)
+            : undefined;
           const { score, indices } = fuzzyScore(debouncedQuery, label);
+          const url = withLangInUrl(r.url, activeLocale);
           return {
             id: r.id,
             label,
-            subtitle: r.description
-              ? stripSearchPreview(stripHtml(r.description))
-              : labelForType(r.type),
-            url: withLangInUrl(r.url, activeLocale),
-            icon: iconForType(r.type),
+            subtitle: breadcrumbForUrl(r.url),
+            description,
+            url,
             score,
+            exactPriority: exactMatchPriority(debouncedQuery, sourceLabel, r.url),
+            sourceIndex,
             indices,
           };
         });
-        items.sort((a, b) => b.score - a.score || a.label.localeCompare(b.label));
+        items.sort(
+          (a, b) =>
+            b.exactPriority - a.exactPriority ||
+            a.sourceIndex - b.sourceIndex ||
+            b.score - a.score ||
+            a.label.localeCompare(b.label),
+        );
         if (!cancelled) {
           setResults(items);
           setActiveIndex(0);
@@ -611,8 +559,9 @@ export function DocsCommandSearch({
       label: r.label,
       subtitle: "Recently viewed",
       url: r.url,
-      icon: <FileIcon />,
       score: 0,
+      exactPriority: 0,
+      sourceIndex: 0,
       indices: [],
     }));
   }, [query, results, recents]);
@@ -666,19 +615,18 @@ export function DocsCommandSearch({
               type="text"
               role="combobox"
               aria-expanded="true"
-              placeholder="Search documentation…"
+              placeholder="Search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
               className="omni-search-input"
             />
-            <kbd className="omni-kbd">⌘ K</kbd>
             <button
               aria-label="Close"
               className="omni-close-btn"
               onClick={() => setOpenWithAnalytics(false, "button")}
             >
-              <CloseIcon />
+              ESC
             </button>
           </div>
         </div>
@@ -704,24 +652,10 @@ export function DocsCommandSearch({
                     onClick={() => execute(item)}
                     className={cn("omni-item", i === activeIndex && "omni-item-active")}
                   >
-                    <div className="omni-item-icon">{item.icon}</div>
                     <div className="omni-item-text">
-                      <div className="omni-item-label">{item.label}</div>
                       <div className="omni-item-subtitle">{item.subtitle}</div>
+                      <div className="omni-item-label">{item.label}</div>
                     </div>
-                    <a
-                      href={item.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="omni-item-ext"
-                      title="Open in new tab"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                      }}
-                    >
-                      <ExternalLinkIcon />
-                    </a>
-                    <ChevronRightIcon />
                   </button>
                 ))}
               </div>
@@ -744,26 +678,15 @@ export function DocsCommandSearch({
                       onClick={() => execute(item)}
                       className={cn("omni-item", idx === activeIndex && "omni-item-active")}
                     >
-                      <div className="omni-item-icon">{item.icon}</div>
                       <div className="omni-item-text">
+                        <div className="omni-item-subtitle">{item.subtitle}</div>
                         <div className="omni-item-label">
                           <HighlightedLabel label={item.label} indices={item.indices} />
                         </div>
-                        <div className="omni-item-subtitle">{item.subtitle}</div>
+                        {item.description && (
+                          <div className="omni-item-description">{item.description}</div>
+                        )}
                       </div>
-                      <a
-                        href={item.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="omni-item-ext"
-                        title="Open in new tab"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                      >
-                        <ExternalLinkIcon />
-                      </a>
-                      <ChevronRightIcon />
                     </button>
                   );
                 })}
@@ -787,14 +710,21 @@ export function DocsCommandSearch({
           <div className="omni-footer-inner">
             <div className="omni-footer-hints">
               <span className="omni-footer-hint">
-                <EnterIcon /> to select
+                <CornerDownLeftIcon /> to select
               </span>
               <span className="omni-footer-hint">
                 <ArrowUpIcon />
                 <ArrowDownIcon /> to navigate
               </span>
               <span className="omni-footer-hint omni-footer-hint-desktop">
-                <CloseIcon /> to close
+                <span className="omni-kbd-sm">ESC</span> to close
+              </span>
+            </div>
+            <div className="omni-footer-filter">
+              <span className="omni-filter-label">Filter</span>
+              <span className="omni-filter-value">
+                All
+                <ArrowDownIcon />
               </span>
             </div>
           </div>

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -21,6 +21,13 @@ interface SearchResult {
 }
 
 type RecentEntry = { id: string; label: string; url: string };
+type SearchFilter = "all" | "pages" | "inside";
+
+const FILTER_LABELS: Record<SearchFilter, string> = {
+  all: "All",
+  pages: "Pages",
+  inside: "Inside pages",
+};
 
 function stripHtml(html: string): string {
   if (typeof document !== "undefined") {
@@ -293,6 +300,7 @@ interface ResultItem {
   subtitle: string;
   description?: string;
   url: string;
+  type: SearchResult["type"];
   score: number;
   exactPriority: number;
   sourceIndex: number;
@@ -321,6 +329,8 @@ export function DocsCommandSearch({
   const [loading, setLoading] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const [recents, setRecents] = useState<RecentEntry[]>([]);
+  const [filter, setFilter] = useState<SearchFilter>("all");
+  const [filterOpen, setFilterOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
@@ -328,6 +338,7 @@ export function DocsCommandSearch({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const searchCacheRef = useRef(new Map<string, ResultItem[]>());
 
   const setOpenWithAnalytics = useCallback(
     (nextOpen: boolean, trigger: string) => {
@@ -400,6 +411,15 @@ export function DocsCommandSearch({
       return;
     }
     let cancelled = false;
+    const controller = new AbortController();
+    const cacheKey = `${activeLocale ?? ""}:${searchApi}:${debouncedQuery}`;
+    const cached = searchCacheRef.current.get(cacheKey);
+    if (cached) {
+      setResults(cached);
+      setActiveIndex(0);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
 
     (async () => {
@@ -407,7 +427,7 @@ export function DocsCommandSearch({
       try {
         const requestUrl = new URL(searchApi, window.location.origin);
         requestUrl.searchParams.set("query", debouncedQuery);
-        const res = await fetch(requestUrl.toString());
+        const res = await fetch(requestUrl.toString(), { signal: controller.signal });
         if (!res.ok || cancelled) return;
         const data: SearchResult[] = await res.json();
         const items: ResultItem[] = data.map((r, sourceIndex) => {
@@ -424,6 +444,7 @@ export function DocsCommandSearch({
             subtitle: breadcrumbForUrl(r.url),
             description,
             url,
+            type: r.type,
             score,
             exactPriority: exactMatchPriority(debouncedQuery, sourceLabel, r.url),
             sourceIndex,
@@ -438,6 +459,11 @@ export function DocsCommandSearch({
             a.label.localeCompare(b.label),
         );
         if (!cancelled) {
+          if (searchCacheRef.current.size >= 20) {
+            const firstKey = searchCacheRef.current.keys().next().value;
+            if (firstKey) searchCacheRef.current.delete(firstKey);
+          }
+          searchCacheRef.current.set(cacheKey, items);
           setResults(items);
           setActiveIndex(0);
           if (analytics) {
@@ -454,6 +480,7 @@ export function DocsCommandSearch({
           }
         }
       } catch {
+        if (controller.signal.aborted) return;
         if (!cancelled && analytics) {
           emitClientAnalyticsEvent({
             type: "search_error",
@@ -471,6 +498,7 @@ export function DocsCommandSearch({
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [activeLocale, analytics, debouncedQuery, searchApi]);
 
@@ -480,6 +508,8 @@ export function DocsCommandSearch({
     } else {
       setQuery("");
       setResults([]);
+      setFilter("all");
+      setFilterOpen(false);
       setActiveIndex(0);
     }
   }, [open]);
@@ -555,9 +585,11 @@ export function DocsCommandSearch({
   );
 
   const displayItems = useMemo(() => {
-    if (results.length > 0) return results;
-    return [];
-  }, [results]);
+    if (results.length === 0) return [];
+    if (filter === "pages") return results.filter((item) => item.type === "page");
+    if (filter === "inside") return results.filter((item) => item.type !== "page");
+    return results;
+  }, [filter, results]);
 
   const recentItems = useMemo((): ResultItem[] => {
     if (query.trim() || results.length > 0) return [];
@@ -566,12 +598,23 @@ export function DocsCommandSearch({
       label: r.label,
       subtitle: "Recently viewed",
       url: r.url,
+      type: "page",
       score: 0,
       exactPriority: 0,
       sourceIndex: 0,
       indices: [],
     }));
   }, [query, results, recents]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filter, debouncedQuery]);
+
+  function updateFilter(nextFilter: SearchFilter) {
+    setFilter(nextFilter);
+    setFilterOpen(false);
+    setActiveIndex(0);
+  }
 
   function moveActive(delta: number) {
     const total = displayItems.length + recentItems.length;
@@ -706,7 +749,9 @@ export function DocsCommandSearch({
               <div className="omni-empty-icon">
                 <HistoryIcon />
               </div>
-              {debouncedQuery
+              {debouncedQuery && results.length > 0
+                ? `No ${FILTER_LABELS[filter].toLowerCase()} results found.`
+                : debouncedQuery
                 ? "No results found. Try a different query."
                 : "Type to search the docs, or browse recent items."}
             </div>
@@ -729,10 +774,35 @@ export function DocsCommandSearch({
             </div>
             <div className="omni-footer-filter">
               <span className="omni-filter-label">Filter</span>
-              <span className="omni-filter-value">
-                All
+              <button
+                type="button"
+                className="omni-filter-button"
+                aria-haspopup="menu"
+                aria-expanded={filterOpen}
+                onClick={() => setFilterOpen((value) => !value)}
+              >
+                {FILTER_LABELS[filter]}
                 <ArrowDownIcon />
-              </span>
+              </button>
+              {filterOpen && (
+                <div className="omni-filter-menu" role="menu" aria-label="Search filter">
+                  {(["all", "pages", "inside"] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={filter === mode}
+                      className={cn(
+                        "omni-filter-option",
+                        filter === mode && "omni-filter-option-active",
+                      )}
+                      onClick={() => updateFilter(mode)}
+                    >
+                      {FILTER_LABELS[mode]}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -164,26 +164,33 @@ function fuzzyScore(query: string, text: string) {
   return { score, indices: Array.from(new Set(indices)).sort((a, b) => a - b) };
 }
 
-function HighlightedLabel({ label, indices }: { label: string; indices: number[] }) {
+function isCodeLikeSnippet(text: string): boolean {
+  return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
+    text,
+  );
+}
+
+function HighlightedLabel({ label, indices = [] }: { label: string; indices?: number[] }) {
   if (!indices.length) return <>{label}</>;
   const out: ReactNode[] = [];
-  for (let pos = 0; pos < label.length; pos++) {
-    if (indices.includes(pos)) {
-      let run = label[pos];
-      let p = pos + 1;
-      while (indices.includes(p) && p < label.length) {
-        run += label[p];
-        p++;
-      }
+  const highlighted = new Set(indices);
+  let pos = 0;
+  while (pos < label.length) {
+    const marked = highlighted.has(pos);
+    let end = pos + 1;
+    while (end < label.length && highlighted.has(end) === marked) end++;
+    const run = label.slice(pos, end);
+
+    if (marked) {
       out.push(
         <mark key={`m-${pos}`} className="omni-highlight">
           {run}
         </mark>,
       );
-      pos = p - 1;
     } else {
-      out.push(<span key={`t-${pos}`}>{label[pos]}</span>);
+      out.push(<span key={`t-${pos}`}>{run}</span>);
     }
+    pos = end;
   }
   return <>{out}</>;
 }
@@ -306,6 +313,8 @@ interface ResultItem {
   exactPriority: number;
   sourceIndex: number;
   indices: number[];
+  descriptionIndices: number[];
+  descriptionCodeLike: boolean;
 }
 
 /**
@@ -438,6 +447,9 @@ export function DocsCommandSearch({
             ? stripSearchPreview(stripHtml(r.description)).slice(0, 220)
             : undefined;
           const { score, indices } = fuzzyScore(debouncedQuery, label);
+          const descriptionMatch = description
+            ? fuzzyScore(debouncedQuery, description)
+            : { indices: [] };
           const url = withLangInUrl(r.url, activeLocale);
           return {
             id: r.id,
@@ -450,6 +462,8 @@ export function DocsCommandSearch({
             exactPriority: exactMatchPriority(debouncedQuery, sourceLabel, r.url),
             sourceIndex,
             indices,
+            descriptionIndices: descriptionMatch.indices,
+            descriptionCodeLike: description ? isCodeLikeSnippet(description) : false,
           };
         });
         items.sort(
@@ -604,6 +618,8 @@ export function DocsCommandSearch({
       exactPriority: 0,
       sourceIndex: 0,
       indices: [],
+      descriptionIndices: [],
+      descriptionCodeLike: false,
     }));
   }, [query, results, recents]);
 
@@ -735,7 +751,17 @@ export function DocsCommandSearch({
                           <HighlightedLabel label={item.label} indices={item.indices} />
                         </div>
                         {item.description && (
-                          <div className="omni-item-description">{item.description}</div>
+                          <div
+                            className={cn(
+                              "omni-item-description",
+                              item.descriptionCodeLike && "omni-item-description-code",
+                            )}
+                          >
+                            <HighlightedLabel
+                              label={item.description}
+                              indices={item.descriptionIndices}
+                            />
+                          </div>
                         )}
                       </div>
                     </button>

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -499,8 +499,7 @@ export function DocsCommandSearch({
             insideLiteralPriority:
               hasDistinctSearchSection(r, sourceLabel) && isLiteralLookupQuery(debouncedQuery)
                 ? Math.max(
-                    literalMatchPriority(debouncedQuery, sourceLabel),
-                    literalMatchPriority(debouncedQuery, label),
+                    literalMatchPriority(debouncedQuery, r.section),
                     literalMatchPriority(debouncedQuery, description),
                   )
                 : 0,
@@ -509,14 +508,20 @@ export function DocsCommandSearch({
             descriptionIndices: descriptionMatch.indices,
           };
         });
-        items.sort(
-          (a, b) =>
-            b.insideLiteralPriority - a.insideLiteralPriority ||
+        items.sort((a, b) => {
+          const literalDelta = b.insideLiteralPriority - a.insideLiteralPriority;
+          if (literalDelta) return literalDelta;
+          if (a.insideLiteralPriority > 0 && b.insideLiteralPriority > 0) {
+            return a.sourceIndex - b.sourceIndex;
+          }
+
+          return (
             b.exactPriority - a.exactPriority ||
             b.score - a.score ||
             a.sourceIndex - b.sourceIndex ||
-            a.label.localeCompare(b.label),
-        );
+            a.label.localeCompare(b.label)
+          );
+        });
         if (!cancelled) {
           if (searchCacheRef.current.size >= 20) {
             const firstKey = searchCacheRef.current.keys().next().value;

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -66,7 +66,11 @@ function breadcrumbForUrl(url: string): string {
 }
 
 function normalizeSearchPhrase(value: string): string {
-  return value.toLowerCase().replace(/[?!.,;:]+$/g, "").replace(/\s+/g, " ").trim();
+  return value
+    .toLowerCase()
+    .replace(/[?!.,;:]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function getUrlSearchSegments(url: string): string[] {
@@ -112,7 +116,10 @@ function resultDisplayLabel(result: SearchResult): string {
   if (section) return section;
 
   const label = stripSearchPreview(stripHtml(result.content));
-  const parts = label.split(/\s+[—–]\s+/).map((part) => part.trim()).filter(Boolean);
+  const parts = label
+    .split(/\s+[—–]\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
   if (result.type === "heading" && parts.length > 1) return parts[parts.length - 1] ?? label;
   return label;
 }

--- a/packages/fumadocs/src/docs-command-search.tsx
+++ b/packages/fumadocs/src/docs-command-search.tsx
@@ -22,6 +22,7 @@ interface SearchResult {
 
 type RecentEntry = { id: string; label: string; url: string };
 type SearchFilter = "all" | "pages" | "inside";
+const BREADCRUMB_SEPARATOR = "\u00a0\u00a0>\u00a0\u00a0";
 
 const FILTER_LABELS: Record<SearchFilter, string> = {
   all: "All",
@@ -66,7 +67,7 @@ function breadcrumbForUrl(url: string): string {
           .replace(/[-_]+/g, " ")
           .replace(/\b\w/g, (char) => char.toUpperCase()),
       );
-    return parts.length > 0 ? parts.join(" > ") : "Docs";
+    return parts.length > 0 ? parts.join(BREADCRUMB_SEPARATOR) : "Docs";
   } catch {
     return "Docs";
   }

--- a/packages/fumadocs/styles/command-grid.css
+++ b/packages/fumadocs/styles/command-grid.css
@@ -605,6 +605,7 @@ figure.shiki:has(figcaption) > div:first-child,
 }
 
 .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -68,7 +68,7 @@
   top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(640px, calc(100% - 1rem));
+  width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   background: var(--color-fd-popover, #fafafa);
@@ -163,10 +163,10 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 460px;
+  max-height: 540px;
   overflow: auto;
   overscroll-behavior: contain;
-  padding: 0.25rem;
+  padding: 0.5rem;
 }
 .omni-body::-webkit-scrollbar {
   width: 6px;
@@ -199,6 +199,7 @@
 .omni-group-items {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 /* Items */
@@ -208,7 +209,7 @@
   width: 100%;
   flex-shrink: 0;
   border-radius: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.75rem 0.875rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -246,6 +247,7 @@
   white-space: nowrap;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   font-weight: 500;
+  line-height: 1.35;
 }
 .omni-item-subtitle {
   min-width: 0;
@@ -265,12 +267,14 @@
   min-width: 0;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  margin-top: 0.25rem;
+  margin-top: 0.625rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
   font-size: 0.875rem;
-  line-height: 1.35rem;
+  line-height: 1.5rem;
   font-weight: 400;
 }
 .omni-item-badge {
@@ -369,6 +373,14 @@
   white-space: nowrap;
 }
 .omni-footer-hint svg {
+  box-sizing: border-box;
+  width: 1.375rem;
+  height: 1.375rem;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 70%, transparent);
+  color: var(--color-fd-muted-foreground, #737373);
   flex-shrink: 0;
 }
 .omni-footer-hint-desktop {

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -65,7 +65,7 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: clamp(1rem, 8vh, 8rem);
+  top: clamp(1.5rem, 10vh, 6rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -63,9 +63,10 @@
 }
 
 .omni-content {
+  --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
   z-index: 51;
-  top: clamp(1.5rem, 10vh, 6rem);
+  top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -86,7 +87,8 @@
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 1rem;
+    --omni-content-top: 1rem;
+    top: var(--omni-content-top);
     width: calc(100% - 1rem);
     max-height: calc(100vh - 2rem);
   }
@@ -167,7 +169,7 @@
 .omni-body {
   flex: 1 1 auto;
   min-height: 0;
-  max-height: min(540px, calc(100vh - 10.5rem));
+  max-height: min(540px, calc(100vh - var(--omni-content-top, 7rem) - 8rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -65,9 +65,11 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: calc(50% - 250px);
+  top: clamp(1rem, 8vh, 8rem);
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
   width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
@@ -163,7 +165,9 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 540px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(540px, calc(100vh - 10.5rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;
@@ -387,6 +391,7 @@
   display: none;
 }
 .omni-footer-filter {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -406,4 +411,47 @@
   align-items: center;
   gap: 0.25rem;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+}
+.omni-filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.omni-filter-button:hover {
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+}
+.omni-filter-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 1;
+  width: 10rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  border-radius: 0.5rem;
+  background: var(--color-fd-popover, #fafafa);
+  padding: 0.25rem;
+  box-shadow: 0 16px 32px -20px rgba(0, 0, 0, 0.45);
+}
+.omni-filter-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+}
+.omni-filter-option:hover,
+.omni-filter-option-active {
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -80,7 +80,6 @@
       ui-sans-serif, sans-serif);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
-  overflow: hidden;
   overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -315,10 +314,6 @@
 .omni-item-chevron {
   display: none;
 }
-.omni-item:hover .omni-item-chevron {
-  opacity: 1;
-}
-
 /* Highlight */
 .omni-highlight {
   border-radius: 0;

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -282,29 +282,8 @@
   font-weight: 400;
 }
 .omni-item-description-code {
-  display: block;
-  max-height: 4.75rem;
-  padding: 0.5rem 0.625rem;
-  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
-  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
-  border-radius: 0.375rem;
-  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace);
-  font-size: 0.8125rem;
-  line-height: 1.45rem;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.omni-item-active .omni-item-description-code {
-  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
-}
-.omni-item-description-code .omni-highlight {
-  border-radius: 0.1875rem;
-  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
-  padding: 0 0.125rem;
-  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
-  text-decoration: none;
 }
 .omni-item-badge {
   display: none;

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -283,10 +283,6 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
-.omni-item-description-code {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace);
-}
 .omni-item-badge {
   display: none;
 }

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -22,7 +22,7 @@
 @keyframes omni-scale-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
   to {
     opacity: 1;
@@ -36,7 +36,7 @@
   }
   to {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
 }
 
@@ -56,28 +56,26 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
 }
 
 .omni-content {
   position: fixed;
-  z-index: 101;
-  top: 18%;
+  z-index: 51;
+  top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(720px, calc(100% - 32px));
-  border-radius: var(--radius, 0.75rem);
-  border: 1px solid var(--color-fd-border, #262626);
-  background: var(--color-fd-popover, #0c0c0c);
-  color: var(--color-fd-foreground, #fafafa);
+  width: min(640px, calc(100% - 1rem));
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
+  background: var(--color-fd-popover, #fafafa);
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   font-family: var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
       ui-sans-serif, sans-serif);
-  box-shadow:
-    0 24px 60px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
   overflow: hidden;
   overscroll-behavior: contain;
@@ -86,12 +84,9 @@
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 10%;
-    width: calc(100% - 24px);
-    max-height: 75vh;
-  }
-  .omni-kbd {
-    display: none;
+    top: 1rem;
+    width: calc(100% - 1rem);
+    max-height: calc(100vh - 2rem);
   }
 }
 
@@ -103,51 +98,72 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  padding: 0.75rem;
 }
 .omni-search-icon {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
+.omni-search-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
 .omni-search-input {
+  width: 0;
   flex: 1;
   background: transparent;
   outline: none;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  color: var(--color-fd-foreground, #fafafa);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   border: none;
 }
 .omni-search-input::placeholder {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-kbd {
-  border-radius: 0.25rem;
-  background: var(--color-fd-muted, #262626);
-  padding: 0.125rem 0.375rem;
-  font-size: 10px;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: transparent;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace);
-  line-height: 1.4;
+  line-height: 1rem;
 }
 .omni-close-btn {
-  margin-left: 0.25rem;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 2.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  padding: 0.375rem 0.5rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  transition: background 120ms;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  transition:
+    background 120ms,
+    color 120ms;
   cursor: pointer;
-  border: none;
   background: none;
 }
 .omni-close-btn:hover {
-  background: var(--color-fd-muted, #262626);
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+  background: var(--color-fd-accent, #e5e5e5);
+}
+.omni-close-btn svg {
+  display: none;
 }
 
 /* Body / listbox */
 .omni-body {
-  max-height: 60vh;
+  max-height: 460px;
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.25rem;
@@ -168,22 +184,17 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.625rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
 
 /* Groups */
 .omni-group {
-  padding: 0.25rem 0;
+  padding: 0;
 }
 .omni-group-label {
-  padding: 0.25rem 0.75rem;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-weight: 500;
+  display: none;
 }
 .omni-group-items {
   display: flex;
@@ -192,12 +203,12 @@
 
 /* Items */
 .omni-item {
-  display: flex;
+  position: relative;
+  display: block;
   width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: calc(var(--radius, 0.75rem) - 4px);
-  padding: 0.5rem 0.75rem;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.625rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -209,10 +220,10 @@
 }
 .omni-item:hover,
 .omni-item-active {
-  background: color-mix(in srgb, var(--color-fd-accent, #262626) 60%, transparent);
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }
 .omni-item-active {
-  color: var(--color-fd-accent-foreground, #fafafa);
+  color: var(--color-fd-accent-foreground, #171717);
 }
 .omni-item-disabled {
   opacity: 0.5;
@@ -220,51 +231,53 @@
 }
 
 .omni-item-icon {
-  flex-shrink: 0;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
+  display: none;
 }
 .omni-item-active .omni-item-icon {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
 .omni-item-text {
-  flex: 1;
   min-width: 0;
 }
 .omni-item-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-weight: 500;
 }
 .omni-item-subtitle {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.75rem;
+  line-height: 1rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0.8;
+  opacity: 1;
 }
 .omni-item-active .omni-item-subtitle {
-  color: var(--color-fd-accent-foreground, #fafafa);
-  opacity: 0.7;
+  color: var(--color-fd-muted-foreground, #737373);
+  opacity: 1;
+}
+.omni-item-description {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-top: 0.25rem;
+  color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35rem;
+  font-weight: 400;
 }
 .omni-item-badge {
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
+  display: none;
 }
 .omni-item-ext {
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
-  transition:
-    color 100ms,
-    background 100ms;
-  text-decoration: none;
+  display: none;
 }
 .omni-item-ext:hover {
   color: var(--color-fd-foreground, #fafafa);
@@ -290,13 +303,7 @@
       "Liberation Mono", "Courier New", monospace);
 }
 .omni-item-chevron {
-  width: 0.875rem;
-  height: 0.875rem;
-  margin-left: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0;
-  transition: opacity 120ms;
-  flex-shrink: 0;
+  display: none;
 }
 .omni-item:hover .omni-item-chevron {
   opacity: 1;
@@ -304,10 +311,12 @@
 
 /* Highlight */
 .omni-highlight {
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 30%, transparent);
-  padding: 0 2px;
-  color: inherit;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--color-fd-primary, #ca8a04);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Empty states */
@@ -317,7 +326,7 @@
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-empty {
-  padding: 2rem 0.75rem;
+  padding: 1.5rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
@@ -336,30 +345,53 @@
 /* Footer */
 .omni-footer {
   border-top: 1px solid var(--color-fd-border, #262626);
+  background: color-mix(in srgb, var(--color-fd-secondary, #f5f5f5) 50%, transparent);
 }
 .omni-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-footer-hints {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 .omni-footer-hint {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  white-space: nowrap;
+}
+.omni-footer-hint svg {
+  flex-shrink: 0;
 }
 .omni-footer-hint-desktop {
   display: none;
+}
+.omni-footer-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  white-space: nowrap;
 }
 @media (min-width: 640px) {
   .omni-footer-hint-desktop {
     display: flex;
   }
+}
+.omni-filter-label {
+  color: var(--color-fd-muted-foreground, #a3a3a3);
+}
+.omni-filter-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
 }

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -281,6 +281,31 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
+.omni-item-description-code {
+  display: block;
+  max-height: 4.75rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.8125rem;
+  line-height: 1.45rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.omni-item-active .omni-item-description-code {
+  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
+}
+.omni-item-description-code .omni-highlight {
+  border-radius: 0.1875rem;
+  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
+  padding: 0 0.125rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  text-decoration: none;
+}
 .omni-item-badge {
   display: none;
 }

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -965,7 +965,7 @@ hr {
 }
 
 .omni-search-input {
-  font-family: var(--fd-font-mono, ui-monospace, monospace);
+  font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif);
 }
 
 .omni-group-label {

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -986,11 +986,6 @@ hr {
   border-radius: 0 !important;
 }
 
-.omni-item-description-code,
-.omni-item-description-code .omni-highlight {
-  border-radius: 0 !important;
-}
-
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent);
   border-radius: 0 !important;

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -969,13 +969,16 @@ hr {
 }
 
 .omni-group-label {
-  display: block !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   letter-spacing: 0.08em;
 }
 
 .omni-footer-inner {
   font-family: var(--fd-font-mono, ui-monospace, monospace);
+}
+
+.omni-footer-hint svg {
+  border-radius: 0 !important;
 }
 
 .omni-highlight {

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -981,6 +981,11 @@ hr {
   border-radius: 0 !important;
 }
 
+.omni-filter-menu,
+.omni-filter-option {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent);
   border-radius: 0 !important;

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -969,6 +969,7 @@ hr {
 }
 
 .omni-group-label {
+  display: block !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace);
   letter-spacing: 0.08em;
 }

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -986,6 +986,11 @@ hr {
   border-radius: 0 !important;
 }
 
+.omni-item-description-code,
+.omni-item-description-code .omni-highlight {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent);
   border-radius: 0 !important;

--- a/packages/fumadocs/styles/threadline.css
+++ b/packages/fumadocs/styles/threadline.css
@@ -693,7 +693,7 @@ figure.shiki button[aria-label*="Copy"]:hover {
     inset-inline-start: var(--fd-threadline-frame-gutter) !important;
     width: var(--fd-sidebar-width, 260px) !important;
     height: calc(100vh - var(--docs-header-height, 48px)) !important;
-    z-index: 102 !important;
+    z-index: 49 !important;
     pointer-events: none !important;
   }
 
@@ -710,24 +710,19 @@ figure.shiki button[aria-label*="Copy"]:hover {
     ) !important;
     width: var(--fd-toc-width, 224px) !important;
     height: calc(100vh - var(--docs-header-height, 48px)) !important;
+    z-index: 49 !important;
     pointer-events: none !important;
   }
 
   body:has(#nd-sidebar) .omni-overlay {
-    left: calc(var(--fd-threadline-frame-gutter) + var(--fd-sidebar-width, 260px)) !important;
+    left: 0 !important;
     right: 0 !important;
     width: auto !important;
   }
 
   body:has(#nd-sidebar) .omni-content {
-    left: calc(
-      var(--fd-threadline-frame-gutter) + var(--fd-sidebar-width, 260px) +
-        (var(--fd-threadline-main-width) + var(--fd-toc-width, 224px)) / 2
-    ) !important;
-    width: min(
-      720px,
-      calc(var(--fd-threadline-main-width) + var(--fd-toc-width, 224px) - 32px)
-    ) !important;
+    left: 50% !important;
+    width: min(720px, calc(100% - 1rem)) !important;
   }
 }
 

--- a/packages/fumadocs/styles/threadline.css
+++ b/packages/fumadocs/styles/threadline.css
@@ -775,6 +775,7 @@ figure.shiki button[aria-label*="Copy"]:hover {
 }
 
 .omni-group-label {
+  display: block !important;
   color: var(--muted-foreground) !important;
   font-size: 0.6875rem !important;
   font-weight: 500 !important;

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -15,7 +15,9 @@ const emit = defineEmits<{ (e: "close"): void }>();
 const route = useRoute();
 
 const query = ref("");
-const currentResults = ref<{ content: string; url: string; description?: string }[]>([]);
+const currentResults = ref<
+  { content: string; url: string; description?: string; section?: string; type?: string }[]
+>([]);
 const loading = ref(false);
 const activeIndex = ref(0);
 const inputEl = ref<HTMLInputElement | null>(null);
@@ -60,9 +62,40 @@ function withLang(url: string): string {
   }
 }
 
+function breadcrumbForUrl(url: string): string {
+  try {
+    const parsed = new URL(url, "https://farming-labs.local");
+    const parts = parsed.pathname
+      .split("/")
+      .filter(Boolean)
+      .map((part) =>
+        decodeURIComponent(part)
+          .replace(/[-_]+/g, " ")
+          .replace(/\b\w/g, (char) => char.toUpperCase()),
+      );
+    return parts.length ? parts.join(" > ") : "Docs";
+  } catch {
+    return "Docs";
+  }
+}
+
+function displayLabelForResult(result: { content: string; section?: string; type?: string }): string {
+  if (result.section) return result.section;
+  const parts = result.content.split(/\s+[—–]\s+/).map((part) => part.trim()).filter(Boolean);
+  return result.type === "heading" && parts.length > 1 ? (parts[parts.length - 1] ?? result.content) : result.content;
+}
+
 const allItems = computed(() => {
   const q = query.value.trim();
-  if (q && currentResults.value.length) return currentResults.value.map((r) => ({ id: r.url, label: r.content, url: r.url, subtitle: r.description ?? "Page" }));
+  if (q && currentResults.value.length) {
+    return currentResults.value.map((r) => ({
+      id: r.url,
+      label: displayLabelForResult(r),
+      url: r.url,
+      subtitle: breadcrumbForUrl(r.url),
+      description: r.description,
+    }));
+  }
   return recentsList.value.map((r) => ({ id: r.id, label: r.label, url: r.url, subtitle: "Recently viewed" }));
 });
 
@@ -183,16 +216,6 @@ function onRowClick(item: { url: string; label?: string; content?: string }) {
   executeItem(item);
 }
 
-function onExternalClick(e: Event, url: string) {
-  e.preventDefault();
-  e.stopPropagation();
-  try {
-    window.open(withLang(url), "_blank", "noopener,noreferrer");
-  } catch {
-    window.location.href = withLang(url);
-  }
-}
-
 function onRowMouseEnter(container: "recent" | "docs", index: number) {
   activeIndex.value = index;
 }
@@ -230,16 +253,12 @@ onMounted(() => {
             role="combobox"
             aria-expanded="true"
             aria-controls="fd-omni-listbox"
-            placeholder="Search documentation…"
+            placeholder="Search"
             autocomplete="off"
             @keydown="handleKeydown"
           />
-          <kbd class="omni-kbd">⌘ K</kbd>
           <button type="button" aria-label="Close" class="omni-close-btn" @click="close">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M18 6 6 18" />
-              <path d="m6 6 12 12" />
-            </svg>
+            ESC
           </button>
         </div>
       </div>
@@ -267,35 +286,10 @@ onMounted(() => {
               @click="onRowClick(r)"
               @mouseenter="onRowMouseEnter('recent', i)"
             >
-              <div class="omni-item-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
-                  <path d="M14 2v4a2 2 0 0 0 2 2h4" />
-                </svg>
-              </div>
               <div class="omni-item-text">
-                <div class="omni-item-label">{{ r.label }}</div>
                 <div class="omni-item-subtitle">Recently viewed</div>
+                <div class="omni-item-label">{{ r.label }}</div>
               </div>
-              <a
-                :href="r.url"
-                class="omni-item-ext"
-                title="Open in new tab"
-                target="_blank"
-                rel="noopener noreferrer"
-                @click.prevent="onExternalClick($event, r.url)"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                  <polyline points="15 3 21 3 21 9" />
-                  <line x1="10" y1="14" x2="21" y2="3" />
-                </svg>
-              </a>
-              <span class="omni-item-chevron" aria-hidden="true">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-              </span>
             </div>
           </div>
         </div>
@@ -315,35 +309,11 @@ onMounted(() => {
               @click="onRowClick(r)"
               @mouseenter="onRowMouseEnter('docs', i)"
             >
-              <div class="omni-item-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
-                  <path d="M14 2v4a2 2 0 0 0 2 2h4" />
-                </svg>
-              </div>
               <div class="omni-item-text">
-                <div class="omni-item-label">{{ r.content }}</div>
-                <div class="omni-item-subtitle">{{ r.description ?? "Page" }}</div>
+                <div class="omni-item-subtitle">{{ breadcrumbForUrl(r.url) }}</div>
+                <div class="omni-item-label">{{ displayLabelForResult(r) }}</div>
+                <div v-if="r.description" class="omni-item-description">{{ r.description }}</div>
               </div>
-              <a
-                :href="r.url"
-                class="omni-item-ext"
-                title="Open in new tab"
-                target="_blank"
-                rel="noopener noreferrer"
-                @click.prevent="onExternalClick($event, r.url)"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                  <polyline points="15 3 21 3 21 9" />
-                  <line x1="10" y1="14" x2="21" y2="3" />
-                </svg>
-              </a>
-              <span class="omni-item-chevron" aria-hidden="true">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-              </span>
             </div>
           </div>
         </div>
@@ -363,26 +333,33 @@ onMounted(() => {
         <div class="omni-footer-inner">
           <div class="omni-footer-hints">
             <span class="omni-footer-hint">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="9 18 15 12 9 6" />
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="m9 10-5 5 5 5" />
+                <path d="M20 4v7a4 4 0 0 1-4 4H4" />
               </svg>
               to select
             </span>
             <span class="omni-footer-hint">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M18 15l-6-6-6 6" />
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="m18 15-6-6-6 6" />
               </svg>
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M6 9l6 6 6-6" />
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="m6 9 6 6 6-6" />
               </svg>
               to navigate
             </span>
             <span class="omni-footer-hint omni-footer-hint-desktop">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M18 6 6 18" />
-                <path d="m6 6 12 12" />
-              </svg>
+              <span class="omni-kbd-sm">ESC</span>
               to close
+            </span>
+          </div>
+          <div class="omni-footer-filter">
+            <span class="omni-filter-label">Filter</span>
+            <span class="omni-filter-value">
+              All
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M6 9l6 6 6-6" />
+              </svg>
             </span>
           </div>
         </div>

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -101,6 +101,84 @@ function displayLabelForResult(result: { content: string; section?: string; type
   return result.type === "heading" && parts.length > 1 ? (parts[parts.length - 1] ?? result.content) : result.content;
 }
 
+function normalizeSearchPhrase(value?: string): string {
+  return (value ?? "").toLowerCase().replace(/[?!.,;:]+$/g, "").replace(/\s+/g, " ").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function literalMatchPriority(searchQuery: string, value?: string): number {
+  const q = normalizeSearchPhrase(searchQuery);
+  const text = normalizeSearchPhrase(value);
+  if (!q || !text) return 0;
+  if (text === q) return 2;
+
+  const boundary = "[^\\p{L}\\p{N}]";
+  return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
+    ? 1
+    : 0;
+}
+
+function tokenizeLiteralQuery(searchQuery: string): string[] {
+  return Array.from(
+    new Set(
+      searchQuery
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}@/_:.-]+/gu, " ")
+        .split(/\s+/)
+        .map((word) => word.replace(/^[^\p{L}\p{N}@]+|[^\p{L}\p{N}]+$/gu, ""))
+        .filter((word) => word.length > 1),
+    ),
+  );
+}
+
+function isLiteralLookupQuery(searchQuery: string): boolean {
+  const q = normalizeSearchPhrase(searchQuery);
+  const words = tokenizeLiteralQuery(q);
+  return words.length > 0 && words.length <= 3 && words.join(" ") === q;
+}
+
+function hasDistinctSearchSection(result: {
+  content: string;
+  section?: string;
+  type?: string;
+}): boolean {
+  if (result.type === "page") return false;
+  if (!result.section) return true;
+  const title = (result.content ?? "").split(/\s+[—–]\s+/)[0] ?? "";
+  return normalizeSearchPhrase(result.section) !== normalizeSearchPhrase(title);
+}
+
+function insideLiteralPriority(
+  result: { content: string; description?: string; section?: string; type?: string },
+  searchQuery: string,
+): number {
+  if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
+  return Math.max(
+    literalMatchPriority(searchQuery, result.section),
+    literalMatchPriority(searchQuery, result.content),
+    literalMatchPriority(searchQuery, result.description),
+  );
+}
+
+function sortResultsForFilter(
+  results: { content: string; url: string; description?: string; section?: string; type?: string; score?: number }[],
+) {
+  const q = query.value.trim();
+  if (!q) return results;
+  return [...results].sort((a, b) => {
+    const literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
+    if (literalDelta) return literalDelta;
+
+    const scoreDelta = (b.score ?? 0) - (a.score ?? 0);
+    if (scoreDelta) return scoreDelta;
+
+    return (a.url ?? "").localeCompare(b.url ?? "");
+  });
+}
+
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => {
     if (char === "&") return "&amp;";
@@ -132,8 +210,10 @@ function highlightSnippet(text: string): string {
 
 const visibleResults = computed(() => {
   if (filter.value === "pages") return currentResults.value.filter((result) => result.type === "page");
-  if (filter.value === "inside") return currentResults.value.filter((result) => result.type !== "page");
-  return currentResults.value;
+  if (filter.value === "inside") {
+    return sortResultsForFilter(currentResults.value.filter((result) => result.type !== "page"));
+  }
+  return sortResultsForFilter(currentResults.value);
 });
 
 const allItems = computed(() => {

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -101,12 +101,6 @@ function displayLabelForResult(result: { content: string; section?: string; type
   return result.type === "heading" && parts.length > 1 ? (parts[parts.length - 1] ?? result.content) : result.content;
 }
 
-function isCodeLikeSnippet(text: string): boolean {
-  return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
-    text,
-  );
-}
-
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => {
     if (char === "&") return "&amp;";
@@ -152,7 +146,6 @@ const allItems = computed(() => {
       subtitle: breadcrumbForUrl(r.url),
       description: r.description,
       descriptionHtml: r.description ? highlightSnippet(r.description) : "",
-      descriptionCodeLike: r.description ? isCodeLikeSnippet(r.description) : false,
     }));
   }
   return recentsList.value.map((r) => ({ id: r.id, label: r.label, url: r.url, subtitle: "Recently viewed" }));
@@ -417,7 +410,6 @@ onBeforeUnmount(() => {
                 <div
                   v-if="r.description"
                   class="omni-item-description"
-                  :class="{ 'omni-item-description-code': r.descriptionCodeLike }"
                   v-html="r.descriptionHtml"
                 />
               </div>

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -101,6 +101,41 @@ function displayLabelForResult(result: { content: string; section?: string; type
   return result.type === "heading" && parts.length > 1 ? (parts[parts.length - 1] ?? result.content) : result.content;
 }
 
+function isCodeLikeSnippet(text: string): boolean {
+  return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
+    text,
+  );
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    if (char === "&") return "&amp;";
+    if (char === "<") return "&lt;";
+    if (char === ">") return "&gt;";
+    if (char === '"') return "&quot;";
+    return "&#39;";
+  });
+}
+
+function highlightSnippet(text: string): string {
+  const q = query.value.trim();
+  if (!q) return escapeHtml(text);
+  const lower = text.toLowerCase();
+  const needle = q.toLowerCase();
+  let pos = 0;
+  let html = "";
+  let idx = lower.indexOf(needle, pos);
+
+  while (idx !== -1) {
+    html += escapeHtml(text.slice(pos, idx));
+    html += `<mark class="omni-highlight">${escapeHtml(text.slice(idx, idx + q.length))}</mark>`;
+    pos = idx + q.length;
+    idx = lower.indexOf(needle, pos);
+  }
+
+  return html + escapeHtml(text.slice(pos));
+}
+
 const visibleResults = computed(() => {
   if (filter.value === "pages") return currentResults.value.filter((result) => result.type === "page");
   if (filter.value === "inside") return currentResults.value.filter((result) => result.type !== "page");
@@ -116,6 +151,8 @@ const allItems = computed(() => {
       url: r.url,
       subtitle: breadcrumbForUrl(r.url),
       description: r.description,
+      descriptionHtml: r.description ? highlightSnippet(r.description) : "",
+      descriptionCodeLike: r.description ? isCodeLikeSnippet(r.description) : false,
     }));
   }
   return recentsList.value.map((r) => ({ id: r.id, label: r.label, url: r.url, subtitle: "Recently viewed" }));
@@ -363,8 +400,8 @@ onBeforeUnmount(() => {
           <div class="omni-group-label">Documentation</div>
           <div id="fd-omni-docs-items" class="omni-group-items">
             <div
-              v-for="(r, i) in visibleResults"
-              :key="r.url"
+              v-for="(r, i) in allItems"
+              :key="r.id"
               class="omni-item"
               :class="{ 'omni-item-active': showDocs && i === activeIndex }"
               :data-url="r.url"
@@ -375,9 +412,14 @@ onBeforeUnmount(() => {
               @mouseenter="onRowMouseEnter('docs', i)"
             >
               <div class="omni-item-text">
-                <div class="omni-item-subtitle">{{ breadcrumbForUrl(r.url) }}</div>
-                <div class="omni-item-label">{{ displayLabelForResult(r) }}</div>
-                <div v-if="r.description" class="omni-item-description">{{ r.description }}</div>
+                <div class="omni-item-subtitle">{{ r.subtitle }}</div>
+                <div class="omni-item-label">{{ r.label }}</div>
+                <div
+                  v-if="r.description"
+                  class="omni-item-description"
+                  :class="{ 'omni-item-description-code': r.descriptionCodeLike }"
+                  v-html="r.descriptionHtml"
+                />
               </div>
             </div>
           </div>

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -158,7 +158,6 @@ function insideLiteralPriority(
   if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
   return Math.max(
     literalMatchPriority(searchQuery, result.section),
-    literalMatchPriority(searchQuery, result.content),
     literalMatchPriority(searchQuery, result.description),
   );
 }
@@ -168,15 +167,21 @@ function sortResultsForFilter(
 ) {
   const q = query.value.trim();
   if (!q) return results;
-  return [...results].sort((a, b) => {
-    const literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
-    if (literalDelta) return literalDelta;
+  return results
+    .map((result, index) => ({ result, index }))
+    .sort((a, b) => {
+      const aLiteralPriority = insideLiteralPriority(a.result, q);
+      const bLiteralPriority = insideLiteralPriority(b.result, q);
+      const literalDelta = bLiteralPriority - aLiteralPriority;
+      if (literalDelta) return literalDelta;
+      if (aLiteralPriority > 0 && bLiteralPriority > 0) return a.index - b.index;
 
-    const scoreDelta = (b.score ?? 0) - (a.score ?? 0);
-    if (scoreDelta) return scoreDelta;
+      const scoreDelta = (b.result.score ?? 0) - (a.result.score ?? 0);
+      if (scoreDelta) return scoreDelta;
 
-    return (a.url ?? "").localeCompare(b.url ?? "");
-  });
+      return a.index - b.index;
+    })
+    .map(({ result }) => result);
 }
 
 function escapeHtml(value: string): string {

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -197,20 +197,18 @@ function escapeHtml(value: string): string {
 function highlightSnippet(text: string): string {
   const q = query.value.trim();
   if (!q) return escapeHtml(text);
-  const lower = text.toLowerCase();
-  const needle = q.toLowerCase();
-  let pos = 0;
   let html = "";
-  let idx = lower.indexOf(needle, pos);
+  let lastIndex = 0;
+  const regex = new RegExp(escapeRegExp(q), "gi");
+  let match: RegExpExecArray | null;
 
-  while (idx !== -1) {
-    html += escapeHtml(text.slice(pos, idx));
-    html += `<mark class="omni-highlight">${escapeHtml(text.slice(idx, idx + q.length))}</mark>`;
-    pos = idx + q.length;
-    idx = lower.indexOf(needle, pos);
+  while ((match = regex.exec(text)) !== null) {
+    html += escapeHtml(text.slice(lastIndex, match.index));
+    html += `<mark class="omni-highlight">${escapeHtml(match[0])}</mark>`;
+    lastIndex = match.index + match[0].length;
   }
 
-  return html + escapeHtml(text.slice(pos));
+  return html + escapeHtml(text.slice(lastIndex));
 }
 
 const visibleResults = computed(() => {
@@ -542,7 +540,6 @@ onBeforeUnmount(() => {
             <button
               type="button"
               class="omni-filter-button"
-              aria-haspopup="menu"
               :aria-expanded="filterOpen"
               @click="filterOpen = !filterOpen"
             >
@@ -551,13 +548,12 @@ onBeforeUnmount(() => {
                 <path d="M6 9l6 6 6-6" />
               </svg>
             </button>
-            <div v-if="filterOpen" class="omni-filter-menu" role="menu" aria-label="Search filter">
+            <div v-if="filterOpen" class="omni-filter-menu" role="group" aria-label="Search filter">
               <button
                 v-for="option in FILTER_OPTIONS"
                 :key="option"
                 type="button"
-                role="menuitemradio"
-                :aria-checked="filter === option"
+                :aria-pressed="filter === option"
                 class="omni-filter-option"
                 :class="{ 'omni-filter-option-active': filter === option }"
                 @click="updateFilter(option)"

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -3,16 +3,24 @@
  * Omni command palette — same behavior as website/components/ui/omni-command-palette.tsx
  * and Astro SearchDialog: recents when empty, /api/docs search, keyboard nav, click to navigate.
  */
-import { ref, computed, watch, onMounted, nextTick } from "vue";
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from "vue";
 import { navigateTo } from "#app";
 import { useRoute } from "vue-router";
 
 const STORAGE_KEY = "fd:omni:recents";
 const MAX_RECENTS = 8;
 const DEBOUNCE_MS = 150;
+const FILTER_LABELS = {
+  all: "All",
+  pages: "Pages",
+  inside: "Inside pages",
+} as const;
+const FILTER_OPTIONS = ["all", "pages", "inside"] as const;
 
 const emit = defineEmits<{ (e: "close"): void }>();
 const route = useRoute();
+
+type SearchFilter = keyof typeof FILTER_LABELS;
 
 const query = ref("");
 const currentResults = ref<
@@ -20,8 +28,15 @@ const currentResults = ref<
 >([]);
 const loading = ref(false);
 const activeIndex = ref(0);
+const filter = ref<SearchFilter>("all");
+const filterOpen = ref(false);
 const inputEl = ref<HTMLInputElement | null>(null);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let abortController: AbortController | null = null;
+const searchCache = new Map<
+  string,
+  { content: string; url: string; description?: string; section?: string; type?: string }[]
+>();
 
 interface RecentEntry {
   id: string;
@@ -85,10 +100,16 @@ function displayLabelForResult(result: { content: string; section?: string; type
   return result.type === "heading" && parts.length > 1 ? (parts[parts.length - 1] ?? result.content) : result.content;
 }
 
+const visibleResults = computed(() => {
+  if (filter.value === "pages") return currentResults.value.filter((result) => result.type === "page");
+  if (filter.value === "inside") return currentResults.value.filter((result) => result.type !== "page");
+  return currentResults.value;
+});
+
 const allItems = computed(() => {
   const q = query.value.trim();
-  if (q && currentResults.value.length) {
-    return currentResults.value.map((r) => ({
+  if (q && visibleResults.value.length) {
+    return visibleResults.value.map((r) => ({
       id: r.url,
       label: displayLabelForResult(r),
       url: r.url,
@@ -100,13 +121,17 @@ const allItems = computed(() => {
 });
 
 const showRecents = computed(() => !query.value.trim());
-const showDocs = computed(() => !!query.value.trim() && currentResults.value.length > 0);
+const showDocs = computed(() => !!query.value.trim() && visibleResults.value.length > 0);
 const showEmpty = computed(() => {
-  if (query.value.trim()) return currentResults.value.length === 0 && !loading.value;
+  if (query.value.trim()) return visibleResults.value.length === 0 && !loading.value;
   return recentsList.value.length === 0;
 });
 const emptyText = computed(() =>
-  query.value.trim() ? "No results found. Try a different query." : "Type to search the docs, or browse recent items.",
+  query.value.trim()
+    ? currentResults.value.length > 0
+      ? `No ${FILTER_LABELS[filter.value].toLowerCase()} results found.`
+      : "No results found. Try a different query."
+    : "Type to search the docs, or browse recent items.",
 );
 
 function loadRecents() {
@@ -116,6 +141,12 @@ function loadRecents() {
 function close() {
   if (typeof document !== "undefined") document.body.style.overflow = "";
   emit("close");
+}
+
+function updateFilter(nextFilter: SearchFilter) {
+  filter.value = nextFilter;
+  filterOpen.value = false;
+  activeIndex.value = 0;
 }
 
 function executeItem(item: { url: string; label?: string; content?: string }) {
@@ -163,24 +194,51 @@ function onInput() {
   loading.value = false;
   currentResults.value = [];
   activeIndex.value = 0;
+  filterOpen.value = false;
+  abortController?.abort();
   if (!q) return;
   if (debounceTimer) clearTimeout(debounceTimer);
+  const requestUrl = withLang(`/api/docs?query=${encodeURIComponent(q)}`);
+  const cached = searchCache.get(requestUrl);
+  if (cached) {
+    currentResults.value = cached;
+    return;
+  }
   debounceTimer = setTimeout(async () => {
+    const controller = new AbortController();
+    abortController = controller;
     loading.value = true;
     try {
-      const res = await fetch(withLang(`/api/docs?query=${encodeURIComponent(q)}`));
+      const res = await fetch(requestUrl, { signal: controller.signal });
       const data = res.ok ? await res.json() : [];
-      currentResults.value = Array.isArray(data) ? data : [];
+      if (controller.signal.aborted) return;
+      const nextResults = Array.isArray(data) ? data : [];
+      if (searchCache.size >= 20) {
+        const firstKey = searchCache.keys().next().value;
+        if (firstKey) searchCache.delete(firstKey);
+      }
+      searchCache.set(requestUrl, nextResults);
+      currentResults.value = nextResults;
       activeIndex.value = 0;
     } catch {
+      if (controller.signal.aborted) return;
       currentResults.value = [];
     } finally {
-      loading.value = false;
+      if (abortController === controller) {
+        abortController = null;
+        loading.value = false;
+      }
     }
   }, DEBOUNCE_MS);
 }
 
 watch(query, onInput);
+watch(filter, () => {
+  activeIndex.value = 0;
+});
+watch(visibleResults, () => {
+  if (activeIndex.value >= visibleResults.value.length) activeIndex.value = 0;
+});
 
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === "Escape") {
@@ -226,6 +284,12 @@ onMounted(() => {
   nextTick(() => {
     inputEl.value?.focus();
   });
+});
+
+onBeforeUnmount(() => {
+  if (typeof document !== "undefined") document.body.style.overflow = "";
+  if (debounceTimer) clearTimeout(debounceTimer);
+  abortController?.abort();
 });
 </script>
 
@@ -298,7 +362,7 @@ onMounted(() => {
           <div class="omni-group-label">Documentation</div>
           <div id="fd-omni-docs-items" class="omni-group-items">
             <div
-              v-for="(r, i) in currentResults"
+              v-for="(r, i) in visibleResults"
               :key="r.url"
               class="omni-item"
               :class="{ 'omni-item-active': showDocs && i === activeIndex }"
@@ -355,12 +419,32 @@ onMounted(() => {
           </div>
           <div class="omni-footer-filter">
             <span class="omni-filter-label">Filter</span>
-            <span class="omni-filter-value">
-              All
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <button
+              type="button"
+              class="omni-filter-button"
+              aria-haspopup="menu"
+              :aria-expanded="filterOpen"
+              @click="filterOpen = !filterOpen"
+            >
+              {{ FILTER_LABELS[filter] }}
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path d="M6 9l6 6 6-6" />
               </svg>
-            </span>
+            </button>
+            <div v-if="filterOpen" class="omni-filter-menu" role="menu" aria-label="Search filter">
+              <button
+                v-for="option in FILTER_OPTIONS"
+                :key="option"
+                type="button"
+                role="menuitemradio"
+                :aria-checked="filter === option"
+                class="omni-filter-option"
+                :class="{ 'omni-filter-option-active': filter === option }"
+                @click="updateFilter(option)"
+              >
+                {{ FILTER_LABELS[option] }}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/nuxt-theme/src/components/SearchDialog.vue
+++ b/packages/nuxt-theme/src/components/SearchDialog.vue
@@ -10,6 +10,7 @@ import { useRoute } from "vue-router";
 const STORAGE_KEY = "fd:omni:recents";
 const MAX_RECENTS = 8;
 const DEBOUNCE_MS = 150;
+const BREADCRUMB_SEPARATOR = "\u00a0\u00a0>\u00a0\u00a0";
 const FILTER_LABELS = {
   all: "All",
   pages: "Pages",
@@ -88,7 +89,7 @@ function breadcrumbForUrl(url: string): string {
           .replace(/[-_]+/g, " ")
           .replace(/\b\w/g, (char) => char.toUpperCase()),
       );
-    return parts.length ? parts.join(" > ") : "Docs";
+    return parts.length ? parts.join(BREADCRUMB_SEPARATOR) : "Docs";
   } catch {
     return "Docs";
   }

--- a/packages/nuxt-theme/styles/command-grid-bundle.css
+++ b/packages/nuxt-theme/styles/command-grid-bundle.css
@@ -605,6 +605,7 @@ figure.shiki:has(figcaption) > div:first-child,
 }
 
 .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/nuxt-theme/styles/command-grid.css
+++ b/packages/nuxt-theme/styles/command-grid.css
@@ -605,6 +605,7 @@ figure.shiki:has(figcaption) > div:first-child,
 }
 
 .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -1,20 +1,28 @@
 /* ═══════════════════════════════════════════════════════════════════
- * Omni Command Palette — core styles (clone of website/components/ui/omni-command-palette)
- * Uses same CSS variables as docs so it auto-adapts to every theme.
+ * Omni Command Palette — core styles
+ * Uses fumadocs CSS variables so it auto-adapts to every theme.
  * ═══════════════════════════════════════════════════════════════════ */
 
 @keyframes omni-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 @keyframes omni-fade-out {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 @keyframes omni-scale-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
   to {
     opacity: 1;
@@ -28,13 +36,19 @@
   }
   to {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
 }
+
 @keyframes omni-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
+
 .omni-spin {
   animation: omni-spin 1s linear infinite;
 }
@@ -42,38 +56,41 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
 }
+
 .omni-content {
   position: fixed;
-  z-index: 101;
-  top: 18%;
+  z-index: 51;
+  top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(720px, calc(100% - 32px));
-  border-radius: var(--radius, 0.75rem);
-  border: 1px solid var(--color-fd-border, #262626);
-  background: var(--color-fd-popover, #0c0c0c);
-  color: var(--color-fd-foreground, #fafafa);
-  box-shadow:
-    0 24px 60px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: min(640px, calc(100% - 1rem));
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
+  background: var(--color-fd-popover, #fafafa);
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-family: var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
+      ui-sans-serif, sans-serif);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
   overflow: hidden;
+  overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
+
 @media (max-width: 639px) {
   .omni-content {
-    top: 10%;
-    width: calc(100% - 24px);
-    max-height: 75vh;
+    top: 1rem;
+    width: calc(100% - 1rem);
+    max-height: calc(100vh - 2rem);
   }
-  .omni-kbd { display: none; }
 }
 
+/* Header */
 .omni-header {
   border-bottom: 1px solid var(--color-fd-border, #262626);
 }
@@ -81,90 +98,117 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  padding: 0.75rem;
 }
 .omni-search-icon {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
+.omni-search-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
 .omni-search-input {
+  width: 0;
   flex: 1;
   background: transparent;
   outline: none;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  color: var(--color-fd-foreground, #fafafa);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   border: none;
 }
 .omni-search-input::placeholder {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-kbd {
-  border-radius: 0.25rem;
-  background: var(--color-fd-muted, #262626);
-  padding: 0.125rem 0.375rem;
-  font-size: 10px;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: transparent;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-family: inherit;
-  line-height: 1.4;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  line-height: 1rem;
 }
 .omni-close-btn {
-  margin-left: 0.25rem;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 2.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  padding: 0.375rem 0.5rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  transition: background 120ms;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  transition:
+    background 120ms,
+    color 120ms;
   cursor: pointer;
-  border: none;
   background: none;
 }
 .omni-close-btn:hover {
-  background: var(--color-fd-muted, #262626);
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+  background: var(--color-fd-accent, #e5e5e5);
+}
+.omni-close-btn svg {
+  display: none;
 }
 
+/* Body / listbox */
 .omni-body {
-  max-height: 60vh;
+  max-height: 460px;
   overflow: auto;
+  overscroll-behavior: contain;
   padding: 0.25rem;
 }
-.omni-body::-webkit-scrollbar { width: 6px; }
-.omni-body::-webkit-scrollbar-track { background: transparent; }
+.omni-body::-webkit-scrollbar {
+  width: 6px;
+}
+.omni-body::-webkit-scrollbar-track {
+  background: transparent;
+}
 .omni-body::-webkit-scrollbar-thumb {
   background: var(--color-fd-muted, #262626);
   border-radius: 3px;
 }
 
+/* Loading */
 .omni-loading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.625rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
+
+/* Groups */
 .omni-group {
-  padding: 0.25rem 0;
+  padding: 0;
 }
 .omni-group-label {
-  padding: 0.25rem 0.75rem;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-weight: 500;
+  display: none;
 }
 .omni-group-items {
   display: flex;
   flex-direction: column;
 }
 
+/* Items */
 .omni-item {
-  display: flex;
+  position: relative;
+  display: block;
   width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: calc(var(--radius, 0.75rem) - 4px);
-  padding: 0.5rem 0.75rem;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.625rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -176,81 +220,113 @@
 }
 .omni-item:hover,
 .omni-item-active {
-  background: color-mix(in srgb, var(--color-fd-accent, #262626) 60%, transparent);
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }
 .omni-item-active {
-  color: var(--color-fd-accent-foreground, #fafafa);
+  color: var(--color-fd-accent-foreground, #171717);
 }
 .omni-item-disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
 .omni-item-icon {
-  flex-shrink: 0;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
+  display: none;
 }
 .omni-item-active .omni-item-icon {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
-.omni-item-text { flex: 1; min-width: 0; }
+.omni-item-text {
+  min-width: 0;
+}
 .omni-item-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-weight: 500;
 }
 .omni-item-subtitle {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.75rem;
+  line-height: 1rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0.8;
+  opacity: 1;
 }
 .omni-item-active .omni-item-subtitle {
-  color: var(--color-fd-accent-foreground, #fafafa);
-  opacity: 0.7;
+  color: var(--color-fd-muted-foreground, #737373);
+  opacity: 1;
+}
+.omni-item-description {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-top: 0.25rem;
+  color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35rem;
+  font-weight: 400;
 }
 .omni-item-badge {
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
+  display: none;
 }
 .omni-item-ext {
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
-  transition: color 100ms, background 100ms;
-  text-decoration: none;
+  display: none;
 }
 .omni-item-ext:hover {
   color: var(--color-fd-foreground, #fafafa);
   background: var(--color-fd-muted, #262626);
 }
-.omni-item-chevron {
-  width: 0.875rem;
-  height: 0.875rem;
-  margin-left: 0.25rem;
+.omni-item-shortcuts {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 10px;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0;
-  transition: opacity 120ms;
-  flex-shrink: 0;
+}
+@media (min-width: 640px) {
+  .omni-item-shortcuts {
+    display: flex;
+  }
+}
+.omni-kbd-sm {
+  border-radius: 0.25rem;
+  background: var(--color-fd-muted, #262626);
+  padding: 0.125rem 0.25rem;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+}
+.omni-item-chevron {
+  display: none;
 }
 .omni-item:hover .omni-item-chevron {
   opacity: 1;
 }
+
+/* Highlight */
 .omni-highlight {
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 30%, transparent);
-  padding: 0 2px;
-  color: inherit;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--color-fd-primary, #ca8a04);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Empty states */
+.omni-empty-group {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-empty {
-  padding: 2rem 0.75rem;
+  padding: 1.5rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
@@ -265,28 +341,57 @@
   border-radius: 9999px;
   background: var(--color-fd-muted, #262626);
 }
+
+/* Footer */
 .omni-footer {
   border-top: 1px solid var(--color-fd-border, #262626);
+  background: color-mix(in srgb, var(--color-fd-secondary, #f5f5f5) 50%, transparent);
 }
 .omni-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 .omni-footer-hints {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 .omni-footer-hint {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  white-space: nowrap;
 }
-.omni-footer-hint-desktop { display: none; }
+.omni-footer-hint svg {
+  flex-shrink: 0;
+}
+.omni-footer-hint-desktop {
+  display: none;
+}
+.omni-footer-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  white-space: nowrap;
+}
 @media (min-width: 640px) {
-  .omni-footer-hint-desktop { display: flex; }
+  .omni-footer-hint-desktop {
+    display: flex;
+  }
+}
+.omni-filter-label {
+  color: var(--color-fd-muted-foreground, #a3a3a3);
+}
+.omni-filter-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
 }

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -68,7 +68,7 @@
   top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(640px, calc(100% - 1rem));
+  width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   background: var(--color-fd-popover, #fafafa);
@@ -163,10 +163,10 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 460px;
+  max-height: 540px;
   overflow: auto;
   overscroll-behavior: contain;
-  padding: 0.25rem;
+  padding: 0.5rem;
 }
 .omni-body::-webkit-scrollbar {
   width: 6px;
@@ -199,6 +199,7 @@
 .omni-group-items {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 /* Items */
@@ -208,7 +209,7 @@
   width: 100%;
   flex-shrink: 0;
   border-radius: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.75rem 0.875rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -246,6 +247,7 @@
   white-space: nowrap;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   font-weight: 500;
+  line-height: 1.35;
 }
 .omni-item-subtitle {
   min-width: 0;
@@ -265,12 +267,14 @@
   min-width: 0;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  margin-top: 0.25rem;
+  margin-top: 0.625rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
   font-size: 0.875rem;
-  line-height: 1.35rem;
+  line-height: 1.5rem;
   font-weight: 400;
 }
 .omni-item-badge {
@@ -369,6 +373,14 @@
   white-space: nowrap;
 }
 .omni-footer-hint svg {
+  box-sizing: border-box;
+  width: 1.375rem;
+  height: 1.375rem;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 70%, transparent);
+  color: var(--color-fd-muted-foreground, #737373);
   flex-shrink: 0;
 }
 .omni-footer-hint-desktop {

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -65,7 +65,7 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: clamp(1rem, 8vh, 8rem);
+  top: clamp(1.5rem, 10vh, 6rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -63,9 +63,10 @@
 }
 
 .omni-content {
+  --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
   z-index: 51;
-  top: clamp(1.5rem, 10vh, 6rem);
+  top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -86,7 +87,8 @@
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 1rem;
+    --omni-content-top: 1rem;
+    top: var(--omni-content-top);
     width: calc(100% - 1rem);
     max-height: calc(100vh - 2rem);
   }
@@ -167,7 +169,7 @@
 .omni-body {
   flex: 1 1 auto;
   min-height: 0;
-  max-height: min(540px, calc(100vh - 10.5rem));
+  max-height: min(540px, calc(100vh - var(--omni-content-top, 7rem) - 8rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -65,9 +65,11 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: calc(50% - 250px);
+  top: clamp(1rem, 8vh, 8rem);
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
   width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
@@ -163,7 +165,9 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 540px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(540px, calc(100vh - 10.5rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;
@@ -387,6 +391,7 @@
   display: none;
 }
 .omni-footer-filter {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -406,4 +411,47 @@
   align-items: center;
   gap: 0.25rem;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+}
+.omni-filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.omni-filter-button:hover {
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+}
+.omni-filter-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 1;
+  width: 10rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  border-radius: 0.5rem;
+  background: var(--color-fd-popover, #fafafa);
+  padding: 0.25rem;
+  box-shadow: 0 16px 32px -20px rgba(0, 0, 0, 0.45);
+}
+.omni-filter-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+}
+.omni-filter-option:hover,
+.omni-filter-option-active {
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -80,7 +80,6 @@
       ui-sans-serif, sans-serif);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
-  overflow: hidden;
   overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -315,10 +314,6 @@
 .omni-item-chevron {
   display: none;
 }
-.omni-item:hover .omni-item-chevron {
-  opacity: 1;
-}
-
 /* Highlight */
 .omni-highlight {
   border-radius: 0;

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -282,29 +282,8 @@
   font-weight: 400;
 }
 .omni-item-description-code {
-  display: block;
-  max-height: 4.75rem;
-  padding: 0.5rem 0.625rem;
-  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
-  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
-  border-radius: 0.375rem;
-  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace);
-  font-size: 0.8125rem;
-  line-height: 1.45rem;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.omni-item-active .omni-item-description-code {
-  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
-}
-.omni-item-description-code .omni-highlight {
-  border-radius: 0.1875rem;
-  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
-  padding: 0 0.125rem;
-  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
-  text-decoration: none;
 }
 .omni-item-badge {
   display: none;

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -283,10 +283,6 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
-.omni-item-description-code {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace);
-}
 .omni-item-badge {
   display: none;
 }

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -281,6 +281,31 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
+.omni-item-description-code {
+  display: block;
+  max-height: 4.75rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.8125rem;
+  line-height: 1.45rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.omni-item-active .omni-item-description-code {
+  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
+}
+.omni-item-description-code .omni-highlight {
+  border-radius: 0.1875rem;
+  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
+  padding: 0 0.125rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  text-decoration: none;
+}
 .omni-item-badge {
   display: none;
 }

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -864,10 +864,13 @@ code:not(pre code) {
   border: 1px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
 }
 
-.omni-search-input,
 .omni-group-label,
 .omni-footer-inner {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-search-input {
+  font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif) !important;
 }
 
 .omni-group-label {

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -841,6 +841,45 @@ code:not(pre code) {
   color: var(--color-fd-foreground) !important;
 }
 
+/* ─── Omni Command Palette — pixel-border theme ──────────────────── */
+
+.omni-content {
+  border-radius: 0 !important;
+  border: 2px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
+  box-shadow:
+    4px 4px 0 0 var(--color-fd-border, hsl(0 0% 15%)),
+    0 24px 60px -12px rgba(0, 0, 0, 0.5) !important;
+}
+
+.omni-item,
+.omni-kbd,
+.omni-kbd-sm,
+.omni-close-btn,
+.omni-empty-icon {
+  border-radius: 0 !important;
+}
+
+.omni-kbd,
+.omni-kbd-sm {
+  border: 1px solid var(--color-fd-border, hsl(0 0% 15%)) !important;
+}
+
+.omni-search-input,
+.omni-group-label,
+.omni-footer-inner {
+  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+.omni-group-label {
+  display: block !important;
+  letter-spacing: 0.08em !important;
+}
+
+.omni-highlight {
+  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
+  border-radius: 0 !important;
+}
+
 /* ─── Feedback (pixel-border theme) ──────────────────────────────── */
 
 .fd-feedback-input,

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -871,8 +871,11 @@ code:not(pre code) {
 }
 
 .omni-group-label {
-  display: block !important;
   letter-spacing: 0.08em !important;
+}
+
+.omni-footer-hint svg {
+  border-radius: 0 !important;
 }
 
 .omni-highlight {

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -883,11 +883,6 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
-.omni-item-description-code,
-.omni-item-description-code .omni-highlight {
-  border-radius: 0 !important;
-}
-
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -883,6 +883,11 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
+.omni-item-description-code,
+.omni-item-description-code .omni-highlight {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/nuxt-theme/styles/pixel-border.css
+++ b/packages/nuxt-theme/styles/pixel-border.css
@@ -878,6 +878,11 @@ code:not(pre code) {
   border-radius: 0 !important;
 }
 
+.omni-filter-menu,
+.omni-filter-option {
+  border-radius: 0 !important;
+}
+
 .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -71,12 +71,6 @@
     return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
   }
 
-  function isCodeLikeSnippet(text) {
-    return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
-      text
-    );
-  }
-
   function escapeHtml(value) {
     return (value ?? "").replace(/[&<>"']/g, (char) => {
       if (char === "&") return "&amp;";
@@ -122,7 +116,6 @@
         subtitle: breadcrumbForUrl(r.url),
         description: r.description,
         descriptionHtml: r.description ? highlightSnippet(r.description) : "",
-        descriptionCodeLike: r.description ? isCodeLikeSnippet(r.description) : false,
       }));
     }
     return recentsList.map((r) => ({
@@ -420,10 +413,7 @@
                   <div class="omni-item-subtitle">{item.subtitle}</div>
                   <div class="omni-item-label">{item.label}</div>
                   {#if item.description}
-                    <div
-                      class="omni-item-description"
-                      class:omni-item-description-code={item.descriptionCodeLike}
-                    >
+                    <div class="omni-item-description">
                       {@html item.descriptionHtml}
                     </div>
                   {/if}

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -71,6 +71,41 @@
     return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
   }
 
+  function isCodeLikeSnippet(text) {
+    return /[`{}()[\];=<>]|(?:^|\s)(?:async|await|bun|class|const|curl|DELETE|export|function|GET|import|interface|let|npm|npx|PATCH|pnpm|POST|return|type|var|yarn)(?:\s|$)|(?:^|\s)[./][\w./-]+|@\w[\w/-]*/.test(
+      text
+    );
+  }
+
+  function escapeHtml(value) {
+    return (value ?? "").replace(/[&<>"']/g, (char) => {
+      if (char === "&") return "&amp;";
+      if (char === "<") return "&lt;";
+      if (char === ">") return "&gt;";
+      if (char === '"') return "&quot;";
+      return "&#39;";
+    });
+  }
+
+  function highlightSnippet(text) {
+    const q = query.trim();
+    if (!q) return escapeHtml(text);
+    const lower = text.toLowerCase();
+    const needle = q.toLowerCase();
+    let pos = 0;
+    let html = "";
+    let idx = lower.indexOf(needle, pos);
+
+    while (idx !== -1) {
+      html += escapeHtml(text.slice(pos, idx));
+      html += `<mark class="omni-highlight">${escapeHtml(text.slice(idx, idx + q.length))}</mark>`;
+      pos = idx + q.length;
+      idx = lower.indexOf(needle, pos);
+    }
+
+    return html + escapeHtml(text.slice(pos));
+  }
+
   let visibleResults = $derived.by(() => {
     if (filter === "pages") return currentResults.filter((result) => result.type === "page");
     if (filter === "inside") return currentResults.filter((result) => result.type !== "page");
@@ -86,6 +121,8 @@
         url: r.url,
         subtitle: breadcrumbForUrl(r.url),
         description: r.description,
+        descriptionHtml: r.description ? highlightSnippet(r.description) : "",
+        descriptionCodeLike: r.description ? isCodeLikeSnippet(r.description) : false,
       }));
     }
     return recentsList.map((r) => ({
@@ -383,7 +420,12 @@
                   <div class="omni-item-subtitle">{item.subtitle}</div>
                   <div class="omni-item-label">{item.label}</div>
                   {#if item.description}
-                    <div class="omni-item-description">{item.description}</div>
+                    <div
+                      class="omni-item-description"
+                      class:omni-item-description-code={item.descriptionCodeLike}
+                    >
+                      {@html item.descriptionHtml}
+                    </div>
                   {/if}
                 </div>
               </button>

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -11,6 +11,12 @@
   const STORAGE_KEY = "fd:omni:recents";
   const MAX_RECENTS = 8;
   const DEBOUNCE_MS = 120;
+  const FILTER_LABELS = {
+    all: "All",
+    pages: "Pages",
+    inside: "Inside pages",
+  };
+  const FILTER_OPTIONS = ["all", "pages", "inside"];
 
   let { onclose } = $props();
 
@@ -19,9 +25,13 @@
   let loading = $state(false);
   let activeId = $state(null);
   let recentsList = $state([]);
+  let filter = $state("all");
+  let filterOpen = $state(false);
   let inputEl = $state(null);
   let listRef = $state(null);
   let debounceTimer = null;
+  let abortController = null;
+  const searchCache = new Map();
 
   function withLang(url) {
     if (!url || url.startsWith("#")) return url;
@@ -60,10 +70,16 @@
     return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
   }
 
+  let visibleResults = $derived.by(() => {
+    if (filter === "pages") return currentResults.filter((result) => result.type === "page");
+    if (filter === "inside") return currentResults.filter((result) => result.type !== "page");
+    return currentResults;
+  });
+
   let flatItems = $derived.by(() => {
     const q = query.trim();
-    if (q && currentResults.length) {
-      return currentResults.map((r) => ({
+    if (q && visibleResults.length) {
+      return visibleResults.map((r) => ({
         id: r.url,
         label: displayLabelForResult(r),
         url: r.url,
@@ -80,13 +96,15 @@
   });
 
   let showRecents = $derived(!query.trim());
-  let showDocs = $derived(!!query.trim() && currentResults.length > 0);
+  let showDocs = $derived(!!query.trim() && visibleResults.length > 0);
   let showEmpty = $derived(
-    query.trim() ? currentResults.length === 0 && !loading : recentsList.length === 0
+    query.trim() ? visibleResults.length === 0 && !loading : recentsList.length === 0
   );
   let emptyText = $derived(
     query.trim()
-      ? "No results found. Try a different query."
+      ? currentResults.length > 0
+        ? `No ${FILTER_LABELS[filter].toLowerCase()} results found.`
+        : "No results found. Try a different query."
       : "Type to search the docs, or browse recent items."
   );
 
@@ -116,6 +134,12 @@
   function close() {
     if (typeof document !== "undefined") document.body.style.overflow = "";
     onclose?.();
+  }
+
+  function updateFilter(nextFilter) {
+    filter = nextFilter;
+    filterOpen = false;
+    activeId = flatItems[0]?.id ?? null;
   }
 
   function executeItem(item) {
@@ -157,19 +181,41 @@
     currentResults = [];
     activeId = null;
     const q = query.trim();
+    filterOpen = false;
+    if (abortController) abortController.abort();
     if (!q) return;
     if (debounceTimer) clearTimeout(debounceTimer);
+    const requestUrl = withLang(`/api/docs?query=${encodeURIComponent(q)}`);
+    const cached = searchCache.get(requestUrl);
+    if (cached) {
+      currentResults = cached;
+      activeId = cached[0]?.url ?? null;
+      return;
+    }
     debounceTimer = setTimeout(async () => {
+      const controller = new AbortController();
+      abortController = controller;
       loading = true;
       try {
-        const res = await fetch(withLang(`/api/docs?query=${encodeURIComponent(q)}`));
+        const res = await fetch(requestUrl, { signal: controller.signal });
         const data = res.ok ? await res.json() : [];
-        currentResults = Array.isArray(data) ? data : [];
+        if (controller.signal.aborted) return;
+        const nextResults = Array.isArray(data) ? data : [];
+        if (searchCache.size >= 20) {
+          const firstKey = searchCache.keys().next().value;
+          if (firstKey) searchCache.delete(firstKey);
+        }
+        searchCache.set(requestUrl, nextResults);
+        currentResults = nextResults;
         activeId = currentResults[0]?.url ?? null;
-      } catch {
+      } catch (error) {
+        if (controller.signal.aborted) return;
         currentResults = [];
       } finally {
-        loading = false;
+        if (abortController === controller) {
+          abortController = null;
+          loading = false;
+        }
       }
     }, DEBOUNCE_MS);
   }
@@ -177,6 +223,11 @@
   $effect(() => {
     void query;
     onInput();
+  });
+
+  $effect(() => {
+    void filter;
+    activeId = flatItems[0]?.id ?? null;
   });
 
   function handleKeydown(e) {
@@ -220,6 +271,7 @@
   onDestroy(() => {
     if (typeof document !== "undefined") document.body.style.overflow = "";
     if (debounceTimer) clearTimeout(debounceTimer);
+    if (abortController) abortController.abort();
   });
 </script>
 
@@ -375,12 +427,34 @@
         </div>
         <div class="omni-footer-filter">
           <span class="omni-filter-label">Filter</span>
-          <span class="omni-filter-value">
-            All
+          <button
+            type="button"
+            class="omni-filter-button"
+            aria-haspopup="menu"
+            aria-expanded={filterOpen}
+            onclick={() => (filterOpen = !filterOpen)}
+          >
+            {FILTER_LABELS[filter]}
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="M6 9l6 6 6-6" />
             </svg>
-          </span>
+          </button>
+          {#if filterOpen}
+            <div class="omni-filter-menu" role="menu" aria-label="Search filter">
+              {#each FILTER_OPTIONS as option}
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={filter === option}
+                  class="omni-filter-option"
+                  class:omni-filter-option-active={filter === option}
+                  onclick={() => updateFilter(option)}
+                >
+                  {FILTER_LABELS[option]}
+                </button>
+              {/each}
+            </div>
+          {/if}
         </div>
       </div>
     </div>

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -121,7 +121,6 @@
     if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
     return Math.max(
       literalMatchPriority(searchQuery, result.section),
-      literalMatchPriority(searchQuery, result.content),
       literalMatchPriority(searchQuery, result.description)
     );
   }
@@ -129,15 +128,21 @@
   function sortResultsForFilter(results) {
     const q = query.trim();
     if (!q) return results;
-    return [...results].sort((a, b) => {
-      const literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
-      if (literalDelta) return literalDelta;
+    return results
+      .map((result, index) => ({ result, index }))
+      .sort((a, b) => {
+        const aLiteralPriority = insideLiteralPriority(a.result, q);
+        const bLiteralPriority = insideLiteralPriority(b.result, q);
+        const literalDelta = bLiteralPriority - aLiteralPriority;
+        if (literalDelta) return literalDelta;
+        if (aLiteralPriority > 0 && bLiteralPriority > 0) return a.index - b.index;
 
-      const scoreDelta = (b.score ?? 0) - (a.score ?? 0);
-      if (scoreDelta) return scoreDelta;
+        const scoreDelta = (b.result.score ?? 0) - (a.result.score ?? 0);
+        if (scoreDelta) return scoreDelta;
 
-      return (a.url ?? "").localeCompare(b.url ?? "");
-    });
+        return a.index - b.index;
+      })
+      .map(({ result }) => result);
   }
 
   function escapeHtml(value) {

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -11,6 +11,7 @@
   const STORAGE_KEY = "fd:omni:recents";
   const MAX_RECENTS = 8;
   const DEBOUNCE_MS = 120;
+  const BREADCRUMB_SEPARATOR = "\u00a0\u00a0>\u00a0\u00a0";
   const FILTER_LABELS = {
     all: "All",
     pages: "Pages",
@@ -57,7 +58,7 @@
             .replace(/[-_]+/g, " ")
             .replace(/\b\w/g, (char) => char.toUpperCase())
         );
-      return parts.length ? parts.join(" > ") : "Docs";
+      return parts.length ? parts.join(BREADCRUMB_SEPARATOR) : "Docs";
     } catch {
       return "Docs";
     }

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -158,20 +158,18 @@
   function highlightSnippet(text) {
     const q = query.trim();
     if (!q) return escapeHtml(text);
-    const lower = text.toLowerCase();
-    const needle = q.toLowerCase();
-    let pos = 0;
     let html = "";
-    let idx = lower.indexOf(needle, pos);
+    let lastIndex = 0;
+    const regex = new RegExp(escapeRegExp(q), "gi");
+    let match;
 
-    while (idx !== -1) {
-      html += escapeHtml(text.slice(pos, idx));
-      html += `<mark class="omni-highlight">${escapeHtml(text.slice(idx, idx + q.length))}</mark>`;
-      pos = idx + q.length;
-      idx = lower.indexOf(needle, pos);
+    while ((match = regex.exec(text)) !== null) {
+      html += escapeHtml(text.slice(lastIndex, match.index));
+      html += `<mark class="omni-highlight">${escapeHtml(match[0])}</mark>`;
+      lastIndex = match.index + match[0].length;
     }
 
-    return html + escapeHtml(text.slice(pos));
+    return html + escapeHtml(text.slice(lastIndex));
   }
 
   let visibleResults = $derived.by(() => {
@@ -539,7 +537,6 @@
           <button
             type="button"
             class="omni-filter-button"
-            aria-haspopup="menu"
             aria-expanded={filterOpen}
             onclick={() => (filterOpen = !filterOpen)}
           >
@@ -549,12 +546,11 @@
             </svg>
           </button>
           {#if filterOpen}
-            <div class="omni-filter-menu" role="menu" aria-label="Search filter">
+            <div class="omni-filter-menu" role="group" aria-label="Search filter">
               {#each FILTER_OPTIONS as option}
                 <button
                   type="button"
-                  role="menuitemradio"
-                  aria-checked={filter === option}
+                  aria-pressed={filter === option}
                   class="omni-filter-option"
                   class:omni-filter-option-active={filter === option}
                   onclick={() => updateFilter(option)}

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -11,7 +11,6 @@
   const STORAGE_KEY = "fd:omni:recents";
   const MAX_RECENTS = 8;
   const DEBOUNCE_MS = 120;
-  const PLACEHOLDER = "Search documentation…";
 
   let { onclose } = $props();
 
@@ -37,14 +36,39 @@
     }
   }
 
+  function breadcrumbForUrl(url) {
+    try {
+      const parsed = new URL(url, "https://farming-labs.local");
+      const parts = parsed.pathname
+        .split("/")
+        .filter(Boolean)
+        .map((part) =>
+          decodeURIComponent(part)
+            .replace(/[-_]+/g, " ")
+            .replace(/\b\w/g, (char) => char.toUpperCase())
+        );
+      return parts.length ? parts.join(" > ") : "Docs";
+    } catch {
+      return "Docs";
+    }
+  }
+
+  function displayLabelForResult(result) {
+    if (result.section) return result.section;
+    const label = result.content ?? "";
+    const parts = label.split(/\s+[—–]\s+/).map((part) => part.trim()).filter(Boolean);
+    return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
+  }
+
   let flatItems = $derived.by(() => {
     const q = query.trim();
     if (q && currentResults.length) {
       return currentResults.map((r) => ({
         id: r.url,
-        label: r.content,
+        label: displayLabelForResult(r),
         url: r.url,
-        subtitle: r.description ?? "Page",
+        subtitle: breadcrumbForUrl(r.url),
+        description: r.description,
       }));
     }
     return recentsList.map((r) => ({
@@ -185,19 +209,6 @@
     e.stopPropagation();
   }
 
-  function onExternalClick(e, url) {
-    e.preventDefault();
-    e.stopPropagation();
-    try {
-      if (typeof window !== "undefined") window.open(url, "_blank", "noopener,noreferrer");
-    } catch {
-      if (typeof window !== "undefined") window.location.href = url;
-    }
-  }
-
-  const FileIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>`;
-  const ExternalIcon = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>`;
-  const ChevronIcon = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>`;
   const EmptyIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>`;
 
   onMount(() => {
@@ -247,16 +258,12 @@
           aria-expanded="true"
           aria-controls="omni-listbox"
           aria-activedescendant={activeId ? `omni-item-${activeId}` : undefined}
-          placeholder={PLACEHOLDER}
+          placeholder="Search"
           autocomplete="off"
           onkeydown={handleKeydown}
         />
-        <kbd class="omni-kbd">⌘ K</kbd>
         <button type="button" aria-label="Close" class="omni-close-btn" onclick={close}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M18 6 6 18" />
-            <path d="m6 6 12 12" />
-          </svg>
+          ESC
         </button>
       </div>
     </div>
@@ -293,27 +300,10 @@
                 onmouseenter={() => (activeId = item.id)}
                 onclick={() => executeItem(item)}
               >
-                <div class="omni-item-icon">
-                  {@html FileIcon}
-                </div>
                 <div class="omni-item-text">
-                  <div class="omni-item-label">{item.label}</div>
                   <div class="omni-item-subtitle">{item.subtitle}</div>
+                  <div class="omni-item-label">{item.label}</div>
                 </div>
-                <a
-                  href={item.url}
-                  class="omni-item-badge"
-                  title="Open in new tab"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-hidden="true"
-                  onclick={(e) => onExternalClick(e, item.url)}
-                >
-                  {@html ExternalIcon}
-                </a>
-                <span class="omni-item-chevron" aria-hidden="true">
-                  {@html ChevronIcon}
-                </span>
               </button>
             {/each}
           </div>
@@ -336,27 +326,13 @@
                 onmouseenter={() => (activeId = item.id)}
                 onclick={() => executeItem(item)}
               >
-                <div class="omni-item-icon">
-                  {@html FileIcon}
-                </div>
                 <div class="omni-item-text">
-                  <div class="omni-item-label">{item.label}</div>
                   <div class="omni-item-subtitle">{item.subtitle}</div>
+                  <div class="omni-item-label">{item.label}</div>
+                  {#if item.description}
+                    <div class="omni-item-description">{item.description}</div>
+                  {/if}
                 </div>
-                <a
-                  href={item.url}
-                  class="omni-item-badge"
-                  title="Open in new tab"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-hidden="true"
-                  onclick={(e) => onExternalClick(e, item.url)}
-                >
-                  {@html ExternalIcon}
-                </a>
-                <span class="omni-item-chevron" aria-hidden="true">
-                  {@html ChevronIcon}
-                </span>
               </button>
             {/each}
           </div>
@@ -377,26 +353,33 @@
       <div class="omni-footer-inner">
         <div class="omni-footer-hints">
           <span class="omni-footer-hint">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="9 18 15 12 9 6" />
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="m9 10-5 5 5 5" />
+              <path d="M20 4v7a4 4 0 0 1-4 4H4" />
             </svg>
             to select
           </span>
           <span class="omni-footer-hint">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M18 15l-6-6-6 6" />
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="m18 15-6-6-6 6" />
             </svg>
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M6 9l6 6 6-6" />
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="m6 9 6 6 6-6" />
             </svg>
             to navigate
           </span>
           <span class="omni-footer-hint omni-footer-hint-desktop">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M18 6 6 18" />
-              <path d="m6 6 12 12" />
-            </svg>
+            <span class="omni-kbd-sm">ESC</span>
             to close
+          </span>
+        </div>
+        <div class="omni-footer-filter">
+          <span class="omni-filter-label">Filter</span>
+          <span class="omni-filter-value">
+            All
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M6 9l6 6 6-6" />
+            </svg>
           </span>
         </div>
       </div>

--- a/packages/svelte-theme/src/components/SearchDialog.svelte
+++ b/packages/svelte-theme/src/components/SearchDialog.svelte
@@ -71,6 +71,75 @@
     return result.type === "heading" && parts.length > 1 ? parts[parts.length - 1] : label;
   }
 
+  function normalizeSearchPhrase(value) {
+    return (value ?? "").toLowerCase().replace(/[?!.,;:]+$/g, "").replace(/\s+/g, " ").trim();
+  }
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function literalMatchPriority(searchQuery, value) {
+    const q = normalizeSearchPhrase(searchQuery);
+    const text = normalizeSearchPhrase(value);
+    if (!q || !text) return 0;
+    if (text === q) return 2;
+
+    const boundary = "[^\\p{L}\\p{N}]";
+    return new RegExp(`(^|${boundary})${escapeRegExp(q)}(?=$|${boundary})`, "u").test(text)
+      ? 1
+      : 0;
+  }
+
+  function tokenizeLiteralQuery(searchQuery) {
+    return Array.from(
+      new Set(
+        searchQuery
+          .toLowerCase()
+          .replace(/[^\p{L}\p{N}@/_:.-]+/gu, " ")
+          .split(/\s+/)
+          .map((word) => word.replace(/^[^\p{L}\p{N}@]+|[^\p{L}\p{N}]+$/gu, ""))
+          .filter((word) => word.length > 1)
+      )
+    );
+  }
+
+  function isLiteralLookupQuery(searchQuery) {
+    const q = normalizeSearchPhrase(searchQuery);
+    const words = tokenizeLiteralQuery(q);
+    return words.length > 0 && words.length <= 3 && words.join(" ") === q;
+  }
+
+  function hasDistinctSearchSection(result) {
+    if (result.type === "page") return false;
+    if (!result.section) return true;
+    const title = (result.content ?? "").split(/\s+[—–]\s+/)[0] ?? "";
+    return normalizeSearchPhrase(result.section) !== normalizeSearchPhrase(title);
+  }
+
+  function insideLiteralPriority(result, searchQuery) {
+    if (!hasDistinctSearchSection(result) || !isLiteralLookupQuery(searchQuery)) return 0;
+    return Math.max(
+      literalMatchPriority(searchQuery, result.section),
+      literalMatchPriority(searchQuery, result.content),
+      literalMatchPriority(searchQuery, result.description)
+    );
+  }
+
+  function sortResultsForFilter(results) {
+    const q = query.trim();
+    if (!q) return results;
+    return [...results].sort((a, b) => {
+      const literalDelta = insideLiteralPriority(b, q) - insideLiteralPriority(a, q);
+      if (literalDelta) return literalDelta;
+
+      const scoreDelta = (b.score ?? 0) - (a.score ?? 0);
+      if (scoreDelta) return scoreDelta;
+
+      return (a.url ?? "").localeCompare(b.url ?? "");
+    });
+  }
+
   function escapeHtml(value) {
     return (value ?? "").replace(/[&<>"']/g, (char) => {
       if (char === "&") return "&amp;";
@@ -102,8 +171,10 @@
 
   let visibleResults = $derived.by(() => {
     if (filter === "pages") return currentResults.filter((result) => result.type === "page");
-    if (filter === "inside") return currentResults.filter((result) => result.type !== "page");
-    return currentResults;
+    if (filter === "inside") {
+      return sortResultsForFilter(currentResults.filter((result) => result.type !== "page"));
+    }
+    return sortResultsForFilter(currentResults);
   });
 
   let flatItems = $derived.by(() => {

--- a/packages/svelte-theme/styles/command-grid-bundle.css
+++ b/packages/svelte-theme/styles/command-grid-bundle.css
@@ -622,6 +622,7 @@ body:has(#nd-docs-layout.dark),
 }
 
 #nd-docs-layout .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/svelte-theme/styles/command-grid.css
+++ b/packages/svelte-theme/styles/command-grid.css
@@ -622,6 +622,7 @@ body:has(#nd-docs-layout.dark),
 }
 
 #nd-docs-layout .omni-group-label {
+  display: block !important;
   letter-spacing: 0.14em;
   color: color-mix(in srgb, var(--color-fd-foreground) 72%, transparent) !important;
 }

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -68,7 +68,7 @@
   top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(640px, calc(100% - 1rem));
+  width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   background: var(--color-fd-popover, #fafafa);
@@ -163,10 +163,10 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 460px;
+  max-height: 540px;
   overflow: auto;
   overscroll-behavior: contain;
-  padding: 0.25rem;
+  padding: 0.5rem;
 }
 .omni-body::-webkit-scrollbar {
   width: 6px;
@@ -199,6 +199,7 @@
 .omni-group-items {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
 }
 
 /* Items */
@@ -208,7 +209,7 @@
   width: 100%;
   flex-shrink: 0;
   border-radius: 0.5rem;
-  padding: 0.5rem 0.625rem;
+  padding: 0.75rem 0.875rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -246,6 +247,7 @@
   white-space: nowrap;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   font-weight: 500;
+  line-height: 1.35;
 }
 .omni-item-subtitle {
   min-width: 0;
@@ -265,12 +267,14 @@
   min-width: 0;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  margin-top: 0.25rem;
+  margin-top: 0.625rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
   color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
   font-size: 0.875rem;
-  line-height: 1.35rem;
+  line-height: 1.5rem;
   font-weight: 400;
 }
 .omni-item-badge {
@@ -369,6 +373,14 @@
   white-space: nowrap;
 }
 .omni-footer-hint svg {
+  box-sizing: border-box;
+  width: 1.375rem;
+  height: 1.375rem;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 70%, transparent);
+  color: var(--color-fd-muted-foreground, #737373);
   flex-shrink: 0;
 }
 .omni-footer-hint-desktop {

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -65,7 +65,7 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: clamp(1rem, 8vh, 8rem);
+  top: clamp(1.5rem, 10vh, 6rem);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -63,9 +63,10 @@
 }
 
 .omni-content {
+  --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
   z-index: 51;
-  top: clamp(1.5rem, 10vh, 6rem);
+  top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -86,7 +87,8 @@
 
 @media (max-width: 639px) {
   .omni-content {
-    top: 1rem;
+    --omni-content-top: 1rem;
+    top: var(--omni-content-top);
     width: calc(100% - 1rem);
     max-height: calc(100vh - 2rem);
   }
@@ -167,7 +169,7 @@
 .omni-body {
   flex: 1 1 auto;
   min-height: 0;
-  max-height: min(540px, calc(100vh - 10.5rem));
+  max-height: min(540px, calc(100vh - var(--omni-content-top, 7rem) - 8rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -65,9 +65,11 @@
 .omni-content {
   position: fixed;
   z-index: 51;
-  top: calc(50% - 250px);
+  top: clamp(1rem, 8vh, 8rem);
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
   width: min(720px, calc(100% - 1rem));
   border-radius: 0.75rem;
   border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
@@ -163,7 +165,9 @@
 
 /* Body / listbox */
 .omni-body {
-  max-height: 540px;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(540px, calc(100vh - 10.5rem));
   overflow: auto;
   overscroll-behavior: contain;
   padding: 0.5rem;
@@ -387,6 +391,7 @@
   display: none;
 }
 .omni-footer-filter {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -406,4 +411,47 @@
   align-items: center;
   gap: 0.25rem;
   color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+}
+.omni-filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 0;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.omni-filter-button:hover {
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+}
+.omni-filter-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 1;
+  width: 10rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  border-radius: 0.5rem;
+  background: var(--color-fd-popover, #fafafa);
+  padding: 0.25rem;
+  box-shadow: 0 16px 32px -20px rgba(0, 0, 0, 0.45);
+}
+.omni-filter-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+}
+.omni-filter-option:hover,
+.omni-filter-option-active {
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -1,6 +1,6 @@
 /* ═══════════════════════════════════════════════════════════════════
- * Omni Command Palette — pixel-perfect sync with website/components/ui/omni-command-palette.tsx
- * Uses same CSS variables as docs so it auto-adapts to every theme.
+ * Omni Command Palette — core styles
+ * Uses fumadocs CSS variables so it auto-adapts to every theme.
  * ═══════════════════════════════════════════════════════════════════ */
 
 @keyframes omni-fade-in {
@@ -22,7 +22,7 @@
 @keyframes omni-scale-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
   to {
     opacity: 1;
@@ -36,7 +36,7 @@
   }
   to {
     opacity: 0;
-    transform: translateX(-50%) scale(0.96) translateY(-4px);
+    transform: translateX(-50%) scale(0.98) translateY(-6px);
   }
 }
 
@@ -49,150 +49,166 @@
   }
 }
 
-#nd-docs-layout .omni-spin {
+.omni-spin {
   animation: omni-spin 1s linear infinite;
 }
 
-#nd-docs-layout .omni-overlay {
+.omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 100;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
 }
 
-#nd-docs-layout .omni-content {
+.omni-content {
   position: fixed;
-  z-index: 101;
-  top: 18%;
+  z-index: 51;
+  top: calc(50% - 250px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(720px, calc(100% - 32px));
-  border-radius: var(--radius, 0.75rem);
-  border: 1px solid var(--color-fd-border, #262626);
-  background: var(--color-fd-popover, #0c0c0c);
-  color: var(--color-fd-foreground, #fafafa);
-  box-shadow:
-    0 24px 60px -12px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.04);
+  width: min(640px, calc(100% - 1rem));
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 70%, transparent);
+  background: var(--color-fd-popover, #fafafa);
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-family: var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text",
+      ui-sans-serif, sans-serif);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
   overflow: hidden;
+  overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @media (max-width: 639px) {
-  #nd-docs-layout .omni-content {
-    top: 10%;
-    width: calc(100% - 24px);
-    max-height: 75vh;
-  }
-  #nd-docs-layout .omni-kbd {
-    display: none;
+  .omni-content {
+    top: 1rem;
+    width: calc(100% - 1rem);
+    max-height: calc(100vh - 2rem);
   }
 }
 
 /* Header */
-#nd-docs-layout .omni-header {
+.omni-header {
   border-bottom: 1px solid var(--color-fd-border, #262626);
 }
-#nd-docs-layout .omni-search-row {
+.omni-search-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
+  padding: 0.75rem;
 }
-#nd-docs-layout .omni-search-icon {
+.omni-search-icon {
   color: var(--color-fd-muted-foreground, #a3a3a3);
   flex-shrink: 0;
 }
-#nd-docs-layout .omni-search-input {
+.omni-search-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+.omni-search-input {
+  width: 0;
   flex: 1;
   background: transparent;
   outline: none;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  color: var(--color-fd-foreground, #fafafa);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
   border: none;
 }
-#nd-docs-layout .omni-search-input::placeholder {
+.omni-search-input::placeholder {
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-#nd-docs-layout .omni-kbd {
-  border-radius: 0.25rem;
-  background: var(--color-fd-muted, #262626);
-  padding: 0.125rem 0.375rem;
-  font-size: 10px;
+.omni-kbd {
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  background: transparent;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-family: inherit;
-  line-height: 1.4;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  line-height: 1rem;
 }
-#nd-docs-layout .omni-close-btn {
-  margin-left: 0.25rem;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
+.omni-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 2.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-fd-border, #d4d4d4);
+  padding: 0.375rem 0.5rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  transition: background 120ms;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  transition:
+    background 120ms,
+    color 120ms;
   cursor: pointer;
-  border: none;
   background: none;
 }
-#nd-docs-layout .omni-close-btn:hover {
-  background: var(--color-fd-muted, #262626);
+.omni-close-btn:hover {
+  color: var(--color-fd-accent-foreground, var(--color-fd-foreground, #171717));
+  background: var(--color-fd-accent, #e5e5e5);
+}
+.omni-close-btn svg {
+  display: none;
 }
 
 /* Body / listbox */
-#nd-docs-layout .omni-body {
-  max-height: 60vh;
+.omni-body {
+  max-height: 460px;
   overflow: auto;
+  overscroll-behavior: contain;
   padding: 0.25rem;
 }
-#nd-docs-layout .omni-body::-webkit-scrollbar {
+.omni-body::-webkit-scrollbar {
   width: 6px;
 }
-#nd-docs-layout .omni-body::-webkit-scrollbar-track {
+.omni-body::-webkit-scrollbar-track {
   background: transparent;
 }
-#nd-docs-layout .omni-body::-webkit-scrollbar-thumb {
+.omni-body::-webkit-scrollbar-thumb {
   background: var(--color-fd-muted, #262626);
   border-radius: 3px;
 }
 
 /* Loading */
-#nd-docs-layout .omni-loading {
+.omni-loading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.625rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
 
 /* Groups */
-#nd-docs-layout .omni-group {
-  padding: 0.25rem 0;
+.omni-group {
+  padding: 0;
 }
-#nd-docs-layout .omni-group-label {
-  padding: 0.25rem 0.75rem;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  font-weight: 500;
+.omni-group-label {
+  display: none;
 }
-#nd-docs-layout .omni-group-items {
+.omni-group-items {
   display: flex;
   flex-direction: column;
 }
 
 /* Items */
-#nd-docs-layout .omni-item {
-  display: flex;
+.omni-item {
+  position: relative;
+  display: block;
   width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: calc(var(--radius, 0.75rem) - 4px);
-  padding: 0.5rem 0.75rem;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.625rem;
   text-align: left;
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -202,73 +218,72 @@
   color: var(--color-fd-foreground, #fafafa);
   transition: background 80ms;
 }
-#nd-docs-layout .omni-item:hover,
-#nd-docs-layout .omni-item-active {
-  background: color-mix(in srgb, var(--color-fd-accent, #262626) 60%, transparent);
+.omni-item:hover,
+.omni-item-active {
+  background: var(--color-fd-accent, rgba(209, 209, 209, 0.5));
 }
-#nd-docs-layout .omni-item-active {
-  color: var(--color-fd-accent-foreground, #fafafa);
+.omni-item-active {
+  color: var(--color-fd-accent-foreground, #171717);
 }
-#nd-docs-layout .omni-item-disabled {
+.omni-item-disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-#nd-docs-layout .omni-item-icon {
-  flex-shrink: 0;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
+.omni-item-icon {
+  display: none;
 }
-#nd-docs-layout .omni-item-active .omni-item-icon {
+.omni-item-active .omni-item-icon {
   color: var(--color-fd-accent-foreground, #fafafa);
 }
-#nd-docs-layout .omni-item-text {
-  flex: 1;
+.omni-item-text {
   min-width: 0;
 }
-#nd-docs-layout .omni-item-label {
+.omni-item-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  font-weight: 500;
 }
-#nd-docs-layout .omni-item-subtitle {
+.omni-item-subtitle {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.75rem;
+  line-height: 1rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0.8;
+  opacity: 1;
 }
-#nd-docs-layout .omni-item-active .omni-item-subtitle {
-  color: var(--color-fd-accent-foreground, #fafafa);
-  opacity: 0.7;
+.omni-item-active .omni-item-subtitle {
+  color: var(--color-fd-muted-foreground, #737373);
+  opacity: 1;
 }
-#nd-docs-layout .omni-item-badge {
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
+.omni-item-description {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-top: 0.25rem;
+  color: color-mix(in srgb, var(--color-fd-popover-foreground, #272727) 82%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35rem;
+  font-weight: 400;
 }
-#nd-docs-layout a.omni-item-badge:hover {
-  color: var(--color-fd-foreground, #fafafa);
+.omni-item-badge {
+  display: none;
 }
-#nd-docs-layout .omni-item-ext {
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  flex-shrink: 0;
-  transition:
-    color 100ms,
-    background 100ms;
-  text-decoration: none;
+.omni-item-ext {
+  display: none;
 }
-#nd-docs-layout .omni-item-ext:hover {
+.omni-item-ext:hover {
   color: var(--color-fd-foreground, #fafafa);
   background: var(--color-fd-muted, #262626);
 }
-#nd-docs-layout .omni-item-shortcuts {
+.omni-item-shortcuts {
   display: none;
   align-items: center;
   gap: 0.25rem;
@@ -276,50 +291,47 @@
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
 @media (min-width: 640px) {
-  #nd-docs-layout .omni-item-shortcuts {
+  .omni-item-shortcuts {
     display: flex;
   }
 }
-#nd-docs-layout .omni-kbd-sm {
+.omni-kbd-sm {
   border-radius: 0.25rem;
   background: var(--color-fd-muted, #262626);
   padding: 0.125rem 0.25rem;
-  font-family: inherit;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
 }
-#nd-docs-layout .omni-item-chevron {
-  width: 0.875rem;
-  height: 0.875rem;
-  margin-left: 0.25rem;
-  color: var(--color-fd-muted-foreground, #a3a3a3);
-  opacity: 0;
-  transition: opacity 120ms;
-  flex-shrink: 0;
+.omni-item-chevron {
+  display: none;
 }
-#nd-docs-layout .omni-item:hover .omni-item-chevron {
+.omni-item:hover .omni-item-chevron {
   opacity: 1;
 }
 
 /* Highlight */
-#nd-docs-layout .omni-highlight {
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 30%, transparent);
-  padding: 0 2px;
-  color: inherit;
+.omni-highlight {
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--color-fd-primary, #ca8a04);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Empty states */
-#nd-docs-layout .omni-empty-group {
+.omni-empty-group {
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-#nd-docs-layout .omni-empty {
-  padding: 2rem 0.75rem;
+.omni-empty {
+  padding: 1.5rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-#nd-docs-layout .omni-empty-icon {
+.omni-empty-icon {
   width: 2rem;
   height: 2rem;
   margin: 0 auto 0.5rem;
@@ -331,32 +343,55 @@
 }
 
 /* Footer */
-#nd-docs-layout .omni-footer {
+.omni-footer {
   border-top: 1px solid var(--color-fd-border, #262626);
+  background: color-mix(in srgb, var(--color-fd-secondary, #f5f5f5) 50%, transparent);
 }
-#nd-docs-layout .omni-footer-inner {
+.omni-footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.75rem;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
   font-size: 0.75rem;
   color: var(--color-fd-muted-foreground, #a3a3a3);
 }
-#nd-docs-layout .omni-footer-hints {
+.omni-footer-hints {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
-#nd-docs-layout .omni-footer-hint {
+.omni-footer-hint {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  white-space: nowrap;
 }
-#nd-docs-layout .omni-footer-hint-desktop {
+.omni-footer-hint svg {
+  flex-shrink: 0;
+}
+.omni-footer-hint-desktop {
   display: none;
 }
+.omni-footer-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  white-space: nowrap;
+}
 @media (min-width: 640px) {
-  #nd-docs-layout .omni-footer-hint-desktop {
+  .omni-footer-hint-desktop {
     display: flex;
   }
+}
+.omni-filter-label {
+  color: var(--color-fd-muted-foreground, #a3a3a3);
+}
+.omni-filter-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
 }

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -80,7 +80,6 @@
       ui-sans-serif, sans-serif);
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
   outline: none;
-  overflow: hidden;
   overscroll-behavior: contain;
   animation: omni-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -315,10 +314,6 @@
 .omni-item-chevron {
   display: none;
 }
-.omni-item:hover .omni-item-chevron {
-  opacity: 1;
-}
-
 /* Highlight */
 .omni-highlight {
   border-radius: 0;

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -282,29 +282,8 @@
   font-weight: 400;
 }
 .omni-item-description-code {
-  display: block;
-  max-height: 4.75rem;
-  padding: 0.5rem 0.625rem;
-  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
-  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
-  border-radius: 0.375rem;
-  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
       "Liberation Mono", "Courier New", monospace);
-  font-size: 0.8125rem;
-  line-height: 1.45rem;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.omni-item-active .omni-item-description-code {
-  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
-}
-.omni-item-description-code .omni-highlight {
-  border-radius: 0.1875rem;
-  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
-  padding: 0 0.125rem;
-  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
-  text-decoration: none;
 }
 .omni-item-badge {
   display: none;

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -283,10 +283,6 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
-.omni-item-description-code {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace);
-}
 .omni-item-badge {
   display: none;
 }

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -281,6 +281,31 @@
   line-height: 1.5rem;
   font-weight: 400;
 }
+.omni-item-description-code {
+  display: block;
+  max-height: 4.75rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--color-fd-border, #d4d4d4) 78%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--color-fd-primary, #ca8a04) 55%, transparent);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--color-fd-muted, #e5e5e5) 42%, transparent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace);
+  font-size: 0.8125rem;
+  line-height: 1.45rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.omni-item-active .omni-item-description-code {
+  background: color-mix(in srgb, var(--color-fd-background, #ffffff) 30%, transparent);
+}
+.omni-item-description-code .omni-highlight {
+  border-radius: 0.1875rem;
+  background: color-mix(in srgb, var(--color-fd-primary, #ca8a04) 25%, transparent);
+  padding: 0 0.125rem;
+  color: var(--color-fd-popover-foreground, var(--color-fd-foreground, #272727));
+  text-decoration: none;
+}
 .omni-item-badge {
   display: none;
 }

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -848,13 +848,16 @@ body:has(#nd-docs-layout),
 }
 
 #nd-docs-layout .omni-group-label {
-  display: block !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   letter-spacing: 0.08em !important;
 }
 
 #nd-docs-layout .omni-footer-inner {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+}
+
+#nd-docs-layout .omni-footer-hint svg {
+  border-radius: 0 !important;
 }
 
 #nd-docs-layout .omni-highlight {

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -865,11 +865,6 @@ body:has(#nd-docs-layout),
   border-radius: 0 !important;
 }
 
-#nd-docs-layout .omni-item-description-code,
-#nd-docs-layout .omni-item-description-code .omni-highlight {
-  border-radius: 0 !important;
-}
-
 #nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -860,6 +860,11 @@ body:has(#nd-docs-layout),
   border-radius: 0 !important;
 }
 
+#nd-docs-layout .omni-filter-menu,
+#nd-docs-layout .omni-filter-option {
+  border-radius: 0 !important;
+}
+
 #nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -865,6 +865,11 @@ body:has(#nd-docs-layout),
   border-radius: 0 !important;
 }
 
+#nd-docs-layout .omni-item-description-code,
+#nd-docs-layout .omni-item-description-code .omni-highlight {
+  border-radius: 0 !important;
+}
+
 #nd-docs-layout .omni-highlight {
   background: color-mix(in srgb, var(--color-fd-primary, #6366f1) 25%, transparent) !important;
   border-radius: 0 !important;

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -848,6 +848,7 @@ body:has(#nd-docs-layout),
 }
 
 #nd-docs-layout .omni-group-label {
+  display: block !important;
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
   letter-spacing: 0.08em !important;
 }

--- a/packages/svelte-theme/styles/pixel-border.css
+++ b/packages/svelte-theme/styles/pixel-border.css
@@ -844,7 +844,7 @@ body:has(#nd-docs-layout),
 }
 
 #nd-docs-layout .omni-search-input {
-  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif) !important;
 }
 
 #nd-docs-layout .omni-group-label {

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -876,7 +876,7 @@ body .fd-prompt-menu-item:hover {
   border-radius: 0 !important;
 }
 .omni-search-input {
-  font-family: var(--fd-font-mono, ui-monospace, monospace) !important;
+  font-family: var(--fd-font-sans, system-ui, -apple-system, sans-serif) !important;
 }
 .omni-group-label {
   font-family: var(--fd-font-mono, ui-monospace, monospace) !important;


### PR DESCRIPTION
## Summary

- Prioritize exact search result labels, section matches, and URL segment matches in built-in docs search.
- Rework the docs search modal rows to use breadcrumb-first Fumadocs-style results with cleaner section titles.
- Restore footer keyboard hints and keep the filter affordance.
- Preserve theme-specific search styling, including blocky pixel-border treatment and command-grid/threadline group labels across framework theme packages.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/search.test.ts`
- `pnpm --filter @farming-labs/docs run typecheck`
- `pnpm --filter @farming-labs/theme run typecheck`
- `pnpm --filter @farming-labs/svelte-theme run typecheck`
- `pnpm --filter @farming-labs/nuxt-theme run typecheck`
- `pnpm --filter @farming-labs/astro-theme run typecheck`
- `pnpm --filter @farming-labs/theme run build`
- `pnpm --filter @farming-labs/docs run test`
- Browser-verified `http://localhost:3004/docs` search results at desktop and narrow widths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the docs search modal with smarter literal/URL-segment/in‑page ranking, breadcrumb‑first results with a quick filter, and a cleaner, consistent UI across `fumadocs`, `@farming-labs/astro-theme`, `@farming-labs/nuxt-theme`, and `@farming-labs/svelte-theme`. Also lightens the overlay, adjusts top/z-index, centers the modal in threadline layouts, and polishes result spacing and filtering.

- **New Features**
  - Ranking: prefer exact labels, joined title+section, short literals, URL segments, and in‑page (site) matches; improved heading handling, tokenization, and phrase normalization.
  - Results UI: breadcrumb‑first rows with section labels and optional multi‑line descriptions; ESC hint restored; quick filter with All / Pages / Inside pages.
  - Snippets: more reliable code highlighting with simpler, unified styling.

- **Refactors**
  - Simplified controls: no per‑result icons/chevrons; input placeholder “Search”; close button shows “ESC”; removed “⌘ K”.
  - Consistent styles: lighter overlay and blur, clamped modal top, unified z‑index/mobile spacing; `omni-group-label` display fix; centered in threadline layouts.
  - Pixel theme: use sans for the search input and descriptions; consistent `kbd`/filter styling; squared corners across items.

<sup>Written for commit 56f58918366b672a2ea4075ba003b76e16c0c4bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

