### PR TITLE
chore: readme refine

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,80 +127,6 @@ The agent discovery JSON also includes structured-data capability metadata plus 
 `robots.route`, and `robots.defaultRoute` so agents can find page metadata and the static crawl
 policy without guessing.
 
-For a custom site-specific skill, place `skill.md` at the project root beside `docs.config.ts`.
-When it is missing, the framework serves a generated fallback based on the docs config.
-
-Enable `sitemap` when you also want crawler-friendly XML and agent-friendly Markdown maps:
-
-```ts
-sitemap: {
-  enabled: true,
-  baseUrl: "https://docs.example.com",
-},
-```
-
-For static hosting, run `pnpm exec docs sitemap generate` before your framework build so
-`public/sitemap.xml`, `public/sitemap.md`, `public/.well-known/sitemap.md`, and the internal
-`.farming-labs/sitemap-manifest.json` stay fresh.
-
-Run `pnpm exec docs robots generate` when you also want a committed `robots.txt` policy. Existing
-files are preserved by default; use `--append` to add the generated block or `--force` to replace
-the file.
-
-## Agent Compaction
-
-Use `docs agent compact` when you want to generate or refresh sibling `agent.md` files from
-resolved docs pages.
-
-```bash
-pnpm exec docs agent compact installation
-pnpm exec docs agent compact --changed
-pnpm exec docs agent compact --stale
-pnpm exec docs agent compact --stale --include-missing
-```
-
-The API key comes from the root Docs Cloud config. Optional compression defaults live under
-`agent.compact`:
-
-```ts
-cloud: {
-  apiKey: { env: "DOCS_CLOUD_API_KEY" },
-},
-agent: {
-  compact: {
-    model: "docs-cloud-compress-v1",
-    aggressiveness: 0.3,
-  },
-},
-```
-
-Per-page token budgets live in frontmatter:
-
-```md
----
-title: "Installation"
-agent:
-  tokenBudget: 777
----
-```
-
-That page-level `agent.tokenBudget` override beats global `agent.compact.maxOutputTokens` defaults
-and CLI `--max-output-tokens` for the same page. If the page already has a sibling `agent.md`, the
-command compacts that file. Otherwise it compacts the generated machine-readable page first and
-writes a new sibling `agent.md`.
-
-Generated files carry hidden provenance metadata so the CLI can detect drift later:
-
-- `docs agent compact --changed` compacts only docs pages whose source files changed in the current
-  git working tree, including staged, unstaged, and untracked docs changes
-- `docs agent compact --stale` refreshes only stale generated `agent.md` files
-- `docs agent compact --stale --include-missing` also creates missing `agent.md` files for
-  explicitly requested pages or pages that define `agent.tokenBudget`
-- hand-edited generated `agent.md` files are treated as modified and skipped by `--stale`
-
-The generated `agent.md` becomes the machine-readable source for `.md` routes,
-`GET /api/docs?format=markdown&path=...`, and MCP `read_page()`.
-
 ## Agent Health Check
 
 Use `docs doctor --agent` when you want to inspect the machine-facing quality of the docs site.
@@ -224,70 +150,12 @@ Framework: nextjs • Entry: docs • Content: app/docs
 Explicit agent-friendly pages: 10/41 pages (24%)
 ```
 
-The command checks the agent surface end to end:
+The command checks docs config resolution, content discovery, API route wiring, public agent routes,
+`llms.txt`, sitemap routes, `robots.txt`, `skill.md`, MCP, search, feedback, page metadata, and
+generated `agent.md` freshness.
 
-- docs config resolution
-- docs content discovery
-- docs API route wiring
-- public agent routes
-- agent discovery spec
-- `llms.txt`
-- `sitemap.xml` / `sitemap.md`
-- `robots.txt`
-- `skill.md`
-- MCP
-- search
-- agent feedback
-- page metadata
-- explicit agent-friendly pages
-- generated `agent.md` freshness and `agent.compact` defaults
-
-It is not required to run the framework, but it is very useful before claiming a docs site is
-agent-ready or agent-optimized, and it works well as a CI check for the machine-facing docs layer.
-
-Add `--url` after deploying when you want to test the public agent surface too:
-
-```bash
-pnpm exec docs doctor --agent --url https://docs.example.com
-pnpm exec docs doctor --agent --url https://docs.example.com --json
-```
-
-Hosted checks request `/.well-known/agent.json`, `/llms.txt`, `/llms-full.txt`, sitemap routes,
-the robots route from the discovery spec, `/skill.md`, `/.well-known/skill.md`, one representative
-`.md` page route, `/mcp`, and `/.well-known/mcp`.
-For MCP, the doctor performs an HTTP initialize handshake, checks the session header, and verifies
-the built-in docs tools are exposed. With hosted checks enabled, the agent score is out of `145`
-instead of `105`.
-
-`docs doctor --site` focuses on the reader-facing surface instead:
-
-- docs config resolution
-- docs content discovery
-- navigation coverage
-- page descriptions
-- page structure
-- search
-- trust signals (`github` / `lastUpdated`)
-- reader feedback
-- reading-time cues
-
-Use `--json` when the result needs to feed another system instead of a person reading the terminal:
-
-```bash
-pnpm exec docs doctor --agent --json
-pnpm exec docs doctor --site --json
-```
-
-That JSON form is useful for:
-
-- CI quality gates
-- GitHub Actions summaries or PR comments
-- dashboards that track docs quality over time
-- automation that reruns `docs agent compact --stale`
-- other agents that need structured readiness signals instead of terminal text
-
-The JSON report itself is written to stdout. Separate loader notices, such as config fallback
-warnings, are outside the JSON payload.
+Hosted checks request the public agent routes and verify the MCP initialize handshake. Use `--json`
+when the result needs to feed CI, dashboards, GitHub Actions summaries, or another system.
 
 ## Common Tasks
 
@@ -304,14 +172,8 @@ Use the full docs for feature-specific setup:
 
 ## Agent Skills
 
-This repo includes installable Agent Skills for assistants working with `@farming-labs/docs`.
-
-```bash
-npx skills add farming-labs/docs
-```
-
-Skills live in [`skills/farming-labs`](./skills/farming-labs) and cover setup, CLI usage,
-configuration, themes, Ask AI, and page actions.
+Installable Agent Skills live in [`skills/farming-labs`](./skills/farming-labs) and cover setup,
+CLI usage, configuration, themes, Ask AI, and page actions.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Keep the Agent/LLM surface route overview in the README.
- Remove setup-heavy details for custom `skill.md`, sitemap generation, robots generation, and agent compaction.
- Condense the doctor/check details and keep Agent Skills as a link to the skills directory.

## Validation

- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Further trimmed the README by removing detailed `sitemap`/`robots`/`skill.md` generation and Agent Compaction instructions, and condensed the Agent Doctor section to a brief checklist with hosted-check and `--json` notes. Kept links to the Agent-friendly docs and CLI, and replaced the skills install command with a pointer to `skills/farming-labs`.

<sup>Written for commit 83243f2f60d3963eb6b384b122dec68bdce116bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->