### PR TITLE
fix: preserve docs.json as cloud init source

### DIFF
--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -111,6 +111,88 @@ describe("cloud cli", () => {
     expect(docsJson.cloud.preview).toBeUndefined();
   });
 
+  it("treats existing frameworkless docs.json as the cloud init source of truth", async () => {
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(path.join(tmpDir, "docs", "index.mdx"), "# Hello\n", "utf-8");
+    writeFileSync(
+      path.join(tmpDir, "docs.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          docs: {
+            mode: "frameworkless",
+            runtime: "nextjs",
+            root: ".docs/site",
+          },
+          content: {
+            docsRoot: "docs",
+            apiReferenceRoot: "api-reference",
+          },
+          cloud: {
+            publish: { mode: "direct-commit", baseBranch: "stable" },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const result = await initCloudConfig({
+      rootDir: tmpDir,
+      apiKeyEnv: "ACME_DOCS_CLOUD_KEY",
+    });
+    const docsJson = JSON.parse(readFileSync(path.join(tmpDir, "docs.json"), "utf-8"));
+
+    expect(result).toMatchObject({
+      configPath: path.join(tmpDir, "docs.json"),
+      docsJsonPath: path.join(tmpDir, "docs.json"),
+      apiKeyEnv: "ACME_DOCS_CLOUD_KEY",
+      configCreated: false,
+      configUpdated: false,
+      docsJsonCreated: false,
+      docsJsonUpdated: true,
+    });
+    expect(existsSync(path.join(tmpDir, "docs.config.ts"))).toBe(false);
+    expect(docsJson).toMatchObject({
+      docs: {
+        mode: "frameworkless",
+        runtime: "nextjs",
+        root: ".docs/site",
+      },
+      content: {
+        docsRoot: "docs",
+        apiReferenceRoot: "api-reference",
+      },
+      cloud: {
+        apiKey: { env: "ACME_DOCS_CLOUD_KEY" },
+        deploy: { enabled: true },
+        analytics: {
+          enabled: true,
+          console: false,
+          includeInputs: false,
+        },
+        publish: {
+          mode: "direct-commit",
+          baseBranch: "stable",
+        },
+      },
+    });
+
+    const secondResult = await initCloudConfig({
+      rootDir: tmpDir,
+      apiKeyEnv: "ACME_DOCS_CLOUD_KEY",
+    });
+
+    expect(secondResult).toMatchObject({
+      configCreated: false,
+      configUpdated: false,
+      docsJsonCreated: false,
+      docsJsonUpdated: false,
+    });
+    expect(existsSync(path.join(tmpDir, "docs.config.ts"))).toBe(false);
+  });
+
   it("initializes Docs Cloud config, analytics, and docs.json", async () => {
     writePackageJson();
     mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });

--- a/packages/docs/src/cli/cloud.test.ts
+++ b/packages/docs/src/cli/cloud.test.ts
@@ -193,6 +193,63 @@ describe("cloud cli", () => {
     expect(existsSync(path.join(tmpDir, "docs.config.ts"))).toBe(false);
   });
 
+  it("does not infer Fumadocs connect mode when docs.json is already the source", async () => {
+    writePackageJson({
+      next: "16.0.0",
+      "fumadocs-core": "16.7.16",
+      "fumadocs-ui": "16.7.16",
+    });
+    mkdirSync(path.join(tmpDir, "docs"), { recursive: true });
+    mkdirSync(path.join(tmpDir, "content", "docs"), { recursive: true });
+    writeFileSync(path.join(tmpDir, "docs", "index.mdx"), "# Atomic docs.json\n", "utf-8");
+    writeFileSync(
+      path.join(tmpDir, "content", "docs", "index.mdx"),
+      "# Fumadocs signal\n",
+      "utf-8",
+    );
+    writeFileSync(path.join(tmpDir, "source.config.ts"), "export default {};\n", "utf-8");
+    writeFileSync(
+      path.join(tmpDir, "docs.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          docs: {
+            mode: "frameworkless",
+            runtime: "nextjs",
+            root: ".docs/site",
+          },
+          content: {
+            docsRoot: "docs",
+          },
+          cloud: {
+            apiKey: { env: "EXISTING_DOCS_CLOUD_KEY" },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const result = await initCloudConfig({ rootDir: tmpDir });
+    const materialized = await materializeCloudConfig({ rootDir: tmpDir });
+    const docsJson = JSON.parse(readFileSync(path.join(tmpDir, "docs.json"), "utf-8"));
+
+    expect(result.docsInfraProfile).toBeUndefined();
+    expect(result.configCreated).toBe(false);
+    expect(result.configPath).toBe(path.join(tmpDir, "docs.json"));
+    expect(materialized.updated).toBe(false);
+    expect(existsSync(path.join(tmpDir, "docs.config.ts"))).toBe(false);
+    expect(docsJson.content.docsRoot).toBe("docs");
+    expect(docsJson.extensions?.docsInfraProfile).toBeUndefined();
+    expect(docsJson.docs).toEqual({
+      mode: "frameworkless",
+      runtime: "nextjs",
+      root: ".docs/site",
+    });
+    expect(docsJson.cloud.apiKey.env).toBe("EXISTING_DOCS_CLOUD_KEY");
+  });
+
   it("initializes Docs Cloud config, analytics, and docs.json", async () => {
     writePackageJson();
     mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1073,10 +1073,7 @@ function resolveConnectedDocsProfile(params: {
   rootDir: string;
   snapshot: DocsConfigSnapshot;
   existing?: ManagedDocsJson;
-  explicit?: ConnectedDocsProfile;
 }): ConnectedDocsProfile | undefined {
-  if (params.explicit) return params.explicit;
-
   const shouldResolveConnectProfile =
     params.snapshot.content?.includes(FUMADOCS_CONNECT_MARKER) || !params.snapshot.path;
   if (!shouldResolveConnectProfile) return undefined;
@@ -1170,10 +1167,13 @@ function resolveDocsBlock(
 function resolveExtensions(
   existing: ManagedDocsJson | undefined,
   docsInfraProfile: ConnectedDocsProfile | undefined,
+  options: { dropStaleDocsInfraProfile?: boolean } = {},
 ): JsonRecord | undefined {
   const existingExtensions = toJsonRecord(existing?.extensions);
   if (!docsInfraProfile) {
-    if (!existingExtensions?.docsInfraProfile) return existingExtensions;
+    if (!existingExtensions?.docsInfraProfile || options.dropStaleDocsInfraProfile === false) {
+      return existingExtensions;
+    }
 
     const { docsInfraProfile: _staleDocsInfraProfile, ...rest } = existingExtensions;
     return Object.keys(rest).length > 0 ? rest : undefined;
@@ -1190,14 +1190,19 @@ function materializeDocsJsonObject(params: {
   snapshot: DocsConfigSnapshot;
   existing?: ManagedDocsJson;
   docsInfraProfile?: ConnectedDocsProfile;
+  detectConnectedDocsProfile?: boolean;
+  dropStaleDocsInfraProfile?: boolean;
 }): ManagedDocsJson {
   const cloud = resolveCloudConfig(params.snapshot, params.existing);
-  const docsInfraProfile = resolveConnectedDocsProfile({
-    rootDir: params.rootDir,
-    snapshot: params.snapshot,
-    existing: params.existing,
-    explicit: params.docsInfraProfile,
-  });
+  const docsInfraProfile =
+    params.docsInfraProfile ??
+    (params.detectConnectedDocsProfile === false
+      ? undefined
+      : resolveConnectedDocsProfile({
+          rootDir: params.rootDir,
+          snapshot: params.snapshot,
+          existing: params.existing,
+        }));
   const docsRoot = resolveDocsRoot(
     params.rootDir,
     params.snapshot,
@@ -1207,7 +1212,9 @@ function materializeDocsJsonObject(params: {
   const apiReferenceRoot = resolveApiReferenceRoot(params.snapshot);
   const existingContent = toJsonRecord(params.existing?.content);
   const site = resolveSiteConfig(params.rootDir, params.snapshot, params.existing);
-  const extensions = resolveExtensions(params.existing, docsInfraProfile);
+  const extensions = resolveExtensions(params.existing, docsInfraProfile, {
+    dropStaleDocsInfraProfile: params.dropStaleDocsInfraProfile,
+  });
 
   const content: ManagedDocsJson["content"] = {
     ...existingContent,
@@ -1264,12 +1271,16 @@ function writeMaterializedCloudConfig(params: {
   snapshot: DocsConfigSnapshot;
   docsInfraProfile?: ConnectedDocsProfile;
   cloudInitApiKeyEnv?: string;
+  detectConnectedDocsProfile?: boolean;
+  dropStaleDocsInfraProfile?: boolean;
 }): MaterializeCloudConfigResult {
   const config = materializeDocsJsonObject({
     rootDir: params.rootDir,
     snapshot: params.snapshot,
     existing: params.existing,
     docsInfraProfile: params.docsInfraProfile,
+    detectConnectedDocsProfile: params.detectConnectedDocsProfile,
+    dropStaleDocsInfraProfile: params.dropStaleDocsInfraProfile,
   });
 
   if (params.cloudInitApiKeyEnv) {
@@ -1305,12 +1316,15 @@ export async function materializeCloudConfig(
   const docsJsonPath = path.join(rootDir, DOCS_JSON_FILE);
   const existing = readExistingDocsJson(docsJsonPath);
   const snapshot = await loadDocsConfigSnapshot(rootDir, options.configPath);
+  const useDocsJsonAsSource = Boolean(existing && !snapshot.path);
   return writeMaterializedCloudConfig({
     rootDir,
     docsJsonPath,
     existing,
     snapshot,
     docsInfraProfile: options.docsInfraProfile,
+    detectConnectedDocsProfile: !useDocsJsonAsSource,
+    dropStaleDocsInfraProfile: !useDocsJsonAsSource,
   });
 }
 
@@ -2453,6 +2467,8 @@ export async function initCloudConfig(options: CloudCommandOptions = {}): Promis
       snapshot: {},
       docsInfraProfile,
       cloudInitApiKeyEnv: apiKeyEnv,
+      detectConnectedDocsProfile: false,
+      dropStaleDocsInfraProfile: false,
     });
 
     return {

--- a/packages/docs/src/cli/cloud.ts
+++ b/packages/docs/src/cli/cloud.ts
@@ -1146,8 +1146,12 @@ function resolveDocsBlock(
   existing?: ManagedDocsJson,
   docsInfraProfile?: ConnectedDocsProfile,
 ): ManagedDocsJson["docs"] {
-  const detectedFramework = detectFramework(rootDir);
   const existingDocs = existing?.docs;
+  if (!snapshot.path && existingDocs) {
+    return existingDocs;
+  }
+
+  const detectedFramework = detectFramework(rootDir);
   const runtime =
     detectedFramework ?? docsInfraProfile?.runtime ?? existingDocs?.runtime ?? "nextjs";
   const hasFrameworkConfig = Boolean(snapshot.path || detectedFramework);
@@ -1227,6 +1231,73 @@ export function serializeMaterializedDocsJson(config: ManagedDocsJson): string {
   return `${JSON.stringify(config, null, 2)}\n`;
 }
 
+function withCloudInitDefaults(
+  cloud: DocsCloudConfig | undefined,
+  existingCloud: DocsCloudConfig | undefined,
+  apiKeyEnv: string,
+): DocsCloudConfig {
+  const normalized = normalizeCloudConfig(cloud);
+
+  if (!existingCloud?.apiKey?.env) {
+    normalized.apiKey = { env: apiKeyEnv };
+  }
+
+  if (!normalized.deploy) {
+    normalized.deploy = { enabled: true };
+  }
+
+  if (typeof normalized.analytics === "undefined") {
+    normalized.analytics = {
+      enabled: true,
+      console: false,
+      includeInputs: false,
+    };
+  }
+
+  return normalizeCloudConfig(normalized);
+}
+
+function writeMaterializedCloudConfig(params: {
+  rootDir: string;
+  docsJsonPath: string;
+  existing?: ManagedDocsJson;
+  snapshot: DocsConfigSnapshot;
+  docsInfraProfile?: ConnectedDocsProfile;
+  cloudInitApiKeyEnv?: string;
+}): MaterializeCloudConfigResult {
+  const config = materializeDocsJsonObject({
+    rootDir: params.rootDir,
+    snapshot: params.snapshot,
+    existing: params.existing,
+    docsInfraProfile: params.docsInfraProfile,
+  });
+
+  if (params.cloudInitApiKeyEnv) {
+    config.cloud = withCloudInitDefaults(
+      config.cloud,
+      params.existing?.cloud,
+      params.cloudInitApiKeyEnv,
+    );
+  }
+
+  const serialized = serializeMaterializedDocsJson(config);
+  const previous = params.existing ? fs.readFileSync(params.docsJsonPath, "utf-8") : undefined;
+  const updated = previous !== serialized;
+
+  if (updated) {
+    fs.writeFileSync(params.docsJsonPath, serialized, "utf-8");
+  }
+
+  return {
+    configPath: params.snapshot.path ?? params.docsJsonPath,
+    docsJsonPath: params.docsJsonPath,
+    config,
+    apiKeyEnv: config.cloud?.apiKey?.env ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV,
+    created: !params.existing,
+    updated,
+  };
+}
+
 export async function materializeCloudConfig(
   options: CloudCommandOptions = {},
 ): Promise<MaterializeCloudConfigResult> {
@@ -1234,28 +1305,13 @@ export async function materializeCloudConfig(
   const docsJsonPath = path.join(rootDir, DOCS_JSON_FILE);
   const existing = readExistingDocsJson(docsJsonPath);
   const snapshot = await loadDocsConfigSnapshot(rootDir, options.configPath);
-  const config = materializeDocsJsonObject({
+  return writeMaterializedCloudConfig({
     rootDir,
-    snapshot,
+    docsJsonPath,
     existing,
+    snapshot,
     docsInfraProfile: options.docsInfraProfile,
   });
-  const serialized = serializeMaterializedDocsJson(config);
-  const previous = existing ? fs.readFileSync(docsJsonPath, "utf-8") : undefined;
-  const updated = previous !== serialized;
-
-  if (updated) {
-    fs.writeFileSync(docsJsonPath, serialized, "utf-8");
-  }
-
-  return {
-    configPath: snapshot.path ?? docsJsonPath,
-    docsJsonPath,
-    config,
-    apiKeyEnv: config.cloud?.apiKey?.env ?? DOCS_CLOUD_DEFAULT_API_KEY_ENV,
-    created: !existing,
-    updated,
-  };
 }
 
 function readCombinedEnv(rootDir: string): Record<string, string> {
@@ -2380,11 +2436,38 @@ export async function syncCloudConfig(options: CloudCommandOptions = {}) {
 
 export async function initCloudConfig(options: CloudCommandOptions = {}): Promise<CloudInitResult> {
   const rootDir = options.rootDir ?? process.cwd();
+  const docsJsonPath = path.join(rootDir, DOCS_JSON_FILE);
+  const existingDocsJson = readExistingDocsJson(docsJsonPath);
   const apiKeyEnv = normalizeEnvName(options.apiKeyEnv, DOCS_CLOUD_DEFAULT_API_KEY_ENV);
   const existingConfigPath = tryResolveDocsConfigPath(rootDir, options.configPath);
+  const useDocsJsonAsSource = Boolean(existingDocsJson && !existingConfigPath);
   const docsInfraProfile =
     options.docsInfraProfile ??
-    (existingConfigPath ? undefined : detectConnectedFumadocsProfile(rootDir));
+    (existingConfigPath || existingDocsJson ? undefined : detectConnectedFumadocsProfile(rootDir));
+
+  if (useDocsJsonAsSource) {
+    const materialized = writeMaterializedCloudConfig({
+      rootDir,
+      docsJsonPath,
+      existing: existingDocsJson,
+      snapshot: {},
+      docsInfraProfile,
+      cloudInitApiKeyEnv: apiKeyEnv,
+    });
+
+    return {
+      configPath: materialized.configPath,
+      docsJsonPath: materialized.docsJsonPath,
+      apiKeyEnv: materialized.apiKeyEnv,
+      analyticsProjectIdEnv: DOCS_CLOUD_DEFAULT_ANALYTICS_PROJECT_ID_ENV,
+      configCreated: false,
+      configUpdated: false,
+      docsJsonCreated: false,
+      docsJsonUpdated: materialized.updated,
+      ...(docsInfraProfile ? { docsInfraProfile } : {}),
+    };
+  }
+
   const configUpdate = ensureDocsConfigCloudInit({
     rootDir,
     configPath: options.configPath,


### PR DESCRIPTION
## Summary

- Treat an existing `docs.json` without `docs.config.*` as the source of truth for `docs cloud init`.
- Preserve frameworkless `docs.mode`, runtime root, content roots, existing cloud feature choices, and existing docs-cloud extensions.
- Add Cloud init defaults directly to `docs.json` without creating a native `docs.config.ts` sidecar.
- Keep repeated `docs cloud init` runs idempotent for docs-json-only projects, even when Fumadocs dependencies/config files are present.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/cli/cloud.test.ts`
- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm exec oxlint packages/docs/src/cli/cloud.ts packages/docs/src/cli/cloud.test.ts`
- `pnpm exec oxfmt --check packages/docs/src/cli/cloud.ts packages/docs/src/cli/cloud.test.ts && git diff --check`
- `pnpm --filter @farming-labs/docs build`
- Built-CLI smoke matrix for: native `docs.config.tsx`, frameworkless `docs.json`, framework-backed `docs.json` without config, fresh Fumadocs connect, fresh framework config creation, and `docs.json` with Fumadocs signals.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use an existing `docs.json` as the source of truth for `docs cloud init` when no `docs.config.*` exists. Preserves frameworkless settings, writes cloud defaults to `docs.json` (no `docs.config.ts`), and keeps repeat runs idempotent.

- **Bug Fixes**
  - Uses `docs.json` as init input and writes defaults (apiKey env, deploy enabled, analytics) back to it.
  - Keeps existing `docs.mode`, runtime/root, and content roots unchanged; subsequent runs are a no-op.

<sup>Written for commit 96671cb4b0b80110c002b896e4da62a223238bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
