### PR TITLE
fix: restore docs theme border contrast

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -39,6 +39,16 @@
 }
 
 @layer base {
+  /* Tailwind is imported after the docs theme so website utilities stay authoritative.
+   * Re-apply the theme's border default after Tailwind's preflight reset so bare
+   * border utilities inside the docs shell do not inherit the current text color. */
+  #nd-docs-layout,
+  #nd-docs-layout *,
+  #nd-docs-layout ::before,
+  #nd-docs-layout ::after {
+    border-color: var(--color-fd-border, currentColor);
+  }
+
   @supports (view-transition-name: root) {
     ::view-transition-group(root) {
       animation-timing-function: var(--expo-out);


### PR DESCRIPTION
## Summary

- restore the semantic border default inside the docs layout after Tailwind preflight
- align code-block header dividers, search shortcut keycaps, and sidebar theme separators with the Pixel Border theme token
- keep the existing stylesheet import order and leave landing-page styles untouched

## Root cause

The website imports Tailwind after the docs theme so local utilities remain authoritative. Tailwind's later preflight reset changed bare `border`, `border-t`, and `border-b` colors back to `currentColor`, causing affected lines to inherit much brighter text colors instead of `--color-fd-border`.

## Validation

- `pnpm lint` (0 errors; existing warnings only)
- `pnpm format:check`
- `pnpm --dir website exec next build`
- browser verification in light and dark modes
- confirmed affected dark-mode borders resolve to `#262626`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore docs border contrast by reapplying the theme border color within the docs layout after Tailwind’s preflight reset. Aligns code-block header dividers, search keycaps, and sidebar separators with the Pixel Border token.

- **Bug Fixes**
  - Reapplies `border-color: var(--color-fd-border, currentColor)` to `#nd-docs-layout` and pseudo-elements to override preflight.
  - Fixes `border`, `border-t`, `border-b` inheriting `currentColor`, restoring consistent contrast in light and dark modes.
  - Preserves stylesheet import order; scope limited to the docs shell.

<sup>Written for commit 90d646db00c7909dd80c467b73c0a60aaf131594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

