### PR TITLE
fix: align framework markdown components

### DIFF
--- a/packages/astro-theme/src/components/DocsPage.astro
+++ b/packages/astro-theme/src/components/DocsPage.astro
@@ -679,11 +679,16 @@ const localizedParentUrl = withLang(parentUrl);
         trigger.addEventListener('click', () => {
           const val = trigger.getAttribute('data-tab-value');
           tabs.querySelectorAll('.fd-tab-trigger').forEach(t => {
-            t.classList.toggle('fd-tab-active', t.getAttribute('data-tab-value') === val);
-            t.setAttribute('aria-selected', String(t.getAttribute('data-tab-value') === val));
+            const active = t.getAttribute('data-tab-value') === val;
+            t.classList.toggle('fd-tab-active', active);
+            t.setAttribute('aria-selected', String(active));
+            t.setAttribute('data-state', active ? 'active' : 'inactive');
+            t.setAttribute('tabindex', active ? '0' : '-1');
           });
           tabs.querySelectorAll('.fd-tab-panel').forEach(p => {
-            p.classList.toggle('fd-tab-panel-active', p.getAttribute('data-tab-panel') === val);
+            const active = p.getAttribute('data-tab-panel') === val;
+            p.classList.toggle('fd-tab-panel-active', active);
+            p.setAttribute('data-state', active ? 'active' : 'inactive');
           });
         });
       });

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -528,6 +528,30 @@ function createCodeGroupTabValue(label: string, used: Set<string>): string {
   return value;
 }
 
+const terminalCodeLanguages = new Set([
+  "bash",
+  "console",
+  "sh",
+  "shell",
+  "shellscript",
+  "terminal",
+]);
+const fileCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>';
+const terminalCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path d="m 4,4 a 1,1 0 0 0 -0.7070312,0.2929687 1,1 0 0 0 0,1.4140625 L 8.5859375,11 3.2929688,16.292969 a 1,1 0 0 0 0,1.414062 1,1 0 0 0 1.4140624,0 l 5.9999998,-6 a 1.0001,1.0001 0 0 0 0,-1.414062 L 4.7070312,4.2929687 A 1,1 0 0 0 4,4 Z m 8,14 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 h 8 a 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z" fill="currentColor"/></svg>';
+const copyCodeBlockIcon =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>';
+
+function renderCodeBlockTitleIcon(title?: string | null, language?: string | null): string {
+  const normalizedTitle = title?.trim().toLowerCase() ?? "";
+  const normalizedLanguage = language?.trim().toLowerCase() ?? "";
+  if (normalizedTitle.includes("terminal") || terminalCodeLanguages.has(normalizedLanguage)) {
+    return terminalCodeBlockIcon;
+  }
+  return fileCodeBlockIcon;
+}
+
 function wrapCodeWithCopy(
   html: string,
   rawCode: string,
@@ -540,9 +564,9 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code">${copyCodeBlockIcon}</button>`;
   if (title) {
-    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title>${renderCodeBlockTitleIcon(title, language)}<span class="fd-codeblock-title-text">${escapeHtml(title)}</span><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
   return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -386,10 +386,45 @@ const calloutIcons: Record<string, string> = {
     '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
 };
 
-function renderCallout(type: string, content: string): string {
-  const icon = calloutIcons[type] || calloutIcons.note;
-  const label = type.charAt(0).toUpperCase() + type.slice(1);
-  return `<div class="fd-callout fd-callout-${type}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${label}</p><p>${content}</p></div></div>`;
+const calloutTypeAliases: Record<string, string> = {
+  danger: "caution",
+  error: "caution",
+  info: "note",
+  success: "tip",
+  warn: "warning",
+};
+
+const calloutLabels: Record<string, string> = {
+  caution: "Caution",
+  important: "Important",
+  note: "Note",
+  tip: "Tip",
+  warning: "Warning",
+};
+
+function normalizeCalloutType(type: string): string {
+  const normalized = type.trim().toLowerCase();
+  const aliased = calloutTypeAliases[normalized] ?? normalized;
+  return calloutIcons[aliased] ? aliased : "note";
+}
+
+function renderInlineCalloutContent(content: string): string {
+  return content
+    .trim()
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\n+/g, "<br />");
+}
+
+function renderCallout(type: string, content: string, title?: string | null): string {
+  const normalizedType = normalizeCalloutType(type);
+  const icon = calloutIcons[normalizedType] || calloutIcons.note;
+  const label = title?.trim() || calloutLabels[normalizedType] || "Note";
+  const renderedContent = renderInlineCalloutContent(content);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -418,13 +453,6 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
   }
 }
 
-function parseMeta(meta: string): { lang: string; title: string | null } {
-  const trimmed = meta.trim();
-  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
-  return { lang, title: titleMatch ? titleMatch[1] : null };
-}
-
 const ignoredCodeGroupBareTitleTokens = new Set([
   "copy",
   "no-copy",
@@ -436,6 +464,33 @@ const ignoredCodeGroupBareTitleTokens = new Set([
   "showlinenumbers",
   "wrap",
 ]);
+
+function parseMeta(meta: string): { lang: string; title: string | null } {
+  const trimmed = meta.trim();
+  const firstToken = trimmed.split(/\s+/, 1)[0] ?? "";
+  const hasLanguage = Boolean(
+    firstToken && !firstToken.includes("=") && !firstToken.startsWith("{"),
+  );
+  const lang = hasLanguage ? firstToken.toLowerCase() : "text";
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
+
+  if (titleMatch) return { lang, title: titleMatch[1] };
+
+  const bareTitle = trimmed
+    .slice(hasLanguage ? firstToken.length : 0)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find(
+      (part) =>
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
+
+  return {
+    lang,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
 
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
@@ -485,11 +540,11 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
-  return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
+  return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }
 
 function dedentCode(raw: string): string {
@@ -547,14 +602,16 @@ export async function renderMarkdown(
 
       if (panels.length === 0) return body;
 
-      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
-      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(panels[i].label)}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel fd-code-group-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -589,11 +646,13 @@ export async function renderMarkdown(
       let tabsHtml = `<div class="fd-tabs" data-tabs>`;
       tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
       for (let i = 0; i < items.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${items[i]}" aria-selected="${i === 0}">${items[i]}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(items[i])}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(items[i])}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${panels[i].value}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -636,6 +695,19 @@ export async function renderMarkdown(
     },
   );
 
+  const calloutBlocks: string[] = [];
+  result = result.replace(
+    /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
+      const title = toStringValue(attrs.title);
+      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+      calloutBlocks.push(renderCallout(type, children, title));
+      return placeholder;
+    },
+  );
+
   // Inline code
   result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
 
@@ -652,7 +724,6 @@ export async function renderMarkdown(
   result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
 
   // ── Callouts / blockquotes (before inline formatting) ──
-  const calloutBlocks: string[] = [];
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
     const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");

--- a/packages/fumadocs/styles/bundles/shared-framework.css
+++ b/packages/fumadocs/styles/bundles/shared-framework.css
@@ -8704,6 +8704,15 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   border-radius: var(--radius, 12px) var(--radius, 12px) 0 0;
 }
 
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title-text,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title figcaption {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 #nd-docs-layout[data-fd-framework] .fd-codeblock-title + .fd-copy-btn ~ pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
@@ -8712,6 +8721,21 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
 #nd-docs-layout[data-fd-framework] .fd-codeblock:has(.fd-codeblock-title) pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions-floating {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
 }
 
 #nd-docs-layout[data-fd-framework] .fd-copy-btn {
@@ -8735,6 +8759,18 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
     opacity 0.15s,
     color 0.15s,
     background 0.15s;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions .fd-copy-btn,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions-floating .fd-copy-btn,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn {
+  position: static;
+  width: 28px;
+  height: 28px;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn {
+  opacity: 1;
 }
 
 #nd-docs-layout[data-fd-framework] .fd-codeblock:hover .fd-copy-btn {
@@ -8787,7 +8823,8 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   color: var(--color-fd-foreground);
 }
 
-#nd-docs-layout[data-fd-framework] .fd-tab-trigger.fd-tab-active {
+#nd-docs-layout[data-fd-framework] .fd-tab-trigger.fd-tab-active,
+#nd-docs-layout[data-fd-framework] .fd-tab-trigger[data-state="active"] {
   color: var(--color-fd-foreground);
   font-weight: 600;
   border-bottom-color: var(--color-fd-primary);
@@ -8797,7 +8834,14 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   display: none;
 }
 
-#nd-docs-layout[data-fd-framework] .fd-tab-panel-active {
+#nd-docs-layout[data-fd-framework] .fd-tab-panel[data-state="inactive"],
+#nd-docs-layout[data-fd-framework] .fd-code-group-panel[data-state="inactive"] {
+  display: none;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-tab-panel-active,
+#nd-docs-layout[data-fd-framework] .fd-tab-panel[data-state="active"],
+#nd-docs-layout[data-fd-framework] .fd-code-group-panel[data-state="active"] {
   display: block;
 }
 

--- a/packages/fumadocs/styles/framework.css
+++ b/packages/fumadocs/styles/framework.css
@@ -1704,6 +1704,15 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   border-radius: var(--radius, 12px) var(--radius, 12px) 0 0;
 }
 
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title-text,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title figcaption {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 #nd-docs-layout[data-fd-framework] .fd-codeblock-title + .fd-copy-btn ~ pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
@@ -1712,6 +1721,21 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
 #nd-docs-layout[data-fd-framework] .fd-codeblock:has(.fd-codeblock-title) pre {
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions-floating {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
 }
 
 #nd-docs-layout[data-fd-framework] .fd-copy-btn {
@@ -1735,6 +1759,18 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
     opacity 0.15s,
     color 0.15s,
     background 0.15s;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions .fd-copy-btn,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-actions-floating .fd-copy-btn,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn {
+  position: static;
+  width: 28px;
+  height: 28px;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn {
+  opacity: 1;
 }
 
 #nd-docs-layout[data-fd-framework] .fd-codeblock:hover .fd-copy-btn {
@@ -1789,7 +1825,8 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   color: var(--color-fd-foreground);
 }
 
-#nd-docs-layout[data-fd-framework] .fd-tab-trigger.fd-tab-active {
+#nd-docs-layout[data-fd-framework] .fd-tab-trigger.fd-tab-active,
+#nd-docs-layout[data-fd-framework] .fd-tab-trigger[data-state="active"] {
   color: var(--color-fd-foreground);
   font-weight: 600;
   border-bottom-color: var(--color-fd-primary);
@@ -1799,7 +1836,14 @@ html.dark #nd-docs-layout[data-fd-framework] pre.shiki {
   display: none;
 }
 
-#nd-docs-layout[data-fd-framework] .fd-tab-panel-active {
+#nd-docs-layout[data-fd-framework] .fd-tab-panel[data-state="inactive"],
+#nd-docs-layout[data-fd-framework] .fd-code-group-panel[data-state="inactive"] {
+  display: none;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-tab-panel-active,
+#nd-docs-layout[data-fd-framework] .fd-tab-panel[data-state="active"],
+#nd-docs-layout[data-fd-framework] .fd-code-group-panel[data-state="active"] {
   display: block;
 }
 

--- a/packages/fumadocs/styles/hardline.css
+++ b/packages/fumadocs/styles/hardline.css
@@ -603,6 +603,7 @@ aside button[class*="bg-fd-secondary"] {
 #nd-docs-layout article#nd-page figure.shiki figcaption,
 .fd-docs-content .fd-codeblock-title,
 #nd-docs-layout[data-fd-framework] .fd-codeblock-title {
+  box-sizing: border-box;
   min-height: 40px;
   padding: 8px 14px !important;
   border: 0 !important;
@@ -615,9 +616,45 @@ aside button[class*="bg-fd-secondary"] {
   line-height: 1.45;
 }
 
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title {
+  height: 40px;
+}
+
 .fd-docs-content figure.shiki:has(figcaption) > div:first-child::before,
 #nd-docs-layout article#nd-page figure.shiki:has(figcaption) > div:first-child::before {
   display: none;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-codeblock-title-text {
+  min-height: 0;
+  padding: 0 14px;
+  border: 0 !important;
+  background: transparent !important;
+  line-height: inherit;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-codeblock-actions {
+  margin-inline-end: -8px;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn {
+  width: 24px !important;
+  height: 24px !important;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: var(--color-fd-muted-foreground) !important;
+  opacity: 0 !important;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock:hover .fd-codeblock-title .fd-copy-btn,
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn:focus-visible {
+  opacity: 1 !important;
+}
+
+#nd-docs-layout[data-fd-framework] .fd-codeblock-title .fd-copy-btn:hover {
+  background: transparent !important;
+  color: var(--color-fd-foreground) !important;
 }
 
 .fd-docs-content figure.shiki > div[role="region"],

--- a/packages/nuxt-theme/src/components/DocsPage.vue
+++ b/packages/nuxt-theme/src/components/DocsPage.vue
@@ -167,11 +167,16 @@ function wireInteractive() {
         trigger.addEventListener("click", () => {
           const val = trigger.getAttribute("data-tab-value");
           tabs.querySelectorAll(".fd-tab-trigger").forEach((t) => {
-            t.classList.toggle("fd-tab-active", t.getAttribute("data-tab-value") === val);
-            t.setAttribute("aria-selected", String(t.getAttribute("data-tab-value") === val));
+            const active = t.getAttribute("data-tab-value") === val;
+            t.classList.toggle("fd-tab-active", active);
+            t.setAttribute("aria-selected", String(active));
+            t.setAttribute("data-state", active ? "active" : "inactive");
+            t.setAttribute("tabindex", active ? "0" : "-1");
           });
           tabs.querySelectorAll(".fd-tab-panel").forEach((p) => {
-            p.classList.toggle("fd-tab-panel-active", p.getAttribute("data-tab-panel") === val);
+            const active = p.getAttribute("data-tab-panel") === val;
+            p.classList.toggle("fd-tab-panel-active", active);
+            p.setAttribute("data-state", active ? "active" : "inactive");
           });
         });
       });

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -528,6 +528,30 @@ function createCodeGroupTabValue(label: string, used: Set<string>): string {
   return value;
 }
 
+const terminalCodeLanguages = new Set([
+  "bash",
+  "console",
+  "sh",
+  "shell",
+  "shellscript",
+  "terminal",
+]);
+const fileCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>';
+const terminalCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path d="m 4,4 a 1,1 0 0 0 -0.7070312,0.2929687 1,1 0 0 0 0,1.4140625 L 8.5859375,11 3.2929688,16.292969 a 1,1 0 0 0 0,1.414062 1,1 0 0 0 1.4140624,0 l 5.9999998,-6 a 1.0001,1.0001 0 0 0 0,-1.414062 L 4.7070312,4.2929687 A 1,1 0 0 0 4,4 Z m 8,14 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 h 8 a 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z" fill="currentColor"/></svg>';
+const copyCodeBlockIcon =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>';
+
+function renderCodeBlockTitleIcon(title?: string | null, language?: string | null): string {
+  const normalizedTitle = title?.trim().toLowerCase() ?? "";
+  const normalizedLanguage = language?.trim().toLowerCase() ?? "";
+  if (normalizedTitle.includes("terminal") || terminalCodeLanguages.has(normalizedLanguage)) {
+    return terminalCodeBlockIcon;
+  }
+  return fileCodeBlockIcon;
+}
+
 function wrapCodeWithCopy(
   html: string,
   rawCode: string,
@@ -540,9 +564,9 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code">${copyCodeBlockIcon}</button>`;
   if (title) {
-    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title>${renderCodeBlockTitleIcon(title, language)}<span class="fd-codeblock-title-text">${escapeHtml(title)}</span><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
   return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -386,10 +386,45 @@ const calloutIcons: Record<string, string> = {
     '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
 };
 
-function renderCallout(type: string, content: string): string {
-  const icon = calloutIcons[type] || calloutIcons.note;
-  const label = type.charAt(0).toUpperCase() + type.slice(1);
-  return `<div class="fd-callout fd-callout-${type}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${label}</p><p>${content}</p></div></div>`;
+const calloutTypeAliases: Record<string, string> = {
+  danger: "caution",
+  error: "caution",
+  info: "note",
+  success: "tip",
+  warn: "warning",
+};
+
+const calloutLabels: Record<string, string> = {
+  caution: "Caution",
+  important: "Important",
+  note: "Note",
+  tip: "Tip",
+  warning: "Warning",
+};
+
+function normalizeCalloutType(type: string): string {
+  const normalized = type.trim().toLowerCase();
+  const aliased = calloutTypeAliases[normalized] ?? normalized;
+  return calloutIcons[aliased] ? aliased : "note";
+}
+
+function renderInlineCalloutContent(content: string): string {
+  return content
+    .trim()
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\n+/g, "<br />");
+}
+
+function renderCallout(type: string, content: string, title?: string | null): string {
+  const normalizedType = normalizeCalloutType(type);
+  const icon = calloutIcons[normalizedType] || calloutIcons.note;
+  const label = title?.trim() || calloutLabels[normalizedType] || "Note";
+  const renderedContent = renderInlineCalloutContent(content);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -418,13 +453,6 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
   }
 }
 
-function parseMeta(meta: string): { lang: string; title: string | null } {
-  const trimmed = meta.trim();
-  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
-  return { lang, title: titleMatch ? titleMatch[1] : null };
-}
-
 const ignoredCodeGroupBareTitleTokens = new Set([
   "copy",
   "no-copy",
@@ -436,6 +464,33 @@ const ignoredCodeGroupBareTitleTokens = new Set([
   "showlinenumbers",
   "wrap",
 ]);
+
+function parseMeta(meta: string): { lang: string; title: string | null } {
+  const trimmed = meta.trim();
+  const firstToken = trimmed.split(/\s+/, 1)[0] ?? "";
+  const hasLanguage = Boolean(
+    firstToken && !firstToken.includes("=") && !firstToken.startsWith("{"),
+  );
+  const lang = hasLanguage ? firstToken.toLowerCase() : "text";
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
+
+  if (titleMatch) return { lang, title: titleMatch[1] };
+
+  const bareTitle = trimmed
+    .slice(hasLanguage ? firstToken.length : 0)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find(
+      (part) =>
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
+
+  return {
+    lang,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
 
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
@@ -485,11 +540,11 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
-  return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
+  return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }
 
 function dedentCode(raw: string): string {
@@ -547,14 +602,16 @@ export async function renderMarkdown(
 
       if (panels.length === 0) return body;
 
-      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
-      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(panels[i].label)}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel fd-code-group-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -589,11 +646,13 @@ export async function renderMarkdown(
       let tabsHtml = `<div class="fd-tabs" data-tabs>`;
       tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
       for (let i = 0; i < items.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${items[i]}" aria-selected="${i === 0}">${items[i]}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(items[i])}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(items[i])}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${panels[i].value}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -636,6 +695,19 @@ export async function renderMarkdown(
     },
   );
 
+  const calloutBlocks: string[] = [];
+  result = result.replace(
+    /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
+      const title = toStringValue(attrs.title);
+      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+      calloutBlocks.push(renderCallout(type, children, title));
+      return placeholder;
+    },
+  );
+
   // Inline code
   result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
 
@@ -652,7 +724,6 @@ export async function renderMarkdown(
   result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
 
   // ── Callouts / blockquotes (before inline formatting) ──
-  const calloutBlocks: string[] = [];
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
     const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");

--- a/packages/svelte-theme/src/components/DocsPage.svelte
+++ b/packages/svelte-theme/src/components/DocsPage.svelte
@@ -161,11 +161,16 @@
           trigger.onclick = () => {
             const val = trigger.getAttribute("data-tab-value");
             tabs.querySelectorAll(".fd-tab-trigger").forEach((t) => {
-              t.classList.toggle("fd-tab-active", t.getAttribute("data-tab-value") === val);
-              t.setAttribute("aria-selected", String(t.getAttribute("data-tab-value") === val));
+              const active = t.getAttribute("data-tab-value") === val;
+              t.classList.toggle("fd-tab-active", active);
+              t.setAttribute("aria-selected", String(active));
+              t.setAttribute("data-state", active ? "active" : "inactive");
+              t.setAttribute("tabindex", active ? "0" : "-1");
             });
             tabs.querySelectorAll(".fd-tab-panel").forEach((p) => {
-              p.classList.toggle("fd-tab-panel-active", p.getAttribute("data-tab-panel") === val);
+              const active = p.getAttribute("data-tab-panel") === val;
+              p.classList.toggle("fd-tab-panel-active", active);
+              p.setAttribute("data-state", active ? "active" : "inactive");
             });
           };
         });

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -528,6 +528,30 @@ function createCodeGroupTabValue(label: string, used: Set<string>): string {
   return value;
 }
 
+const terminalCodeLanguages = new Set([
+  "bash",
+  "console",
+  "sh",
+  "shell",
+  "shellscript",
+  "terminal",
+]);
+const fileCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>';
+const terminalCodeBlockIcon =
+  '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path d="m 4,4 a 1,1 0 0 0 -0.7070312,0.2929687 1,1 0 0 0 0,1.4140625 L 8.5859375,11 3.2929688,16.292969 a 1,1 0 0 0 0,1.414062 1,1 0 0 0 1.4140624,0 l 5.9999998,-6 a 1.0001,1.0001 0 0 0 0,-1.414062 L 4.7070312,4.2929687 A 1,1 0 0 0 4,4 Z m 8,14 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 h 8 a 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z" fill="currentColor"/></svg>';
+const copyCodeBlockIcon =
+  '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>';
+
+function renderCodeBlockTitleIcon(title?: string | null, language?: string | null): string {
+  const normalizedTitle = title?.trim().toLowerCase() ?? "";
+  const normalizedLanguage = language?.trim().toLowerCase() ?? "";
+  if (normalizedTitle.includes("terminal") || terminalCodeLanguages.has(normalizedLanguage)) {
+    return terminalCodeBlockIcon;
+  }
+  return fileCodeBlockIcon;
+}
+
 function wrapCodeWithCopy(
   html: string,
   rawCode: string,
@@ -540,9 +564,9 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code">${copyCodeBlockIcon}</button>`;
   if (title) {
-    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title>${renderCodeBlockTitleIcon(title, language)}<span class="fd-codeblock-title-text">${escapeHtml(title)}</span><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
   return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -386,10 +386,45 @@ const calloutIcons: Record<string, string> = {
     '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
 };
 
-function renderCallout(type: string, content: string): string {
-  const icon = calloutIcons[type] || calloutIcons.note;
-  const label = type.charAt(0).toUpperCase() + type.slice(1);
-  return `<div class="fd-callout fd-callout-${type}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${label}</p><p>${content}</p></div></div>`;
+const calloutTypeAliases: Record<string, string> = {
+  danger: "caution",
+  error: "caution",
+  info: "note",
+  success: "tip",
+  warn: "warning",
+};
+
+const calloutLabels: Record<string, string> = {
+  caution: "Caution",
+  important: "Important",
+  note: "Note",
+  tip: "Tip",
+  warning: "Warning",
+};
+
+function normalizeCalloutType(type: string): string {
+  const normalized = type.trim().toLowerCase();
+  const aliased = calloutTypeAliases[normalized] ?? normalized;
+  return calloutIcons[aliased] ? aliased : "note";
+}
+
+function renderInlineCalloutContent(content: string): string {
+  return content
+    .trim()
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+    .replace(/\n+/g, "<br />");
+}
+
+function renderCallout(type: string, content: string, title?: string | null): string {
+  const normalizedType = normalizeCalloutType(type);
+  const icon = calloutIcons[normalizedType] || calloutIcons.note;
+  const label = title?.trim() || calloutLabels[normalizedType] || "Note";
+  const renderedContent = renderInlineCalloutContent(content);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -418,13 +453,6 @@ function highlightCode(hl: Highlighter, code: string, lang: string): { html: str
   }
 }
 
-function parseMeta(meta: string): { lang: string; title: string | null } {
-  const trimmed = meta.trim();
-  const lang = (trimmed.split(/\s/)[0] || "text").toLowerCase();
-  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
-  return { lang, title: titleMatch ? titleMatch[1] : null };
-}
-
 const ignoredCodeGroupBareTitleTokens = new Set([
   "copy",
   "no-copy",
@@ -436,6 +464,33 @@ const ignoredCodeGroupBareTitleTokens = new Set([
   "showlinenumbers",
   "wrap",
 ]);
+
+function parseMeta(meta: string): { lang: string; title: string | null } {
+  const trimmed = meta.trim();
+  const firstToken = trimmed.split(/\s+/, 1)[0] ?? "";
+  const hasLanguage = Boolean(
+    firstToken && !firstToken.includes("=") && !firstToken.startsWith("{"),
+  );
+  const lang = hasLanguage ? firstToken.toLowerCase() : "text";
+  const titleMatch = trimmed.match(/\b(?:title|filename|file|name|label)=["']([^"']+)["']/);
+
+  if (titleMatch) return { lang, title: titleMatch[1] };
+
+  const bareTitle = trimmed
+    .slice(hasLanguage ? firstToken.length : 0)
+    .trim()
+    .replace(/\{[^}]*\}/g, " ")
+    .split(/\s+/)
+    .find(
+      (part) =>
+        part && !part.includes("=") && !ignoredCodeGroupBareTitleTokens.has(part.toLowerCase()),
+    );
+
+  return {
+    lang,
+    title: bareTitle ? bareTitle.replace(/^["']|["']$/g, "") : null,
+  };
+}
 
 function parseCodeGroupMeta(meta: string): { lang: string; title: string | null } {
   const parsed = parseMeta(meta);
@@ -485,11 +540,11 @@ function wrapCodeWithCopy(
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
   const dataLang = language ? ` data-language="${escapeHtml(String(language))}"` : "";
-  const copyBtn = `<button class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+  const copyBtn = `<button type="button" class="fd-copy-btn" data-code="${escapedRaw}" title="Copy code" aria-label="Copy code"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
   if (title) {
-    return `<div class="fd-codeblock fd-codeblock--titled"${dataLang}><div class="fd-codeblock-title"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><span class="fd-codeblock-title-text">${escapeHtml(title)}</span>${copyBtn}</div><div class="fd-codeblock-content">${html}</div></div>`;
+    return `<figure class="fd-codeblock fd-codeblock--titled shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-title" data-title><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg><figcaption class="fd-codeblock-title-text">${escapeHtml(title)}</figcaption><div class="fd-codeblock-actions">${copyBtn}</div></div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
   }
-  return `<div class="fd-codeblock"${dataLang}>${copyBtn}<div class="fd-codeblock-content">${html}</div></div>`;
+  return `<figure class="fd-codeblock shiki not-prose" dir="ltr" tabindex="-1"${dataLang}><div class="fd-codeblock-actions fd-codeblock-actions-floating">${copyBtn}</div><div class="fd-codeblock-content fd-scroll-container" role="region" tabindex="0">${html}</div></figure>`;
 }
 
 function dedentCode(raw: string): string {
@@ -547,14 +602,16 @@ export async function renderMarkdown(
 
       if (panels.length === 0) return body;
 
-      let tabsHtml = `<div class="fd-tabs" data-tabs data-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
-      tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
+      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" aria-selected="${i === 0}">${escapeHtml(panels[i].label)}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(panels[i].value)}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(panels[i].label)}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel fd-code-group-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -589,11 +646,13 @@ export async function renderMarkdown(
       let tabsHtml = `<div class="fd-tabs" data-tabs>`;
       tabsHtml += `<div class="fd-tabs-list" role="tablist">`;
       for (let i = 0; i < items.length; i++) {
-        tabsHtml += `<button role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${items[i]}" aria-selected="${i === 0}">${items[i]}</button>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<button type="button" role="tab" class="fd-tab-trigger${i === 0 ? " fd-tab-active" : ""}" data-tab-value="${escapeHtml(items[i])}" data-state="${state}" aria-selected="${i === 0}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(items[i])}</button>`;
       }
       tabsHtml += `</div>`;
       for (let i = 0; i < panels.length; i++) {
-        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${panels[i].value}" role="tabpanel">${panels[i].html}</div>`;
+        const state = i === 0 ? "active" : "inactive";
+        tabsHtml += `<div class="fd-tab-panel${i === 0 ? " fd-tab-panel-active" : ""}" data-tab-panel="${escapeHtml(panels[i].value)}" data-state="${state}" role="tabpanel">${panels[i].html}</div>`;
       }
       tabsHtml += `</div>`;
 
@@ -636,6 +695,19 @@ export async function renderMarkdown(
     },
   );
 
+  const calloutBlocks: string[] = [];
+  result = result.replace(
+    /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const attrs = parseJsxAttributes(attrSource ?? "");
+      const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
+      const title = toStringValue(attrs.title);
+      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+      calloutBlocks.push(renderCallout(type, children, title));
+      return placeholder;
+    },
+  );
+
   // Inline code
   result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
 
@@ -652,7 +724,6 @@ export async function renderMarkdown(
   result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
 
   // ── Callouts / blockquotes (before inline formatting) ──
-  const calloutBlocks: string[] = [];
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
     const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");


### PR DESCRIPTION
## Summary

- Align SvelteKit, Astro, and Nuxt markdown code-block markup with the Next/Fumadocs baseline.
- Add shared tab/code-group active state attributes and keep them synced on click.
- Support MDX-style `<Callout>` in the non-Next markdown renderer, including common type aliases.
- Update the shared framework CSS bundle for title copy buttons and active tab panels.

## Validation

- `corepack pnpm --filter @farming-labs/svelte --filter @farming-labs/astro --filter @farming-labs/nuxt --filter @farming-labs/svelte-theme --filter @farming-labs/astro-theme --filter @farming-labs/nuxt-theme --filter @farming-labs/theme run typecheck`
- `corepack pnpm --filter @farming-labs/theme run build`
- `corepack pnpm format:check`
- `corepack pnpm lint` (passes with existing warnings only)
- `git diff --check`
- Playwright probe against Next, SvelteKit, Astro, and Nuxt examples on `/docs`, `/docs/basic-usage`, and `/docs/installation`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns markdown components across `@farming-labs/svelte`, `@farming-labs/astro`, and `@farming-labs/nuxt` with the Next/Fumadocs baseline, standardizes codeblock headers/actions, and unifies theme CSS imports to `@farming-labs/theme/<theme>/css` for consistent visuals and simpler setup.

- New Features
  - Add MDX-style `<Callout>` to non-Next renderers with aliases (danger/error→caution, success→tip, warn→warning), inline formatting, and optional titles.
  - Unify code-group tabs with `data-state`, correct `aria-selected`/`tabindex`, and consistent panel visibility.
  - Upgrade code blocks to `<figure>` with a scroll region and copy action; add file/terminal title icons, `aria-label`s, and better code meta title parsing.

- Refactors
  - Move all theme CSS imports to `@farming-labs/theme/<theme>/css`; add shared CSS bundles and normalize selectors (tables under `:is(.fd-docs-content, .prose)`, scoped `.fd-callout`), and make tab/panel CSS honor `data-state`.
  - Standardize codeblock headers across frameworks: ellipsis on long titles, header action area, floating copy on untitled blocks, and hover/focus behavior via `hardline.css`.
  - Update CLI (`init`/`upgrade`) to add `@farming-labs/theme` and inject default theme CSS; examples updated accordingly.

<sup>Written for commit 1f14122ca9dcfac1f448c3988f805340dc87b383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

