### PR TITLE
fix: expand telemetry top sites table

### DIFF
--- a/website/app/telemetry/page.tsx
+++ b/website/app/telemetry/page.tsx
@@ -495,7 +495,12 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
           <GroupTable title="Deployment providers" groups={data.deploymentProviders} />
           <GroupTable title="Agent surfaces" groups={data.agentSurfaces} />
           <GroupTable title="Feature flags" groups={data.featureFlags} />
-          <GroupTable title="Top sites" groups={data.topSites} keyLabel="Site origin" />
+          <GroupTable
+            title="Top sites"
+            groups={data.topSites}
+            keyLabel="Site origin"
+            className="xl:col-span-2 2xl:col-span-3"
+          />
           <GroupTable
             title="Top identity hashes"
             groups={data.topIdentities}


### PR DESCRIPTION
## What changed

- Makes the telemetry dashboard's Top sites table span the full responsive grid width.
- Matches the existing full-row treatment used by the Top identity hashes table.

## Why

Site origins can be long, so keeping Top sites in a single grid column made the table feel cramped compared with the rest of the telemetry dashboard.

## Validation

- `git diff --check`
- `pnpm format:check`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm --dir website exec next build` (passes with existing Next warnings)
- Local Playwright check on `/telemetry` at 1600px confirmed the Top sites section width equals the telemetry grid width and there is no horizontal overflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the telemetry dashboard Top sites table to span the full responsive grid on xl and 2xl breakpoints, matching the Top identity hashes full-row treatment. This improves readability for long site origins and removes the cramped feel.

<sup>Written for commit c38eb684156fdc1b2e6af2bd13046db8deda83ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

