### PR TITLE
fix: keep website utilities above docs theme css

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
 @import "@farming-labs/theme/pixel-border/css";
+@import "tailwindcss";
 @theme {
   --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-geist-mono), ui-monospace, "Cascadia Code",


### PR DESCRIPTION
## Summary
- load the website docs theme CSS before Tailwind so app-level Tailwind utilities win on non-doc pages
- preserves the full docs theme bundle for the `/docs` layout while fixing homepage/cloud utility overrides introduced by the unified theme CSS import

## Verification
- `git diff --check`
- `corepack pnpm format:check`
- `corepack pnpm lint` (passes with existing warnings only)
- `corepack pnpm --dir website exec next build`
- Playwright visual smoke checks for `/`, `/cloud`, and `/docs` in local dev server, including dark-mode checks for `/` and `/cloud`

Note: the full `website build` script was not run because its nested plain `pnpm` call resolves to global pnpm 11 locally and prompted to remove/reinstall workspace module directories; I declined that mutation and ran the narrower Next build through `corepack` instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the docs theme CSS before Tailwind so website utilities win on non-doc pages. This prevents docs theme overrides on `/` and `/cloud` while keeping the full docs theme on `/docs`.

<sup>Written for commit 15e19213cca9b510a610b6cdbd59f1ef501bcc64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

