### PR TITLE
chore: add status page footer link

### DIFF
--- a/website/app/agent-score/agent-score-page.tsx
+++ b/website/app/agent-score/agent-score-page.tsx
@@ -2238,12 +2238,19 @@ function FooterSection() {
             </p>
           </div>
           <div className="flex w-full max-w-full flex-col items-start gap-3 sm:items-end sm:justify-center">
-            <div className="flex w-full max-w-full items-center justify-start gap-6 sm:justify-end">
+            <div className="flex w-full max-w-full flex-wrap items-center justify-start gap-x-6 gap-y-3 sm:justify-end">
               <Link
                 href="/docs"
                 className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
               >
                 Documentation
+              </Link>
+              <Link
+                href="https://status.farming-labs.dev"
+                target="_blank"
+                className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
+              >
+                Status
               </Link>
               <Link
                 href="https://github.com/farming-labs/docs"

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -722,12 +722,19 @@ function CloudFooterSection() {
           </div>
 
           <div className="flex w-full max-w-full flex-col items-start gap-3 sm:items-end sm:justify-center">
-            <div className="flex w-full max-w-full items-center justify-start gap-6 sm:justify-end">
+            <div className="flex w-full max-w-full flex-wrap items-center justify-start gap-x-6 gap-y-3 sm:justify-end">
               <Link
                 href="/docs"
                 className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
               >
                 Documentation
+              </Link>
+              <Link
+                href="https://status.farming-labs.dev"
+                target="_blank"
+                className="font-mono text-xs uppercase text-black/30 transition-colors hover:text-black/60 hover:no-underline dark:text-white/30 dark:hover:text-white/60"
+              >
+                Status
               </Link>
               <Link
                 href="/cloud#enterprise-support"

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1130,12 +1130,19 @@ function FooterSection() {
               </Link>
             </p>
           </div>
-          <div className="flex max-w-full w-full justify-end items-center gap-6">
+          <div className="flex max-w-full w-full flex-wrap justify-end items-center gap-x-6 gap-y-3">
             <Link
               href="/docs"
               className="text-xs uppercase font-mono text-black/30 dark:text-white/30 hover:text-black/60 dark:hover:text-white/60 transition-colors hover:no-underline"
             >
               Documentation
+            </Link>
+            <Link
+              href="https://status.farming-labs.dev"
+              target="_blank"
+              className="text-xs uppercase font-mono text-black/30 dark:text-white/30 hover:text-black/60 dark:hover:text-white/60 transition-colors hover:no-underline"
+            >
+              Status
             </Link>
             <Link
               href="https://github.com/farming-labs/docs"


### PR DESCRIPTION
## Summary

- Add a Status footer link to `https://status.farming-labs.dev` on the homepage, Cloud page, and Agent Score page.
- Let footer link rows wrap with row/column gaps so the added label stays tidy on smaller screens.

## Validation

- `pnpm --filter @farming-labs/docs-website exec tsc --noEmit --pretty false`
- `pnpm format:check`
- Browser checked `/`, `/cloud`, and `/agent-score` on the local dev server; all rendered with the new Status link and no error overlay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Status footer link to https://status.farming-labs.dev on the homepage, Cloud, and Agent Score pages. Updated the footer to allow wrapping with gap spacing so links stay tidy on smaller screens.

<sup>Written for commit c1f38973ccd1abe0fa579df2ebd05e1bbfe50d65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

