### PR TITLE
fix: track analytics client navigation

### DIFF
--- a/packages/fumadocs/src/client-location.ts
+++ b/packages/fumadocs/src/client-location.ts
@@ -43,12 +43,21 @@ function subscribe(onStoreChange: () => void) {
   };
 }
 
-function getSnapshot() {
+function getSearchSnapshot() {
   if (typeof window === "undefined") return "";
   return window.location.search;
 }
 
+function getPathnameSnapshot() {
+  if (typeof window === "undefined") return "";
+  return window.location.pathname;
+}
+
 export function useWindowSearchParams(): URLSearchParams {
-  const search = useSyncExternalStore(subscribe, getSnapshot, () => "");
+  const search = useSyncExternalStore(subscribe, getSearchSnapshot, () => "");
   return new URLSearchParams(search);
+}
+
+export function useWindowPathname(): string {
+  return useSyncExternalStore(subscribe, getPathnameSnapshot, () => "");
 }

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -556,6 +556,7 @@ export function DocsPageClient({
   const pathname = usePathname();
   const browserPathname = useWindowPathname();
   const searchParams = useWindowSearchParams();
+  const browserSearch = searchParams.toString();
   const activeLocale = resolveClientLocale(searchParams, locale);
   const resolvedPublicPath = normalizePublicDocsPath(publicPath, entry);
   const llmsLangQuery = activeLocale ? `?lang=${encodeURIComponent(activeLocale)}` : "";
@@ -580,10 +581,11 @@ export function DocsPageClient({
       properties: {
         entry,
         pathname: normalizedPath,
+        search: browserSearch,
         isChangelogRoute,
       },
     });
-  }, [analytics, activeLocale, entry, isChangelogRoute, normalizedPath]);
+  }, [analytics, activeLocale, browserSearch, entry, isChangelogRoute, normalizedPath]);
 
   useEffect(() => {
     return installDocsPathNavigationGuard(entry, resolvedPublicPath);

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -6,7 +6,7 @@ import { createPortal } from "react-dom";
 import { usePathname, useRouter } from "fumadocs-core/framework";
 import type { CopyMarkdownFormat, DocsFeedbackData, ReadingTimeFormat } from "@farming-labs/docs";
 import { PageActions } from "./page-actions.js";
-import { useWindowSearchParams } from "./client-location.js";
+import { useWindowPathname, useWindowSearchParams } from "./client-location.js";
 import { DocsFeedback } from "./docs-feedback.js";
 import { resolveClientLocale, withLangInUrl } from "./i18n.js";
 import { emitClientAnalyticsEvent } from "./client-analytics.js";
@@ -553,15 +553,15 @@ export function DocsPageClient({
   const [titlePortalHost, setTitlePortalHost] = useState<HTMLElement | null>(null);
   const [titleControlsPortalHost, setTitleControlsPortalHost] = useState<HTMLElement | null>(null);
   const [tocActionsPortalHost, setTocActionsPortalHost] = useState<HTMLElement | null>(null);
-  const [browserPath, setBrowserPath] = useState<string | null>(null);
   const pathname = usePathname();
+  const browserPathname = useWindowPathname();
   const searchParams = useWindowSearchParams();
   const activeLocale = resolveClientLocale(searchParams, locale);
   const resolvedPublicPath = normalizePublicDocsPath(publicPath, entry);
   const llmsLangQuery = activeLocale ? `?lang=${encodeURIComponent(activeLocale)}` : "";
 
   const pageDescription = description ?? descriptionMap?.[pathname.replace(/\/$/, "") || "/"];
-  const normalizedPath = (browserPath ?? pathname).replace(/\/$/, "") || "/";
+  const normalizedPath = (browserPathname || pathname).replace(/\/$/, "") || "/";
   const isChangelogRoute = !!(
     changelogBasePath &&
     (normalizedPath === changelogBasePath || normalizedPath.startsWith(`${changelogBasePath}/`))
@@ -630,11 +630,7 @@ export function DocsPageClient({
     });
 
     return () => cancelAnimationFrame(timer);
-  }, [activeLocale, browserPath, children, entry, pathname, resolvedPublicPath]);
-
-  useEffect(() => {
-    setBrowserPath(window.location.pathname);
-  }, [pathname]);
+  }, [activeLocale, browserPathname, children, entry, pathname, resolvedPublicPath]);
 
   useEffect(() => {
     const root = document.documentElement;


### PR DESCRIPTION
## Summary
- subscribe the docs page client to browser pathname changes from patched history events
- drive page-view analytics from the live browser pathname so Next.js client navigation emits a new page view
- include query-string changes in the page-view effect so shared/query URLs and client-side query navigation are reflected
- remove the pathname mirror state that only updated when the framework pathname hook changed

## Root Cause
Production ingestion and dashboard reads are working: a direct collector probe returned `HTTP 202` with `stored: 1`, and full browser loads appeared in the dashboard feed. The missing events were client-side navigations. In production, clicking from `/docs/installation` to `/docs/cli` updated the URL but no fresh analytics event appeared, because the docs page analytics effect only reacted when the framework pathname hook changed. The existing history patch already emitted `fd-location-change`, but only search params subscribed to it.

## Coverage
This keeps normal shared-link opens covered through the first page load, and adds coverage for internal path clicks, browser back/forward, and query-string-only navigation. Hash-only anchor jumps intentionally do not create separate page views so table-of-contents clicks do not inflate visit counts.

## Validation
- verified production collector accepts page-view events and dashboard reads them back
- reproduced the miss with a live browser client navigation from `/docs/installation` to `/docs/cli`
- `oxlint packages/fumadocs/src/client-location.ts packages/fumadocs/src/docs-page-client.tsx`
- `pnpm --filter @farming-labs/theme test -- client-analytics docs-page-client`
- `pnpm --filter @farming-labs/theme typecheck`
- `git diff --check`
