### PR TITLE
fix: restore class-based theme mode

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -1,5 +1,8 @@
 @import "@farming-labs/theme/pixel-border/css";
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-geist-mono), ui-monospace, "Cascadia Code",

--- a/website/components/ui/code-block.tsx
+++ b/website/components/ui/code-block.tsx
@@ -42,7 +42,7 @@ export default function CodeBlock({
     <div className={`relative group max-w-full ${className}`}>
       <PixelCard variant="code" className="p-0!">
         {(title || filename) && (
-          <div className="code-block-header flex items-center justify-between px-3 sm:px-4 py-2.5 min-w-0 overflow-hidden border-b border-neutral-200 dark:border-white/10 bg-neutral-100/80">
+          <div className="code-block-header flex items-center justify-between px-3 sm:px-4 py-2.5 min-w-0 overflow-hidden border-b border-neutral-200 dark:border-white/10 bg-neutral-50">
             <div className="flex items-center gap-2 min-w-0">
               {filename && (
                 <span className="text-[11px] sm:text-xs font-mono truncate text-neutral-500 dark:text-[color-mix(in_srgb,var(--color-fd-foreground,#fff)_50%,transparent)]">
@@ -61,7 +61,7 @@ export default function CodeBlock({
         )}
         <div className="relative">
           <pre
-            className="px-3 sm:px-4 py-3.5 text-[12px] sm:text-[13px] leading-relaxed overflow-x-auto font-mono text-neutral-800 dark:text-inherit"
+            className="px-3 sm:px-4 py-3.5 text-[12px] sm:text-[13px] leading-relaxed overflow-x-auto font-mono text-neutral-900 dark:text-inherit"
             style={maxHeight ? { maxHeight, overflowY: "auto" } : undefined}
           >
             <code

--- a/website/components/ui/feature-grid-card.tsx
+++ b/website/components/ui/feature-grid-card.tsx
@@ -16,13 +16,13 @@ export function FeatureGridCard({
   chips: readonly string[];
 }) {
   return (
-    <div className="relative flex h-full flex-col justify-between gap-6 bg-white px-5 pb-5 pt-6 shadow-xs dark:bg-black">
+    <div className="relative flex h-full flex-col justify-between gap-6 bg-neutral-50/80 px-5 pb-5 pt-6 shadow-xs dark:bg-black">
       <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute right-2 top-1 h-28 w-28 rounded-full bg-black/[0.012] blur-3xl dark:bg-white/[0.018] sm:h-32 sm:w-32" />
-        <div className="absolute inset-0 bg-[radial-gradient(44%_46%_at_84%_18%,rgba(0,0,0,0.02),transparent_72%)] dark:bg-[radial-gradient(44%_46%_at_84%_18%,rgba(255,255,255,0.03),transparent_72%)]" />
+        <div className="absolute right-2 top-1 h-28 w-28 rounded-full bg-black/[0.018] blur-3xl dark:bg-white/[0.018] sm:h-32 sm:w-32" />
+        <div className="absolute inset-0 bg-[radial-gradient(44%_46%_at_84%_18%,rgba(0,0,0,0.032),transparent_72%)] dark:bg-[radial-gradient(44%_46%_at_84%_18%,rgba(255,255,255,0.03),transparent_72%)]" />
         {BackgroundIcon ? (
           <div className="absolute -right-2 -top-2 z-0 flex items-start justify-end sm:-right-12 sm:-top-12">
-            <BackgroundIcon className="size-36 stroke-1 text-black/[0.03] dark:text-white/[0.025] sm:size-52" />
+            <BackgroundIcon className="size-36 stroke-1 text-black/[0.045] dark:text-white/[0.025] sm:size-52" />
           </div>
         ) : null}
         <div className="absolute inset-0 hidden bg-[radial-gradient(50%_80%_at_25%_0%,rgba(255,255,255,0.08),transparent)] dark:block" />
@@ -34,18 +34,18 @@ export function FeatureGridCard({
       <span className="absolute -left-px -top-px z-20 block size-2 border-l-2 border-t-2 border-black dark:border-white" />
 
       <div className="relative z-10 space-y-5">
-        <div className="flex w-fit items-center justify-center rounded-none border border-black/10 bg-black/[0.03] p-3 dark:border-white/10 dark:bg-white/[0.04]">
+        <div className="flex w-fit items-center justify-center rounded-none border border-black/[0.12] bg-white p-3 dark:border-white/10 dark:bg-white/[0.04]">
           <Icon className="size-5 stroke-[1.5] text-black dark:text-white" />
         </div>
 
         <div className="space-y-2">
-          <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-black/45 dark:text-white/45">
+          <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-black/50 dark:text-white/45">
             # {label}
           </p>
           <h3 className="font-pixel text-xl font-medium tracking-normal text-black dark:text-white">
             {title}
           </h3>
-          <p className="text-sm leading-relaxed text-black/55 dark:text-white/45">{description}</p>
+          <p className="text-sm leading-relaxed text-black/60 dark:text-white/45">{description}</p>
         </div>
       </div>
       <hr className="mt-4 -mx-5 bg-black/10 dark:bg-white/10" />
@@ -53,7 +53,7 @@ export function FeatureGridCard({
         {chips.map((chip) => (
           <span
             key={chip}
-            className="inline-flex border border-black/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-black/50 dark:border-white/10 dark:text-white/45"
+            className="inline-flex border border-black/[0.12] bg-white/70 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-black/55 dark:border-white/10 dark:bg-transparent dark:text-white/45"
           >
             {chip}
           </span>

--- a/website/components/ui/pixel-card.tsx
+++ b/website/components/ui/pixel-card.tsx
@@ -15,21 +15,21 @@ export default function PixelCard({
   showTexture = true,
 }: PixelCardProps) {
   const baseClasses =
-    "border border-black/10 dark:border-white/5 bg-white/80 dark:bg-black/50 backdrop-blur-sm relative";
+    "border border-black/[0.12] dark:border-white/5 bg-white/95 dark:bg-black/50 backdrop-blur-sm relative";
 
   const variantClasses = {
     default:
-      "p-6 rounded-none border border-black/10 dark:border-white/10 bg-neutral-50/90 dark:bg-black/[20%] hover:bg-neutral-100/90 dark:hover:bg-black/[20%] hover:border-black/10 dark:hover:border-white/10",
-    code: "px-4 py-2.5 rounded-none bg-neutral-100 dark:bg-black border-black/15 dark:border-white/15 overflow-hidden",
+      "p-6 rounded-none border border-black/[0.12] dark:border-white/10 bg-white dark:bg-black/[20%] hover:bg-neutral-50 dark:hover:bg-black/[20%] hover:border-black/15 dark:hover:border-white/10",
+    code: "px-4 py-2.5 rounded-none bg-white dark:bg-black border-black/[0.18] dark:border-white/15 overflow-hidden",
     highlight:
-      "p-6 rounded-none border-black/5 dark:border-white/5 bg-black/[2%] dark:bg-white/[2%] backdrop-blur-md",
+      "p-6 rounded-none border-black/10 dark:border-white/5 bg-neutral-50/90 dark:bg-white/[2%] backdrop-blur-md",
   };
 
   return (
     <div className={cn(baseClasses, variantClasses[variant], className)}>
       {showTexture ? (
         <div
-          className="absolute inset-0 pointer-events-none opacity-45 mix-blend-multiply contrast-125 dark:opacity-80 dark:mix-blend-overlay dark:contrast-100"
+          className="absolute inset-0 pointer-events-none opacity-[0.16] mix-blend-multiply contrast-100 dark:opacity-80 dark:mix-blend-overlay dark:contrast-100"
           style={{
             backgroundImage: "url(/shades.png)",
             backgroundRepeat: "repeat",


### PR DESCRIPTION
## What changed

- Restores Tailwind v4 class-based `dark:` handling so the app theme toggle follows `.light` / `.dark` instead of the visitor's system preference.
- Tightens light-mode contrast for the shared website `PixelCard`, `CodeBlock`, and feature card primitives so light panels read clearly without changing the dark-mode styling branches.

## Why

After the unified theme CSS import work, light mode could look visually mixed on systems that prefer dark mode because Tailwind `dark:` utilities were still driven by the system color scheme. The app already persists the selected mode in `localStorage.theme` and applies `.light` / `.dark`, so Tailwind needs to follow that class cascade.

## Validation

- `git diff --check`
- `pnpm format:check`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm --dir website exec next build` (passes with existing Next warnings)
- Playwright visual checks for `/`, `/cloud`, `/docs/installation`, and `/docs/customization/components` with:
  - system dark + app light
  - system light + app dark
- Verified no horizontal overflow on checked pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores class-based theme mode so `tailwindcss` `dark:` utilities follow `.light`/`.dark` instead of the OS setting, and tightens light‑mode contrast in shared UI cards. Fixes mixed theme visuals while keeping dark mode unchanged.

- **Bug Fixes**
  - Align `dark:` with the app’s class cascade by adding `@custom-variant dark (&:where(.dark, .dark *));` in `website/app/global.css` so theme respects `localStorage.theme`.
  - Improve light‑mode clarity in `PixelCard`, `CodeBlock`, and `FeatureGridCard` by adjusting backgrounds, borders, and text colors; dark‑mode styles untouched.

<sup>Written for commit 06f52e6081a5c971de9fbd594e39c19053e8f540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

