### PR TITLE
fix: keep changelog release rail in sync after hash navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run build
         run: pnpm build
 
+      - name: Install Playwright Chromium
+        run: pnpm --dir examples/next exec playwright install --with-deps --only-shell chromium
+
+      - name: Run changelog end-to-end tests
+        run: pnpm --dir examples/next exec playwright test e2e/changelog.spec.ts --workers=1
+
       - name: Run typecheck
         run: pnpm typecheck
 

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -141,7 +141,7 @@ export default defineDocs({
     title: "Changelog",
     description:
       "Track the latest updates, bug fixes, and shipped improvements across @farming-labs/docs.",
-    search: false,
+    search: true,
     actionsComponent: ChangelogActions,
   },
   nav: {

--- a/examples/next/e2e/changelog.spec.ts
+++ b/examples/next/e2e/changelog.spec.ts
@@ -34,4 +34,41 @@ test.describe("Changelog UI", () => {
       page.getByRole("heading", { name: "What shipped", level: 2 }).first(),
     ).toBeVisible();
   });
+
+  test("release rail follows scrolling after hash navigation", async ({ page }) => {
+    await page.goto("/docs/changelogs");
+
+    const rail = page.locator('[data-fd-changelog-toc][data-variant="releases"]');
+    const middleRelease = rail.locator('a[href="#2026-04-03"]');
+    const oldestRelease = rail.locator('a[href="#2026-03-18"]');
+
+    await middleRelease.click();
+    await expect(page).toHaveURL(/#2026-04-03$/);
+    await expect(middleRelease).toHaveAttribute("data-active", "true");
+
+    await page.locator('[id="2026-03-18"]').evaluate((element) => {
+      element.scrollIntoView({ block: "start" });
+    });
+
+    await expect(oldestRelease).toHaveAttribute("data-active", "true");
+    await expect(page).toHaveURL(/#2026-04-03$/);
+  });
+
+  test("release rail highlights deep-link hash then follows scroll", async ({ page }) => {
+    await page.goto("/docs/changelogs#2026-04-03");
+
+    const rail = page.locator('[data-fd-changelog-toc][data-variant="releases"]');
+    const middleRelease = rail.locator('a[href="#2026-04-03"]');
+    const oldestRelease = rail.locator('a[href="#2026-03-18"]');
+
+    await expect(page).toHaveURL(/#2026-04-03$/);
+    await expect(middleRelease).toHaveAttribute("data-active", "true");
+
+    await page.locator('[id="2026-03-18"]').evaluate((element) => {
+      element.scrollIntoView({ block: "start" });
+    });
+
+    await expect(oldestRelease).toHaveAttribute("data-active", "true");
+    await expect(page).toHaveURL(/#2026-04-03$/);
+  });
 });

--- a/examples/next/e2e/changelog.spec.ts
+++ b/examples/next/e2e/changelog.spec.ts
@@ -3,9 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("Changelog UI", () => {
   test("index shows timeline rail, tags, and MDX", async ({ page }) => {
     await page.goto("/docs/changelogs");
-    const visibleTimelineLine = page
-      .locator('[data-testid="changelog-timeline-line"]:visible')
-      .first();
+    const visibleTimelineLine = page.locator(".fd-changelog-directory-line:visible").first();
     const visibleTag = page.locator('[data-testid="changelog-tag"]:visible').first();
 
     await expect(page.getByRole("heading", { name: "Changelog", level: 1 })).toBeVisible();
@@ -70,5 +68,127 @@ test.describe("Changelog UI", () => {
 
     await expect(oldestRelease).toHaveAttribute("data-active", "true");
     await expect(page).toHaveURL(/#2026-04-03$/);
+  });
+
+  test("release rail keeps scroll state when search rerenders its items", async ({ page }) => {
+    await page.goto("/docs/changelogs#2026-04-03");
+    await page.waitForTimeout(300);
+
+    const rail = page.locator('[data-fd-changelog-toc][data-variant="releases"]');
+    const latestRelease = rail.locator('a[href="#2026-04-15"]');
+    const search = page.getByPlaceholder("Search changelog entries");
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await expect(latestRelease).toHaveAttribute("data-active", "true");
+
+    const releaseLinks = rail.locator("a");
+    await search.fill("OpenAPI");
+    await expect(releaseLinks).toHaveCount(1);
+    await search.fill("");
+    await expect(releaseLinks).toHaveCount(3);
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+        }),
+    );
+
+    const activeRelease = rail.locator('a[data-active="true"]');
+    expect(await activeRelease.count()).toBe(1);
+    expect(await activeRelease.getAttribute("href")).toBe("#2026-04-15");
+    expect(await activeRelease.getAttribute("aria-current")).toBe("location");
+    await expect(page).toHaveURL(/#2026-04-03$/);
+  });
+
+  test("release rail ignores delayed hash updates after scroll takes over", async ({ page }) => {
+    await page.goto("/docs/changelogs#2026-04-03");
+    await page.waitForTimeout(300);
+
+    const rail = page.locator('[data-fd-changelog-toc][data-variant="releases"]');
+    const releaseLinks = rail.locator("a");
+    const search = page.getByPlaceholder("Search changelog entries");
+    const clockTime = new Date("2026-01-01T00:00:00Z");
+
+    await page.clock.install({ time: clockTime });
+    await page.clock.pauseAt(new Date(clockTime.getTime() + 1_000));
+
+    await search.fill("OpenAPI");
+    await page.clock.runFor(1);
+    expect(await releaseLinks.count()).toBe(1);
+
+    await search.fill("");
+    await page.clock.runFor(1);
+    expect(await releaseLinks.count()).toBe(3);
+
+    await page.evaluate(() => {
+      document.documentElement.style.scrollBehavior = "auto";
+      window.scrollTo(0, 0);
+      window.dispatchEvent(new Event("scroll"));
+    });
+    await page.clock.runFor(32);
+
+    let activeRelease = rail.locator('a[data-active="true"]');
+    expect(await activeRelease.count()).toBe(1);
+    expect(await activeRelease.getAttribute("href")).toBe("#2026-04-15");
+
+    await page.clock.runFor(300);
+
+    activeRelease = rail.locator('a[data-active="true"]');
+    expect(await activeRelease.count()).toBe(1);
+    expect(await activeRelease.getAttribute("href")).toBe("#2026-04-15");
+    expect(await activeRelease.getAttribute("aria-current")).toBe("location");
+    await expect(page).toHaveURL(/#2026-04-03$/);
+  });
+
+  test("release rail activates a short final release at the document end", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/docs/changelogs");
+
+    const rail = page.locator('[data-fd-changelog-toc][data-variant="releases"]');
+    const oldestRelease = rail.locator('a[href="#2026-03-18"]');
+
+    await expect(oldestRelease).toBeVisible();
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+        }),
+    );
+
+    await page.locator('[id="2026-03-18"]').evaluate((element) => {
+      const target = element as HTMLElement;
+      target.style.height = "4rem";
+      target.style.overflow = "hidden";
+    });
+
+    await page.evaluate(() => {
+      document.documentElement.style.scrollBehavior = "auto";
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const scrollingElement = document.scrollingElement ?? document.documentElement;
+          return (
+            scrollingElement.scrollHeight -
+            scrollingElement.scrollTop -
+            scrollingElement.clientHeight
+          );
+        }),
+      )
+      .toBeLessThanOrEqual(2);
+
+    const targetPosition = await page.locator('[id="2026-03-18"]').evaluate((element) => ({
+      threshold: Math.max(140, window.innerHeight * 0.18),
+      top: element.getBoundingClientRect().top,
+    }));
+    expect(targetPosition.top).toBeGreaterThan(targetPosition.threshold);
+
+    const activeRelease = rail.locator('a[data-active="true"]');
+    await expect(activeRelease).toHaveCount(1);
+    await expect(activeRelease).toHaveAttribute("href", "#2026-03-18");
+    await expect(oldestRelease).toHaveAttribute("aria-current", "location");
   });
 });

--- a/packages/next/src/changelog-rail-search.tsx
+++ b/packages/next/src/changelog-rail-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 export interface ChangelogDirectoryEntry {
   slug: string;
@@ -160,13 +160,9 @@ export function ChangelogTOC({
 }) {
   const tocId = `fd-changelog-toc-${variant}-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
   const [activeHref, setActiveHref] = useState(items[0]?.href ?? "");
+  const activeSourceRef = useRef<"hash" | "scroll">("hash");
 
   useEffect(() => {
-    if (items.length === 0) {
-      setActiveHref("");
-      return;
-    }
-
     let frameId = 0;
 
     const updateActiveHrefFromScroll = () => {
@@ -185,45 +181,73 @@ export function ChangelogTOC({
         }
       }
 
+      const scrollingElement = document.scrollingElement ?? document.documentElement;
+      const isAtDocumentEnd =
+        scrollingElement.scrollTop > 0 &&
+        scrollingElement.scrollHeight -
+          scrollingElement.scrollTop -
+          scrollingElement.clientHeight <=
+          2;
+
+      if (isAtDocumentEnd) {
+        for (let index = items.length - 1; index >= 0; index -= 1) {
+          const item = items[index];
+          if (item && getHashTargetElement(item.href)) {
+            nextActiveHref = item.href;
+            break;
+          }
+        }
+      }
+
       setActiveHref(nextActiveHref);
     };
 
     const updateActiveHrefFromHash = () => {
-      if (!window.location.hash) {
-        updateActiveHrefFromScroll();
-        return;
-      }
+      if (!window.location.hash) return false;
 
       const hashHref = `#${decodeHashValue(window.location.hash.slice(1))}`;
       if (items.some((item) => item.href === hashHref)) {
         setActiveHref(hashHref);
-      } else {
-        updateActiveHrefFromScroll();
+        return true;
       }
+
+      return false;
     };
 
-    const scheduleScrollUpdate = () => {
-      if (frameId !== 0) return;
-      frameId = window.requestAnimationFrame(() => {
-        frameId = 0;
-        updateActiveHrefFromScroll();
-      });
-    };
+    const syncActiveHref = () => {
+      if (activeSourceRef.current === "hash" && updateActiveHrefFromHash()) return;
 
-    const bootUpdate = () => {
-      if (window.location.hash) {
-        updateActiveHrefFromHash();
-        return;
-      }
+      activeSourceRef.current = "scroll";
       updateActiveHrefFromScroll();
     };
 
-    updateActiveHrefFromHash();
-    const initialUpdateId = window.setTimeout(bootUpdate, 0);
-    const settledUpdateId = window.setTimeout(bootUpdate, 250);
-    window.addEventListener("scroll", scheduleScrollUpdate, { passive: true });
-    window.addEventListener("resize", scheduleScrollUpdate);
-    window.addEventListener("hashchange", updateActiveHrefFromHash);
+    const scheduleActiveHrefUpdate = () => {
+      if (frameId !== 0) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = 0;
+        syncActiveHref();
+      });
+    };
+
+    const handleScroll = () => {
+      activeSourceRef.current = "scroll";
+      scheduleActiveHrefUpdate();
+    };
+
+    const handleHashChange = () => {
+      activeSourceRef.current = "hash";
+      if (updateActiveHrefFromHash()) return;
+
+      activeSourceRef.current = "scroll";
+      scheduleActiveHrefUpdate();
+    };
+
+    syncActiveHref();
+    const initialUpdateId = window.setTimeout(syncActiveHref, 0);
+    const settledUpdateId = window.setTimeout(syncActiveHref, 250);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", scheduleActiveHrefUpdate);
+    window.addEventListener("hashchange", handleHashChange);
 
     return () => {
       window.clearTimeout(initialUpdateId);
@@ -231,9 +255,9 @@ export function ChangelogTOC({
       if (frameId !== 0) {
         window.cancelAnimationFrame(frameId);
       }
-      window.removeEventListener("scroll", scheduleScrollUpdate);
-      window.removeEventListener("resize", scheduleScrollUpdate);
-      window.removeEventListener("hashchange", updateActiveHrefFromHash);
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", scheduleActiveHrefUpdate);
+      window.removeEventListener("hashchange", handleHashChange);
     };
   }, [items]);
 
@@ -515,7 +539,7 @@ export function ChangelogDirectory({
             <EmptyResults query={query} />
           )}
         </div>
-        {hasResults ? <ChangelogTOC title="Releases" items={tocItems} /> : null}
+        <ChangelogTOC title="Releases" items={tocItems} />
       </div>
     </div>
   );

--- a/packages/next/src/changelog-rail-search.tsx
+++ b/packages/next/src/changelog-rail-search.tsx
@@ -169,7 +169,7 @@ export function ChangelogTOC({
 
     let frameId = 0;
 
-    const updateActiveHref = () => {
+    const updateActiveHrefFromScroll = () => {
       const threshold = Math.max(140, window.innerHeight * 0.18);
       let nextActiveHref = items[0]?.href ?? "";
 
@@ -185,38 +185,55 @@ export function ChangelogTOC({
         }
       }
 
-      if (window.location.hash) {
-        const hashHref = `#${decodeHashValue(window.location.hash.slice(1))}`;
-        if (items.some((item) => item.href === hashHref)) {
-          nextActiveHref = hashHref;
-        }
-      }
-
       setActiveHref(nextActiveHref);
     };
 
-    const scheduleUpdate = () => {
+    const updateActiveHrefFromHash = () => {
+      if (!window.location.hash) {
+        updateActiveHrefFromScroll();
+        return;
+      }
+
+      const hashHref = `#${decodeHashValue(window.location.hash.slice(1))}`;
+      if (items.some((item) => item.href === hashHref)) {
+        setActiveHref(hashHref);
+      } else {
+        updateActiveHrefFromScroll();
+      }
+    };
+
+    const scheduleScrollUpdate = () => {
       if (frameId !== 0) return;
       frameId = window.requestAnimationFrame(() => {
         frameId = 0;
-        updateActiveHref();
+        updateActiveHrefFromScroll();
       });
     };
 
-    updateActiveHref();
-    window.setTimeout(updateActiveHref, 0);
-    window.setTimeout(updateActiveHref, 250);
-    window.addEventListener("scroll", scheduleUpdate, { passive: true });
-    window.addEventListener("resize", scheduleUpdate);
-    window.addEventListener("hashchange", scheduleUpdate);
+    const bootUpdate = () => {
+      if (window.location.hash) {
+        updateActiveHrefFromHash();
+        return;
+      }
+      updateActiveHrefFromScroll();
+    };
+
+    updateActiveHrefFromHash();
+    const initialUpdateId = window.setTimeout(bootUpdate, 0);
+    const settledUpdateId = window.setTimeout(bootUpdate, 250);
+    window.addEventListener("scroll", scheduleScrollUpdate, { passive: true });
+    window.addEventListener("resize", scheduleScrollUpdate);
+    window.addEventListener("hashchange", updateActiveHrefFromHash);
 
     return () => {
+      window.clearTimeout(initialUpdateId);
+      window.clearTimeout(settledUpdateId);
       if (frameId !== 0) {
         window.cancelAnimationFrame(frameId);
       }
-      window.removeEventListener("scroll", scheduleUpdate);
-      window.removeEventListener("resize", scheduleUpdate);
-      window.removeEventListener("hashchange", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleScrollUpdate);
+      window.removeEventListener("resize", scheduleScrollUpdate);
+      window.removeEventListener("hashchange", updateActiveHrefFromHash);
     };
   }, [items]);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the changelog release rail so it stays in sync after hash navigation and follows scroll again. Deep links now highlight the right release on load, and the URL hash no longer changes while you scroll.

- **Bug Fixes**
  - Split hash vs scroll updates and track the active source; preserve the active release when search rerenders the rail, activate the last release at page end, ignore late hash updates, always render the rail, and clean up listeners/timeouts.
  - Add Playwright e2e tests (deep links, post-hash scroll, search rerenders, end-of-page) and run them in CI.

<sup>Written for commit e457f58eff32f5e0a234d92657d3a9c18bd9b0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

