### PR TITLE
chore: add readmes for all packages

### DIFF
--- a/packages/astro-theme/README.md
+++ b/packages/astro-theme/README.md
@@ -1,0 +1,80 @@
+# @farming-labs/astro-theme
+
+The Astro-native UI layer and theme preset package for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It renders the docs shell, page content, search dialog, AI chat, and theme controls. Content
+loading and route handlers live in `@farming-labs/astro`.
+
+## Install
+
+```bash
+npm install @farming-labs/docs @farming-labs/astro @farming-labs/astro-theme @farming-labs/theme
+```
+
+The CLI can scaffold the complete Astro integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+## Configure the theme
+
+```ts
+// src/lib/docs.config.ts
+import { defineDocs } from "@farming-labs/docs";
+import { fumadocs } from "@farming-labs/astro-theme";
+
+export default defineDocs({
+  entry: "docs",
+  contentDir: "docs",
+  theme: fumadocs(),
+  nav: { title: "Docs", url: "/docs" },
+});
+```
+
+## Render the docs UI
+
+Astro components are exported from component subpaths:
+
+```astro
+---
+import DocsLayout from "@farming-labs/astro-theme/src/components/DocsLayout.astro";
+import DocsContent from "@farming-labs/astro-theme/src/components/DocsContent.astro";
+import SearchDialog from "@farming-labs/astro-theme/src/components/SearchDialog.astro";
+import "@farming-labs/theme/default/css";
+
+import config from "../../lib/docs.config";
+import { load } from "../../lib/docs.server";
+
+const data = await load(Astro.url.pathname);
+---
+
+<DocsLayout tree={data.tree} config={config}>
+  <DocsContent data={data} config={config} />
+</DocsLayout>
+<SearchDialog config={config} />
+```
+
+The server-side `load()` function comes from `@farming-labs/astro/server`.
+
+## Themes and components
+
+The package ships `DocsLayout`, `DocsContent`, `DocsPage`, `SearchDialog`, `FloatingAIChat`, and
+`ThemeToggle` Astro components.
+
+Preset subpaths are `fumadocs`, `pixel-border`, `darksharp`, `colorful`, `greentree`, `hardline`,
+`concrete`, `command-grid`, and `ledger`. The `fumadocs` preset uses
+`@farming-labs/theme/default/css`; the other presets use the matching
+`@farming-labs/theme/<preset>/css` entrypoint.
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Themes](https://docs.farming-labs.dev/docs/themes)
+- [Astro example](https://github.com/farming-labs/docs/tree/main/examples/astro)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,0 +1,75 @@
+# @farming-labs/astro
+
+The Astro runtime adapter for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It loads Markdown and MDX content, builds navigation, renders page content on the server, and
+provides Astro handlers for docs, search, AI, agent discovery, MCP, and API references.
+
+## Package responsibilities
+
+- `@farming-labs/docs` — shared config, types, content features, and CLI
+- `@farming-labs/astro` — Astro content loading and server handlers
+- `@farming-labs/astro-theme` — Astro layout and UI components
+- `@farming-labs/theme` — shared preset CSS
+
+## Install
+
+The CLI can wire the complete Astro integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+For manual installation:
+
+```bash
+npm install @farming-labs/docs @farming-labs/astro @farming-labs/astro-theme @farming-labs/theme
+```
+
+Dynamic docs routes also require an Astro server adapter such as `@astrojs/vercel`,
+`@astrojs/netlify`, `@astrojs/node`, or `@astrojs/cloudflare`.
+
+## Server integration
+
+Preload content with Vite and create the docs server:
+
+```ts
+// src/lib/docs.server.ts
+import { createDocsServer } from "@farming-labs/astro/server";
+import config from "./docs.config";
+
+const contentFiles = import.meta.glob("/docs/**/*.{md,mdx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export const { load, GET, POST, MCP } = createDocsServer({
+  ...config,
+  _preloadedContent: contentFiles,
+});
+```
+
+Call `load(Astro.url.pathname)` from the docs page and render the result with components from
+`@farming-labs/astro-theme`. The CLI generates the pages, API routes, public forwarding, theme
+CSS import, and Astro adapter configuration.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/astro/server` | Docs server, loaders, API/MCP handlers, and API-reference helper |
+| `@farming-labs/astro/content` | Content discovery and navigation utilities |
+| `@farming-labs/astro/markdown` | Server-side Markdown rendering |
+| `@farming-labs/astro/api-reference` | API-reference route handler |
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Astro example](https://github.com/farming-labs/docs/tree/main/examples/astro)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/fumadocs/README.md
+++ b/packages/fumadocs/README.md
@@ -1,0 +1,96 @@
+# @farming-labs/theme
+
+The React UI layer and shared theme preset package for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It provides the docs shell, root providers, MDX components, search and AI interfaces, theme
+factories, and the CSS used across every Farming Labs framework integration.
+
+## Where it fits
+
+- **Next.js and TanStack Start:** supplies the React layout, providers, components, and CSS
+- **SvelteKit, Astro, and Nuxt:** supplies shared preset CSS while the matching `*-theme` package
+  supplies framework-native UI components
+- **`@farming-labs/docs`:** supplies the shared configuration, content features, and CLI
+
+## Install
+
+For Next.js:
+
+```bash
+npm install @farming-labs/docs @farming-labs/next @farming-labs/theme
+```
+
+For TanStack Start:
+
+```bash
+npm install @farming-labs/docs @farming-labs/tanstack-start @farming-labs/theme
+```
+
+The setup CLI installs the correct package set automatically:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+## Choose a theme
+
+Use a theme factory in `docs.config.ts`:
+
+```ts
+import { defineDocs } from "@farming-labs/docs";
+import { fumadocs } from "@farming-labs/theme";
+
+export default defineDocs({
+  entry: "docs",
+  theme: fumadocs(),
+});
+```
+
+Then import its CSS. The default `fumadocs()` preset uses the `default/css` entrypoint:
+
+```css
+@import "tailwindcss";
+@import "@farming-labs/theme/default/css";
+```
+
+Other presets use matching factory and CSS subpaths:
+
+```ts
+import { hardline } from "@farming-labs/theme/hardline";
+```
+
+```css
+@import "@farming-labs/theme/hardline/css";
+```
+
+Available preset subpaths include `default`, `darksharp`, `pixel-border`, `colorful`, `shiny`,
+`darkbold`, `greentree`, `hardline`, `concrete`, `command-grid`, `ledger`, and `threadline`.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/theme` | Default theme, `RootProvider`, layout helpers, and React UI |
+| `@farming-labs/theme/<preset>` | Theme factory for a preset |
+| `@farming-labs/theme/<preset>/css` | Complete CSS for a preset |
+| `@farming-labs/theme/mdx` | Farming Labs MDX component map |
+| `@farming-labs/theme/search` | Legacy `createDocsSearchAPI()` compatibility helper |
+| `@farming-labs/theme/ai` | AI search and chat UI |
+| `@farming-labs/theme/tanstack` | TanStack Start provider and layout integration |
+
+## Runtime requirements
+
+The package currently declares Next.js 16+, React 19.2+, and React DOM 19.2+ as peers because its
+root entrypoints provide the React and Next.js UI. SvelteKit, Astro, and Nuxt integrations consume
+the shared CSS subpaths while rendering UI through their framework-native theme packages.
+
+## Learn more
+
+- [Themes](https://docs.farming-labs.dev/docs/themes)
+- [Creating themes](https://docs.farming-labs.dev/docs/themes/creating-themes)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,88 @@
+# @farming-labs/next
+
+The Next.js App Router adapter for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It connects the shared docs configuration and theme to Next.js, compiles Markdown and MDX,
+generates the standard docs routes, and provides Next-native runtime helpers for documentation
+APIs, API references, MCP, and changelogs.
+
+## What this package does
+
+- Wraps `next.config.ts` with the Farming Labs MDX and routing integration
+- Generates missing docs layouts, API routes, MCP routes, and enabled feature routes
+- Adds machine-readable Markdown, agent discovery, sitemap, and `llms.txt` rewrites
+- Provides App Router layout, metadata, API-reference, and changelog helpers
+- Preserves user-authored files and existing Next.js configuration
+
+The shared config and CLI live in `@farming-labs/docs`. React UI, MDX components, providers, and
+theme CSS live in `@farming-labs/theme`.
+
+## Install
+
+The CLI can add docs to an existing Next.js project:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+For manual installation:
+
+```bash
+npm install @farming-labs/docs @farming-labs/next @farming-labs/theme
+```
+
+## Minimal setup
+
+Create `docs.config.ts` with `defineDocs()`, then wrap the Next.js config:
+
+```ts
+// next.config.ts
+import { withDocs } from "@farming-labs/next/config";
+
+export default withDocs();
+```
+
+Existing Next.js configuration can be passed directly:
+
+```ts
+export default withDocs({
+  reactStrictMode: true,
+});
+```
+
+Import the selected theme in your global stylesheet:
+
+```css
+@import "tailwindcss";
+@import "@farming-labs/theme/default/css";
+```
+
+Write documentation pages under `app/docs/` or `src/app/docs/`. The CLI also adds the root
+`RootProvider`, generated docs layout, and server routes needed for a complete setup.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/next/config` | `withDocs()` Next.js configuration wrapper |
+| `@farming-labs/next/layout` | App Router docs layout and metadata helpers |
+| `@farming-labs/next/api` | Docs API and MCP route handlers |
+| `@farming-labs/next/api-reference` | Generated API-reference routes and pages |
+| `@farming-labs/next/changelog` | Generated changelog page helpers |
+
+## Requirements
+
+- Next.js 16 or newer
+- React and React DOM 19.2 or newer
+- `@farming-labs/docs` and `@farming-labs/theme`
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Next.js example](https://github.com/farming-labs/docs/tree/main/examples/next)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/nuxt-theme/README.md
+++ b/packages/nuxt-theme/README.md
@@ -1,0 +1,85 @@
+# @farming-labs/nuxt-theme
+
+The Vue and Nuxt UI layer and theme preset package for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It renders the docs shell, page content, table of contents, breadcrumbs, search, AI chat, API
+reference switcher, and theme controls. Content loading and Nitro handlers live in
+`@farming-labs/nuxt`.
+
+## Install
+
+```bash
+npm install @farming-labs/docs @farming-labs/nuxt @farming-labs/nuxt-theme @farming-labs/theme
+```
+
+The CLI can scaffold the complete Nuxt integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+## Configure the theme
+
+```ts
+// docs.config.ts
+import { defineDocs } from "@farming-labs/docs";
+import { fumadocs } from "@farming-labs/nuxt-theme";
+
+export default defineDocs({
+  entry: "docs",
+  contentDir: "docs",
+  theme: fumadocs(),
+  nav: { title: "Docs", url: "/docs" },
+});
+```
+
+Add the matching shared CSS in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  css: ["@farming-labs/theme/default/css"],
+});
+```
+
+## Render the docs UI
+
+```vue
+<script setup lang="ts">
+import { DocsContent, DocsLayout } from "@farming-labs/nuxt-theme";
+import config from "~/docs.config";
+
+const { data } = await useFetch("/api/docs", {
+  query: { pathname: useRoute().path },
+});
+</script>
+
+<template>
+  <DocsLayout :tree="data.tree" :config="config">
+    <DocsContent :data="data" :config="config" />
+  </DocsLayout>
+</template>
+```
+
+## Main exports
+
+- `DocsLayout`, `DocsContent`, and `DocsPage`
+- `TableOfContents`, `Breadcrumb`, and `ThemeToggle`
+- `SearchDialog`, `FloatingAIChat`, and `ApiReferenceSwitcher`
+- Theme preset factories
+
+Preset subpaths are `fumadocs`, `pixel-border`, `darksharp`, `colorful`, `greentree`, `hardline`,
+`concrete`, `command-grid`, and `ledger`. The `fumadocs` preset uses
+`@farming-labs/theme/default/css`; the other presets use the matching
+`@farming-labs/theme/<preset>/css` entrypoint.
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Themes](https://docs.farming-labs.dev/docs/themes)
+- [Nuxt example](https://github.com/farming-labs/docs/tree/main/examples/nuxt)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -1,0 +1,76 @@
+# @farming-labs/nuxt
+
+The Nuxt and Nitro runtime adapter for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It loads Markdown and MDX content from Nitro storage, builds navigation, renders page content on
+the server, and provides H3 handlers for docs, search, AI, agent discovery, MCP, and API references.
+
+## Package responsibilities
+
+- `@farming-labs/docs` — shared config, types, content features, and CLI
+- `@farming-labs/nuxt` — Nitro content loading and server handlers
+- `@farming-labs/nuxt-theme` — Vue layout and UI components
+- `@farming-labs/theme` — shared preset CSS
+
+## Install
+
+The CLI can wire the complete Nuxt integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+For manual installation:
+
+```bash
+npm install @farming-labs/docs @farming-labs/nuxt @farming-labs/nuxt-theme @farming-labs/theme
+```
+
+## Server integration
+
+Create the main Nitro API handler:
+
+```ts
+// server/api/docs.ts
+import { defineDocsHandler } from "@farming-labs/nuxt/server";
+import config from "../../docs.config";
+
+export default defineDocsHandler(config, useStorage);
+```
+
+The generated setup also adds public-route middleware with `defineDocsPublicHandler()` and makes
+the docs directory available through Nitro storage:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  css: ["@farming-labs/theme/default/css"],
+  nitro: {
+    moduleSideEffects: ["@farming-labs/nuxt/server"],
+    serverAssets: [{ baseName: "docs", dir: "docs" }],
+  },
+});
+```
+
+Render the returned page data with `DocsLayout` and `DocsContent` from
+`@farming-labs/nuxt-theme`.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/nuxt/server` | Nitro handlers, docs server, public forwarding, and MCP |
+| `@farming-labs/nuxt/content` | Content discovery and navigation utilities |
+| `@farming-labs/nuxt/markdown` | Server-side Markdown rendering |
+| `@farming-labs/nuxt/api-reference` | API-reference route handler |
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Nuxt example](https://github.com/farming-labs/docs/tree/main/examples/nuxt)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/svelte-theme/README.md
+++ b/packages/svelte-theme/README.md
@@ -1,0 +1,81 @@
+# @farming-labs/svelte-theme
+
+The Svelte 5 UI layer and theme preset package for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs) on SvelteKit.
+
+It renders the docs shell, page content, sidebar, table of contents, search, AI dialogs, page
+actions, and theme controls. Content loading and route handlers live in `@farming-labs/svelte`.
+
+## Install
+
+```bash
+npm install @farming-labs/docs @farming-labs/svelte @farming-labs/svelte-theme @farming-labs/theme
+```
+
+The CLI can scaffold the complete SvelteKit integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+## Configure the theme
+
+```ts
+// src/lib/docs.config.ts
+import { defineDocs } from "@farming-labs/docs";
+import { fumadocs } from "@farming-labs/svelte-theme";
+
+export default defineDocs({
+  entry: "docs",
+  contentDir: "docs",
+  theme: fumadocs(),
+  nav: { title: "Docs", url: "/docs" },
+});
+```
+
+Import the matching shared CSS in `src/app.css`:
+
+```css
+@import "@farming-labs/theme/default/css";
+```
+
+## Render the docs UI
+
+```svelte
+<script>
+  import { DocsLayout } from "@farming-labs/svelte-theme";
+  import config from "$lib/docs.config";
+
+  let { data, children } = $props();
+</script>
+
+<DocsLayout tree={data.tree} {config}>
+  {@render children()}
+</DocsLayout>
+```
+
+Use `DocsContent` from the same package in the page component. The `data` passed to these
+components comes from `@farming-labs/svelte/server`.
+
+## Main exports
+
+- `DocsLayout`, `DocsContent`, `DocsSidebar`, and `DocsPage`
+- `TableOfContents`, `Breadcrumb`, `MobileNav`, and `ThemeToggle`
+- `SearchDialog`, `AskAIDialog`, and `FloatingAIChat`
+- `Callout` and theme preset factories
+
+Preset subpaths are `fumadocs`, `pixel-border`, `darksharp`, `colorful`, `greentree`, `hardline`,
+`concrete`, `command-grid`, and `ledger`. The `fumadocs` preset uses
+`@farming-labs/theme/default/css`; the other presets use the matching
+`@farming-labs/theme/<preset>/css` entrypoint.
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [Themes](https://docs.farming-labs.dev/docs/themes)
+- [SvelteKit example](https://github.com/farming-labs/docs/tree/main/examples/sveltekit)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,73 @@
+# @farming-labs/svelte
+
+The SvelteKit runtime adapter for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It loads Markdown, MDX, and SVX content, builds navigation, renders page content on the server, and
+provides SvelteKit handlers for docs, search, AI, agent discovery, MCP, and API references.
+
+## Package responsibilities
+
+- `@farming-labs/docs` — shared config, types, content features, and CLI
+- `@farming-labs/svelte` — SvelteKit content loading and server handlers
+- `@farming-labs/svelte-theme` — Svelte layout and UI components
+- `@farming-labs/theme` — shared preset CSS
+
+## Install
+
+The CLI can wire the complete SvelteKit integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+For manual installation:
+
+```bash
+npm install @farming-labs/docs @farming-labs/svelte @farming-labs/svelte-theme @farming-labs/theme
+```
+
+## Server integration
+
+Preload content with Vite and create the docs server:
+
+```ts
+// src/lib/docs.server.ts
+import { createDocsServer } from "@farming-labs/svelte/server";
+import config from "./docs.config";
+
+const contentFiles = import.meta.glob("/docs/**/*.{md,mdx,svx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export const { load, GET, POST, MCP } = createDocsServer({
+  ...config,
+  _preloadedContent: contentFiles,
+});
+```
+
+Re-export `load` from the docs `+layout.server.ts` and `GET`/`POST` from the docs API route. Use
+`DocsLayout` and `DocsContent` from `@farming-labs/svelte-theme` for presentation. The CLI
+generates all of these files, including public agent and MCP forwarding.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/svelte/server` | Docs server, loaders, API/MCP handlers, and API-reference helper |
+| `@farming-labs/svelte/content` | Content discovery and navigation utilities |
+| `@farming-labs/svelte/markdown` | Server-side Markdown rendering |
+| `@farming-labs/svelte/config` | Optional mdsvex configuration helper |
+| `@farming-labs/svelte/api-reference` | API-reference route handler |
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [SvelteKit example](https://github.com/farming-labs/docs/tree/main/examples/sveltekit)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -1,0 +1,91 @@
+# @farming-labs/tanstack-start
+
+The TanStack Start adapter for
+[`@farming-labs/docs`](https://www.npmjs.com/package/@farming-labs/docs).
+
+It compiles Markdown and MDX with Vite, loads documentation content on the server, builds
+navigation and page metadata, exposes docs and MCP handlers, and renders pages with the Farming
+Labs React theme.
+
+## What this package does
+
+- Adds the Farming Labs MDX pipeline to Vite
+- Loads filesystem content and builds navigation trees on the server
+- Provides handlers for pages, search, AI, agent discovery, MCP, and API references
+- Supplies the `TanstackDocsPage` React renderer for TanStack Router routes
+
+The shared config and CLI live in `@farming-labs/docs`. Providers, React UI, MDX components, and
+theme CSS live in `@farming-labs/theme`.
+
+## Install
+
+The CLI can scaffold the full integration:
+
+```bash
+npx @farming-labs/docs@latest init
+```
+
+For manual installation:
+
+```bash
+npm install @farming-labs/docs @farming-labs/tanstack-start @farming-labs/theme
+```
+
+## Minimal setup
+
+Add the docs MDX plugin before the TanStack Start plugin:
+
+```ts
+// vite.config.ts
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { docsMdx } from "@farming-labs/tanstack-start/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [docsMdx(), tanstackStart()],
+});
+```
+
+Create the server integration:
+
+```ts
+// src/lib/docs.server.ts
+import { createDocsServer } from "@farming-labs/tanstack-start/server";
+import docsConfig from "../../docs.config";
+
+export const docsServer = createDocsServer({
+  ...docsConfig,
+  rootDir: process.cwd(),
+});
+```
+
+Render loaded page data with the React adapter:
+
+```tsx
+import { TanstackDocsPage } from "@farming-labs/tanstack-start/react";
+
+<TanstackDocsPage config={docsConfig} data={loaderData} />;
+```
+
+A complete integration also needs docs and API routes, `RootProvider` from
+`@farming-labs/theme/tanstack`, and the selected theme CSS. The CLI creates those files.
+
+## Main entrypoints
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@farming-labs/tanstack-start/vite` | Vite MDX compilation plugin |
+| `@farming-labs/tanstack-start/server` | Content loading and docs API/MCP handlers |
+| `@farming-labs/tanstack-start/react` | `TanstackDocsPage` renderer |
+| `@farming-labs/tanstack-start/content` | Lower-level content and navigation utilities |
+| `@farming-labs/tanstack-start/api-reference` | API-reference route handler |
+
+## Learn more
+
+- [Documentation](https://docs.farming-labs.dev/docs)
+- [TanStack Start example](https://github.com/farming-labs/docs/tree/main/examples/tanstack-start)
+- [GitHub repository](https://github.com/farming-labs/docs)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- add npm-facing READMEs for the remaining nine published packages
- distinguish the framework runtime adapters from their UI and theme packages
- document package pairings, minimal setup, important entrypoints, examples, and requirements

## Why

Only `@farming-labs/docs` had a package-local README. Because each workspace is published from its own directory, the other npm package pages did not explain what the package does or how it fits into the Farming Labs stack.

These READMEs give every package a focused npm landing page without changing runtime behavior.

## Validation

- ran `npm pack --dry-run --json` for all ten package workspaces
- confirmed every tarball includes `README.md`
- ran `git diff --cached --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm-facing READMEs for the remaining nine published packages to explain responsibilities, pairings, minimal setup, key entrypoints, and requirements. No runtime changes.

- **Validation**
  - Ran `npm pack --dry-run --json` for all workspaces and confirmed each tarball includes `README.md`.
  - Verified formatting with `git diff --cached --check`.

<sup>Written for commit 46b848cb7ea0bb9874531ccf78df3f97aa3526ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

