### PR TITLE
fix: build docs package before tests

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -50,7 +50,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "pnpm run build && vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- build `@farming-labs/docs` before running its Vitest suite
- make `pnpm test` reliable in fresh CI runners and clean local checkouts
- keep the cross-adapter conformance test exercising the actual package exports

## Root cause

PR #353 added a conformance test that imports adapter source files. Those adapters import `@farming-labs/docs` and `@farming-labs/docs/server`, whose exports point to ignored `dist/*.mjs` files. The isolated CI test job installed dependencies and ran tests without building that package first, so all four adapter cases failed package resolution.

This predates PR #358 and is also the only failing job on the current `main` run.

## Validation

- reproduced the failure from a clean no-`dist` state: 4 adapter tests failed
- reran `pnpm test` from the same no-`dist` state after this change: 51 files and 698 tests passed
- `pnpm build && pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` (0 errors; 43 existing warnings)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build `@farming-labs/docs` before running tests to fix CI failures and make `pnpm test` reliable in clean checkouts. This ensures adapter conformance tests resolve `@farming-labs/docs` and `@farming-labs/docs/server` exports from built `dist` files.

- **Bug Fixes**
  - Update `packages/docs` test script to `pnpm run build && vitest run`.

<sup>Written for commit 0b984db9c95dfbe71e798bfb5c15c8069659e50f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

