### PR TITLE
test: enforce a cross-adapter agent surface contract

### DIFF
--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { DocsAgentAdapter } from "./agent-conformance.js";
+import { runDocsAgentConformance } from "./agent-conformance.js";
+
+const adapters = [
+  ["tanstack-start", "../../tanstack-start/src/server.ts"],
+  ["sveltekit", "../../svelte/src/server.ts"],
+  ["astro", "../../astro/src/server.ts"],
+  ["nuxt", "../../nuxt/src/server.ts"],
+] as const satisfies readonly (readonly [DocsAgentAdapter, string])[];
+
+describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
+  it("conforms to the shared public agent contract", async () => {
+    // Keep the module path dynamic so the core typecheck does not pull adapter source files into
+    // its declaration root. Vitest still executes the real adapter implementation.
+    const moduleUrl = new URL(modulePath, import.meta.url).href;
+    const { createDocsServer } = (await import(moduleUrl)) as {
+      createDocsServer(config: Record<string, unknown>): {
+        GET(context: { request: Request; url?: URL }): Promise<Response>;
+        MCP: { POST(context: { request: Request }): Promise<Response> };
+      };
+    };
+    const server = createDocsServer({
+      entry: "docs",
+      nav: { title: "Conformance Docs" },
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      mcp: true,
+      sitemap: true,
+      robots: true,
+      _preloadedContent: {
+        "/docs/en/page.md": `---\ntitle: Introduction\ndescription: Start here.\n---\n\n# Introduction\n\nWelcome.`,
+        "/docs/fr/page.md": `---\ntitle: Introduction\n---\n\n# Introduction\n\nBonjour.`,
+      },
+    });
+
+    const report = await runDocsAgentConformance({
+      adapter,
+      async handle(request, surface) {
+        if (surface === "mcp-initialize") return server.MCP.POST({ request });
+        return server.GET({ request, url: new URL(request.url) });
+      },
+    });
+
+    expect(report.cases.filter((result) => !result.passed)).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});

--- a/packages/docs/src/agent-conformance.test.ts
+++ b/packages/docs/src/agent-conformance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDocsAgentContractCases,
+  DOCS_AGENT_CONTRACT_VERSION,
+  runDocsAgentConformance,
+} from "./agent-conformance.js";
+
+describe("agent conformance contract", () => {
+  it("defines every required agent surface once", () => {
+    const cases = createDocsAgentContractCases();
+    const surfaces = cases.map((contractCase) => contractCase.surface);
+
+    expect(new Set(surfaces).size).toBe(surfaces.length);
+    expect(surfaces).toEqual(
+      expect.arrayContaining([
+        "discovery",
+        "markdown-alias",
+        "markdown-negotiation",
+        "markdown-locale",
+        "llms",
+        "agents",
+        "skill",
+        "sitemap-xml",
+        "robots",
+        "mcp-initialize",
+      ]),
+    );
+  });
+
+  it("returns actionable failures without stopping the remaining cases", async () => {
+    const report = await runDocsAgentConformance({
+      adapter: "next",
+      locale: false,
+      handle: async (_request, surface) =>
+        new Response(surface, {
+          status: surface === "discovery" ? 500 : 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    });
+
+    expect(report.contractVersion).toBe(DOCS_AGENT_CONTRACT_VERSION);
+    expect(report.passed).toBe(false);
+    expect(report.cases).toHaveLength(createDocsAgentContractCases({ locale: false }).length);
+    expect(report.cases.find((result) => result.surface === "discovery")?.issues).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("expected status 200"),
+        expect.stringContaining("expected content-type application/json"),
+      ]),
+    );
+  });
+});

--- a/packages/docs/src/agent-conformance.ts
+++ b/packages/docs/src/agent-conformance.ts
@@ -1,0 +1,287 @@
+import {
+  DEFAULT_AGENT_FEEDBACK_ROUTE,
+  DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
+  DEFAULT_AGENTS_MD_ROUTE,
+  DEFAULT_DOCS_CONFIG_ROUTE,
+  DEFAULT_DOCS_DIAGNOSTICS_ROUTE,
+  DEFAULT_LLMS_FULL_TXT_ROUTE,
+  DEFAULT_LLMS_TXT_ROUTE,
+  DEFAULT_MCP_WELL_KNOWN_ROUTE,
+  DEFAULT_SKILL_MD_ROUTE,
+} from "./agent.js";
+import { DEFAULT_SITEMAP_MD_ROUTE, DEFAULT_SITEMAP_XML_ROUTE } from "./sitemap.js";
+import { DEFAULT_ROBOTS_TXT_ROUTE } from "./robots.js";
+
+export const DOCS_AGENT_CONTRACT_VERSION = "1.0";
+
+export type DocsAgentAdapter = "next" | "tanstack-start" | "sveltekit" | "astro" | "nuxt";
+
+export type DocsAgentContractSurface =
+  | "discovery"
+  | "config"
+  | "diagnostics"
+  | "feedback-schema"
+  | "markdown-alias"
+  | "markdown-negotiation"
+  | "markdown-locale"
+  | "markdown-missing"
+  | "llms"
+  | "llms-full"
+  | "agents"
+  | "skill"
+  | "sitemap-xml"
+  | "sitemap-markdown"
+  | "robots"
+  | "mcp-initialize";
+
+export interface DocsAgentContractRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+export interface DocsAgentContractExpectation {
+  statuses: readonly number[];
+  contentTypes: readonly string[];
+  bodyIncludes?: readonly string[];
+}
+
+export interface DocsAgentContractCase {
+  surface: DocsAgentContractSurface;
+  request: DocsAgentContractRequest;
+  expect: DocsAgentContractExpectation;
+}
+
+export interface DocsAgentConformanceCaseResult {
+  surface: DocsAgentContractSurface;
+  passed: boolean;
+  status?: number;
+  contentType?: string;
+  issues: string[];
+}
+
+export interface DocsAgentConformanceReport {
+  adapter: DocsAgentAdapter;
+  contractVersion: typeof DOCS_AGENT_CONTRACT_VERSION;
+  passed: boolean;
+  cases: DocsAgentConformanceCaseResult[];
+}
+
+export interface RunDocsAgentConformanceOptions {
+  adapter: DocsAgentAdapter;
+  /** Origin used to construct requests. Defaults to http://localhost. */
+  origin?: string;
+  /** Public docs entry. Defaults to docs. */
+  entry?: string;
+  /** Locale fixture expected to render the word "Bonjour". Set false to skip. */
+  locale?: string | false;
+  handle(request: Request, surface: DocsAgentContractSurface): Response | Promise<Response>;
+}
+
+function normalizeOrigin(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function normalizeEntry(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "") || "docs";
+}
+
+/**
+ * The framework-neutral public surface every first-party adapter must implement.
+ * Adapter tests consume this list so new routes and invariants are added once.
+ */
+export function createDocsAgentContractCases(
+  options: {
+    origin?: string;
+    entry?: string;
+    locale?: string | false;
+  } = {},
+): DocsAgentContractCase[] {
+  const origin = normalizeOrigin(options.origin ?? "http://localhost");
+  const entry = normalizeEntry(options.entry ?? "docs");
+  const locale = options.locale === undefined ? "fr" : options.locale;
+  const url = (route: string) => `${origin}${route.startsWith("/") ? route : `/${route}`}`;
+  const markdown = ["text/markdown"] as const;
+  const json = ["application/json"] as const;
+
+  const cases: DocsAgentContractCase[] = [
+    {
+      surface: "discovery",
+      request: { url: url(DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE) },
+      expect: { statuses: [200], contentTypes: json },
+    },
+    {
+      surface: "config",
+      request: { url: url(DEFAULT_DOCS_CONFIG_ROUTE) },
+      expect: { statuses: [200], contentTypes: json, bodyIncludes: ["docs-config-map.v1"] },
+    },
+    {
+      surface: "diagnostics",
+      request: { url: url(DEFAULT_DOCS_DIAGNOSTICS_ROUTE) },
+      expect: { statuses: [200], contentTypes: json, bodyIncludes: ["docs-diagnostics.v1"] },
+    },
+    {
+      surface: "feedback-schema",
+      request: { url: url(`${DEFAULT_AGENT_FEEDBACK_ROUTE}/schema`) },
+      expect: { statuses: [200], contentTypes: ["application/schema+json"] },
+    },
+    {
+      surface: "markdown-alias",
+      request: { url: url(`/${entry}.md`) },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["Introduction"] },
+    },
+    {
+      surface: "markdown-negotiation",
+      request: {
+        url: url(`/${entry}`),
+        init: { headers: { Accept: "text/markdown" } },
+      },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["Introduction"] },
+    },
+    {
+      surface: "markdown-missing",
+      request: { url: url(`/${entry}/missing.md`) },
+      // 200 is the legacy recovery-document behavior. The HTTP semantics contract may move it to
+      // 404 without making the recovery body disappear.
+      expect: { statuses: [200, 404], contentTypes: markdown, bodyIncludes: ["not found"] },
+    },
+    {
+      surface: "llms",
+      request: { url: url(DEFAULT_LLMS_TXT_ROUTE) },
+      expect: { statuses: [200], contentTypes: ["text/plain"], bodyIncludes: ["Introduction"] },
+    },
+    {
+      surface: "llms-full",
+      request: { url: url(DEFAULT_LLMS_FULL_TXT_ROUTE) },
+      expect: { statuses: [200], contentTypes: ["text/plain"], bodyIncludes: ["Introduction"] },
+    },
+    {
+      surface: "agents",
+      request: { url: url(DEFAULT_AGENTS_MD_ROUTE) },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["AGENTS.md"] },
+    },
+    {
+      surface: "skill",
+      request: { url: url(DEFAULT_SKILL_MD_ROUTE) },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["name:"] },
+    },
+    {
+      surface: "sitemap-xml",
+      request: { url: url(DEFAULT_SITEMAP_XML_ROUTE) },
+      expect: {
+        statuses: [200],
+        contentTypes: ["application/xml", "text/xml"],
+        bodyIncludes: ["<urlset"],
+      },
+    },
+    {
+      surface: "sitemap-markdown",
+      request: { url: url(DEFAULT_SITEMAP_MD_ROUTE) },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["Introduction"] },
+    },
+    {
+      surface: "robots",
+      request: { url: url(DEFAULT_ROBOTS_TXT_ROUTE) },
+      expect: { statuses: [200], contentTypes: ["text/plain"], bodyIncludes: ["User-agent:"] },
+    },
+    {
+      surface: "mcp-initialize",
+      request: {
+        url: url(DEFAULT_MCP_WELL_KNOWN_ROUTE),
+        init: {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "MCP-Protocol-Version": "2025-11-25",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              clientInfo: { name: "agent-conformance", version: DOCS_AGENT_CONTRACT_VERSION },
+            },
+          }),
+        },
+      },
+      expect: {
+        statuses: [200],
+        contentTypes: ["application/json", "text/event-stream"],
+        bodyIncludes: ["serverInfo", "protocolVersion"],
+      },
+    },
+  ];
+
+  if (locale) {
+    cases.splice(6, 0, {
+      surface: "markdown-locale",
+      request: { url: url(`/${entry}.md?lang=${encodeURIComponent(locale)}`) },
+      expect: { statuses: [200], contentTypes: markdown, bodyIncludes: ["Bonjour"] },
+    });
+  }
+
+  return cases;
+}
+
+function matchesContentType(actual: string, expected: readonly string[]): boolean {
+  const normalized = actual.toLowerCase();
+  return expected.some((value) => normalized.startsWith(value.toLowerCase()));
+}
+
+export async function runDocsAgentConformance(
+  options: RunDocsAgentConformanceOptions,
+): Promise<DocsAgentConformanceReport> {
+  const cases = createDocsAgentContractCases(options);
+  const results: DocsAgentConformanceCaseResult[] = [];
+
+  for (const contractCase of cases) {
+    const issues: string[] = [];
+
+    try {
+      const response = await options.handle(
+        new Request(contractCase.request.url, contractCase.request.init),
+        contractCase.surface,
+      );
+      const contentType = response.headers.get("content-type") ?? "";
+      const body = await response.text();
+
+      if (!contractCase.expect.statuses.includes(response.status)) {
+        issues.push(
+          `expected status ${contractCase.expect.statuses.join(" or ")}, received ${response.status}`,
+        );
+      }
+
+      if (!matchesContentType(contentType, contractCase.expect.contentTypes)) {
+        issues.push(
+          `expected content-type ${contractCase.expect.contentTypes.join(" or ")}, received ${contentType || "<missing>"}`,
+        );
+      }
+
+      for (const requiredText of contractCase.expect.bodyIncludes ?? []) {
+        if (!body.toLowerCase().includes(requiredText.toLowerCase())) {
+          issues.push(`response body did not include ${JSON.stringify(requiredText)}`);
+        }
+      }
+
+      results.push({
+        surface: contractCase.surface,
+        passed: issues.length === 0,
+        status: response.status,
+        contentType,
+        issues,
+      });
+    } catch (error) {
+      issues.push(error instanceof Error ? error.message : String(error));
+      results.push({ surface: contractCase.surface, passed: false, issues });
+    }
+  }
+
+  return {
+    adapter: options.adapter,
+    contractVersion: DOCS_AGENT_CONTRACT_VERSION,
+    passed: results.every((result) => result.passed),
+    cases: results,
+  };
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -35,6 +35,21 @@ export { deepMerge } from "./utils.js";
 export { createTheme, extendTheme } from "./create-theme.js";
 export { resolveDocsI18n, resolveDocsLocale, resolveDocsPath } from "./i18n.js";
 export {
+  DOCS_AGENT_CONTRACT_VERSION,
+  createDocsAgentContractCases,
+  runDocsAgentConformance,
+} from "./agent-conformance.js";
+export type {
+  DocsAgentAdapter,
+  DocsAgentConformanceCaseResult,
+  DocsAgentConformanceReport,
+  DocsAgentContractCase,
+  DocsAgentContractExpectation,
+  DocsAgentContractRequest,
+  DocsAgentContractSurface,
+  RunDocsAgentConformanceOptions,
+} from "./agent-conformance.js";
+export {
   buildDocsPageStructuredData,
   buildPageOpenGraph,
   buildPageTwitter,

--- a/packages/fumadocs/src/agent-conformance.test.ts
+++ b/packages/fumadocs/src/agent-conformance.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDocsAgentConformance } from "@farming-labs/docs";
+import { createDocsAPI, createDocsMCPAPI } from "./docs-api.js";
+
+describe("Next.js agent surface contract", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("conforms to the shared public agent contract", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-agent-conformance-next-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs", "en"), { recursive: true });
+    mkdirSync(join(rootDir, "app", "docs", "fr"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "en", "page.mdx"),
+      `---\ntitle: Introduction\ndescription: Start here.\n---\n\n# Introduction\n\nWelcome.`,
+    );
+    writeFileSync(
+      join(rootDir, "app", "docs", "fr", "page.mdx"),
+      `---\ntitle: Introduction\n---\n\n# Introduction\n\nBonjour.`,
+    );
+
+    const options = {
+      rootDir,
+      entry: "docs",
+      nav: { title: "Conformance Docs" },
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      mcp: true,
+      sitemap: true,
+      robots: true,
+    };
+    const docs = createDocsAPI(options);
+    const mcp = createDocsMCPAPI(options);
+
+    const report = await runDocsAgentConformance({
+      adapter: "next",
+      async handle(request, surface) {
+        if (surface === "mcp-initialize") return mcp.POST(request);
+        return docs.GET(request);
+      },
+    });
+
+    expect(report.cases.filter((result) => !result.passed)).toEqual([]);
+    expect(report.passed).toBe(true);
+  });
+});

--- a/website/app/docs/guides/adapter-agent-conformance/page.mdx
+++ b/website/app/docs/guides/adapter-agent-conformance/page.mdx
@@ -1,0 +1,93 @@
+---
+title: "Adapter Agent Conformance"
+description: "Validate that a framework adapter exposes the same agent-readable documentation contract as the first-party adapters"
+related:
+  - /docs/guides/agent-friendly-docs
+  - /docs/customization/mcp
+  - /docs/customization/llms-txt
+  - /docs/customization/sitemaps
+  - /docs/cli
+---
+
+# Adapter Agent Conformance
+
+Every `@farming-labs/docs` adapter should expose the same machine-readable surface. The shared
+conformance runner turns that expectation into an executable contract instead of relying on each
+adapter to maintain a separate checklist.
+
+<Agent>
+Use `runDocsAgentConformance` when building or changing a framework adapter. Provide one callback
+that dispatches ordinary requests to the adapter's public GET handler and the `mcp-initialize`
+case to its MCP POST handler. Use the standard fixture titles `Introduction` and `Bonjour` so the
+contract can verify default and localized Markdown. A passing report must contain no failed cases.
+</Agent>
+
+## Covered surfaces
+
+The versioned contract verifies:
+
+- agent discovery, config, diagnostics, and feedback schema
+- explicit `.md` aliases and `Accept: text/markdown` negotiation
+- default and localized page content
+- actionable missing-page recovery
+- `llms.txt` and `llms-full.txt`
+- `AGENTS.md` and `skill.md`
+- XML and Markdown sitemaps plus `robots.txt`
+- a Streamable HTTP MCP initialize request
+
+The first-party Next.js, TanStack Start, SvelteKit, Astro, and Nuxt adapters run this same contract
+in their package tests.
+
+## Use it in an adapter test
+
+```ts title="src/agent-conformance.test.ts" framework="custom" runnable
+import { expect, it } from "vitest";
+import { runDocsAgentConformance } from "@farming-labs/docs";
+import { createDocsServer } from "./server";
+
+it("implements the agent surface contract", async () => {
+  const server = createDocsServer({
+    entry: "docs",
+    i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+    mcp: true,
+    sitemap: true,
+    robots: true,
+    _preloadedContent: {
+      "/docs/en/page.md": "---\ntitle: Introduction\n---\n# Introduction",
+      "/docs/fr/page.md": "---\ntitle: Introduction\n---\n# Introduction\n\nBonjour",
+    },
+  });
+
+  const report = await runDocsAgentConformance({
+    adapter: "sveltekit",
+    async handle(request, surface) {
+      if (surface === "mcp-initialize") {
+        return server.MCP.POST({ request });
+      }
+
+      return server.GET({ request, url: new URL(request.url) });
+    },
+  });
+
+  expect(report.cases.filter((result) => !result.passed)).toEqual([]);
+});
+```
+
+The report includes the contract version and an individual result for every surface. Failure
+messages include the unexpected status, content type, or missing response text so adapter drift is
+visible in CI.
+
+## Extending the contract
+
+Add a new invariant to `createDocsAgentContractCases` once, then update every first-party adapter
+in the same change. Keep backwards-compatible transitions explicit; for example, the missing-page
+case temporarily accepts both the legacy recovery status and a standards-correct `404`, while
+requiring the useful recovery document in either response.
+
+Run the relevant adapter test and core typecheck before publishing:
+
+```bash title="terminal"
+pnpm --filter @farming-labs/docs build
+pnpm --filter @farming-labs/svelte test
+pnpm --filter @farming-labs/svelte typecheck
+```


### PR DESCRIPTION
## What changed

- adds a versioned, framework-neutral agent surface contract and conformance report API
- runs the same discovery, Markdown, locale, llms, AGENTS, skill, sitemap, robots, feedback, diagnostics, and MCP initialize cases against all five first-party adapters
- documents how adapter authors can run the contract in their own tests

## Why

Agent routes are implemented through several framework adapters. A shared executable contract makes route and response drift visible in CI and gives future agent-surface changes one place to declare their invariants.

The missing-page case deliberately accepts the legacy `200` recovery response and a standards-correct `404` during migration, while requiring the actionable Markdown recovery body in both cases.

## Validation

- `pnpm --filter @farming-labs/docs test` — 44 files, 561 tests passed
- `pnpm --filter @farming-labs/theme test` — 15 files, 144 tests passed
- typechecks passed for core, theme, SvelteKit, Astro, TanStack Start, and Nuxt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a versioned, cross-adapter agent surface contract and conformance runner in `@farming-labs/docs`, and enforces it across Next.js, TanStack Start, SvelteKit, Astro, and Nuxt. Adds tests and docs so adapter authors can validate routes and responses consistently in CI.

- New Features
  - Exported `runDocsAgentConformance`, `createDocsAgentContractCases`, and `DOCS_AGENT_CONTRACT_VERSION` from `@farming-labs/docs`.
  - Verifies discovery, config, diagnostics, feedback schema, Markdown alias/negotiation/locale/missing, `llms*.txt`, `AGENTS.md`, `skill.md`, sitemap XML/Markdown, `robots.txt`, and MCP initialize.
  - Produces a per-case report that continues after failures and includes actionable messages; supports locale toggle and simple handler wiring (`GET` and MCP `POST`).
  - Runs the same contract against all first-party adapters; adds a Next.js example test in `@farming-labs/fumadocs`.
  - Adds a guide at `/docs/guides/adapter-agent-conformance` showing how to use the runner.
  - During migration, the missing-page case accepts `200` or `404` but requires the actionable Markdown recovery body in both.

<sup>Written for commit e8160fd4cba46469a36512c15892f005e8d47047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

