### PR TITLE
fix: ignore localhost telemetry

### DIFF
--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -28,6 +28,8 @@ export {
   emitDocsTelemetryProjectEvent,
   getDocsTelemetryFeatures,
   inferDocsTelemetryAgentSurface,
+  isLocalDocsTelemetryOrigin,
+  normalizeDocsTelemetryOrigin,
   resolveDocsTelemetryConfig,
 } from "./telemetry.js";
 export { resolveChangelogConfig } from "./changelog.js";

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -619,6 +619,35 @@ sidebar:
     expect(pages.some((page) => page.url === "/docs/overview/what-is-surge")).toBe(true);
   });
 
+  it("does not emit telemetry for tools called through a local MCP request", async () => {
+    const rootDir = createTempDocsProject();
+    const source = createFilesystemDocsMcpSource({
+      rootDir,
+      entry: "docs",
+      contentDir: "docs",
+    });
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const handlers = createDocsMcpHttpHandler({
+        source,
+        mcp: { enabled: true },
+        telemetry: { enabled: true, siteOrigin: "https://docs.example.com" },
+      });
+      const response = await callMcpTool(handlers, "list_pages", {});
+
+      expect(response.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("serves a working MCP transport with the built-in tools", async () => {
     const rootDir = createTempDocsProject();
     const source = createFilesystemDocsMcpSource({

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -2003,6 +2003,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   function trackMcpTool(tool: string, values?: { locale?: string; resultCount?: number }) {
     emitDocsTelemetryMcpToolEvent(telemetryConfig, {
       framework: telemetryFramework,
+      request: options.requestContext?.request,
       tool,
       locale: values?.locale,
       resultCount: values?.resultCount,

--- a/packages/docs/src/telemetry.test.ts
+++ b/packages/docs/src/telemetry.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitDocsTelemetryEvent,
+  emitDocsTelemetryMcpToolEvent,
   emitDocsTelemetryProjectEvent,
   getDocsTelemetryFeatures,
   inferDocsTelemetryAgentSurface,
+  isLocalDocsTelemetryOrigin,
+  normalizeDocsTelemetryOrigin,
   resolveDocsTelemetryConfig,
 } from "./telemetry.js";
 import type { DocsTelemetryEvent } from "./types.js";
@@ -110,6 +113,126 @@ describe("telemetry", () => {
         },
       },
     });
+  });
+
+  it.each([
+    ["http://localhost:3200", true],
+    ["localhost:3200", true],
+    ["https://LOCALHOST.:3200/docs", true],
+    ["http://preview.localhost:4321", true],
+    ["http://localhost.localdomain:3200", true],
+    ["http://localhost6:3200", true],
+    ["http://ip6-localhost:3200", true],
+    ["http://127.0.0.1:3200", true],
+    ["http://127.42.0.8:3200", true],
+    ["http://127.1:3200", true],
+    ["http://0.0.0.0:3200", true],
+    ["http://[::1]:3200", true],
+    ["http://[::]:3200", true],
+    ["http://[::ffff:127.0.0.1]:3200", true],
+    ["http:/localhost:3200", true],
+    [String.raw`http:\\localhost:3200`, true],
+    ["https://localhost.example.com", false],
+    ["https://docs.example.com", false],
+    [undefined, false],
+  ])("classifies local telemetry origin %s", (origin, expected) => {
+    expect(isLocalDocsTelemetryOrigin(origin)).toBe(expected);
+  });
+
+  it("normalizes public origins and rejects malformed origins", () => {
+    expect(normalizeDocsTelemetryOrigin("DOCS.Example.com:8443/path")).toBe(
+      "https://docs.example.com:8443",
+    );
+    expect(normalizeDocsTelemetryOrigin("http:/localhost:3200")).toBe("http://localhost:3200");
+    expect(normalizeDocsTelemetryOrigin(String.raw`https:\\localhost:3200`)).toBe(
+      "https://localhost:3200",
+    );
+    for (const origin of [
+      "http://localhost:bad",
+      "ftp://localhost:3200",
+      "file://localhost/docs",
+      "   ",
+    ]) {
+      expect(normalizeDocsTelemetryOrigin(origin)).toBeUndefined();
+    }
+  });
+
+  it("does not send telemetry events for local origins", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsTelemetryEvent(
+      true,
+      telemetryEvent({ site: { origin: "https://localhost:3200" } }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit project telemetry for local requests", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitDocsTelemetryProjectEvent(
+      {
+        entry: "docs",
+        telemetry: { enabled: true, siteOrigin: "https://docs.example.com" },
+      },
+      {
+        framework: "next",
+        request: new Request("http://localhost:3200/api/docs"),
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit MCP tool telemetry for local requests", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitDocsTelemetryMcpToolEvent(
+      {
+        telemetry: { enabled: true, siteOrigin: "https://docs.example.com" },
+      },
+      {
+        framework: "next",
+        request: new Request("http://localhost:3200/mcp"),
+        tool: "read_page",
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "http://localhost:bad",
+    "http:/localhost:3200",
+    String.raw`http:\\localhost:3200`,
+    "ftp://localhost:3200",
+    "",
+    "   ",
+  ])("does not send telemetry events with malformed site origin %s", async (siteOrigin) => {
+    process.env.NODE_ENV = "production";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return new Response(null, { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await emitDocsTelemetryEvent(true, telemetryEvent({ site: { origin: siteOrigin } }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("uses configured site origin for project events", async () => {

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -131,15 +131,69 @@ function readRequestOrigin(request: Request | undefined): string | undefined {
   }
 }
 
-function normalizeTelemetryOrigin(candidate: string | undefined): string | undefined {
-  if (!candidate) return undefined;
+/** Normalize an HTTP(S) telemetry site value to its origin. */
+export function normalizeDocsTelemetryOrigin(candidate: string | undefined): string | undefined {
+  if (typeof candidate !== "string") return undefined;
+
+  const trimmed = candidate.trim();
+  if (!trimmed) return undefined;
 
   try {
-    const withProtocol = /^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`;
-    return new URL(withProtocol).origin;
+    // Treat values with a URI scheme as URLs so malformed HTTP separators and non-HTTP schemes
+    // cannot be reinterpreted as a public hostname (for example, `ftp://localhost` -> `ftp`).
+    // A numeric suffix remains a bare host plus port, as in `localhost:3200`.
+    const hasScheme = /^[a-z][a-z\d+.-]*:(?!\d)/i.test(trimmed);
+    const url = new URL(hasScheme ? trimmed : `https://${trimmed}`);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+
+    return url.origin;
   } catch {
     return undefined;
   }
+}
+
+/** Return whether a telemetry origin points at a local development server. */
+export function isLocalDocsTelemetryOrigin(candidate: string | undefined): boolean {
+  const origin = normalizeDocsTelemetryOrigin(candidate);
+  if (!origin) return false;
+
+  const hostname = new URL(origin).hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.+$/, "");
+
+  if (
+    [
+      "localhost",
+      "localhost.localdomain",
+      "localhost6",
+      "localhost6.localdomain6",
+      "ip6-localhost",
+      "ip6-loopback",
+    ].includes(hostname) ||
+    hostname.endsWith(".localhost")
+  ) {
+    return true;
+  }
+  if (hostname === "::" || hostname === "::1") return true;
+
+  // URL normalizes IPv4 shorthand such as 127.1 before this check.
+  const ipv4 = hostname.split(".").map((part) => Number(part));
+  if (
+    ipv4.length === 4 &&
+    ipv4.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+  ) {
+    return ipv4[0] === 127 || ipv4.every((part) => part === 0);
+  }
+
+  // URL serializes IPv4-mapped IPv6 addresses in hexadecimal form.
+  return /^::ffff:7f[0-9a-f]{2}:/.test(hostname) || hostname === "::ffff:0:0";
+}
+
+function isBlockedDocsTelemetryOrigin(candidate: string | undefined): boolean {
+  if (candidate === undefined) return false;
+
+  return !normalizeDocsTelemetryOrigin(candidate) || isLocalDocsTelemetryOrigin(candidate);
 }
 
 function readDeploymentOrigin(): string | undefined {
@@ -156,7 +210,7 @@ function readDeploymentOrigin(): string | undefined {
   ];
 
   for (const candidate of candidates) {
-    const origin = normalizeTelemetryOrigin(candidate);
+    const origin = normalizeDocsTelemetryOrigin(candidate);
     if (origin) return origin;
   }
 
@@ -288,15 +342,23 @@ function createDocsTelemetryEvent(
   config: Partial<DocsConfig>,
   input: DocsTelemetryEventInput,
   context: DocsTelemetryContext = {},
-): DocsTelemetryEvent {
+): DocsTelemetryEvent | undefined {
   const telemetryConfig =
     config.telemetry && typeof config.telemetry === "object" ? config.telemetry : undefined;
-  const siteOrigin =
-    context.siteOrigin ??
-    input.site?.origin ??
-    normalizeTelemetryOrigin(telemetryConfig?.siteOrigin) ??
-    readRequestOrigin(context.request) ??
-    readDeploymentOrigin();
+  const siteOriginCandidates = [
+    context.siteOrigin,
+    input.site?.origin,
+    telemetryConfig?.siteOrigin,
+    readRequestOrigin(context.request),
+    readDeploymentOrigin(),
+  ];
+
+  // A public grouping override must never mask that the request itself came from a local runtime.
+  if (siteOriginCandidates.some(isBlockedDocsTelemetryOrigin)) return undefined;
+
+  const siteOrigin = siteOriginCandidates
+    .map(normalizeDocsTelemetryOrigin)
+    .find((origin): origin is string => Boolean(origin));
   const deployment = input.deployment ?? detectDeployment();
   const properties =
     context.properties || input.properties
@@ -363,7 +425,21 @@ export async function emitDocsTelemetryEvent(
   event: DocsTelemetryEvent,
 ): Promise<void> {
   const resolved = resolveDocsTelemetryConfig(telemetry);
-  if (!resolved.enabled || !resolved.endpoint || typeof fetch !== "function") return;
+  const eventSiteOrigin = event.site?.origin;
+  const normalizedSiteOrigin = normalizeDocsTelemetryOrigin(eventSiteOrigin);
+  if (
+    !resolved.enabled ||
+    !resolved.endpoint ||
+    typeof fetch !== "function" ||
+    (eventSiteOrigin !== undefined &&
+      (!normalizedSiteOrigin || isLocalDocsTelemetryOrigin(eventSiteOrigin)))
+  ) {
+    return;
+  }
+
+  const eventToSend = normalizedSiteOrigin
+    ? { ...event, site: { origin: normalizedSiteOrigin } }
+    : event;
 
   try {
     const ingestKey = readRuntimeEnv("DOCS_TELEMETRY_INGEST_KEY");
@@ -378,7 +454,7 @@ export async function emitDocsTelemetryEvent(
     await fetch(resolved.endpoint, {
       method: "POST",
       headers,
-      body: JSON.stringify({ event }),
+      body: JSON.stringify({ event: eventToSend }),
       keepalive: true,
     });
   } catch {
@@ -397,6 +473,8 @@ export function emitDocsTelemetryProjectEvent(
     },
     context,
   );
+  if (!event) return;
+
   const key = projectEventKey(event);
   const sent = getSentProjectKeys();
   const now = Date.now();
@@ -427,6 +505,7 @@ export function emitDocsTelemetryAgentSurfaceEvent(
     },
     context,
   );
+  if (!event) return;
 
   void emitDocsTelemetryEvent(config.telemetry, event);
 }
@@ -447,6 +526,7 @@ export function emitDocsTelemetryMcpToolEvent(
     },
     context,
   );
+  if (!event) return;
 
   void emitDocsTelemetryEvent(config.telemetry, event);
 }

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -985,7 +985,8 @@ export interface DocsTelemetryConfig {
   /**
    * Public site origin to include in telemetry events.
    *
-   * When omitted, the runtime request origin or deployment URL is used when available.
+   * When omitted, the runtime request origin or deployment URL is used when available. Localhost
+   * and loopback origins are ignored.
    */
   siteOrigin?: string;
   /**

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -60,6 +60,9 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 | `metadata` | `DocsMetadata` | — | SEO and JSON-LD inputs: titleTemplate, description, etc. |
 | `og` | `OGConfig` | — | Dynamic Open Graph images |
 
+Telemetry ignores local development origins such as `localhost`, `*.localhost`, IPv4 loopback, and
+IPv6 loopback or wildcard binding addresses even when `telemetry: true` is configured.
+
 ---
 
 ## Docs Review CI

--- a/website/app/api/telemetry/events/route.ts
+++ b/website/app/api/telemetry/events/route.ts
@@ -1,4 +1,8 @@
-import type { DocsTelemetryEvent } from "@farming-labs/docs";
+import {
+  isLocalDocsTelemetryOrigin,
+  normalizeDocsTelemetryOrigin,
+  type DocsTelemetryEvent,
+} from "@farming-labs/docs";
 import { Prisma } from "@prisma/client";
 import { createHash, createHmac } from "node:crypto";
 import { NextResponse } from "next/server";
@@ -35,17 +39,6 @@ function readNestedRecord(value: unknown, key: string) {
   if (!isRecord(value)) return undefined;
   const next = value[key];
   return isRecord(next) ? next : undefined;
-}
-
-function normalizeOrigin(value: string | undefined) {
-  if (!value) return undefined;
-
-  try {
-    const withProtocol = /^https?:\/\//i.test(value) ? value : `https://${value}`;
-    return new URL(withProtocol).origin.toLowerCase();
-  } catch {
-    return undefined;
-  }
 }
 
 function isPrismaSchemaMissing(error: unknown) {
@@ -189,7 +182,7 @@ function createTelemetryIdentityHash({
 }) {
   if (!packageName) return undefined;
 
-  const normalizedSiteOrigin = normalizeOrigin(siteOrigin);
+  const normalizedSiteOrigin = normalizeDocsTelemetryOrigin(siteOrigin);
   const stableProjectIdentity = normalizedSiteOrigin
     ? `site:${normalizedSiteOrigin}`
     : deploymentId
@@ -261,6 +254,21 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Telemetry event type is required" }, { status: 400 });
     }
 
+    const hasSite = Object.prototype.hasOwnProperty.call(eventBody, "site");
+    const site = readNestedRecord(eventBody, "site");
+    const hasSiteOrigin = Boolean(site && Object.prototype.hasOwnProperty.call(site, "origin"));
+    const rawSiteOrigin = readString(site?.origin, { max: 512 });
+    const siteOrigin = normalizeDocsTelemetryOrigin(rawSiteOrigin);
+    if (
+      (hasSite && !site) ||
+      (hasSiteOrigin && (!siteOrigin || isLocalDocsTelemetryOrigin(siteOrigin)))
+    ) {
+      return NextResponse.json(
+        { ok: true, stored: false, reason: "non-public-site-origin" },
+        { status: 202 },
+      );
+    }
+
     const identityRateLimitKey = createTelemetryIdentityRateLimitKey(eventBody, eventType);
     if (
       identityRateLimitKey &&
@@ -271,7 +279,6 @@ export async function POST(request: Request) {
 
     const packageInfo = readNestedRecord(eventBody, "package");
     const runtime = readNestedRecord(eventBody, "runtime");
-    const site = readNestedRecord(eventBody, "site");
     const deployment = readNestedRecord(eventBody, "deployment");
     const features = readNestedRecord(eventBody, "features");
     const properties = readNestedRecord(eventBody, "properties");
@@ -279,7 +286,6 @@ export async function POST(request: Request) {
     const packageVersion = readString(packageInfo?.version, { max: 80 });
     const framework = readString(eventBody.framework, { max: 80 });
     const runtimeName = readString(runtime?.name, { max: 80 });
-    const siteOrigin = readString(site?.origin, { max: 512 });
     const deploymentProvider = readString(deployment?.provider, { max: 80 });
     const deploymentEnvironment = readString(deployment?.environment, { max: 120 });
     const deploymentId = readString(deployment?.id, { max: 160 });

--- a/website/app/docs/customization/telemetry/page.mdx
+++ b/website/app/docs/customization/telemetry/page.mdx
@@ -73,6 +73,11 @@ Telemetry does not collect:
 - cookies or cross-site tracking identifiers
 - per-user sessions
 
+Local development origins are ignored even when telemetry is explicitly enabled. This includes
+`localhost`, `*.localhost`, the `127.0.0.0/8` loopback range, and IPv6 loopback or wildcard binding
+addresses. Events from those origins are not sent or stored, and historical local origins are not
+shown in the telemetry dashboard.
+
 ## Options
 
 ```ts title="docs.config.ts"

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -204,6 +204,10 @@ provider signals, site origin, enabled docs features, and coarse agent-surface e
 fingerprints, search queries, Ask AI questions, feedback comments, copied content, docs source
 content, cookies, or per-user sessions.
 
+Local development origins are ignored even when telemetry is explicitly enabled. Requests from
+`localhost`, `*.localhost`, IPv4 loopback, and IPv6 loopback or wildcard binding addresses are not
+sent or stored.
+
 ---
 
 ## `analytics` and `DocsAnalyticsConfig`

--- a/website/app/telemetry/page.tsx
+++ b/website/app/telemetry/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { isLocalDocsTelemetryOrigin, normalizeDocsTelemetryOrigin } from "@farming-labs/docs";
 import { Prisma } from "@prisma/client";
 import { Activity, AlertTriangle, Database, Fingerprint, Globe2 } from "lucide-react";
 import { prisma } from "@/lib/prisma";
@@ -147,21 +148,43 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
   const last24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   try {
-    const totalEvents = await prisma.docsTelemetryEvent.count();
-    const eventsLast24h = await prisma.docsTelemetryEvent.count({
-      where: { createdAt: { gte: last24h } },
-    });
-    const distinctIdentities = await prisma.docsTelemetryEvent.findMany({
-      where: { identityHash: { not: null } },
-      distinct: ["identityHash"],
-      select: { identityHash: true },
-    });
     const distinctSites = await prisma.docsTelemetryEvent.findMany({
       where: { siteOrigin: { not: null } },
       distinct: ["siteOrigin"],
       select: { siteOrigin: true },
     });
+    const excludedSiteOrigins = distinctSites
+      .map((site) => site.siteOrigin)
+      .filter(
+        (origin): origin is string =>
+          typeof origin === "string" &&
+          (!normalizeDocsTelemetryOrigin(origin) || isLocalDocsTelemetryOrigin(origin)),
+      );
+    const visibleTelemetryWhere: Prisma.DocsTelemetryEventWhereInput =
+      excludedSiteOrigins.length > 0
+        ? {
+            OR: [{ siteOrigin: null }, { siteOrigin: { notIn: excludedSiteOrigins } }],
+          }
+        : {};
+    const visibleTelemetrySql =
+      excludedSiteOrigins.length > 0
+        ? Prisma.sql`AND (
+            "DocsTelemetryEvent"."siteOrigin" IS NULL
+            OR "DocsTelemetryEvent"."siteOrigin" NOT IN (${Prisma.join(excludedSiteOrigins)})
+          )`
+        : Prisma.empty;
+
+    const totalEvents = await prisma.docsTelemetryEvent.count({ where: visibleTelemetryWhere });
+    const eventsLast24h = await prisma.docsTelemetryEvent.count({
+      where: { ...visibleTelemetryWhere, createdAt: { gte: last24h } },
+    });
+    const distinctIdentities = await prisma.docsTelemetryEvent.findMany({
+      where: { ...visibleTelemetryWhere, identityHash: { not: null } },
+      distinct: ["identityHash"],
+      select: { identityHash: true },
+    });
     const recentEvents = await prisma.docsTelemetryEvent.findMany({
+      where: visibleTelemetryWhere,
       orderBy: { createdAt: "desc" },
       take: limit,
       select: {
@@ -182,36 +205,37 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
     });
     const eventTypeGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["eventType"],
+      where: visibleTelemetryWhere,
       _count: { _all: true },
       _max: { createdAt: true },
     });
     const frameworkGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["framework"],
-      where: { framework: { not: null } },
+      where: { ...visibleTelemetryWhere, framework: { not: null } },
       _count: { _all: true },
       _max: { createdAt: true },
     });
     const packageVersionGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["packageVersion"],
-      where: { packageVersion: { not: null } },
+      where: { ...visibleTelemetryWhere, packageVersion: { not: null } },
       _count: { _all: true },
       _max: { createdAt: true },
     });
     const deploymentProviderGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["deploymentProvider"],
-      where: { deploymentProvider: { not: null } },
+      where: { ...visibleTelemetryWhere, deploymentProvider: { not: null } },
       _count: { _all: true },
       _max: { createdAt: true },
     });
     const topSiteGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["siteOrigin"],
-      where: { siteOrigin: { not: null } },
+      where: { ...visibleTelemetryWhere, siteOrigin: { not: null } },
       _count: { _all: true },
       _max: { createdAt: true },
     });
     const topIdentityGroups = await prisma.docsTelemetryEvent.groupBy({
       by: ["identityHash"],
-      where: { identityHash: { not: null } },
+      where: { ...visibleTelemetryWhere, identityHash: { not: null } },
       _count: { _all: true },
       _max: { createdAt: true },
     });
@@ -229,6 +253,7 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
         END
       ) AS feature(key, value)
       WHERE feature.value = 'true'::jsonb
+      ${visibleTelemetrySql}
       GROUP BY feature.key
       ORDER BY count DESC, feature.key ASC
       LIMIT 24
@@ -247,6 +272,8 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
           END AS key,
           "createdAt"
         FROM "DocsTelemetryEvent"
+        WHERE TRUE
+        ${visibleTelemetrySql}
       )
       SELECT
         key,
@@ -264,7 +291,7 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
       totalEvents,
       eventsLast24h,
       uniqueIdentities: distinctIdentities.length,
-      uniqueSites: distinctSites.length,
+      uniqueSites: distinctSites.length - excludedSiteOrigins.length,
       recentEvents,
       eventTypes: toGroupCounts(eventTypeGroups, "eventType", "unknown"),
       frameworks: toGroupCounts(frameworkGroups, "framework", "unknown"),


### PR DESCRIPTION
## Summary

- suppress localhost, loopback, wildcard-bind, and malformed-origin telemetry in the shared package pipeline, including request-scoped MCP tool events
- reject blocked site origins before identity hashing or database storage
- exclude historical local and invalid origins from every telemetry dashboard metric
- document the policy and add adversarial regression coverage

## Root cause

A configured public grouping origin could mask a local request origin. The ingestion route also accepted origin values without applying the same validation, while dashboard aggregates included historical local rows.

## Validation

- `pnpm --dir packages/docs test -- src/telemetry.test.ts src/mcp.test.ts` (51 files, 698 tests)
- `pnpm typecheck` (all 10 workspace packages)
- `pnpm --dir website exec tsc --noEmit`
- `pnpm format:check`
- `pnpm lint` (0 errors; 43 pre-existing warnings)
- ingestion smoke test: local, loopback, malformed HTTP, non-HTTP, null-origin, and malformed-site payloads return 202 with `stored: false`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block telemetry from localhost, loopback, wildcard-bind, and malformed origins across the docs telemetry pipeline. Events from those origins are not sent or stored, and the dashboard hides historical local entries.

- **Bug Fixes**
  - Normalize and validate site origins in `@farming-labs/docs`; add helpers to detect local origins.
  - Suppress event emission for local/malformed origins, including request-scoped MCP tool and project events.
  - Ingestion API validates `site.origin` and rejects non-public or malformed values before hashing or storage (202, stored: false).
  - Telemetry dashboard filters out local/invalid origins from all metrics and recent events; unique site counts exclude them.
  - Docs updated to document the policy; added regression tests for adversarial inputs.

<sup>Written for commit e6dd57f908804d72f35d7c6f28829e9255cec475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

