### PR TITLE
feat: add audience-aware docs content

### DIFF
--- a/packages/astro/src/content.ts
+++ b/packages/astro/src/content.ts
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
@@ -95,8 +95,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
 
       const raw = fs.readFileSync(full, "utf-8");
       const { data, content } = matter(raw);
-      const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-      const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+      const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+      const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
       const related = normalizeDocsRelated(data.related);
 
       const baseName = name.replace(/\.(md|mdx|svx)$/, "");
@@ -150,9 +150,10 @@ function readAgentDoc(dir: string) {
 
   const raw = fs.readFileSync(agentPath, "utf-8");
   const { content } = matter(raw);
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdown(content),
-    agentRawContent: content,
+    agentContent: stripMarkdown(agentRawContent),
+    agentRawContent,
   };
 }
 

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
@@ -597,7 +597,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAgentMdxContent(content, "human");
+  let result = resolveDocsAudienceMdxContent(content, "human");
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -64,7 +64,7 @@ import {
   renderDocsSkillDocument,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
@@ -500,8 +500,8 @@ function searchIndexFromMap(
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+    const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
     const related = normalizeDocsRelated(data.related);
     const agentDoc = isIdx ? readAgentDocFromMap(contentMap, dirPrefix, slug) : undefined;
     const title =
@@ -542,9 +542,10 @@ function readAgentDocFromMap(contentMap: ContentFileMap, dirPrefix: string, slug
   if (!raw) return undefined;
 
   const { content } = matter(stripGeneratedAgentProvenance(raw));
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdownText(content),
-    agentRawContent: content,
+    agentContent: stripMarkdownText(agentRawContent),
+    agentRawContent,
   };
 }
 
@@ -769,7 +770,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
     const readingTime = resolvePageReadingTime(data, humanRawContent, {
       enabledByDefault: readingTimeOptions.enabled,
       wordsPerMinute: readingTimeOptions.wordsPerMinute,

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
+    "@mdx-js/mdx": "^3.1.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@scalar/core": "^0.4.3",
     "@vercel/sandbox": "^2.0.0",

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -10,16 +10,20 @@ const adapters = [
 ] as const satisfies readonly (readonly [DocsAgentAdapter, string])[];
 
 describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
-  it("conforms to the shared public agent contract", async () => {
+  async function loadCreateDocsServer() {
     // Keep the module path dynamic so the core typecheck does not pull adapter source files into
     // its declaration root. Vitest still executes the real adapter implementation.
     const moduleUrl = new URL(modulePath, import.meta.url).href;
-    const { createDocsServer } = (await import(moduleUrl)) as {
+    return (await import(moduleUrl)) as {
       createDocsServer(config: Record<string, unknown>): {
         GET(context: { request: Request; url?: URL }): Promise<Response>;
         MCP: { POST(context: { request: Request }): Promise<Response> };
       };
     };
+  }
+
+  it("conforms to the shared public agent contract", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
     const server = createDocsServer({
       entry: "docs",
       nav: { title: "Conformance Docs" },
@@ -43,5 +47,52 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
 
     expect(report.cases.filter((result) => !result.passed)).toEqual([]);
     expect(report.passed).toBe(true);
+  });
+
+  it("applies the same audience policy to search and agent outputs", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
+    const server = createDocsServer({
+      entry: "docs",
+      nav: { title: "Audience Docs" },
+      mcp: true,
+      sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/page.md": `---
+title: Audience
+description: Audience policy
+---
+
+# Audience
+
+Shared context.
+
+<Human>Human coral walkthrough.</Human>
+
+<Audience only="agent">Agent indigo procedure.</Audience>`,
+      },
+    });
+
+    async function get(path: string) {
+      const url = new URL(path, "https://docs.example.com");
+      return server.GET({ request: new Request(url), url });
+    }
+
+    const humanSearch = await get("/api/docs?query=human%20coral%20walkthrough");
+    const agentSearch = await get("/api/docs?query=agent%20indigo%20procedure");
+    expect(await humanSearch.text()).toContain("Audience");
+    expect(await agentSearch.json()).toEqual([]);
+
+    const markdown = await (await get("/docs.md")).text();
+    expect(markdown).toContain("Agent indigo procedure.");
+    expect(markdown).not.toContain("Human coral walkthrough.");
+
+    const llmsFull = await (await get("/llms-full.txt")).text();
+    expect(llmsFull).toContain("Agent indigo procedure.");
+    expect(llmsFull).not.toContain("Human coral walkthrough.");
+
+    const sitemap = await (await get("/sitemap.xml")).text();
+    expect(sitemap).toContain("https://docs.example.com/docs");
+    expect(sitemap).not.toContain("Human coral walkthrough.");
+    expect(sitemap).not.toContain("Agent indigo procedure.");
   });
 });

--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -48,6 +48,188 @@ Run pnpm test.
       },
     ]);
   });
+
+  it("recognizes static agent audiences without counting human or example markup", () => {
+    const source = [
+      "<Human>Human guidance.</Human>",
+      '<Audience only="human">Human audience.</Audience>',
+      "<Audience only={audience}>Dynamic audience.</Audience>",
+      '<Audience only="agent">Run `pnpm test`.</Audience>',
+      "<Audience only='agent'>Read `src/server.ts`.</Audience>",
+      '<Audience only={"agent"}>Verify `/docs.md`.</Audience>',
+      "<Audience only={'agent'}><Human>Hidden from agents.</Human>Keep `docs.config.ts`.</Audience>",
+      '`<Audience only="agent">Inline example.</Audience>`',
+      "```mdx",
+      '<Audience only="agent">Fenced example.</Audience>',
+      "```",
+      '<Agent audience="implementation">Use `src/index.ts`.</Agent>',
+      "<Human><Agent>Unreachable agent context.</Agent></Human>",
+      '<Audience only="agent" />',
+      '<Audience data-only="agent">Shared metadata, not an audience declaration.</Audience>',
+      '{/* <Audience only="agent">MDX comment.</Audience> */}',
+      "<!-- <Agent>HTML comment.</Agent> -->",
+      'export const example = "<Agent>Module string.</Agent>";',
+      "<Audience",
+      '  only="agent"',
+      ">",
+      "Run `pnpm exec docs doctor` after multiline authoring.",
+      "</Audience>",
+    ].join("\n");
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/audience.mdx" })).toEqual([
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 4,
+        content: "Run `pnpm test`.",
+      },
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 5,
+        content: "Read `src/server.ts`.",
+      },
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 6,
+        content: "Verify `/docs.md`.",
+      },
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 7,
+        content: "Keep `docs.config.ts`.",
+      },
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 12,
+        content: "Use `src/index.ts`.",
+      },
+      {
+        sourcePath: "docs/audience.mdx",
+        line: 19,
+        content: "Run `pnpm exec docs doctor` after multiline authoring.",
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      "multiline import",
+      `import {
+  thing,
+}
+from "<Agent>module path literal</Agent>";`,
+    ],
+    ["multiline code span", "Shared `starts\n<Agent>literal code</Agent>` end."],
+    ["escaped markup", String.raw`\<Agent>literal escaped\</Agent>`],
+    ["JSX prop string", '<Example code="<Agent>literal prop</Agent>" />'],
+    ["MDX expression string", '{"<Agent>literal expression</Agent>"}'],
+    ["Markdown link title", '[link](https://example.com "See <Agent>literal</Agent>")'],
+    [
+      "raw script block",
+      `<script>
+const sample = "<Agent>literal script</Agent>";
+</script>`,
+    ],
+  ])("ignores audience-looking literals in a %s", (_name, literal) => {
+    const source = `${literal}\n\n<Agent>real agent content</Agent>`;
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/literals.mdx" })).toEqual([
+      {
+        sourcePath: "docs/literals.mdx",
+        line: literal.split("\n").length + 2,
+        content: "real agent content",
+      },
+    ]);
+  });
+
+  it.each([
+    ["fenced raw element", "```md\n<script>\n```", "```md\n</script>\n```"],
+    ["inline raw element", "`<script>`", "`</script>`"],
+    ["expression raw element", '{"<script>"}', '{"</script>"}'],
+    ["escaped HTML comment", "\\<!--", "\\-->"],
+  ])("extracts live context between separated %s delimiters", (_name, opening, closing) => {
+    const source = `${opening}\n\n<Agent>real agent content</Agent>\n\n${closing}`;
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/delimiters.mdx" })).toEqual([
+      {
+        sourcePath: "docs/delimiters.mdx",
+        line: opening.split("\n").length + 2,
+        content: "real agent content",
+      },
+    ]);
+  });
+
+  it("ignores audience-looking frontmatter without shifting Unicode offsets", () => {
+    const source = `---
+description: "😀 <Agent>frontmatter literal</Agent>"
+---
+
+<Agent>real agent content</Agent>`;
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/frontmatter.mdx" })).toEqual([
+      {
+        sourcePath: "docs/frontmatter.mdx",
+        line: 5,
+        content: "real agent content",
+      },
+    ]);
+
+    const blockScalar = `---
+description: |
+  ---
+  <Agent>literal YAML</Agent>
+---
+
+<Agent>real block scalar content</Agent>`;
+    expect(extractAgentBlocks(blockScalar, { sourcePath: "docs/frontmatter.mdx" })).toEqual([
+      {
+        sourcePath: "docs/frontmatter.mdx",
+        line: 7,
+        content: "real block scalar content",
+      },
+    ]);
+  });
+
+  it("extracts agent context nested in a generic component expression", () => {
+    const source =
+      "<Card title={<Agent>Use `src/agent.ts`.</Agent>} subtitle={<Human>Visual hint.</Human>} />";
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/card.mdx" })).toEqual([
+      {
+        sourcePath: "docs/card.mdx",
+        line: 1,
+        content: "Use `src/agent.ts`.",
+      },
+    ]);
+
+    const spreadSource =
+      "<Card {...{ title: <Agent>Use `src/spread.ts`.</Agent>, subtitle: <Human>Hint.</Human> }} />";
+    expect(extractAgentBlocks(spreadSource, { sourcePath: "docs/card.mdx" })).toEqual([
+      {
+        sourcePath: "docs/card.mdx",
+        line: 1,
+        content: "Use `src/spread.ts`.",
+      },
+    ]);
+  });
+
+  it("extracts live Svelte MDX context without counting code or link-title literals", () => {
+    const source = `{#if enabled}
+{() => /<Agent>literal<\\/Agent>/.test(value)}
+- ~~~mdx
+  <Agent>literal fenced content</Agent>
+  ~~~
+[link](https://example.com "<Agent>literal title</Agent>")
+<Agent>live Svelte content</Agent>
+{/if}`;
+
+    expect(extractAgentBlocks(source, { sourcePath: "docs/page.svx" })).toEqual([
+      {
+        sourcePath: "docs/page.svx",
+        line: 7,
+        content: "live Svelte content",
+      },
+    ]);
+  });
 });
 
 describe("analyzeAgentUsefulness", () => {
@@ -117,6 +299,25 @@ ${shared}
       generic: 4,
       useful: 1,
     });
+  });
+
+  it("scores Audience agent blocks but not human-only audience content", () => {
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        {
+          ...page(
+            "audiences",
+            `<Human>Run the human walkthrough.</Human>
+<Audience only="human">Use the interactive form.</Audience>
+<Audience only="agent">Run \`pnpm exec docs doctor\` after editing \`docs.config.ts\`.</Audience>`,
+          ),
+          actionable: false,
+        },
+      ],
+    });
+
+    expect(report.metrics.agentBlocks).toMatchObject({ total: 1, useful: 1 });
   });
 
   it("keeps fenced commands in exact duplicate signatures", () => {

--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -451,6 +451,84 @@ fi
     });
   });
 
+  it("excludes human-only content from agent task completeness", () => {
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        {
+          ...page(
+            "human-only-guidance",
+            `# Deploy
+
+<Human>
+## Prerequisites
+
+Install Node.js before starting.
+
+## Expected result
+
+You should see a successful deployment.
+
+## Recovery
+
+If deployment fails, roll back.
+</Human>
+
+<Agent>Deploy the docs.</Agent>`,
+          ),
+          actionable: true,
+        },
+      ],
+    });
+    const taskCodes = report.findings
+      .filter((finding) => finding.category === "task")
+      .map((finding) => finding.code);
+
+    expect(taskCodes).toEqual(
+      expect.arrayContaining([
+        "task-missing-prerequisites",
+        "task-missing-expected-result",
+        "task-missing-recovery",
+      ]),
+    );
+    expect(report.metrics.taskCompleteness).toMatchObject({
+      completePages: 0,
+      missingPrerequisites: 1,
+      missingExpectedResults: 1,
+      missingRecovery: 1,
+      coverage: 0,
+    });
+  });
+
+  it("ignores human-only fenced commands for agent actionability and command health", () => {
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        page(
+          "human-only-command",
+          [
+            "# Human walkthrough",
+            "",
+            "<Human>",
+            "~~~bash",
+            "pnpm run missing-human-script",
+            "~~~",
+            "</Human>",
+          ].join("\n"),
+        ),
+      ],
+    });
+
+    expect(report.metrics.actionablePages).toBe(0);
+    expect(report.metrics.commands).toEqual({
+      total: 0,
+      healthy: 0,
+      unhealthy: 0,
+      unverified: 0,
+    });
+    expect(report.findings.filter((finding) => finding.category === "command")).toEqual([]);
+  });
+
   it("uses sibling agent.md guidance for actionability and command source paths", () => {
     const report = analyzeAgentUsefulness({
       rootDir,

--- a/packages/docs/src/agent-usefulness.ts
+++ b/packages/docs/src/agent-usefulness.ts
@@ -7,6 +7,7 @@ import {
   normalizeAgentVersion,
 } from "./agent-scope.js";
 import { extractCodeBlocksFromMarkdown } from "./code-blocks.js";
+import { findDocsAudienceMdxTags, type DocsAudienceMdxTag } from "./audience.js";
 import type { DocsMcpPage } from "./mcp.js";
 import type { PageAgentCommand, PageAgentFrontmatter } from "./types.js";
 
@@ -418,88 +419,90 @@ const PACKAGE_MANAGER_OPTIONS_WITH_VALUES = new Set([
   "-w",
 ]);
 
-/** Extract actual `<Agent>` blocks while ignoring examples inside fenced code blocks. */
+interface AgentContextScope {
+  id: number;
+  name: DocsAudienceMdxTag["name"];
+  only?: "human" | "agent";
+}
+
+function isAgentContextVisible(scopes: readonly AgentContextScope[]): boolean {
+  return scopes.every((scope) => scope.only === undefined || scope.only === "agent");
+}
+
+/**
+ * Extract actual agent-only context while ignoring examples in fenced and inline code.
+ *
+ * `<Agent>` is agent-only shorthand. `<Audience>` counts only when `only` is the
+ * static value `"agent"`; human-only and dynamic/invalid audience declarations do
+ * not contribute to agent-context usefulness metrics.
+ */
 export function extractAgentBlocks(
   source: string,
   options: { sourcePath?: string; route?: string } = {},
 ): AgentBlockOccurrence[] {
   const sourcePath = options.sourcePath ?? "unknown";
-  const lines = source.split(/\r?\n/);
+  const tags = findDocsAudienceMdxTags(source);
   const blocks: AgentBlockOccurrence[] = [];
-  let fence: { character: "`" | "~"; length: number } | undefined;
+  const scopes: AgentContextScope[] = [];
+  let nextScopeId = 1;
+  let cursor = 0;
   let active:
     | {
         line: number;
-        depth: number;
+        scopeId: number;
         content: string[];
       }
     | undefined;
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    const trimmed = line.trim();
-    const nextFence = advanceFence(trimmed, fence);
+  const appendVisibleContent = (content: string) => {
+    if (active && isAgentContextVisible(scopes)) active.content.push(content);
+  };
 
-    if (active) {
-      if (fence || nextFence) {
-        active.content.push(line);
-        fence = nextFence;
-        continue;
-      }
+  const finishActiveBlock = () => {
+    if (!active) return;
+    blocks.push({
+      sourcePath,
+      route: options.route,
+      line: active.line,
+      content: active.content.join("").trim(),
+    });
+    active = undefined;
+  };
 
-      const nested = /^<Agent(?:\s[^>]*)?>\s*$/.test(trimmed);
-      if (nested) {
-        active.depth += 1;
-        continue;
-      }
+  for (const tag of tags) {
+    const activeScope = scopes.at(-1);
+    if (tag.closing && activeScope?.name !== tag.name) continue;
 
-      const closeWithContent = /^(.*?)<\/Agent>\s*$/.exec(line);
-      if (closeWithContent) {
-        if (closeWithContent[1]) active.content.push(closeWithContent[1]);
-        active.depth -= 1;
-        if (active.depth === 0) {
-          blocks.push({
-            sourcePath,
-            route: options.route,
-            line: active.line,
-            content: active.content.join("\n").trim(),
-          });
-          active = undefined;
-        }
-        continue;
-      }
+    appendVisibleContent(source.slice(cursor, tag.index));
+    cursor = tag.end;
 
-      active.content.push(line);
+    if (tag.closing) {
+      const closedScope = scopes.pop();
+      if (active && closedScope?.id === active.scopeId) finishActiveBlock();
       continue;
     }
 
-    if (fence || nextFence) {
-      fence = nextFence;
-      continue;
-    }
+    if (tag.selfClosing) continue;
 
-    if (/^<Agent(?:\s[^>]*)?\s*\/>$/.test(trimmed)) continue;
+    const scope: AgentContextScope = {
+      id: nextScopeId,
+      name: tag.name,
+      only: tag.only,
+    };
+    nextScopeId += 1;
+    scopes.push(scope);
 
-    const singleLine = /^<Agent(?:\s[^>]*)?>(.*?)<\/Agent>\s*$/.exec(trimmed);
-    if (singleLine) {
-      blocks.push({
-        sourcePath,
-        route: options.route,
-        line: index + 1,
-        content: (singleLine[1] ?? "").trim(),
-      });
-      continue;
-    }
-
-    const opening = /^<Agent(?:\s[^>]*)?>(.*)$/.exec(trimmed);
-    if (opening) {
+    const isAgentOnly = tag.name === "Agent" || (tag.name === "Audience" && tag.only === "agent");
+    if (!active && isAgentOnly && isAgentContextVisible(scopes)) {
       active = {
-        line: index + 1,
-        depth: 1,
-        content: opening[1] ? [opening[1]] : [],
+        line: source.slice(0, tag.index).split(/\r?\n/).length,
+        scopeId: scope.id,
+        content: [],
       };
     }
   }
+
+  appendVisibleContent(source.slice(cursor));
 
   return blocks;
 }
@@ -775,7 +778,7 @@ function analyzeBlockQuality(
           category: "context",
           line: item.block.line,
           relatedFiles: relatedFiles.filter((file) => file !== item.block.sourcePath),
-          message: `Agent block duplicates context used on ${group.length - 1} other page${group.length === 2 ? "" : "s"}.`,
+          message: `Agent-only block duplicates context used on ${group.length - 1} other page${group.length === 2 ? "" : "s"}.`,
         }),
       );
     }
@@ -800,7 +803,7 @@ function analyzeBlockQuality(
             severity: "warning",
             category: "context",
             line: item.block.line,
-            message: `${Math.round(ratio * 100)}% of this Agent block repeats sentences used across the docs corpus.`,
+            message: `${Math.round(ratio * 100)}% of this agent-only block repeats sentences used across the docs corpus.`,
           }),
         );
       }
@@ -816,7 +819,7 @@ function analyzeBlockQuality(
           category: "context",
           line: item.block.line,
           message:
-            "Agent block is generic and lacks a concrete command, path, identifier, version, or task-specific constraint.",
+            "Agent-only block is generic and lacks a concrete command, path, identifier, version, or task-specific constraint.",
         }),
       );
     }

--- a/packages/docs/src/agent-usefulness.ts
+++ b/packages/docs/src/agent-usefulness.ts
@@ -7,7 +7,11 @@ import {
   normalizeAgentVersion,
 } from "./agent-scope.js";
 import { extractCodeBlocksFromMarkdown } from "./code-blocks.js";
-import { findDocsAudienceMdxTags, type DocsAudienceMdxTag } from "./audience.js";
+import {
+  findDocsAudienceMdxTags,
+  resolveDocsAudienceMdxContent,
+  type DocsAudienceMdxTag,
+} from "./audience.js";
 import type { DocsMcpPage } from "./mcp.js";
 import type { PageAgentCommand, PageAgentFrontmatter } from "./types.js";
 
@@ -186,6 +190,7 @@ interface PageAnalysis {
   page: AgentUsefulnessPage;
   agent?: PageAgentFrontmatter;
   blocks: AgentBlockOccurrence[];
+  projectedSource: string;
   shellCommands: AnalyzedCommand[];
   actionable: boolean;
 }
@@ -540,11 +545,11 @@ export function analyzeAgentUsefulness(
   const knownRoutes = new Set(options.pages.map((page) => normalizeRoute(page.route)));
 
   for (const analysis of pages) {
-    const { page, agent, actionable } = analysis;
+    const { page, agent, actionable, projectedSource } = analysis;
 
     if (actionable) {
       const guidance = [
-        stripFencedContent(page.source),
+        stripFencedContent(projectedSource),
         page.agentSource ? stripFencedContent(page.agentSource) : undefined,
         ...analysis.blocks.map((block) => stripFencedContent(block.content)),
       ]
@@ -702,11 +707,12 @@ export function analyzeAgentUsefulness(
 
 function analyzePage(page: AgentUsefulnessPage): PageAnalysis {
   const agent = normalizePageAgentFrontmatter(page.agent);
+  const projectedSource = resolveDocsAudienceMdxContent(page.source, "agent");
   const blocks = extractAgentBlocks(page.source, {
     sourcePath: page.sourcePath,
     route: page.route,
   });
-  const shellCommands = collectPageCommands(page, agent);
+  const shellCommands = collectPageCommands(page, agent, projectedSource);
   const actionable =
     page.actionable ??
     (hasStructuredPageAgentContract(agent) ||
@@ -714,7 +720,7 @@ function analyzePage(page: AgentUsefulnessPage): PageAnalysis {
       blocks.some((block) => ACTIONABLE_PATTERN.test(block.content)) ||
       ACTIONABLE_PATTERN.test(page.agentSource ?? ""));
 
-  return { page, agent, blocks, shellCommands, actionable };
+  return { page, agent, blocks, projectedSource, shellCommands, actionable };
 }
 
 function analyzeBlockQuality(
@@ -1097,6 +1103,7 @@ function commandAnalysis(findings: AgentUsefulnessFinding[]): CommandAnalysis {
 function collectPageCommands(
   page: AgentUsefulnessPage,
   agent: PageAgentFrontmatter | undefined,
+  projectedSource: string,
 ): AnalyzedCommand[] {
   const commands: AnalyzedCommand[] = [];
 
@@ -1114,7 +1121,7 @@ function collectPageCommands(
     }
   }
 
-  collectMarkdownCommands(commands, page.source, page.sourcePath);
+  collectMarkdownCommands(commands, projectedSource, page.sourcePath);
   if (page.agentSource) {
     collectMarkdownCommands(commands, page.agentSource, page.agentSourcePath ?? page.sourcePath);
   }

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { findDocsAudienceMdxTags } from "./audience.js";
 import {
   acceptsDocsMarkdown,
   buildDocsAgentDiscoverySpec,
@@ -7,6 +8,7 @@ import {
   buildDocsMcpEndpointCandidates,
   createDocsMarkdownResponse,
   detectDocsMarkdownAgentRequest,
+  findDocsAudienceMdxIssues,
   findDocsMarkdownPage,
   getDocsMarkdownCanonicalLinkHeader,
   getDocsMarkdownVaryHeader,
@@ -29,6 +31,7 @@ import {
   resolveDocsMarkdownRecovery,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
+  resolveDocsAudienceMdxContent,
   resolveDocsAgentMdxContent,
   resolveDocsAgentsFormat,
   resolveDocsLlmsTxtFormat,
@@ -502,6 +505,23 @@ describe("agent route helpers", () => {
 
     const issue = getDocsLlmsTxtMaxCharsIssue("/llms.txt", content.llmsTxt, content.maxChars);
     expect(issue?.mode).toBe("warn");
+  });
+
+  it("uses the agent projection for runtime llms-full.txt content", () => {
+    const content = renderDocsLlmsTxt([
+      {
+        url: "/docs/audience",
+        title: "Audience",
+        content: "Human search text.",
+        rawContent: "Shared.\n\nHuman-only.",
+        agentFallbackRawContent: "Shared.\n\nAgent-only.",
+      },
+    ]);
+
+    expect(content.llmsFullTxt).toContain("Shared.");
+    expect(content.llmsFullTxt).toContain("Agent-only.");
+    expect(content.llmsFullTxt).not.toContain("Human-only.");
+    expect(content.llmsTxt).not.toContain("Agent-only.");
   });
 
   it("detects public docs forwarder requests without taking over api/docs", () => {
@@ -1068,9 +1088,419 @@ describe("agent route helpers", () => {
     expect(renderDocsMarkdownDocument(page!, { llms: false })).not.toContain(
       "LLM index: /llms.txt",
     );
+
+    const contentOnlyDocument = renderDocsMarkdownDocument({
+      ...page!,
+      content: "Human-only fallback.",
+      rawContent: "Human-only fallback.",
+      agentFallbackRawContent: undefined,
+      agentContent: "Agent content-only override.",
+    });
+    expect(contentOnlyDocument).toContain("Agent content-only override.");
+    expect(contentOnlyDocument).not.toContain("Human-only fallback.");
+
+    const fallbackContentOnlyDocument = renderDocsMarkdownDocument({
+      ...page!,
+      content: "Human-only fallback.",
+      rawContent: "Human-only fallback.",
+      agentFallbackRawContent: undefined,
+      agentFallbackContent: "Agent content-only projection.",
+    });
+    expect(fallbackContentOnlyDocument).toContain("Agent content-only projection.");
+    expect(fallbackContentOnlyDocument).not.toContain("Human-only fallback.");
     expect(document).toContain("Related: /docs/configuration");
     expect(document).toContain("Hidden");
     expect(document).toContain("## Sitemap");
+  });
+
+  it("resolves Agent, Human, and Audience blocks without changing literal examples", () => {
+    const source = `Shared.
+
+<Agent audience="implementation">Agent shorthand.</Agent>
+<Agent version=">=2">Quoted greater-than attribute.</Agent>
+<Agent when={version >= 2}>Expression greater-than attribute.</Agent>
+<Human>Human shorthand.</Human>
+<Audience only="agent">Agent explicit.</Audience>
+<Audience only={'human'}>Human explicit.</Audience>
+<Audience
+  only={"agent"}
+>
+Multiline agent.
+</Audience>
+<Audience only={runtimeAudience}>Dynamic stays shared.</Audience>
+<Human><Agent>Conflicting nested content.</Agent></Human>
+<Agent />
+
+\`<Agent>inline example</Agent>\`
+
+\`\`\`mdx
+<Agent>fenced example</Agent>
+\`\`\`
+
+~~~~mdx
+<Human>tilde-fenced example</Human>
+~~~~
+
+{/* <Human>MDX comment example</Human> */}
+<!-- <Audience only="agent">HTML comment example</Audience> -->
+export const audienceExample = "<Agent>module string example</Agent>";
+export const multilineAudienceExample = {
+  value: "<Agent>multiline module string example</Agent>",
+};
+
+\`\`\`md
+\`\`\`js
+<Agent>nested fence example</Agent>
+\`\`\`
+\`\`\``;
+
+    const human = resolveDocsAudienceMdxContent(source, "human");
+    const agent = resolveDocsAudienceMdxContent(source, "agent");
+
+    expect(human).toContain("Shared.");
+    expect(human).toContain("Human shorthand.");
+    expect(human).toContain("Human explicit.");
+    expect(human).toContain("Dynamic stays shared.");
+    expect(human).not.toContain("Agent shorthand.");
+    expect(human).not.toContain("Quoted greater-than attribute.");
+    expect(human).not.toContain("Expression greater-than attribute.");
+    expect(human).not.toContain("Agent explicit.");
+    expect(human).not.toContain("Multiline agent.");
+    expect(agent).toContain("Shared.");
+    expect(agent).toContain("Agent shorthand.");
+    expect(agent).toContain("Quoted greater-than attribute.");
+    expect(agent).toContain("Expression greater-than attribute.");
+    expect(agent).toContain("Agent explicit.");
+    expect(agent).toContain("Multiline agent.");
+    expect(agent).toContain("Dynamic stays shared.");
+    expect(agent).not.toContain("Human shorthand.");
+    expect(agent).not.toContain("Human explicit.");
+    expect(human).not.toContain("Conflicting nested content.");
+    expect(agent).not.toContain("Conflicting nested content.");
+
+    for (const projection of [human, agent]) {
+      expect(projection).toContain("`<Agent>inline example</Agent>`");
+      expect(projection).toContain("<Agent>fenced example</Agent>");
+      expect(projection).toContain("<Human>tilde-fenced example</Human>");
+      expect(projection).toContain("{/* <Human>MDX comment example</Human> */}");
+      expect(projection).toContain(
+        '<!-- <Audience only="agent">HTML comment example</Audience> -->',
+      );
+      expect(projection).toContain(
+        'export const audienceExample = "<Agent>module string example</Agent>";',
+      );
+      expect(projection).toContain('value: "<Agent>multiline module string example</Agent>",');
+      expect(projection).toContain("<Agent>nested fence example</Agent>");
+    }
+
+    expect(resolveDocsAgentMdxContent(source, "agent")).toBe(agent);
+    expect(findDocsAudienceMdxIssues(source).map((issue) => issue.code)).toEqual(["dynamic-only"]);
+  });
+
+  it.each([
+    [
+      "multiline imports",
+      `import {
+  thing,
+}
+from "<Agent>module path literal</Agent>";`,
+    ],
+    [
+      "multiline code spans",
+      "Shared `inline code starts\n<Agent>literal code example</Agent>` end.",
+    ],
+    ["escaped JSX", String.raw`\<Agent>literal escaped example\</Agent>`],
+    ["quoted JSX props", '<Example code="<Agent>literal prop example</Agent>" />'],
+    ["MDX expression strings", '{"<Agent>literal expression example</Agent>"}'],
+    [
+      "semicolonless JSX exports",
+      'export const Demo = <Example label="<Agent>literal export example</Agent>" />',
+    ],
+    ["comparison exports", "export const compare = left<right;"],
+    ["generic class exports", "export class Store extends Base<Model> {}"],
+    ["generic arrow exports", "export const identity = <T>(value: T) => value;"],
+    ["expression regex literals", String.raw`{() => /<Agent>literal regex<\/Agent>/.test(value)}`],
+    ["module regex literals", 'export const pattern = /[{"]/;'],
+    [
+      "JSX fragment exports",
+      `export const Demo = <>
+  <Agent>literal exported component</Agent>
+</>`,
+    ],
+    ["Markdown link titles", '[link](https://example.com "See <Agent>literal</Agent>")'],
+    [
+      "blockquote fences",
+      `> ~~~mdx
+> <Agent>literal blockquote fence</Agent>
+> ~~~~~`,
+    ],
+    [
+      "nested list fences",
+      `- outer
+  - ~~~mdx
+    <Agent>literal nested list fence</Agent>
+    ~~~`,
+    ],
+    ["HTML comments", "<!-- <Agent>literal HTML comment</Agent> -->"],
+    [
+      "raw script blocks",
+      `<script>
+const sample = "<Agent>literal script</Agent>";
+</script>`,
+    ],
+  ])("preserves audience-looking literals in %s", (_name, literal) => {
+    const source = `${literal}\n\n<Agent>real agent content</Agent>`;
+
+    expect(resolveDocsAudienceMdxContent(source, "human")).toBe(literal);
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toBe(`${literal}\n\nreal agent content`);
+  });
+
+  it.each([
+    [
+      "fenced raw-element delimiters",
+      "```md\n<script>\n```\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```",
+    ],
+    ["inline raw-element delimiters", "`<script>`\n\n<Agent>SECRET</Agent>\n\n`</script>`"],
+    ["expression raw-element delimiters", '{"<script>"}\n\n<Agent>SECRET</Agent>\n\n{"</script>"}'],
+    [
+      "module raw-element delimiters",
+      'export const open = "<script>";\n\n<Agent>SECRET</Agent>\n\nexport const close = "</script>";',
+    ],
+    [
+      "JSX prop raw-element delimiters",
+      '<Card open="<script>" />\n\n<Agent>SECRET</Agent>\n\n<Card close="</script>" />',
+    ],
+    ["escaped raw-element delimiters", "\\<script>\n\n<Agent>SECRET</Agent>\n\n\\</script>"],
+    [
+      "fenced HTML comment delimiters",
+      "```md\n<!--\n```\n\n<Agent>SECRET</Agent>\n\n```md\n-->\n```",
+    ],
+    ["escaped HTML comment delimiters", "\\<!--\n\n<Agent>SECRET</Agent>\n\n\\-->"],
+  ])("does not pair %s across live audience content", (_name, source) => {
+    const human = resolveDocsAudienceMdxContent(source, "human");
+    const agent = resolveDocsAudienceMdxContent(source, "agent");
+
+    expect(human).not.toContain("SECRET");
+    expect(agent).toContain("SECRET");
+    expect(findDocsAudienceMdxTags(source)).toHaveLength(2);
+  });
+
+  it.each([
+    [
+      "script delimiters inside comments",
+      "<!-- <script> -->\n\n<Agent>SECRET</Agent>\n\n<!-- </script> -->",
+    ],
+    [
+      "style delimiters inside comments",
+      "<!-- <style> -->\n\n<Agent>SECRET</Agent>\n\n<!-- </style> -->",
+    ],
+    [
+      "comment delimiters inside raw script",
+      '<script>\nconst value = "<!--";\n</script>\n\n<Agent>SECRET</Agent>\n\n<div>--></div>',
+    ],
+    [
+      "arrow regex and fenced closing delimiter",
+      "{() => /<script>/.test(value)}\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```",
+    ],
+    [
+      "JSX prop regex and fenced closing delimiter",
+      "<Card test={() => /<script>/.test(value)} />\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```",
+    ],
+    [
+      "keyword-prefixed regex and fenced closing delimiter",
+      "{(() => { return /<script>/.test(value) })()}\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```",
+    ],
+    [
+      "Svelte directive regex and fenced closing delimiter",
+      "{#if /<script>/.test(value)}\n<Agent>SECRET</Agent>\n```md\n</script>\n```\n{/if}",
+    ],
+    [
+      "angle-bracket link destination and fenced closing delimiter",
+      "[link](<script>)\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```",
+    ],
+    [
+      "angle-bracket image destination and fenced comment closing delimiter",
+      "![image](<!--)\n\n<Agent>SECRET</Agent>\n\n```md\n-->\n```",
+    ],
+    [
+      "self-closing raw element and fenced closing delimiter",
+      '<script src="example.js" />\n\n<Agent>SECRET</Agent>\n\n```md\n</script>\n```',
+    ],
+  ])("keeps %s from swallowing live audience content", (_name, source) => {
+    expect(resolveDocsAudienceMdxContent(source, "human")).not.toContain("SECRET");
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toContain("SECRET");
+    expect(findDocsAudienceMdxTags(source)).toHaveLength(2);
+  });
+
+  it.each(["script-loader", "style-guide", "script.foo"])(
+    "does not treat the custom %s element as raw code",
+    (name) => {
+      const source = `<${name}>\n<Agent>SECRET</Agent>\n</${name}>\n<script>ok</script>`;
+      expect(resolveDocsAudienceMdxContent(source, "human")).not.toContain("SECRET");
+      expect(resolveDocsAudienceMdxContent(source, "agent")).toContain("SECRET");
+    },
+  );
+
+  it("treats an unclosed lowercase raw element as literal content through EOF", () => {
+    const source = '<script>\nconst sample = "<Agent>literal script</Agent>";';
+    expect(resolveDocsAudienceMdxContent(source, "human")).toBe(source);
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toBe(source);
+    expect(findDocsAudienceMdxTags(source)).toEqual([]);
+  });
+
+  it("uses JSX-safe replacements for audience elements inside MDX expressions", () => {
+    const source = `<Card title={<Agent>Agent title</Agent>} subtitle={<Human>Human subtitle</Human>} />`;
+    const human = resolveDocsAudienceMdxContent(source, "human");
+    const agent = resolveDocsAudienceMdxContent(source, "agent");
+
+    expect(human).toBe("<Card title={null} subtitle={<>Human subtitle</>} />");
+    expect(agent).toBe("<Card title={<>Agent title</>} subtitle={null} />");
+
+    const audienceWithExpressionProp =
+      "<Agent child={<Human>Ignored prop.</Human>}>Agent body.</Agent>";
+    expect(resolveDocsAudienceMdxContent(audienceWithExpressionProp, "human")).toBe("");
+    expect(resolveDocsAudienceMdxContent(audienceWithExpressionProp, "agent")).toBe("Agent body.");
+
+    const expressionAudienceWithProp =
+      "{<Agent child={<Human>Ignored prop.</Human>}>Agent body.</Agent>}";
+    expect(resolveDocsAudienceMdxContent(expressionAudienceWithProp, "human")).toBe("{null}");
+    expect(resolveDocsAudienceMdxContent(expressionAudienceWithProp, "agent")).toBe(
+      "{<>Agent body.</>}",
+    );
+
+    const nestedChildren = "{<Box><Agent>A</Agent>B<Human>H</Human></Box>}";
+    expect(resolveDocsAudienceMdxContent(nestedChildren, "human")).toBe(
+      "{<Box>{null}B<>H</></Box>}",
+    );
+    expect(resolveDocsAudienceMdxContent(nestedChildren, "agent")).toBe(
+      "{<Box><>A</>B{null}</Box>}",
+    );
+
+    const spreadAttribute = "<Card {...{ title: <Agent>A</Agent>, subtitle: <Human>H</Human> }} />";
+    expect(resolveDocsAudienceMdxContent(spreadAttribute, "human")).toBe(
+      "<Card {...{ title: null, subtitle: <>H</> }} />",
+    );
+    expect(resolveDocsAudienceMdxContent(spreadAttribute, "agent")).toBe(
+      "<Card {...{ title: <>A</>, subtitle: null }} />",
+    );
+  });
+
+  it("keeps frontmatter literals out of the audience tree without shifting Unicode offsets", () => {
+    const source = `---
+description: "😀 <Agent>frontmatter literal</Agent>"
+---
+
+<Agent>real agent content</Agent>`;
+
+    expect(resolveDocsAudienceMdxContent(source, "human")).toBe(
+      '---\ndescription: "😀 <Agent>frontmatter literal</Agent>"\n---',
+    );
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toContain("real agent content");
+
+    const blockScalar = `---
+description: |
+  ---
+  <Agent>literal YAML</Agent>
+---
+
+<Agent>real block scalar content</Agent>`;
+    expect(resolveDocsAudienceMdxContent(blockScalar, "human")).toBe(
+      "---\ndescription: |\n  ---\n  <Agent>literal YAML</Agent>\n---",
+    );
+    expect(resolveDocsAudienceMdxContent(blockScalar, "agent")).toContain(
+      "real block scalar content",
+    );
+  });
+
+  it("projects audience blocks in Svelte MDX without falling back to literal scanners", () => {
+    const source = `{#if enabled}
+{() => /<Agent>literal<\\/Agent>/.test(value)}
+<Agent when={/[}]/.test(value) && score > 1}>Svelte agent content.</Agent>
+- outer
+  - ~~~mdx
+    <Agent>literal fenced content</Agent>
+    ~~~
+[link](https://example.com "<Agent>literal title</Agent>")
+{/if}
+
+<Agent>real trailing content</Agent>`;
+
+    const human = resolveDocsAudienceMdxContent(source, "human");
+    const agent = resolveDocsAudienceMdxContent(source, "agent");
+    expect(human).not.toContain("Svelte agent content.");
+    expect(human).not.toContain("real trailing content");
+    expect(agent).toContain("Svelte agent content.");
+    expect(agent).toContain("real trailing content");
+    for (const projection of [human, agent]) {
+      expect(projection).toContain("/<Agent>literal<\\/Agent>/");
+      expect(projection).toContain("<Agent>literal fenced content</Agent>");
+      expect(projection).toContain('"<Agent>literal title</Agent>"');
+    }
+  });
+
+  it("preserves whitespace inside protected literals while projecting audience content", () => {
+    const source = `Before
+
+
+
+\`\`\`txt
+a
+
+
+b
+\`\`\`
+
+<Agent>secret</Agent>
+
+After`;
+
+    for (const audience of ["human", "agent"] as const) {
+      expect(resolveDocsAudienceMdxContent(source, audience)).toContain("```txt\na\n\n\nb\n```");
+    }
+  });
+
+  it("treats Audience spread props as dynamic shared content", () => {
+    const source = `<Audience only="agent" {...props}>Shared fallback.</Audience>`;
+
+    expect(resolveDocsAudienceMdxContent(source, "human")).toBe("Shared fallback.");
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toBe("Shared fallback.");
+    expect(findDocsAudienceMdxIssues(source).map((issue) => issue.code)).toEqual(["dynamic-only"]);
+
+    expect(
+      findDocsAudienceMdxIssues(
+        '<Agent only="human">Agent shorthand.</Agent><Human only="agent">Human shorthand.</Human>',
+      ).map((issue) => issue.code),
+    ).toEqual(["ignored-agent-only", "ignored-human-only"]);
+  });
+
+  it("resolves indented audience elements as live MDX components", () => {
+    const source = `- Item
+    <Agent>Agent-only nested detail.</Agent>
+
+    <Human>Human-only nested detail.</Human>`;
+
+    expect(resolveDocsAudienceMdxContent(source, "human")).not.toContain(
+      "Agent-only nested detail.",
+    );
+    expect(resolveDocsAudienceMdxContent(source, "human")).toContain("Human-only nested detail.");
+    expect(resolveDocsAudienceMdxContent(source, "agent")).toContain("Agent-only nested detail.");
+    expect(resolveDocsAudienceMdxContent(source, "agent")).not.toContain(
+      "Human-only nested detail.",
+    );
+  });
+
+  it("does not confuse capitalized Script and Style components with raw code elements", () => {
+    const source = `<Script>
+<Agent>Agent-only script child.</Agent>
+</Script>
+<Style><Human>Human-only style child.</Human></Style>`;
+
+    const human = resolveDocsAudienceMdxContent(source, "human");
+    const agent = resolveDocsAudienceMdxContent(source, "agent");
+    expect(human).not.toContain("Agent-only script child.");
+    expect(human).toContain("Human-only style child.");
+    expect(agent).toContain("Agent-only script child.");
+    expect(agent).not.toContain("Human-only style child.");
   });
 
   it("renders the generated skill.md document", () => {
@@ -1218,6 +1648,11 @@ describe("agent route helpers", () => {
     });
     expect(spec.markdown.rootPage).toBe("/docs.md");
     expect(spec.markdown.signatureAgentHeader).toBe("Signature-Agent");
+    expect(spec.markdown.resolutionOrder).toEqual([
+      "agent.md",
+      "agent audience projection",
+      "shared page markdown",
+    ]);
     expect(spec.llms.publicTxt).toBe("/llms.txt");
     expect(spec.agents).toEqual({
       enabled: true,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -31,6 +31,13 @@ import {
 } from "./sitemap.js";
 import type { DocsSitemapConfig } from "./types.js";
 
+export {
+  findDocsAudienceMdxIssues,
+  resolveDocsAudienceExposure,
+  resolveDocsAudienceMdxContent,
+  resolveDocsAgentMdxContent,
+} from "./audience.js";
+
 export const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 export const DEFAULT_DOCS_CONFIG_FORMAT = "docs-config-map.v1";
 export const DEFAULT_DOCS_CONFIG_ROUTE = `${DEFAULT_DOCS_API_ROUTE}?format=config`;
@@ -436,6 +443,11 @@ export interface DocsLlmsTxtPageInput {
   title: string;
   description?: string;
   content: string;
+  rawContent?: string;
+  agentContent?: string;
+  agentRawContent?: string;
+  agentFallbackContent?: string;
+  agentFallbackRawContent?: string;
 }
 
 export interface DocsLlmsTxtGeneratedSection extends DocsLlmsTxtResolvedSection {
@@ -1706,7 +1718,14 @@ function renderLlmsFullTxtPages(pages: DocsLlmsTxtPageInput[], baseUrl: string):
     content += `## ${page.title}\n\n`;
     content += `URL: ${baseUrl}${page.url}\n\n`;
     if (page.description) content += `${page.description}\n\n`;
-    content += `${page.content}\n\n---\n\n`;
+    const agentContent =
+      page.agentRawContent ??
+      page.agentFallbackRawContent ??
+      page.agentContent ??
+      page.agentFallbackContent ??
+      page.rawContent ??
+      page.content;
+    content += `${agentContent}\n\n---\n\n`;
   }
   return content;
 }
@@ -3043,8 +3062,9 @@ export function renderDocsMarkdownDocument(
   page: DocsMarkdownPage,
   options?: DocsMarkdownDocumentOptions,
 ): string {
-  if (page.agentRawContent !== undefined) {
-    const body = upsertPageAgentContractMarkdown(page.agentRawContent, page.agent);
+  const explicitAgentContent = page.agentRawContent ?? page.agentContent;
+  if (explicitAgentContent !== undefined) {
+    const body = upsertPageAgentContractMarkdown(explicitAgentContent, page.agent);
     return appendDocsMarkdownSitemapFooter(
       prependDocsMarkdownFrontmatter(body, resolveDocsMarkdownPageMetadata(page, options)),
       options?.sitemap,
@@ -3059,7 +3079,7 @@ export function renderDocsMarkdownDocument(
   lines.push(
     "",
     upsertPageAgentContractMarkdown(
-      page.agentFallbackRawContent ?? page.rawContent ?? page.content,
+      page.agentFallbackRawContent ?? page.agentFallbackContent ?? page.rawContent ?? page.content,
       page.agent,
     ),
   );
@@ -3162,85 +3182,6 @@ export function renderDocsAgentsDocument(options: DocsAgentsDocumentOptions): st
   return lines.join("\n");
 }
 
-export function resolveDocsAgentMdxContent(content: string, audience: "human" | "agent"): string {
-  const lines = content.split("\n");
-  const output: string[] = [];
-  let fenceMarker: string | null = null;
-  let agentDepth = 0;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
-
-    if (fenceMatch) {
-      if (!fenceMarker) {
-        fenceMarker = fenceMatch[1];
-      } else if (trimmed.startsWith(fenceMarker)) {
-        fenceMarker = null;
-      }
-
-      if (audience === "agent" || agentDepth === 0) {
-        output.push(line);
-      }
-      continue;
-    }
-
-    if (!fenceMarker) {
-      if (/^<Agent(?:\s[^>]*)?\/>$/.test(trimmed)) {
-        continue;
-      }
-
-      const singleLineMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>([\s\S]*?)<\/Agent>\s*$/);
-      if (singleLineMatch) {
-        if (audience === "agent" && singleLineMatch[2]) {
-          output.push(`${singleLineMatch[1]}${singleLineMatch[2]}`);
-        }
-        continue;
-      }
-
-      const openMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>\s*$/);
-      if (openMatch) {
-        agentDepth += 1;
-        continue;
-      }
-
-      const openWithContentMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>(.*)$/);
-      if (openWithContentMatch) {
-        agentDepth += 1;
-        if (audience === "agent" && openWithContentMatch[2]) {
-          output.push(`${openWithContentMatch[1]}${openWithContentMatch[2]}`);
-        }
-        continue;
-      }
-
-      const closeWithContentMatch = line.match(/^(.*)<\/Agent>\s*$/);
-      if (closeWithContentMatch && agentDepth > 0) {
-        if (audience === "agent" && closeWithContentMatch[1].trim()) {
-          output.push(closeWithContentMatch[1]);
-        }
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-
-      if (/^<\/Agent>\s*$/.test(trimmed) && agentDepth > 0) {
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-    }
-
-    if (agentDepth > 0 && audience === "human") {
-      continue;
-    }
-
-    output.push(line);
-  }
-
-  return output
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 /** Resolve only the task tools that the advertised MCP endpoint actually exposes. */
 export function resolveDocsAgentContractMcpTools(
   mcp: DocsMcpResolvedConfig,
@@ -3338,7 +3279,7 @@ export function buildDocsAgentDiscoverySpec({
       pagePattern: `/${normalizedEntry}/{slug}.md`,
       rootPage: `/${normalizedEntry}.md`,
       apiPattern: `${DEFAULT_DOCS_API_ROUTE}?format=markdown&path={slug}`,
-      resolutionOrder: ["agent.md", "Agent blocks", "page markdown"],
+      resolutionOrder: ["agent.md", "agent audience projection", "shared page markdown"],
     },
     agentContract: {
       enabled: true,

--- a/packages/docs/src/audience.ts
+++ b/packages/docs/src/audience.ts
@@ -1,0 +1,1520 @@
+import { createProcessor } from "@mdx-js/mdx";
+
+/** The two content projections emitted by the docs framework. */
+export type DocsContentAudience = "human" | "agent";
+
+/** Resolve whether content with an optional audience restriction is visible. */
+export function resolveDocsAudienceExposure(only: unknown, audience: DocsContentAudience): boolean {
+  return (only !== "human" && only !== "agent") || only === audience;
+}
+
+type DocsAudienceTagName = "Agent" | "Human" | "Audience";
+
+interface DocsAudienceScope {
+  name: DocsAudienceTagName;
+  only?: DocsContentAudience;
+}
+
+export interface DocsAudienceMdxTag {
+  index: number;
+  end: number;
+  name: DocsAudienceTagName;
+  closing: boolean;
+  selfClosing: boolean;
+  attributes: string;
+  only?: DocsContentAudience;
+  /** Tags nested in MDX JavaScript expressions need JSX-safe replacements. */
+  expression?: boolean;
+  /** Hidden expression tags that are JSX children need an expression container. */
+  jsxChild?: boolean;
+  hasOnlyAttribute?: boolean;
+  hasSpreadAttribute?: boolean;
+  onlyKind?: "static" | "dynamic" | "invalid" | "missing";
+}
+
+interface ProtectedRange {
+  start: number;
+  end: number;
+}
+
+export interface DocsAudienceMdxIssue {
+  code:
+    | "missing-only"
+    | "invalid-only"
+    | "dynamic-only"
+    | "ignored-agent-only"
+    | "ignored-human-only";
+  index: number;
+  message: string;
+}
+
+const DOCS_AUDIENCE_TAG_NAMES = ["Audience", "Agent", "Human"] as const;
+const DOCS_AUDIENCE_TAG_CANDIDATE_PATTERN = /<\/?(?:Audience|Agent|Human)(?=[\s/>])/;
+
+function parseAudienceOnly(attributes: string): DocsContentAudience | undefined {
+  if (/\{\s*\.\.\./.test(attributes)) return undefined;
+  const match = attributes.match(
+    /(?:^|\s)only\s*=\s*(?:"(human|agent)"|'(human|agent)'|\{\s*"(human|agent)"\s*\}|\{\s*'(human|agent)'\s*\})/,
+  );
+  const value = match?.slice(1).find(Boolean);
+  return value === "human" || value === "agent" ? value : undefined;
+}
+
+function isEscapedAt(content: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && content[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+const JAVASCRIPT_REGEX_PREFIX_KEYWORDS = new Set([
+  "await",
+  "case",
+  "delete",
+  "do",
+  "else",
+  "each",
+  "if",
+  "in",
+  "instanceof",
+  "key",
+  "new",
+  "of",
+  "return",
+  "throw",
+  "catch",
+  "const",
+  "debug",
+  "html",
+  "render",
+  "snippet",
+  "then",
+  "typeof",
+  "void",
+  "yield",
+]);
+
+function canStartJavascriptRegex(content: string, cursor: number, boundary: number): boolean {
+  let previous = cursor - 1;
+  while (previous > boundary && /\s/.test(content[previous] ?? "")) previous -= 1;
+  if (previous <= boundary || /[([{=,:;!?&|>]/.test(content[previous] ?? "")) return true;
+  const precedingWord = content.slice(boundary + 1, cursor).match(/([A-Za-z_$][\w$]*)\s*$/)?.[1];
+  return JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(precedingWord ?? "");
+}
+
+function readAudienceTagAt(content: string, index: number): DocsAudienceMdxTag | undefined {
+  let cursor = index + 1;
+  const closing = content[cursor] === "/";
+  if (closing) cursor += 1;
+
+  const name = DOCS_AUDIENCE_TAG_NAMES.find(
+    (candidate) =>
+      content.startsWith(candidate, cursor) &&
+      /[\s/>]/.test(content[cursor + candidate.length] ?? ""),
+  );
+  if (!name) return undefined;
+
+  cursor += name.length;
+  const attributesStart = cursor;
+  let braceDepth = 0;
+  let quote: '"' | "'" | "`" | undefined;
+  let blockComment = false;
+  let lineComment = false;
+
+  while (cursor < content.length) {
+    const character = content[cursor];
+    const next = content[cursor + 1];
+
+    if (lineComment) {
+      if (character === "\n") lineComment = false;
+      cursor += 1;
+      continue;
+    }
+
+    if (blockComment) {
+      if (character === "*" && next === "/") {
+        blockComment = false;
+        cursor += 2;
+      } else {
+        cursor += 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (character === "\\") {
+        cursor += 2;
+        continue;
+      }
+      if (character === quote) quote = undefined;
+      cursor += 1;
+      continue;
+    }
+
+    if (braceDepth > 0 && character === "/" && next === "*") {
+      blockComment = true;
+      cursor += 2;
+      continue;
+    }
+    if (braceDepth > 0 && character === "/" && next === "/") {
+      lineComment = true;
+      cursor += 2;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+    } else if (character === "{") {
+      braceDepth += 1;
+    } else if (character === "}" && braceDepth > 0) {
+      braceDepth -= 1;
+    } else if (character === ">" && braceDepth === 0) {
+      let attributesEnd = cursor;
+      let slashIndex = cursor - 1;
+      while (slashIndex >= attributesStart && /\s/.test(content[slashIndex] ?? "")) {
+        slashIndex -= 1;
+      }
+      const selfClosing = content[slashIndex] === "/";
+      if (selfClosing) attributesEnd = slashIndex;
+      const attributes = content.slice(attributesStart, attributesEnd);
+
+      return {
+        index,
+        end: cursor + 1,
+        name,
+        closing,
+        selfClosing,
+        attributes,
+        only:
+          name === "Agent" ? "agent" : name === "Human" ? "human" : parseAudienceOnly(attributes),
+      };
+    }
+
+    cursor += 1;
+  }
+
+  return undefined;
+}
+
+function findAudienceTags(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): DocsAudienceMdxTag[] {
+  const tags: DocsAudienceMdxTag[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const index = content.indexOf("<", cursor);
+    if (index === -1) break;
+    if (isEscapedAt(content, index) || isInsideRange(index, protectedRanges)) {
+      cursor = index + 1;
+      continue;
+    }
+    const tag = readAudienceTagAt(content, index);
+    if (tag) {
+      tags.push(tag);
+      cursor = tag.end;
+    } else {
+      cursor = index + 1;
+    }
+  }
+
+  return tags;
+}
+
+interface MdxAstPosition {
+  start?: { offset?: number };
+  end?: { offset?: number };
+}
+
+interface MdxAstNode {
+  type?: string;
+  name?: string | null;
+  attributes?: MdxAstAttribute[];
+  children?: MdxAstNode[];
+  position?: MdxAstPosition;
+  data?: { estree?: unknown };
+  title?: unknown;
+}
+
+interface MdxAstAttribute {
+  type?: string;
+  name?: string;
+  value?: unknown;
+  position?: MdxAstPosition;
+  data?: { estree?: unknown };
+}
+
+interface AudienceAttributeInfo {
+  only?: DocsContentAudience;
+  hasOnlyAttribute: boolean;
+  hasSpreadAttribute: boolean;
+  onlyKind: "static" | "dynamic" | "invalid" | "missing";
+}
+
+const docsAudienceMdxProcessor = createProcessor({ format: "mdx" });
+const docsAudienceMarkdownProcessor = createProcessor({ format: "md" });
+
+function getOffset(position: MdxAstPosition | undefined, edge: "start" | "end") {
+  const value = position?.[edge]?.offset;
+  return typeof value === "number" ? value : undefined;
+}
+
+function maskRangesForMdxParser(content: string, ranges: readonly ProtectedRange[]): string {
+  if (ranges.length === 0) return content;
+  const characters = content.split("");
+  for (const range of ranges) {
+    for (let index = range.start; index < range.end; index += 1) {
+      if (characters[index] !== "\n" && characters[index] !== "\r") characters[index] = " ";
+    }
+  }
+  return characters.join("");
+}
+
+function findLeadingFrontmatterRange(content: string): ProtectedRange | undefined {
+  const bomLength = content.startsWith("\uFEFF") ? 1 : 0;
+  const opening = content.slice(bomLength).match(/^(---|\+\+\+)[\t ]*(?:\r?\n|$)/);
+  const marker = opening?.[1];
+  if (!opening || !marker) return undefined;
+
+  let offset = bomLength + opening[0].length;
+  for (const line of content.slice(offset).split(/(?<=\n)/)) {
+    offset += line.length;
+    const value = line.replace(/\r?\n$/, "");
+    const isClosingDelimiter =
+      marker === "---" ? /^(?:---|\.\.\.)[\t ]*$/.test(value) : /^\+\+\+[\t ]*$/.test(value);
+    if (isClosingDelimiter) {
+      return { start: 0, end: offset };
+    }
+  }
+  return undefined;
+}
+
+function findHtmlLiteralRanges(
+  content: string,
+  excludedRanges: readonly ProtectedRange[] = [],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  const rawPattern = /<(script|style)(?=[\s/>])/g;
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    rawPattern.lastIndex = cursor;
+    const rawMatch = rawPattern.exec(content);
+    const commentStart = content.indexOf("<!--", cursor);
+    const rawStart = rawMatch?.index ?? -1;
+    const useComment = commentStart !== -1 && (rawStart === -1 || commentStart < rawStart);
+    const start = useComment ? commentStart : rawStart;
+    if (start === -1) break;
+
+    if (isEscapedAt(content, start) || isInsideRange(start, excludedRanges)) {
+      cursor = start + 1;
+      continue;
+    }
+
+    if (useComment) {
+      const closing = content.indexOf("-->", start + 4);
+      const end = closing === -1 ? content.length : closing + 3;
+      ranges.push({ start, end });
+      cursor = end;
+      continue;
+    }
+
+    const name = rawMatch?.[1];
+    if (!name) {
+      cursor = start + 1;
+      continue;
+    }
+    const opening = readGenericMdxJsxTag(content, start);
+    if (!opening) {
+      cursor = start + 1;
+      continue;
+    }
+    if (opening.selfClosing) {
+      cursor = opening.end;
+      continue;
+    }
+
+    const closingPattern = new RegExp(`</${name}\\s*>`, "g");
+    closingPattern.lastIndex = opening.end;
+    const closing = closingPattern.exec(content);
+    if (!closing) {
+      ranges.push({ start, end: content.length });
+      break;
+    }
+
+    ranges.push({ start, end: closingPattern.lastIndex });
+    cursor = closingPattern.lastIndex;
+  }
+  return ranges;
+}
+
+function prepareMdxParserSource(content: string): string {
+  const baseExcludedRanges = findDelimiterExclusionRanges(content);
+  const svelteDirectives = findSvelteDirectiveRanges(content, baseExcludedRanges);
+  const excludedRanges = mergeProtectedRanges([...baseExcludedRanges, ...svelteDirectives]);
+  const ranges: ProtectedRange[] = [
+    ...findHtmlLiteralRanges(content, excludedRanges),
+    ...svelteDirectives,
+  ];
+  const frontmatter = findLeadingFrontmatterRange(content);
+  if (frontmatter) ranges.push(frontmatter);
+
+  return maskRangesForMdxParser(content, mergeProtectedRanges(ranges));
+}
+
+function getExpressionLiteralString(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const expressionValue = value as {
+    value?: unknown;
+    data?: {
+      estree?: {
+        body?: Array<{ expression?: { type?: string; value?: unknown } }>;
+      };
+    };
+  };
+  const expression = expressionValue.data?.estree?.body?.[0]?.expression;
+  return expression?.type === "Literal" && typeof expression.value === "string"
+    ? expression.value
+    : undefined;
+}
+
+function getMdxAudienceAttributeInfo(
+  attributes: readonly MdxAstAttribute[],
+): AudienceAttributeInfo {
+  const hasSpreadAttribute = attributes.some(
+    (attribute) => attribute.type === "mdxJsxExpressionAttribute",
+  );
+  const onlyAttribute = [...attributes]
+    .reverse()
+    .find((attribute) => attribute.type === "mdxJsxAttribute" && attribute.name === "only");
+  if (hasSpreadAttribute) {
+    return {
+      hasOnlyAttribute: Boolean(onlyAttribute),
+      hasSpreadAttribute,
+      onlyKind: "dynamic",
+    };
+  }
+  if (!onlyAttribute) {
+    return { hasOnlyAttribute: false, hasSpreadAttribute: false, onlyKind: "missing" };
+  }
+
+  const value =
+    typeof onlyAttribute.value === "string"
+      ? onlyAttribute.value
+      : getExpressionLiteralString(onlyAttribute.value);
+  if (value === "human" || value === "agent") {
+    return {
+      only: value,
+      hasOnlyAttribute: true,
+      hasSpreadAttribute: false,
+      onlyKind: "static",
+    };
+  }
+  return {
+    hasOnlyAttribute: true,
+    hasSpreadAttribute: false,
+    onlyKind: typeof onlyAttribute.value === "object" ? "dynamic" : "invalid",
+  };
+}
+
+function getEstreeAudienceAttributeInfo(attributes: readonly unknown[]): AudienceAttributeInfo {
+  const records = attributes.filter((attribute): attribute is Record<string, unknown> =>
+    Boolean(attribute && typeof attribute === "object"),
+  );
+  const hasSpreadAttribute = records.some((attribute) => attribute.type === "JSXSpreadAttribute");
+  const onlyAttribute = [...records].reverse().find((attribute) => {
+    const name = attribute.name as { type?: string; name?: string } | undefined;
+    return (
+      attribute.type === "JSXAttribute" && name?.type === "JSXIdentifier" && name.name === "only"
+    );
+  });
+  if (hasSpreadAttribute) {
+    return {
+      hasOnlyAttribute: Boolean(onlyAttribute),
+      hasSpreadAttribute,
+      onlyKind: "dynamic",
+    };
+  }
+  if (!onlyAttribute) {
+    return { hasOnlyAttribute: false, hasSpreadAttribute: false, onlyKind: "missing" };
+  }
+
+  const attributeValue = onlyAttribute.value as
+    | { type?: string; value?: unknown; expression?: { type?: string; value?: unknown } }
+    | undefined;
+  const value =
+    attributeValue?.type === "Literal"
+      ? attributeValue.value
+      : attributeValue?.type === "JSXExpressionContainer" &&
+          attributeValue.expression?.type === "Literal"
+        ? attributeValue.expression.value
+        : undefined;
+  if (value === "human" || value === "agent") {
+    return {
+      only: value,
+      hasOnlyAttribute: true,
+      hasSpreadAttribute: false,
+      onlyKind: "static",
+    };
+  }
+  return {
+    hasOnlyAttribute: true,
+    hasSpreadAttribute: false,
+    onlyKind: attributeValue?.type === "JSXExpressionContainer" ? "dynamic" : "invalid",
+  };
+}
+
+function getOpeningTagEnd(
+  content: string,
+  start: number,
+  name: DocsAudienceTagName,
+  attributes: readonly MdxAstAttribute[],
+): number | undefined {
+  const searchStart = Math.max(
+    start + name.length + 1,
+    ...attributes.map((attribute) => getOffset(attribute.position, "end") ?? 0),
+  );
+  const closingBracket = content.indexOf(">", searchStart);
+  return closingBracket === -1 ? undefined : closingBracket + 1;
+}
+
+function addMdxAudienceElementTags(
+  content: string,
+  node: MdxAstNode,
+  tags: DocsAudienceMdxTag[],
+): void {
+  const name = node.name as DocsAudienceTagName;
+  const start = getOffset(node.position, "start");
+  const nodeEnd = getOffset(node.position, "end");
+  if (start === undefined || nodeEnd === undefined) return;
+
+  const attributes = node.attributes ?? [];
+  const openingEnd = getOpeningTagEnd(content, start, name, attributes);
+  if (openingEnd === undefined) return;
+  const closingStart = content.lastIndexOf(`</${name}`, nodeEnd);
+  const hasClosingTag = closingStart >= openingEnd;
+  const attributeInfo = getMdxAudienceAttributeInfo(attributes);
+  const rawAttributes = content.slice(start + name.length + 1, openingEnd - 1);
+
+  tags.push({
+    index: start,
+    end: openingEnd,
+    name,
+    closing: false,
+    selfClosing: !hasClosingTag,
+    attributes: rawAttributes,
+    only: name === "Agent" ? "agent" : name === "Human" ? "human" : attributeInfo.only,
+    hasOnlyAttribute: attributeInfo.hasOnlyAttribute,
+    hasSpreadAttribute: attributeInfo.hasSpreadAttribute,
+    onlyKind: attributeInfo.onlyKind,
+  });
+
+  if (hasClosingTag) {
+    tags.push({
+      index: closingStart,
+      end: nodeEnd,
+      name,
+      closing: true,
+      selfClosing: false,
+      attributes: "",
+    });
+  }
+}
+
+function getEstreeJsxIdentifierName(value: unknown): DocsAudienceTagName | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const name = value as { type?: string; name?: string };
+  return name.type === "JSXIdentifier" &&
+    DOCS_AUDIENCE_TAG_NAMES.some((candidate) => candidate === name.name)
+    ? (name.name as DocsAudienceTagName)
+    : undefined;
+}
+
+function addEstreeAudienceElementTags(
+  content: string,
+  node: Record<string, unknown>,
+  tags: DocsAudienceMdxTag[],
+  jsxChild: boolean,
+): void {
+  const opening = node.openingElement as Record<string, unknown> | undefined;
+  if (!opening) return;
+  const name = getEstreeJsxIdentifierName(opening.name);
+  const start = typeof opening.start === "number" ? opening.start : undefined;
+  const openingEnd = typeof opening.end === "number" ? opening.end : undefined;
+  const nodeEnd = typeof node.end === "number" ? node.end : undefined;
+  if (!name || start === undefined || openingEnd === undefined || nodeEnd === undefined) return;
+
+  const attributes = Array.isArray(opening.attributes) ? opening.attributes : [];
+  const attributeInfo = getEstreeAudienceAttributeInfo(attributes);
+  const closing = node.closingElement as Record<string, unknown> | null | undefined;
+  const closingStart = closing && typeof closing.start === "number" ? closing.start : undefined;
+  const closingEnd = closing && typeof closing.end === "number" ? closing.end : undefined;
+
+  tags.push({
+    index: start,
+    end: openingEnd,
+    name,
+    closing: false,
+    selfClosing: closingStart === undefined,
+    attributes: content.slice(start + name.length + 1, openingEnd - 1),
+    only: name === "Agent" ? "agent" : name === "Human" ? "human" : attributeInfo.only,
+    expression: true,
+    jsxChild,
+    hasOnlyAttribute: attributeInfo.hasOnlyAttribute,
+    hasSpreadAttribute: attributeInfo.hasSpreadAttribute,
+    onlyKind: attributeInfo.onlyKind,
+  });
+
+  if (closingStart !== undefined && closingEnd !== undefined) {
+    tags.push({
+      index: closingStart,
+      end: closingEnd,
+      name,
+      closing: true,
+      selfClosing: false,
+      attributes: "",
+      expression: true,
+      jsxChild,
+    });
+  }
+}
+
+function collectEstreeAudienceTags(
+  content: string,
+  value: unknown,
+  tags: DocsAudienceMdxTag[],
+  seen = new WeakSet<object>(),
+  parent?: Record<string, unknown>,
+  parentKey?: string,
+): void {
+  if (!value || typeof value !== "object" || seen.has(value)) return;
+  seen.add(value);
+  const record = value as Record<string, unknown>;
+  if (record.type === "JSXElement") {
+    const opening = record.openingElement as Record<string, unknown> | undefined;
+    if (getEstreeJsxIdentifierName(opening?.name)) {
+      const jsxChild =
+        parentKey === "children" &&
+        (parent?.type === "JSXElement" || parent?.type === "JSXFragment");
+      addEstreeAudienceElementTags(content, record, tags, jsxChild);
+      for (const child of Array.isArray(record.children) ? record.children : []) {
+        collectEstreeAudienceTags(content, child, tags, seen, record, "children");
+      }
+      return;
+    }
+  }
+
+  for (const [key, child] of Object.entries(record)) {
+    if (key === "loc" || key === "range" || key === "comments") continue;
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        collectEstreeAudienceTags(content, item, tags, seen, record, key);
+      }
+    } else {
+      collectEstreeAudienceTags(content, child, tags, seen, record, key);
+    }
+  }
+}
+
+function collectMdxAudienceTags(content: string, node: MdxAstNode, tags: DocsAudienceMdxTag[]) {
+  const isMdxJsxElement = node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement";
+  if (isMdxJsxElement && (node.name === "script" || node.name === "style")) return;
+  const isAudienceElement = Boolean(
+    isMdxJsxElement &&
+    node.name &&
+    DOCS_AUDIENCE_TAG_NAMES.some((candidate) => candidate === node.name),
+  );
+  if (isAudienceElement) {
+    addMdxAudienceElementTags(content, node, tags);
+  }
+
+  if (node.type !== "mdxjsEsm") {
+    if (node.type === "mdxFlowExpression" || node.type === "mdxTextExpression") {
+      collectEstreeAudienceTags(content, node.data?.estree, tags);
+    }
+    if (isMdxJsxElement && !isAudienceElement) {
+      for (const attribute of node.attributes ?? []) {
+        collectEstreeAudienceTags(content, attribute.data?.estree, tags);
+        if (attribute.value && typeof attribute.value === "object") {
+          const value = attribute.value as { data?: { estree?: unknown } };
+          collectEstreeAudienceTags(content, value.data?.estree, tags);
+        }
+      }
+    }
+  }
+
+  for (const child of node.children ?? []) collectMdxAudienceTags(content, child, tags);
+}
+
+function findMdxAstAudienceTags(content: string): DocsAudienceMdxTag[] | undefined {
+  try {
+    const tree = docsAudienceMdxProcessor.parse(prepareMdxParserSource(content)) as MdxAstNode;
+    const tags: DocsAudienceMdxTag[] = [];
+    collectMdxAudienceTags(content, tree, tags);
+    return tags.sort((left, right) => left.index - right.index || left.end - right.end);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Locate effective audience tags while excluding Markdown/MDX literal contexts. */
+export function findDocsAudienceMdxTags(content: string): DocsAudienceMdxTag[] {
+  if (!DOCS_AUDIENCE_TAG_CANDIDATE_PATTERN.test(content)) return [];
+  return findMdxAstAudienceTags(content) ?? findAudienceTags(content, findProtectedRanges(content));
+}
+
+function isAudienceVisible(scopes: DocsAudienceScope[], audience: DocsContentAudience): boolean {
+  return scopes.every((scope) => resolveDocsAudienceExposure(scope.only, audience));
+}
+
+function mergeProtectedRanges(ranges: ProtectedRange[]): ProtectedRange[] {
+  const sorted = [...ranges].sort(
+    (left, right) => left.start - right.start || left.end - right.end,
+  );
+  const merged: ProtectedRange[] = [];
+
+  for (const range of sorted) {
+    const previous = merged.at(-1);
+    if (!previous || range.start > previous.end) {
+      merged.push({ ...range });
+      continue;
+    }
+    previous.end = Math.max(previous.end, range.end);
+  }
+
+  return merged;
+}
+
+function findMarkdownLiteralRanges(content: string): ProtectedRange[] {
+  try {
+    const tree = docsAudienceMarkdownProcessor.parse(content) as MdxAstNode;
+    const ranges: ProtectedRange[] = [];
+
+    const visit = (node: MdxAstNode) => {
+      const start = getOffset(node.position, "start");
+      const end = getOffset(node.position, "end");
+      if (start !== undefined && end !== undefined) {
+        if (node.type === "code" || node.type === "inlineCode" || node.type === "definition") {
+          ranges.push({ start, end });
+        } else if (node.type === "link" || node.type === "image") {
+          const contentEnd = Math.max(
+            start,
+            ...(node.children ?? []).map((child) => getOffset(child.position, "end") ?? start),
+          );
+          ranges.push({ start: contentEnd, end });
+        }
+      }
+      for (const child of node.children ?? []) visit(child);
+    };
+
+    visit(tree);
+    return ranges;
+  } catch {
+    return [];
+  }
+}
+
+function findMarkdownLinkDestinationRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const start = content.indexOf("](", cursor);
+    if (start === -1) break;
+    if (isEscapedAt(content, start) || isInsideRange(start, protectedRanges)) {
+      cursor = start + 1;
+      continue;
+    }
+
+    let end = start + 2;
+    let parenthesisDepth = 1;
+    let angleDestination = false;
+    let quote: '"' | "'" | undefined;
+    while (end < content.length && parenthesisDepth > 0) {
+      const character = content[end];
+      if (character === "\\") {
+        end += 2;
+        continue;
+      }
+      if (quote) {
+        if (character === quote) quote = undefined;
+        end += 1;
+        continue;
+      }
+      if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === "<" && parenthesisDepth === 1) {
+        const closingAngle = content.indexOf(">", end + 1);
+        const closingParenthesis = content.indexOf(")", end + 1);
+        angleDestination = closingAngle !== -1 && closingAngle < closingParenthesis;
+      } else if (character === ">" && angleDestination) {
+        angleDestination = false;
+      } else if (!angleDestination && character === "(") {
+        parenthesisDepth += 1;
+      } else if (!angleDestination && character === ")") {
+        parenthesisDepth -= 1;
+      }
+      end += 1;
+    }
+
+    if (parenthesisDepth === 0) ranges.push({ start: start + 1, end });
+    cursor = Math.max(start + 1, end);
+  }
+
+  return ranges;
+}
+
+function findFenceRanges(content: string): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let fence:
+    | {
+        marker: "`" | "~";
+        length: number;
+        start: number;
+      }
+    | undefined;
+  let offset = 0;
+
+  const stripBlockquoteContainers = (line: string) => {
+    let value = line;
+    while (/^ {0,3}>[\t ]?/.test(value)) value = value.replace(/^ {0,3}>[\t ]?/, "");
+    return value;
+  };
+
+  const stripOpeningListContainers = (line: string) => {
+    let value = line;
+    while (/^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/.test(value)) {
+      value = value.replace(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/, "");
+    }
+    return value;
+  };
+
+  for (const line of content.split(/(?<=\n)/)) {
+    const lineWithoutNewline = line.replace(/\r?\n$/, "");
+    const containerRelativeLine = stripBlockquoteContainers(lineWithoutNewline);
+    const candidateLine = fence
+      ? containerRelativeLine
+      : stripOpeningListContainers(containerRelativeLine);
+    const match = candidateLine.match(/^[\t ]*(`{3,}|~{3,})(.*)$/);
+
+    if (!fence && match?.[1]) {
+      fence = {
+        marker: match[1][0] as "`" | "~",
+        length: match[1].length,
+        start: offset,
+      };
+    } else if (
+      fence &&
+      match?.[1]?.[0] === fence.marker &&
+      match[1].length >= fence.length &&
+      /^[\t ]*$/.test(match[2] ?? "")
+    ) {
+      ranges.push({ start: fence.start, end: offset + line.length });
+      fence = undefined;
+    }
+
+    offset += line.length;
+  }
+
+  if (fence) ranges.push({ start: fence.start, end: content.length });
+  return ranges;
+}
+
+function findSvelteDirectiveRanges(
+  content: string,
+  excludedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let index = 0;
+
+  while (index < content.length) {
+    const start = content.indexOf("{", index);
+    if (start === -1) break;
+    const sigil = content[start + 1];
+    if (
+      !/[#/:@]/.test(sigil ?? "") ||
+      !/[A-Za-z]/.test(content[start + 2] ?? "") ||
+      isEscapedAt(content, start) ||
+      isInsideRange(start, excludedRanges)
+    ) {
+      index = start + 1;
+      continue;
+    }
+
+    let cursor = start + 2;
+    let braceDepth = 1;
+    let quote: '"' | "'" | "`" | undefined;
+    let blockComment = false;
+    let lineComment = false;
+    let regex = false;
+    let regexCharacterClass = false;
+
+    while (cursor < content.length && braceDepth > 0) {
+      const character = content[cursor];
+      const next = content[cursor + 1];
+
+      if (lineComment) {
+        if (character === "\n") lineComment = false;
+        cursor += 1;
+        continue;
+      }
+      if (blockComment) {
+        if (character === "*" && next === "/") {
+          blockComment = false;
+          cursor += 2;
+        } else {
+          cursor += 1;
+        }
+        continue;
+      }
+      if (quote) {
+        if (character === "\\") {
+          cursor += 2;
+          continue;
+        }
+        if (character === quote) quote = undefined;
+        cursor += 1;
+        continue;
+      }
+      if (regex) {
+        if (character === "\\") {
+          cursor += 2;
+          continue;
+        }
+        if (character === "[") regexCharacterClass = true;
+        if (character === "]") regexCharacterClass = false;
+        if (character === "/" && !regexCharacterClass) regex = false;
+        cursor += 1;
+        continue;
+      }
+
+      if (character === "/" && next === "*") {
+        blockComment = true;
+        cursor += 2;
+        continue;
+      }
+      if (character === "/" && next === "/") {
+        lineComment = true;
+        cursor += 2;
+        continue;
+      }
+      if (character === '"' || character === "'" || character === "`") {
+        quote = character;
+        cursor += 1;
+        continue;
+      }
+      if (character === "/") {
+        if (canStartJavascriptRegex(content, cursor, start + 1)) {
+          regex = true;
+          cursor += 1;
+          continue;
+        }
+      }
+
+      if (character === "{") braceDepth += 1;
+      if (character === "}") braceDepth -= 1;
+      cursor += 1;
+    }
+
+    if (braceDepth === 0) ranges.push({ start, end: cursor });
+    index = Math.max(start + 1, cursor);
+  }
+
+  return ranges;
+}
+
+interface MdxModuleScanState {
+  braceDepth: number;
+  bracketDepth: number;
+  parenthesisDepth: number;
+  quote?: '"' | "'" | "`";
+  blockComment: boolean;
+  sawBlock: boolean;
+  jsxDepth: number;
+  jsxTag?: { closing: boolean };
+}
+
+function scanMdxModuleLine(line: string, state: MdxModuleScanState): void {
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    const next = line[index + 1];
+
+    if (state.blockComment) {
+      if (character === "*" && next === "/") {
+        state.blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (state.quote) {
+      if (character === "\\") {
+        index += 1;
+        continue;
+      }
+      if (character === state.quote) state.quote = undefined;
+      continue;
+    }
+
+    if (character === "/" && next === "/") break;
+    if (character === "/" && next === "*") {
+      state.blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      state.quote = character;
+      continue;
+    }
+
+    if (state.jsxTag) {
+      if (character === "{") {
+        state.braceDepth += 1;
+      } else if (character === "}" && state.braceDepth > 0) {
+        state.braceDepth -= 1;
+      } else if (character === ">" && state.braceDepth === 0) {
+        let previous = index - 1;
+        while (previous >= 0 && /[\t ]/.test(line[previous] ?? "")) previous -= 1;
+        const selfClosing = line[previous] === "/";
+        let following = index + 1;
+        while (following < line.length && /[\t ]/.test(line[following] ?? "")) following += 1;
+        const genericTypeParameters = !state.jsxTag.closing && line[following] === "(";
+        if (state.jsxTag.closing) {
+          state.jsxDepth = Math.max(0, state.jsxDepth - 1);
+        } else if (!selfClosing && !genericTypeParameters) {
+          state.jsxDepth += 1;
+        }
+        state.jsxTag = undefined;
+      }
+      continue;
+    }
+
+    if (character === "<") {
+      let previous = index - 1;
+      while (previous >= 0 && /[\t ]/.test(line[previous] ?? "")) previous -= 1;
+      const previousCharacter = line[previous];
+      const atExpressionStart =
+        previousCharacter === undefined || /[=([{,:?!;]/.test(previousCharacter);
+      const openingElement =
+        (state.jsxDepth > 0 || atExpressionStart) && /[A-Za-z]/.test(next ?? "");
+      const closingElement =
+        state.jsxDepth > 0 && next === "/" && /[A-Za-z]/.test(line[index + 2] ?? "");
+      const openingFragment = atExpressionStart && next === ">";
+      const closingFragment = state.jsxDepth > 0 && next === "/" && line[index + 2] === ">";
+
+      if (openingFragment) {
+        state.jsxDepth += 1;
+        index += 1;
+        continue;
+      }
+      if (closingFragment) {
+        state.jsxDepth = Math.max(0, state.jsxDepth - 1);
+        index += 2;
+        continue;
+      }
+      if (openingElement || closingElement) {
+        state.jsxTag = { closing: closingElement };
+        continue;
+      }
+    }
+
+    if (character === "{") {
+      state.braceDepth += 1;
+      state.sawBlock = true;
+      continue;
+    }
+    if (character === "}") {
+      state.braceDepth = Math.max(0, state.braceDepth - 1);
+    } else if (character === "[") {
+      state.bracketDepth += 1;
+    } else if (character === "]") {
+      state.bracketDepth = Math.max(0, state.bracketDepth - 1);
+    } else if (character === "(") {
+      state.parenthesisDepth += 1;
+    } else if (character === ")") {
+      state.parenthesisDepth = Math.max(0, state.parenthesisDepth - 1);
+    }
+  }
+}
+
+function shouldContinueMdxModule(
+  statement: string,
+  state: MdxModuleScanState,
+  nextSignificantLine?: string,
+): boolean {
+  if (
+    state.quote ||
+    state.blockComment ||
+    state.braceDepth > 0 ||
+    state.bracketDepth > 0 ||
+    state.parenthesisDepth > 0 ||
+    state.jsxTag ||
+    state.jsxDepth > 0
+  ) {
+    return true;
+  }
+
+  const trimmed = statement.trimEnd();
+  const isImportDeclaration = /^\s*import\b(?!\s*[.(])/.test(statement);
+  if (isImportDeclaration) {
+    const hasSource =
+      /^\s*import\s*(?:type\s+)?["'`]/.test(statement) ||
+      /\bfrom\s*["'`][\s\S]*["'`]\s*;?\s*$/.test(trimmed);
+    if (!hasSource && !/;\s*$/.test(trimmed)) return true;
+  }
+
+  const isExportList = /^\s*export\s+(?:type\s+)?\{/.test(statement);
+  const isExportAll = /^\s*export\s+\*/.test(statement);
+  if (
+    (isExportList || isExportAll) &&
+    !/\bfrom\s*["'`][\s\S]*["'`]\s*;?\s*$/.test(trimmed) &&
+    (isExportAll || /^\s*from\b/.test(nextSignificantLine ?? ""))
+  ) {
+    return true;
+  }
+
+  if (/=>\s*$/.test(trimmed) || /[=([{,:.?+\-*/%&|^!]$/.test(trimmed)) return true;
+  if (/\b(?:as|default|extends|from|implements|satisfies)$/.test(trimmed)) return true;
+
+  const declarationNeedsBlock =
+    /^\s*export\s+(?:default\s+)?(?:(?:async\s+)?function|class|enum|interface|module|namespace)\b/.test(
+      statement,
+    );
+  return declarationNeedsBlock && !state.sawBlock;
+}
+
+function isInsideRange(index: number, ranges: readonly ProtectedRange[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function findMdxModuleRanges(content: string, protectedRanges: ProtectedRange[]): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  const lines = content.split(/(?<=\n)/);
+  let offset = 0;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex] ?? "";
+    const firstNonWhitespace = line.search(/\S/);
+    if (
+      /^\s*(?:import|export)\b/.test(line) &&
+      !isInsideRange(offset + Math.max(0, firstNonWhitespace), protectedRanges)
+    ) {
+      const start = offset;
+      const state: MdxModuleScanState = {
+        braceDepth: 0,
+        bracketDepth: 0,
+        parenthesisDepth: 0,
+        blockComment: false,
+        sawBlock: false,
+        jsxDepth: 0,
+      };
+      let statement = "";
+
+      while (lineIndex < lines.length) {
+        const moduleLine = lines[lineIndex] ?? "";
+        statement += moduleLine;
+        scanMdxModuleLine(moduleLine, state);
+        offset += moduleLine.length;
+        const nextSignificantLine = lines
+          .slice(lineIndex + 1)
+          .find((candidate) => candidate.trim().length > 0);
+        if (!shouldContinueMdxModule(statement, state, nextSignificantLine)) break;
+        lineIndex += 1;
+      }
+
+      ranges.push({ start, end: offset });
+      continue;
+    }
+    offset += line.length;
+  }
+
+  return ranges;
+}
+
+function findInlineCodeRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let index = 0;
+
+  while (index < content.length) {
+    if (
+      content[index] !== "`" ||
+      isEscapedAt(content, index) ||
+      isInsideRange(index, protectedRanges)
+    ) {
+      index += 1;
+      continue;
+    }
+
+    let markerLength = 1;
+    while (content[index + markerLength] === "`") markerLength += 1;
+    let closingIndex = index + markerLength;
+
+    while (closingIndex < content.length) {
+      closingIndex = content.indexOf("`", closingIndex);
+      if (closingIndex === -1) break;
+      if (isInsideRange(closingIndex, protectedRanges)) {
+        closingIndex += 1;
+        continue;
+      }
+
+      let closingLength = 1;
+      while (content[closingIndex + closingLength] === "`") closingLength += 1;
+      if (closingLength === markerLength) break;
+      closingIndex += closingLength;
+    }
+
+    if (closingIndex === -1) {
+      index += markerLength;
+      continue;
+    }
+
+    ranges.push({ start: index, end: closingIndex + markerLength });
+    index = closingIndex + markerLength;
+  }
+
+  return ranges;
+}
+
+function findMdxExpressionLiteralRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let index = 0;
+
+  while (index < content.length) {
+    if (
+      content[index] !== "{" ||
+      isEscapedAt(content, index) ||
+      isInsideRange(index, protectedRanges)
+    ) {
+      index += 1;
+      continue;
+    }
+
+    let cursor = index + 1;
+    let depth = 1;
+    while (cursor < content.length && depth > 0) {
+      if (isInsideRange(cursor, protectedRanges)) {
+        cursor += 1;
+        continue;
+      }
+
+      const character = content[cursor];
+      const next = content[cursor + 1];
+      if (character === '"' || character === "'" || character === "`") {
+        const quote = character;
+        const start = cursor;
+        cursor += 1;
+        while (cursor < content.length) {
+          if (content[cursor] === "\\") {
+            cursor += 2;
+            continue;
+          }
+          if (content[cursor] === quote) {
+            cursor += 1;
+            break;
+          }
+          cursor += 1;
+        }
+        ranges.push({ start, end: cursor });
+        continue;
+      }
+      if (character === "/" && next === "*") {
+        const start = cursor;
+        const end = content.indexOf("*/", cursor + 2);
+        cursor = end === -1 ? content.length : end + 2;
+        ranges.push({ start, end: cursor });
+        continue;
+      }
+      if (character === "/" && next === "/") {
+        const start = cursor;
+        const newline = content.indexOf("\n", cursor + 2);
+        cursor = newline === -1 ? content.length : newline;
+        ranges.push({ start, end: cursor });
+        continue;
+      }
+      if (character === "/") {
+        if (canStartJavascriptRegex(content, cursor, index)) {
+          const start = cursor;
+          let inCharacterClass = false;
+          cursor += 1;
+          while (cursor < content.length) {
+            if (content[cursor] === "\\") {
+              cursor += 2;
+              continue;
+            }
+            if (content[cursor] === "[") inCharacterClass = true;
+            if (content[cursor] === "]") inCharacterClass = false;
+            if (content[cursor] === "/" && !inCharacterClass) {
+              cursor += 1;
+              while (/[A-Za-z]/.test(content[cursor] ?? "")) cursor += 1;
+              break;
+            }
+            if (content[cursor] === "\n") break;
+            cursor += 1;
+          }
+          ranges.push({ start, end: cursor });
+          continue;
+        }
+      }
+      if (character === "{") depth += 1;
+      if (character === "}") depth -= 1;
+      cursor += 1;
+    }
+
+    index = Math.max(index + 1, cursor);
+  }
+
+  return ranges;
+}
+
+function readGenericMdxJsxTag(
+  content: string,
+  index: number,
+): { end: number; literals: ProtectedRange[]; selfClosing: boolean } | undefined {
+  let cursor = index + 1;
+  if (content[cursor] === "/") cursor += 1;
+  if (!/[A-Za-z]/.test(content[cursor] ?? "")) return undefined;
+
+  const nameStart = cursor;
+  while (/[\w:.-]/.test(content[cursor] ?? "")) cursor += 1;
+  const name = content.slice(nameStart, cursor);
+  if (DOCS_AUDIENCE_TAG_NAMES.some((candidate) => candidate === name)) return undefined;
+  if (!/[\s/>]/.test(content[cursor] ?? "")) return undefined;
+
+  const literals: ProtectedRange[] = [];
+  let braceDepth = 0;
+  while (cursor < content.length) {
+    const character = content[cursor];
+    const next = content[cursor + 1];
+    if (character === '"' || character === "'" || character === "`") {
+      const quote = character;
+      const start = cursor;
+      cursor += 1;
+      while (cursor < content.length) {
+        if (content[cursor] === "\\") {
+          cursor += 2;
+          continue;
+        }
+        if (content[cursor] === quote) {
+          cursor += 1;
+          break;
+        }
+        cursor += 1;
+      }
+      literals.push({ start, end: cursor });
+      continue;
+    }
+    if (braceDepth > 0 && character === "/" && next === "*") {
+      const start = cursor;
+      const end = content.indexOf("*/", cursor + 2);
+      cursor = end === -1 ? content.length : end + 2;
+      literals.push({ start, end: cursor });
+      continue;
+    }
+    if (braceDepth > 0 && character === "/" && next === "/") {
+      const start = cursor;
+      const newline = content.indexOf("\n", cursor + 2);
+      cursor = newline === -1 ? content.length : newline;
+      literals.push({ start, end: cursor });
+      continue;
+    }
+    if (character === "{") {
+      braceDepth += 1;
+    } else if (character === "}" && braceDepth > 0) {
+      braceDepth -= 1;
+    } else if (character === ">" && braceDepth === 0) {
+      let previous = cursor - 1;
+      while (previous >= index && /\s/.test(content[previous] ?? "")) previous -= 1;
+      return { end: cursor + 1, literals, selfClosing: content[previous] === "/" };
+    }
+    cursor += 1;
+  }
+
+  return undefined;
+}
+
+function findGenericMdxJsxLiteralRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const index = content.indexOf("<", cursor);
+    if (index === -1) break;
+    if (isEscapedAt(content, index) || isInsideRange(index, protectedRanges)) {
+      cursor = index + 1;
+      continue;
+    }
+    const tag = readGenericMdxJsxTag(content, index);
+    if (!tag) {
+      cursor = index + 1;
+      continue;
+    }
+    ranges.push(...tag.literals);
+    cursor = tag.end;
+  }
+
+  return ranges;
+}
+
+function findDelimiterExclusionRanges(content: string): ProtectedRange[] {
+  const markdownLiterals = findMarkdownLiteralRanges(content);
+  const fences = findFenceRanges(content);
+  const frontmatter = findLeadingFrontmatterRange(content);
+  const literalBlocks = mergeProtectedRanges([
+    ...markdownLiterals,
+    ...fences,
+    ...(frontmatter ? [frontmatter] : []),
+  ]);
+  const inlineCode = findInlineCodeRanges(content, literalBlocks);
+  const markdownLinks = findMarkdownLinkDestinationRanges(content, literalBlocks);
+  const nonModuleRanges = mergeProtectedRanges([...literalBlocks, ...inlineCode, ...markdownLinks]);
+  const moduleRanges = findMdxModuleRanges(content, nonModuleRanges);
+  const nonExpressionRanges = mergeProtectedRanges([...nonModuleRanges, ...moduleRanges]);
+  const expressionLiterals = findMdxExpressionLiteralRanges(content, nonExpressionRanges);
+  const nonJsxRanges = mergeProtectedRanges([...nonExpressionRanges, ...expressionLiterals]);
+  return mergeProtectedRanges([
+    ...nonJsxRanges,
+    ...findGenericMdxJsxLiteralRanges(content, nonJsxRanges),
+  ]);
+}
+
+function findProtectedRanges(content: string): ProtectedRange[] {
+  const baseExcludedRanges = findDelimiterExclusionRanges(content);
+  const svelteDirectives = findSvelteDirectiveRanges(content, baseExcludedRanges);
+  const excludedRanges = mergeProtectedRanges([...baseExcludedRanges, ...svelteDirectives]);
+  const htmlLiterals = findHtmlLiteralRanges(content, excludedRanges);
+  return mergeProtectedRanges([...excludedRanges, ...htmlLiterals]);
+}
+
+function normalizeProjectedWhitespace(content: string): string {
+  const protectedRanges = findProtectedRanges(content);
+  return content
+    .replace(/\n{3,}/g, (newlines, offset: number) => {
+      const end = offset + newlines.length;
+      const overlapsLiteral = protectedRanges.some(
+        (range) => range.start < end && range.end > offset,
+      );
+      return overlapsLiteral ? newlines : "\n\n";
+    })
+    .trim();
+}
+
+/** Find audience declarations that cannot be projected consistently at build time. */
+export function findDocsAudienceMdxIssues(content: string): DocsAudienceMdxIssue[] {
+  const issues: DocsAudienceMdxIssue[] = [];
+
+  for (const tag of findDocsAudienceMdxTags(content)) {
+    if (tag.closing) continue;
+    const { attributes } = tag;
+    const hasOnlyAttribute = tag.hasOnlyAttribute ?? /(?:^|\s)only\s*=/.test(attributes);
+    const hasSpreadAttribute = tag.hasSpreadAttribute ?? /\{\s*\.\.\./.test(attributes);
+
+    if ((tag.name === "Agent" || tag.name === "Human") && hasOnlyAttribute) {
+      const shorthandAudience = tag.name === "Agent" ? "agent" : "human";
+      issues.push({
+        code: tag.name === "Agent" ? "ignored-agent-only" : "ignored-human-only",
+        index: tag.index,
+        message: `<${tag.name}> is always ${shorthandAudience}-only, so its \`only\` prop is ignored. Use <Audience only="${shorthandAudience}"> when you need the explicit form.`,
+      });
+      continue;
+    }
+
+    if (tag.name !== "Audience") continue;
+    if (hasSpreadAttribute) {
+      issues.push({
+        code: "dynamic-only",
+        index: tag.index,
+        message:
+          'Audience spread props cannot be projected consistently. Remove the spread and use the static literal `only="human"` or `only="agent"`.',
+      });
+      continue;
+    }
+    if (tag.only) continue;
+    if (!hasOnlyAttribute) {
+      issues.push({
+        code: "missing-only",
+        index: tag.index,
+        message: '<Audience> requires the static literal `only="human"` or `only="agent"`.',
+      });
+      continue;
+    }
+
+    const dynamicOnly = tag.onlyKind === "dynamic" || /(?:^|\s)only\s*=\s*\{/.test(attributes);
+    issues.push({
+      code: dynamicOnly ? "dynamic-only" : "invalid-only",
+      index: tag.index,
+      message: dynamicOnly
+        ? 'Dynamic Audience.only expressions cannot be projected consistently. Use the static literal `only="human"` or `only="agent"`.'
+        : 'Audience.only must be the static literal `"human"` or `"agent"`.',
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Resolve MDX into its human or agent projection.
+ *
+ * `<Agent>` is shorthand for `<Audience only="agent">`, while `<Human>` is
+ * shorthand for `<Audience only="human">`. Unknown `Audience.only` values are
+ * treated as shared content so an authoring typo never silently deletes content.
+ * These primitives shape content for each surface; they are not an access-control boundary.
+ */
+export function resolveDocsAudienceMdxContent(
+  content: string,
+  audience: DocsContentAudience,
+): string {
+  const scopes: DocsAudienceScope[] = [];
+  let output = "";
+  let cursor = 0;
+  let resolvedTag = false;
+
+  for (const tag of findDocsAudienceMdxTags(content)) {
+    const activeScope = scopes.at(-1);
+    if (tag.closing && activeScope?.name !== tag.name) continue;
+    resolvedTag = true;
+
+    const visibleBeforeTag = isAudienceVisible(scopes, audience);
+    if (visibleBeforeTag) {
+      output += content.slice(cursor, tag.index);
+    }
+    cursor = tag.end;
+
+    if (tag.closing) {
+      if (tag.expression && visibleBeforeTag) output += "</>";
+      scopes.pop();
+      continue;
+    }
+
+    if (tag.selfClosing) {
+      if (tag.expression && visibleBeforeTag) output += tag.jsxChild ? "{null}" : "null";
+      continue;
+    }
+
+    scopes.push({ name: tag.name, only: tag.only });
+    if (tag.expression && visibleBeforeTag) {
+      output += isAudienceVisible(scopes, audience) ? "<>" : tag.jsxChild ? "{null}" : "null";
+    }
+  }
+
+  if (isAudienceVisible(scopes, audience)) output += content.slice(cursor);
+
+  return resolvedTag ? normalizeProjectedWhitespace(output) : content;
+}
+
+/** Backwards-compatible name retained for existing integrations. */
+export function resolveDocsAgentMdxContent(content: string, audience: DocsContentAudience): string {
+  return resolveDocsAudienceMdxContent(content, audience);
+}

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -97,7 +97,9 @@ pnpm add example
       path.join(tmpDir, "docs", "guides", "install", "agent.md"),
       `# Install for agents
 
-Run the exact package command.
+<Human>Follow the visual installation wizard.</Human>
+
+<Audience only="agent">Run the exact package command.</Audience>
 
 \`\`\`sh
 pnpm add example
@@ -137,6 +139,7 @@ pnpm add example
     expect(page).toContain("# Install for agents");
     expect(page).toContain("pnpm add example");
     expect(page).not.toContain("Human instructions");
+    expect(page).not.toContain("visual installation wizard");
     expect(page).not.toContain("last_updated:");
 
     expect(readFileSync(path.join(tmpDir, "public", "llms.txt"), "utf-8")).toContain(
@@ -144,9 +147,12 @@ pnpm add example
     );
     expect(existsSync(path.join(tmpDir, "public", "docs", "llms.txt"))).toBe(true);
     expect(existsSync(path.join(tmpDir, "public", "docs", "llms-full.txt"))).toBe(true);
-    expect(
-      readFileSync(path.join(tmpDir, "public", "docs", "guides", "llms-full.txt"), "utf-8"),
-    ).toContain("pnpm add example");
+    const guidesLlmsFull = readFileSync(
+      path.join(tmpDir, "public", "docs", "guides", "llms-full.txt"),
+      "utf-8",
+    );
+    expect(guidesLlmsFull).toContain("pnpm add example");
+    expect(guidesLlmsFull).not.toContain("visual installation wizard");
 
     const discovery = JSON.parse(
       readFileSync(path.join(tmpDir, "public", ".well-known", "agent.json"), "utf-8"),

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -1132,8 +1132,12 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
         markdownUrl: staticMarkdownRoute(page, sourceEntry, routeEntry),
         title: page.title,
         description: page.description,
-        content:
-          page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent ?? page.content,
+        content: page.content,
+        rawContent: page.rawContent,
+        agentContent: page.agentContent,
+        agentRawContent: page.agentRawContent,
+        agentFallbackContent: page.agentFallbackContent,
+        agentFallbackRawContent: page.agentFallbackRawContent,
       })),
       llms,
     );

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -514,6 +514,7 @@ function buildResolvedPageSourceDocument(page: DocsMcpPage): string {
   return stripGeneratedPageAgentContractMarkdown(
     renderDocsMarkdownDocument({
       ...page,
+      agentContent: undefined,
       agentRawContent: undefined,
     }),
   );

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -474,6 +474,50 @@ Use this docs site through markdown routes and MCP.
     }
   });
 
+  it("counts human-only primitives as audience-tailored coverage without usefulness credit", async () => {
+    writePackageJson(tmpDir, "doctor-human-audience", { next: "16.0.0" });
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  agent: { evaluations: false },
+};`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "page.mdx"),
+      `---
+title: Overview
+description: Docs home
+---
+
+# Overview
+
+<Human>Use the interactive setup wizard.</Human>
+<Audience only="human">This screenshot is for readers.</Audience>
+`,
+      "utf-8",
+    );
+    process.chdir(tmpDir);
+
+    const report = await inspectAgentReadiness();
+    const coverage = report.checks.find((check) => check.id === "coverage");
+    const quality = report.checks.find((check) => check.id === "agent-context-quality");
+
+    expect(report.coverage).toMatchObject({
+      totalPages: 1,
+      pagesWithAgentFiles: 0,
+      pagesWithAgentBlocks: 1,
+      explicitPages: 1,
+      explicitCoverage: 100,
+    });
+    expect(coverage).toMatchObject({ title: "Audience-tailored page optimization" });
+    expect(coverage?.detail).toContain("1 page with embedded audience projections");
+    expect(report.usefulness?.agentBlocks.total).toBe(0);
+    expect(quality?.detail).toContain("No embedded agent-only blocks");
+  });
+
   it("uses the detected project framework when scoring page applicability", async () => {
     writePackageJson(tmpDir, "doctor-framework-mismatch", { next: "16.0.0" });
     writeFileSync(

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -94,6 +94,7 @@ export interface AgentDoctorCheck {
 export interface AgentDoctorCoverage {
   totalPages: number;
   pagesWithAgentFiles: number;
+  /** Pages whose embedded audience primitives produce distinct human and agent projections. */
   pagesWithAgentBlocks: number;
   explicitPages: number;
   explicitCoverage: number;
@@ -2900,16 +2901,16 @@ export async function inspectAgentReadiness(
   checks.push(
     makeCheck(
       "coverage",
-      "Explicit page optimization",
+      "Audience-tailored page optimization",
       coverageResult.status,
       coverageResult.score,
       10,
       coverage.totalPages > 0
-        ? `${coverage.explicitPages}/${coverage.totalPages} pages define explicit machine-only context (${coverage.pagesWithAgentFiles} agent.md, ${coverage.pagesWithAgentBlocks} Agent blocks, ${coverage.explicitCoverage}% of pages).`
-        : "No docs pages were available to score explicit page optimization.",
+        ? `${coverage.explicitPages}/${coverage.totalPages} pages define audience-tailored context (${coverage.pagesWithAgentFiles} page${coverage.pagesWithAgentFiles === 1 ? "" : "s"} with agent.md, ${coverage.pagesWithAgentBlocks} page${coverage.pagesWithAgentBlocks === 1 ? "" : "s"} with embedded audience projections, ${coverage.explicitCoverage}% of pages).`
+        : "No docs pages were available to score audience-tailored page optimization.",
       coverage.explicitCoverage >= 50
         ? undefined
-        : "Add agent.md files or <Agent> blocks to more pages, or run docs agent compact to create page-level machine docs.",
+        : 'Add agent.md files or audience primitives such as <Agent>, <Human>, or <Audience only="agent"> to more pages, or run docs agent compact to create page-level machine docs.',
     ),
   );
 
@@ -2921,12 +2922,12 @@ export async function inspectAgentReadiness(
       contextQualityResult.score,
       15,
       usefulness.metrics.agentBlocks.total > 0
-        ? `${usefulness.metrics.agentBlocks.useful}/${usefulness.metrics.agentBlocks.total} Agent blocks are specific and non-repetitive (${usefulness.metrics.agentBlocks.duplicate} duplicate, ${usefulness.metrics.agentBlocks.boilerplate} boilerplate, ${usefulness.metrics.agentBlocks.generic} generic).`
-        : "No embedded Agent blocks were present; page contracts and sibling agent.md files remain available as alternatives.",
+        ? `${usefulness.metrics.agentBlocks.useful}/${usefulness.metrics.agentBlocks.total} agent-only blocks are specific and non-repetitive (${usefulness.metrics.agentBlocks.duplicate} duplicate, ${usefulness.metrics.agentBlocks.boilerplate} boilerplate, ${usefulness.metrics.agentBlocks.generic} generic).`
+        : "No embedded agent-only blocks were present; page contracts and sibling agent.md files remain available as alternatives.",
       usefulness.metrics.agentBlocks.total > 0 &&
         usefulness.metrics.agentBlocks.useful === usefulness.metrics.agentBlocks.total
         ? undefined
-        : "Replace repeated Agent boilerplate with page-specific constraints, commands, files, expected results, and recovery guidance.",
+        : "Replace repeated agent-only boilerplate with page-specific constraints, commands, files, expected results, and recovery guidance.",
     ),
   );
 
@@ -3353,11 +3354,11 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
     console.log(`${pc.bold("Hosted URL:")} ${report.url}`);
   }
   console.log(
-    `${pc.bold("Explicit agent-friendly pages:")} ${report.coverage.explicitPages}/${report.coverage.totalPages} pages ${pc.dim(`(${report.coverage.explicitCoverage}%)`)}`,
+    `${pc.bold("Audience-tailored pages:")} ${report.coverage.explicitPages}/${report.coverage.totalPages} pages ${pc.dim(`(${report.coverage.explicitCoverage}%)`)}`,
   );
   if (report.usefulness) {
     console.log(
-      `${pc.bold("Useful Agent blocks:")} ${report.usefulness.agentBlocks.useful}/${report.usefulness.agentBlocks.total} ${pc.dim(`• ${report.usefulness.taskCompleteness.completePages}/${report.usefulness.actionablePages} actionable pages task-complete`)}`,
+      `${pc.bold("Useful agent-only blocks:")} ${report.usefulness.agentBlocks.useful}/${report.usefulness.agentBlocks.total} ${pc.dim(`• ${report.usefulness.taskCompleteness.completePages}/${report.usefulness.actionablePages} actionable pages task-complete`)}`,
     );
   }
   if (report.evaluations) {

--- a/packages/docs/src/cli/review.test.ts
+++ b/packages/docs/src/cli/review.test.ts
@@ -408,6 +408,102 @@ Point to the closest related docs instead of inventing config.
     expect(report.score).toBeLessThan(100);
   });
 
+  it("accepts Agent and agent-only Audience blocks but not human-only audience content", async () => {
+    mkdirSync(join(tmpDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  review: {
+    rules: {
+      agentContext: "warn",
+      goldenTasks: "off",
+    },
+  },
+};
+`,
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "page.mdx"),
+      `---
+title: Docs
+description: Docs home
+---
+
+Overview.
+`,
+      "utf-8",
+    );
+
+    git(["init"]);
+    git(["config", "user.email", "docs@example.com"]);
+    git(["config", "user.name", "Docs Test"]);
+    git(["add", "."]);
+    git(["commit", "-m", "initial docs"]);
+
+    const pages = [
+      [
+        "agent",
+        '<Agent audience="implementation">The contract targets `docs.config.ts` v2.0.0.</Agent>',
+      ],
+      [
+        "audience-agent",
+        "<Audience only={'agent'}>The contract targets `src/docs.ts` v2.0.0.</Audience>",
+      ],
+      [
+        "audience-dynamic",
+        "<Audience only={runtimeAudience}>The runtime audience is unsupported.</Audience>",
+      ],
+      ["human", "<Human>Use the interactive setup form.</Human>"],
+      ["audience-human", '<Audience only="human">Use the interactive setup form.</Audience>'],
+    ] as const;
+
+    for (const [slug, audienceBlock] of pages) {
+      mkdirSync(join(tmpDir, "app", "docs", slug), { recursive: true });
+      writeFileSync(
+        join(tmpDir, "app", "docs", slug, "page.mdx"),
+        `---
+title: ${slug}
+description: ${slug} page
+---
+
+Configure the docs implementation.
+
+${audienceBlock}
+`,
+        "utf-8",
+      );
+    }
+
+    git(["add", "."]);
+    git(["commit", "-m", "add audience pages"]);
+    process.chdir(tmpDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const report = await runReview({ ci: true });
+
+    expect(report?.status).toBe("measured");
+    if (!report || report.status !== "measured") throw new Error("Expected a measured review");
+    const missingAgentContext = report.findings
+      .filter((finding) => finding.message.startsWith("Implementation-heavy docs page"))
+      .map((finding) => finding.file);
+    expect(missingAgentContext).toEqual([
+      "app/docs/audience-dynamic/page.mdx",
+      "app/docs/audience-human/page.mdx",
+      "app/docs/human/page.mdx",
+    ]);
+    expect(report.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: "app/docs/audience-dynamic/page.mdx",
+          code: "audience-dynamic-only",
+          severity: "warn",
+        }),
+      ]),
+    );
+  });
+
   function git(args: string[]) {
     execFileSync("git", args, { cwd: tmpDir, stdio: "ignore" });
   }

--- a/packages/docs/src/cli/review.ts
+++ b/packages/docs/src/cli/review.ts
@@ -20,9 +20,11 @@ import { analyzeAgentSurfaceDrift } from "../agent-surface-drift.js";
 import {
   analyzeAgentUsefulness,
   createAgentUsefulnessPagesFromMcp,
+  extractAgentBlocks,
   type AgentUsefulnessMetrics,
 } from "../agent-usefulness.js";
 import { runDocsGoldenTasks, type DocsGoldenTasksReport } from "../agent-evals.js";
+import { findDocsAudienceMdxIssues } from "../audience.js";
 import {
   createFilesystemDocsMcpSource,
   getDocsConfigSchema,
@@ -653,6 +655,17 @@ function checkAgentContext(
   review: ResolvedDocsReviewConfig,
   options: { file: string; source: string; rootDir: string; agent: unknown },
 ) {
+  for (const issue of findDocsAudienceMdxIssues(options.source)) {
+    pushFinding(findings, review, {
+      rule: "agentContext",
+      code: `audience-${issue.code}`,
+      severity: issue.code === "dynamic-only" ? "error" : "warn",
+      file: options.file,
+      line: lineForIndex(options.source, issue.index),
+      message: issue.message,
+    });
+  }
+
   for (const issue of getPageAgentFrontmatterIssues(options.agent)) {
     pushFinding(findings, review, {
       rule: "agentContext",
@@ -702,7 +715,7 @@ function checkAgentContext(
     if (agent?.task && agent.outcome) return;
   }
 
-  if (options.source.includes("<Agent>") || options.source.includes("</Agent>")) return;
+  if (extractAgentBlocks(options.source, { sourcePath: options.file }).length > 0) return;
   if (existsSync(path.join(path.dirname(path.join(options.rootDir, options.file)), "agent.md")))
     return;
   if (
@@ -718,7 +731,8 @@ function checkAgentContext(
     severity: "suggestion",
     file: options.file,
     line: 1,
-    message: "Implementation-heavy docs page could use an <Agent> block or sibling agent.md.",
+    message:
+      'Implementation-heavy docs page could use an <Agent> block, <Audience only="agent"> block, or sibling agent.md.',
   });
 }
 
@@ -765,7 +779,7 @@ function printReviewReport(report: DocsReviewMeasuredReport) {
   );
   if (report.usefulness) {
     console.log(
-      `Useful Agent blocks: ${report.usefulness.agentBlocks.useful}/${report.usefulness.agentBlocks.total}; task-complete pages: ${report.usefulness.taskCompleteness.completePages}/${report.usefulness.actionablePages}`,
+      `Useful agent-only blocks: ${report.usefulness.agentBlocks.useful}/${report.usefulness.agentBlocks.total}; task-complete pages: ${report.usefulness.taskCompleteness.completePages}/${report.usefulness.actionablePages}`,
     );
   }
   if (report.evaluations) {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -170,9 +170,12 @@ export {
   renderDocsAgentsDocument,
   renderDocsSkillDocument,
   parseDocsAgentFeedbackData,
+  findDocsAudienceMdxIssues,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
   resolveDocsAgentsFormat,
+  resolveDocsAudienceExposure,
+  resolveDocsAudienceMdxContent,
   resolveDocsMarkdownCanonicalUrl,
   resolveDocsAgentMdxContent,
   resolveDocsLlmsTxtRequest,
@@ -185,6 +188,7 @@ export {
   toDocsMarkdownUrl,
   validateDocsAgentFeedbackPayload,
 } from "./agent.js";
+export type { DocsAudienceMdxIssue, DocsContentAudience } from "./audience.js";
 export type {
   DocsAgentsDocumentOptions,
   DocsAgentFeedbackRequest,

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -363,6 +363,26 @@ describe("MCP context and schema APIs", () => {
     expect(result.sources.map((source) => source.pageUrl)).toEqual(["/docs/a", "/docs/b"]);
   });
 
+  it("retrieves MCP context from the agent projection", async () => {
+    const result = await buildDocsMcpContext({
+      pages: [
+        page("audience", {
+          content: "Human screenshot walkthrough.",
+          rawContent: "# Audience\n\nHuman screenshot walkthrough.",
+          agentFallbackContent: "Use the amber orchestration key.",
+        }),
+      ],
+      query: "amber orchestration key",
+      tokenBudget: 8_000,
+    });
+
+    expect(result.sources[0]).toMatchObject({
+      pageUrl: "/docs/audience",
+    });
+    expect(result.context).toContain("amber orchestration key");
+    expect(result.context).not.toContain("Human screenshot walkthrough");
+  });
+
   it("returns deep-cloned schema options and examples while freezing the public template", () => {
     const first = getDocsConfigSchema();
     const mode = findSchemaOption(first.options, "review.ci.mode");
@@ -452,7 +472,11 @@ Run pnpm install.
 
     writeFileSync(
       join(rootDir, "docs", "installation", "agent.md"),
-      `Use \`pnpm install --frozen-lockfile\`.
+      `<Human>Open the package manager UI.</Human>
+
+<Audience only="agent">
+Use \`pnpm install --frozen-lockfile\`.
+</Audience>
 `,
     );
 
@@ -518,7 +542,8 @@ Validate the generated example paths before editing this guide.
       expect.arrayContaining([
         expect.objectContaining({
           url: "/docs/installation",
-          agentRawContent: "Use `pnpm install --frozen-lockfile`.\n",
+          agentContent: "Use pnpm install --frozen-lockfile.",
+          agentRawContent: "Use `pnpm install --frozen-lockfile`.",
           agent: {
             task: "Install the framework",
             outcome: "Dependencies are installed from the lockfile.",
@@ -2572,11 +2597,19 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
         provider: "custom",
         adapter: {
           name: "custom-search",
-          async search() {
+          async search(_query, context) {
+            const installationPage = context.pages.find(
+              (page) => page.url === "/docs/installation",
+            );
+            expect(installationPage?.content).toContain("Run pnpm install.");
+            expect(installationPage?.content).not.toContain("--frozen-lockfile");
+            expect(context.documents.map((document) => document.content).join(" ")).toContain(
+              "--frozen-lockfile",
+            );
             return [
               {
                 id: "custom-hit",
-                url: "/docs/custom-hit",
+                url: "/docs/installation",
                 content: "Custom search result",
                 description: "Resolved through the shared adapter pipeline.",
                 type: "page",
@@ -2641,8 +2674,9 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
       result?: { content?: Array<{ text?: string }> };
     }>(searchResponse);
 
-    expect(searchPayload.result?.content?.[0]?.text).toContain("/docs/custom-hit");
-    expect(searchPayload.result?.content?.[0]?.text).toContain("Custom search result");
+    expect(searchPayload.result?.content?.[0]?.text).toContain('"id": "custom-hit"');
+    expect(searchPayload.result?.content?.[0]?.text).toContain("/docs/installation");
+    expect(searchPayload.result?.content?.[0]?.text).not.toContain("Custom search result");
   });
 
   it("falls back to simple search for self-referential MCP search configs", async () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -7,6 +7,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod/v4";
 import { stripGeneratedAgentProvenance } from "./agent-provenance.js";
+import { resolveDocsAudienceMdxContent } from "./audience.js";
 import {
   hasStructuredPageAgentContract,
   normalizePageAgentFrontmatter,
@@ -2637,6 +2638,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             pages: toSearchSourcePages(pages),
             query,
             search: toolSearchConfig ?? true,
+            audience: "agent",
             locale,
             siteTitle: options.source.siteTitle,
             limit: resolvedLimit,
@@ -3678,85 +3680,6 @@ function titleize(value: string): string {
   return value.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function resolveAgentMdxContent(content: string, audience: "human" | "agent"): string {
-  const lines = content.split("\n");
-  const output: string[] = [];
-  let fenceMarker: string | null = null;
-  let agentDepth = 0;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
-
-    if (fenceMatch) {
-      if (!fenceMarker) {
-        fenceMarker = fenceMatch[1];
-      } else if (trimmed.startsWith(fenceMarker)) {
-        fenceMarker = null;
-      }
-
-      if (audience === "agent" || agentDepth === 0) {
-        output.push(line);
-      }
-      continue;
-    }
-
-    if (!fenceMarker) {
-      if (/^<Agent(?:\s[^>]*)?\/>$/.test(trimmed)) {
-        continue;
-      }
-
-      const singleLineMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>([\s\S]*?)<\/Agent>\s*$/);
-      if (singleLineMatch) {
-        if (audience === "agent" && singleLineMatch[2]) {
-          output.push(`${singleLineMatch[1]}${singleLineMatch[2]}`);
-        }
-        continue;
-      }
-
-      const openMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>\s*$/);
-      if (openMatch) {
-        agentDepth += 1;
-        continue;
-      }
-
-      const openWithContentMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>(.*)$/);
-      if (openWithContentMatch) {
-        agentDepth += 1;
-        if (audience === "agent" && openWithContentMatch[2]) {
-          output.push(`${openWithContentMatch[1]}${openWithContentMatch[2]}`);
-        }
-        continue;
-      }
-
-      const closeWithContentMatch = line.match(/^(.*)<\/Agent>\s*$/);
-      if (closeWithContentMatch && agentDepth > 0) {
-        if (audience === "agent" && closeWithContentMatch[1]) {
-          output.push(closeWithContentMatch[1]);
-        }
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-
-      if (/^<\/Agent>\s*$/.test(trimmed) && agentDepth > 0) {
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-    }
-
-    if (agentDepth > 0 && audience === "human") {
-      continue;
-    }
-
-    output.push(line);
-  }
-
-  return output
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 function stripMarkdownForMcp(content: string): string {
   return content
     .replace(/^(import|export)\s.*$/gm, "")
@@ -3847,8 +3770,8 @@ function scanFilesystemDocsPages(
         hasVisibleDescendantFilesystemDocsPage(dir);
       if (hiddenFolderIndex) continue;
 
-      const humanRawContent = resolveAgentMdxContent(content, "human");
-      const pageAgentRawContent = resolveAgentMdxContent(content, "agent");
+      const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+      const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
       const pageAgentContent =
         pageAgentRawContent !== humanRawContent
           ? stripMarkdownForMcp(pageAgentRawContent)
@@ -3902,9 +3825,10 @@ function readFilesystemAgentDoc(dir: string) {
 
   const raw = stripGeneratedAgentProvenance(fs.readFileSync(agentPath, "utf-8"));
   const { content } = matter(raw);
+  const agentContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdownForMcp(content),
-    agentRawContent: content,
+    agentContent: stripMarkdownForMcp(agentContent),
+    agentRawContent: agentContent,
   };
 }
 
@@ -4058,8 +3982,8 @@ function toSearchSourcePages(pages: DocsMcpPage[]): DocsSearchSourcePage[] {
   return pages.map((page) => ({
     title: page.title,
     url: page.url,
-    content: page.agentContent ?? page.agentFallbackContent ?? page.content,
-    rawContent: page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent,
+    content: page.content,
+    rawContent: page.rawContent,
     sourcePath: page.sourcePath,
     lastModified: page.lastModified,
     locale: page.locale,
@@ -4549,7 +4473,13 @@ function countDocsSections(sections: DocsMcpDocsSection[]): number {
 }
 
 function extractDocsMcpCodeExamples(page: DocsMcpPage): DocsMcpCodeExample[] {
-  const source = page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent;
+  const source =
+    page.agentRawContent ??
+    page.agentFallbackRawContent ??
+    page.agentContent ??
+    page.agentFallbackContent ??
+    page.rawContent ??
+    page.content;
   if (!source) return [];
 
   const examples: DocsMcpCodeExample[] = [];
@@ -4827,9 +4757,9 @@ function getDocsMcpSourceMarkdown(page: DocsMcpPage): string {
   return (
     page.agentRawContent ??
     page.agentFallbackRawContent ??
-    page.rawContent ??
     page.agentContent ??
     page.agentFallbackContent ??
+    page.rawContent ??
     page.content
   );
 }
@@ -4957,6 +4887,7 @@ export async function buildDocsMcpContext(
       maxResults: 50,
       chunking: { strategy: "section" },
     },
+    audience: "agent",
     locale: options.locale,
     siteTitle: options.siteTitle,
     limit: 50,
@@ -5143,8 +5074,9 @@ function normalizeUrlPath(value: string): string {
 }
 
 function renderPageDocument(page: DocsMcpPage): string {
-  if (page.agentRawContent !== undefined) {
-    return upsertPageAgentContractMarkdown(page.agentRawContent, page.agent);
+  const explicitAgentContent = page.agentRawContent ?? page.agentContent;
+  if (explicitAgentContent !== undefined) {
+    return upsertPageAgentContractMarkdown(explicitAgentContent, page.agent);
   }
 
   const relatedLines = renderDocsRelatedMarkdownLines(page.related);
@@ -5155,7 +5087,7 @@ function renderPageDocument(page: DocsMcpPage): string {
   lines.push(
     "",
     upsertPageAgentContractMarkdown(
-      page.agentFallbackRawContent ?? page.rawContent ?? page.content,
+      page.agentFallbackRawContent ?? page.agentFallbackContent ?? page.rawContent ?? page.content,
       page.agent,
     ),
   );

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -896,6 +896,89 @@ pnpm add @farming-labs/docs
     expect(context.context).not.toContain("Human coral walkthrough");
   });
 
+  it("sanitizes MCP snippets for local pages against the agent projection", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              serverInfo: { name: "remote-docs", version: "1.0.0" },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    results: [
+                      {
+                        id: "mcp-audience-safe",
+                        url: "/docs/audience-safe",
+                        content: "Audience-safe retrieval",
+                        description: "Human coral walkthrough.",
+                        type: "page",
+                      },
+                    ],
+                  }),
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ) as typeof fetch;
+
+    try {
+      const context = await buildDocsAskAIContext({
+        pages: [
+          {
+            title: "Audience-safe retrieval",
+            url: "/docs/audience-safe",
+            content: "Shared setup. Human coral walkthrough.",
+            rawContent: "# Audience-safe retrieval\n\nShared setup. Human coral walkthrough.",
+            agentFallbackContent: "Shared setup. Agent indigo procedure.",
+            agentFallbackRawContent:
+              "# Audience-safe retrieval\n\nShared setup. Agent indigo procedure.",
+          },
+        ],
+        query: "shared setup",
+        search: {
+          provider: "mcp",
+          endpoint: "https://remote.example/mcp",
+        },
+        limit: 1,
+      });
+
+      expect(context.searchResults.some((result) => result.id === "mcp-audience-safe")).toBe(true);
+      expect(JSON.stringify(context.searchResults)).not.toContain("Human coral walkthrough");
+      expect(context.context).toContain("Agent indigo procedure");
+      expect(context.context).not.toContain("Human coral walkthrough");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("keeps duplicate heading titles on the same page when URL hashes differ", async () => {
     const context = await buildDocsAskAIContext({
       pages: [

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -64,6 +64,35 @@ Second section.
     ]);
   });
 
+  it("builds distinct human and agent audience indexes", () => {
+    const audiencePages = [
+      {
+        title: "Audience policy",
+        url: "/docs/audience",
+        content: "Shared text. Human troubleshooting token.",
+        rawContent: "# Audience policy\n\nShared text. Human troubleshooting token.",
+        agentFallbackContent: "Shared text. Agent execution token.",
+        agentFallbackRawContent: "# Audience policy\n\nShared text. Agent execution token.",
+      },
+    ];
+
+    const humanDocuments = buildDocsSearchDocuments(audiencePages);
+    const agentDocuments = buildDocsSearchDocuments(audiencePages, {}, "agent");
+
+    expect(humanDocuments.map((document) => document.content).join(" ")).toContain(
+      "Human troubleshooting token",
+    );
+    expect(humanDocuments.map((document) => document.content).join(" ")).not.toContain(
+      "Agent execution token",
+    );
+    expect(agentDocuments.map((document) => document.content).join(" ")).toContain(
+      "Agent execution token",
+    );
+    expect(agentDocuments.map((document) => document.content).join(" ")).not.toContain(
+      "Human troubleshooting token",
+    );
+  });
+
   it("uses CommonMark headings and never treats fenced shell comments as headings", () => {
     const documents = buildDocsSearchDocuments([
       {
@@ -188,6 +217,82 @@ export const auth = betterAuth({});
 });
 
 describe("performDocsSearch", () => {
+  it("keeps public search human-only while allowing explicit agent retrieval", async () => {
+    const audiencePages = [
+      {
+        title: "Audience policy",
+        url: "/docs/audience",
+        content: "Human walkthrough.",
+        rawContent: "# Audience policy\n\nHuman walkthrough.",
+        agentFallbackContent: "Use the cobalt automation token.",
+        agentFallbackRawContent: "# Audience policy\n\nUse the cobalt automation token.",
+      },
+    ];
+
+    const humanResults = await performDocsSearch({
+      pages: audiencePages,
+      query: "cobalt automation token",
+    });
+    const agentResults = await performDocsSearch({
+      pages: audiencePages,
+      query: "cobalt automation token",
+      audience: "agent",
+    });
+
+    expect(humanResults).toHaveLength(0);
+    expect(agentResults[0]?.url).toBe("/docs/audience");
+  });
+
+  it("never syncs the agent projection into a public hosted index", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ hits: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ) as typeof fetch;
+
+    try {
+      await performDocsSearch({
+        pages: [
+          {
+            title: "Audience sync",
+            url: "/docs/audience-sync",
+            content: "Human coral walkthrough.",
+            rawContent: "# Audience sync\n\nHuman coral walkthrough.",
+            agentFallbackContent: "Agent indigo procedure.",
+            agentFallbackRawContent: "# Audience sync\n\nAgent indigo procedure.",
+          },
+        ],
+        query: "indigo procedure",
+        audience: "agent",
+        search: {
+          provider: "algolia",
+          appId: "audience-sync-app",
+          indexName: "audience-sync-index",
+          searchApiKey: "search-key",
+          adminApiKey: "admin-key",
+          syncOnSearch: true,
+        },
+      });
+
+      const syncPayload = JSON.parse(
+        String(vi.mocked(globalThis.fetch).mock.calls[0]?.[1]?.body),
+      ) as { requests: Array<{ body: { content?: string } }> };
+      const indexedContent = syncPayload.requests
+        .map((request) => request.body.content ?? "")
+        .join(" ");
+      expect(indexedContent).toContain("Human coral walkthrough");
+      expect(indexedContent).not.toContain("Agent indigo procedure");
+    } finally {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    }
+  });
+
   it("returns simple search results with snippets", async () => {
     const results = await performDocsSearch({
       pages,
@@ -443,7 +548,7 @@ Customize the loading UI.
     expect(results[0]?.url?.startsWith("/docs/installation")).toBe(true);
   });
 
-  it("uses an MCP adapter when configured", async () => {
+  it("trusts agent-native MCP results without matching them to the local human index", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi
       .fn()
@@ -479,11 +584,11 @@ Customize the loading UI.
                     results: [
                       {
                         id: "mcp-1",
-                        url: "/docs/installation",
-                        content: "Installation — Quickstart",
-                        description: "Pulled from MCP search_docs.",
+                        url: "/docs/remote-agent-runbook",
+                        content: "Remote agent runbook",
+                        description: "Agent-only procedure from MCP search_docs.",
                         type: "heading",
-                        section: "Quickstart",
+                        section: "Procedure",
                       },
                     ],
                   }),
@@ -503,7 +608,9 @@ Customize the loading UI.
     try {
       const results = await performDocsSearch({
         pages,
-        query: "quickstart",
+        query: "remote agent runbook",
+        audience: "agent",
+        limit: 1,
         search: resolveSearchRequestConfig(
           {
             provider: "mcp",
@@ -516,12 +623,12 @@ Customize the loading UI.
       expect(results).toEqual([
         {
           id: "mcp-1",
-          url: "/docs/installation",
-          content: "Installation — Quickstart",
-          description: "Pulled from MCP search_docs.",
+          url: "/docs/remote-agent-runbook",
+          content: "Remote agent runbook",
+          description: "Agent-only procedure from MCP search_docs.",
           type: "heading",
           score: undefined,
-          section: "Quickstart",
+          section: "Procedure",
         },
       ]);
       expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
@@ -618,6 +725,28 @@ Nine built-in themes are available: fumadocs, darksharp, pixel-border, colorful,
 });
 
 describe("buildDocsAskAIContext", () => {
+  it("retrieves agent-only terms and excludes human-only text", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Audience-aware setup",
+          url: "/docs/audience-aware",
+          content: "Shared introduction. Human screenshot walkthrough.",
+          rawContent: "# Setup\n\nShared introduction. Human screenshot walkthrough.",
+          agentFallbackContent: "Shared introduction. Use the zircon handshake nonce.",
+          agentFallbackRawContent:
+            "# Setup\n\nShared introduction.\n\n## Automation\n\nUse the zircon handshake nonce.",
+        },
+      ],
+      query: "zircon handshake nonce",
+      limit: 1,
+    });
+
+    expect(context.results[0]?.url).toBe("/docs/audience-aware#automation");
+    expect(context.context).toContain("zircon handshake nonce");
+    expect(context.context).not.toContain("Human screenshot walkthrough");
+  });
+
   it("retrieves and includes a contract when only its task terms match", async () => {
     const context = await buildDocsAskAIContext({
       pages: [
@@ -731,6 +860,42 @@ pnpm add @farming-labs/docs
     expect(context.context).toContain("pnpm add @farming-labs/docs");
   });
 
+  it("sanitizes hosted search snippets against the agent projection", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Audience-safe retrieval",
+          url: "/docs/audience-safe",
+          content: "Shared setup. Human coral walkthrough.",
+          rawContent: "# Audience-safe retrieval\n\nShared setup. Human coral walkthrough.",
+          agentFallbackContent: "Shared setup. Agent indigo procedure.",
+          agentFallbackRawContent:
+            "# Audience-safe retrieval\n\nShared setup. Agent indigo procedure.",
+        },
+      ],
+      query: "shared setup",
+      search: createCustomSearchAdapter({
+        name: "human-index",
+        async search() {
+          return [
+            {
+              id: "hosted-audience-safe",
+              url: "/docs/audience-safe",
+              content: "Audience-safe retrieval",
+              description: "Human coral walkthrough.",
+              type: "page",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(context.searchResults.some((result) => result.id === "hosted-audience-safe")).toBe(true);
+    expect(JSON.stringify(context.searchResults)).not.toContain("Human coral walkthrough");
+    expect(context.context).toContain("Agent indigo procedure");
+    expect(context.context).not.toContain("Human coral walkthrough");
+  });
+
   it("keeps duplicate heading titles on the same page when URL hashes differ", async () => {
     const context = await buildDocsAskAIContext({
       pages: [
@@ -814,9 +979,7 @@ Sensitive whole-page fallback content.
       }),
     });
 
-    expect(context.searchResults).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "stale-anchor" })]),
-    );
+    expect(context.searchResults).toEqual([]);
     expect(context.results).toEqual([]);
     expect(context.context).not.toContain("Sensitive whole-page fallback content.");
   });

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -487,6 +487,7 @@ function mergeSearchResults(...groups: DocsSearchResult[][]): DocsSearchResult[]
 function sanitizeExternalAgentSearchResults(
   results: DocsSearchResult[],
   localAgentResults: DocsSearchResult[],
+  preserveUnmatched?: (result: DocsSearchResult) => boolean,
 ): DocsSearchResult[] {
   const localByKey = new Map(
     localAgentResults.map((result) => [getSearchResultKey(result), result] as const),
@@ -503,7 +504,7 @@ function sanitizeExternalAgentSearchResults(
     const local =
       localByKey.get(getSearchResultKey(result)) ??
       localPageResults.get(normalizeUrlPathname(result.url));
-    if (!local) return [];
+    if (!local) return preserveUnmatched?.(result) ? [result] : [];
 
     return [
       {
@@ -1633,13 +1634,20 @@ export async function performDocsSearch(options: {
 
     const localAudienceResults =
       audience === "agent" ? await createSimpleSearchAdapter().search(query, context) : [];
-    // MCP `search_docs` is an agent surface and is expected to return its own
-    // audience-safe projection. Hosted and custom providers may still expose a
-    // human index, so their snippets must be replaced with local agent content.
+    const localPagePaths = new Set(options.pages.map((page) => normalizeUrlPathname(page.url)));
+    // External providers may expose a human index, so local-page snippets must
+    // be replaced with the local agent projection. MCP can also return pages
+    // outside this docs corpus; preserve those agent-native remote results.
     const safeAdapterResults =
-      audience === "agent" && search.provider !== "mcp"
-        ? sanitizeExternalAgentSearchResults(results, localAudienceResults)
-        : results;
+      audience !== "agent"
+        ? results
+        : sanitizeExternalAgentSearchResults(
+            results,
+            localAudienceResults,
+            search.provider === "mcp"
+              ? (result) => !localPagePaths.has(normalizeUrlPathname(result.url))
+              : undefined,
+          );
 
     return prioritizeLiteralInsideResults(
       options.query,

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -20,6 +20,7 @@ import {
   renderPageAgentContractMarkdown,
   upsertPageAgentContractMarkdown,
 } from "./agent-contract.js";
+import type { DocsContentAudience } from "./audience.js";
 import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;
@@ -219,7 +220,12 @@ function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
 
 function getAskAIPageContent(page: DocsSearchSourcePage): string {
   return upsertPageAgentContractMarkdown(
-    page.agentRawContent ?? page.agentFallbackRawContent ?? page.rawContent ?? page.content,
+    page.agentRawContent ??
+      page.agentFallbackRawContent ??
+      page.agentContent ??
+      page.agentFallbackContent ??
+      page.rawContent ??
+      page.content,
     page.agent,
   )
     .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
@@ -478,12 +484,81 @@ function mergeSearchResults(...groups: DocsSearchResult[][]): DocsSearchResult[]
   return results;
 }
 
-function pageToSearchDocument(page: DocsSearchSourcePage): DocsSearchDocument {
+function sanitizeExternalAgentSearchResults(
+  results: DocsSearchResult[],
+  localAgentResults: DocsSearchResult[],
+): DocsSearchResult[] {
+  const localByKey = new Map(
+    localAgentResults.map((result) => [getSearchResultKey(result), result] as const),
+  );
+  const localPageResults = new Map<string, DocsSearchResult>();
+
+  for (const result of localAgentResults) {
+    const pageUrl = normalizeUrlPathname(result.url);
+    const existing = localPageResults.get(pageUrl);
+    if (!existing || result.type === "page") localPageResults.set(pageUrl, result);
+  }
+
+  return results.flatMap((result) => {
+    const local =
+      localByKey.get(getSearchResultKey(result)) ??
+      localPageResults.get(normalizeUrlPathname(result.url));
+    if (!local) return [];
+
+    return [
+      {
+        ...local,
+        id: result.id,
+        score: result.score ?? local.score,
+      },
+    ];
+  });
+}
+
+function getPageAudienceRawContent(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string {
+  if (audience === "agent") {
+    return (
+      page.agentRawContent ??
+      page.agentFallbackRawContent ??
+      page.agentContent ??
+      page.agentFallbackContent ??
+      page.rawContent ??
+      page.content
+    );
+  }
+
+  return page.rawContent ?? page.content;
+}
+
+function getPageAudienceSearchText(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string {
+  if (audience === "agent") {
+    return (
+      page.agentContent ??
+      page.agentFallbackContent ??
+      stripMarkdownText(getPageAudienceRawContent(page, audience))
+    );
+  }
+
+  return page.content || stripMarkdownText(getPageAudienceRawContent(page, audience));
+}
+
+function pageToSearchDocument(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience = "human",
+): DocsSearchDocument {
   return {
     id: makeDocumentId(page.url, "page"),
     url: page.url,
     title: page.title,
-    content: normalizeWhitespace([page.content, getPageAgentContractSearchText(page)].join(" ")),
+    content: normalizeWhitespace(
+      [getPageAudienceSearchText(page, audience), getPageAgentContractSearchText(page)].join(" "),
+    ),
     description: page.description,
     type: "page",
     locale: page.locale,
@@ -496,6 +571,7 @@ function pageToSearchDocument(page: DocsSearchSourcePage): DocsSearchDocument {
 function buildExactPageSearchResults(
   query: string,
   pages: DocsSearchSourcePage[],
+  audience: DocsContentAudience = "human",
 ): DocsSearchResult[] {
   const normalizedQuery = normalizeSearchPhrase(query);
   if (!normalizedQuery) return [];
@@ -503,7 +579,7 @@ function buildExactPageSearchResults(
   const results: DocsSearchResult[] = [];
 
   for (const page of pages) {
-    const document = pageToSearchDocument(page);
+    const document = pageToSearchDocument(page, audience);
     const title = normalizeSearchPhrase(page.title);
     const urlSegments = getUrlSearchSegments(page.url);
     const isExactPageMatch = title === normalizedQuery || urlSegments.includes(normalizedQuery);
@@ -556,10 +632,6 @@ function prioritizeLiteralInsideResults(
   });
 }
 
-function shouldSupplementAskAIWithSimpleSearch(search: ResolvedDocsSearchConfig): boolean {
-  return search.enabled && search.provider !== "simple";
-}
-
 function rankAskAIContextResult(query: string, result: DocsAskAIContextResult): number {
   return scoreDocument(query, {
     id: result.id,
@@ -584,8 +656,11 @@ function makeDocumentId(url: string, suffix: string): string {
   return `${url}#${suffix}`;
 }
 
-function splitPageIntoSections(page: DocsSearchSourcePage): DocsSearchDocument[] {
-  const raw = page.rawContent ?? page.content;
+function splitPageIntoSections(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience = "human",
+): DocsSearchDocument[] {
+  const raw = getPageAudienceRawContent(page, audience);
   return parseDocsMarkdownSections(raw).flatMap((section, index) => {
     const content = normalizeWhitespace(stripMarkdownText(section.content));
     if (!content) return [];
@@ -611,15 +686,16 @@ function splitPageIntoSections(page: DocsSearchSourcePage): DocsSearchDocument[]
 export function buildDocsSearchDocuments(
   pages: DocsSearchSourcePage[],
   chunking: DocsSearchChunkingConfig = {},
+  audience: DocsContentAudience = "human",
 ): DocsSearchDocument[] {
   const strategy = chunking.strategy ?? "section";
 
   return pages.flatMap((page) => {
-    const base = pageToSearchDocument(page);
+    const base = pageToSearchDocument(page, audience);
 
     if (strategy === "page") return [base];
 
-    const sections = splitPageIntoSections(page);
+    const sections = splitPageIntoSections(page, audience);
     if (sections.length === 0) return [base];
 
     const pageSummary = base.content ? [base] : [];
@@ -1515,6 +1591,8 @@ export async function performDocsSearch(options: {
   pages: DocsSearchSourcePage[];
   query: string;
   search?: boolean | DocsSearchConfig;
+  /** Selects which audience projection is searchable. Public site search defaults to human. */
+  audience?: DocsContentAudience;
   locale?: string;
   pathname?: string;
   siteTitle?: string;
@@ -1523,7 +1601,8 @@ export async function performDocsSearch(options: {
   const search = normalizeDocsSearchConfig(options.search);
   if (!search.enabled) return [];
 
-  const documents = buildDocsSearchDocuments(options.pages, search.chunking);
+  const audience = options.audience ?? "human";
+  const documents = buildDocsSearchDocuments(options.pages, search.chunking, audience);
   const context: DocsSearchAdapterContext = {
     pages: options.pages,
     documents,
@@ -1541,13 +1620,34 @@ export async function performDocsSearch(options: {
 
   try {
     const adapter = await resolveSearchAdapter(search, context);
-    await maybeSyncSearchIndex(adapter, search, context);
+    const syncContext =
+      audience === "agent"
+        ? {
+            ...context,
+            documents: buildDocsSearchDocuments(options.pages, search.chunking, "human"),
+          }
+        : context;
+    await maybeSyncSearchIndex(adapter, search, syncContext);
     const results = await adapter.search(query, context);
     if (search.provider === "simple") return results;
 
+    const localAudienceResults =
+      audience === "agent" ? await createSimpleSearchAdapter().search(query, context) : [];
+    // MCP `search_docs` is an agent surface and is expected to return its own
+    // audience-safe projection. Hosted and custom providers may still expose a
+    // human index, so their snippets must be replaced with local agent content.
+    const safeAdapterResults =
+      audience === "agent" && search.provider !== "mcp"
+        ? sanitizeExternalAgentSearchResults(results, localAudienceResults)
+        : results;
+
     return prioritizeLiteralInsideResults(
       options.query,
-      mergeSearchResults(buildExactPageSearchResults(options.query, options.pages), results),
+      mergeSearchResults(
+        buildExactPageSearchResults(options.query, options.pages, audience),
+        safeAdapterResults,
+        localAudienceResults,
+      ),
     ).slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
   } catch {
     return createSimpleSearchAdapter().search(query, context);
@@ -1571,33 +1671,16 @@ export async function buildDocsAskAIContext(options: {
   const initialSearch = options.search === false ? true : options.search;
   const initialSearchConfig = normalizeDocsSearchConfig(initialSearch);
   const primarySearch = initialSearchConfig.enabled ? initialSearch : true;
-  const primarySearchConfig = normalizeDocsSearchConfig(primarySearch);
-  const primarySearchResults = await performDocsSearch({
+  const searchResults = await performDocsSearch({
     pages: options.pages,
     query: options.query,
     search: primarySearch,
+    audience: "agent",
     locale: options.locale,
     pathname: options.pathname,
     siteTitle: options.siteTitle,
     limit: searchLimit,
   });
-  const localSearchResults = shouldSupplementAskAIWithSimpleSearch(primarySearchConfig)
-    ? await performDocsSearch({
-        pages: options.pages,
-        query: options.query,
-        search: {
-          provider: "simple",
-          enabled: true,
-          chunking: primarySearchConfig.chunking,
-          maxResults: searchLimit,
-        },
-        locale: options.locale,
-        pathname: options.pathname,
-        siteTitle: options.siteTitle,
-        limit: searchLimit,
-      })
-    : [];
-  const searchResults = mergeSearchResults(primarySearchResults, localSearchResults);
 
   const seen = new Set<string>();
   const maxResultChars = options.maxResultChars ?? DEFAULT_ASK_AI_RESULT_CHARS;

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -579,6 +579,10 @@ description: "Start here"
 # Introduction
 
 Welcome to the docs.
+
+<Human>Use the visual coral walkthrough.</Human>
+
+<Audience only="agent">Use the scripted indigo workflow.</Audience>
 `,
     );
     mkdirSync(join(rootDir, "app", "docs", "installation"), { recursive: true });
@@ -634,12 +638,23 @@ Install the package.
     const llmsFullApiText = await llmsFullApi.text();
     expect(llmsFullApi.status).toBe(200);
     expect(llmsFullApiText).toContain("Welcome to the docs.");
+    expect(llmsFullApiText).toContain("scripted indigo workflow");
+    expect(llmsFullApiText).not.toContain("visual coral walkthrough");
 
     for (const path of ["/llms-full.txt", "/.well-known/llms-full.txt", "/docs/llms-full.txt"]) {
       const response = await GET(new Request(`http://localhost${path}`));
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/plain");
       expect(await response.text()).toBe(llmsFullApiText);
+    }
+
+    for (const path of ["/sitemap.xml", "/docs/sitemap.md"]) {
+      const response = await GET(new Request(`http://localhost${path}`));
+      const sitemap = await response.text();
+      expect(response.status).toBe(200);
+      expect(sitemap).toContain("/docs");
+      expect(sitemap).not.toContain("visual coral walkthrough");
+      expect(sitemap).not.toContain("scripted indigo workflow");
     }
 
     const skillApi = await GET(new Request("http://localhost/api/docs?format=skill"));
@@ -1057,7 +1072,7 @@ Use the product-specific coding workflow first.
     }
   });
 
-  it("keeps Agent blocks out of the normal search index", async () => {
+  it("uses the human audience projection for normal search", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-agent-search-route-"));
     tempDirs.push(rootDir);
 
@@ -1072,9 +1087,11 @@ title: "Introduction"
 
 Visible content.
 
-<Agent>
+<Human>Search should return this human-only coral token.</Human>
+
+<Audience only="agent">
 Search should not return this hidden agent-only zebra token.
-</Agent>
+</Audience>
 `,
     );
 
@@ -1093,6 +1110,15 @@ Search should not return this hidden agent-only zebra token.
       .join("\n");
 
     expect(renderedSearchText).not.toContain("agent-only zebra token");
+
+    const humanResponse = await GET(
+      new Request("http://localhost/api/docs?query=human-only%20coral%20token"),
+    );
+    const humanPayload = (await humanResponse.json()) as Array<{
+      content: string;
+      description?: string;
+    }>;
+    expect(humanPayload.some((result) => result.content.includes("Introduction"))).toBe(true);
   });
 
   it("serves markdown through the default docs api route, including Agent blocks and preferring agent.md when present", async () => {
@@ -1140,6 +1166,12 @@ Run \`pnpm dev\`.
 <Agent>
 Verify the onboarding command examples before changing this page.
 </Agent>
+
+<Human>Follow the visual dashboard walkthrough.</Human>
+
+<Audience only="agent">
+Run the deterministic onboarding verifier.
+</Audience>
 `,
     );
     const quickstartLastModified = new Date("2026-07-18T14:23:45.000Z");
@@ -1164,7 +1196,10 @@ This embedded agent block should be ignored because agent.md overrides the page.
     );
     writeFileSync(
       join(rootDir, "app", "docs", "overview", "agent.md"),
-      "Use this page as the implementation map.\n",
+      `<Human>Open the overview dashboard.</Human>
+
+<Audience only="agent">Use this page as the implementation map.</Audience>
+`,
     );
     writeFileSync(
       join(rootDir, "app", "docs", "configuration", "page.mdx"),
@@ -1215,6 +1250,8 @@ Config content.
     expect(fallbackDocument).toContain(
       "Verify the onboarding command examples before changing this page.",
     );
+    expect(fallbackDocument).toContain("Run the deterministic onboarding verifier.");
+    expect(fallbackDocument).not.toContain("Follow the visual dashboard walkthrough.");
     expect(fallbackDocument).toContain("## Agent Contract");
     expect(fallbackDocument).toContain("- Framework: `nextjs`");
     expect(fallbackDocument).toContain("### Verification\n\n- The docs route returns HTTP 200");
@@ -1260,6 +1297,7 @@ Config content.
     expect(agentDocument).toContain('canonical_url: "http://localhost/docs/overview"');
     expect(agentDocument).toContain('markdown_url: "http://localhost/docs/overview.md"');
     expect(agentDocument).toContain("Use this page as the implementation map.");
+    expect(agentDocument).not.toContain("Open the overview dashboard.");
     expect(agentDocument).toContain("## Sitemap");
 
     const rewrittenFallbackResponse = await GET(
@@ -2420,6 +2458,7 @@ description: "Start building quickly"
       pagePattern: "/docs/{slug}.md",
       rootPage: "/docs.md",
       apiPattern: "/api/docs?format=markdown&path={slug}",
+      resolutionOrder: ["agent.md", "agent audience projection", "shared page markdown"],
     });
     expect(spec.llms).toEqual({
       enabled: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -46,6 +46,7 @@ import {
   renderDocsMarkdownDocument,
   resolveDocsMetadataBaseUrl,
   renderDocsLlmsTxt,
+  resolveDocsAudienceMdxContent,
   resolveDocsI18n,
   resolveDocsLlmsTxtRequest,
   resolveDocsLlmsTxtSections,
@@ -58,6 +59,7 @@ import {
   resolveDocsSitemapConfig,
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
+  stripGeneratedAgentProvenance,
 } from "@farming-labs/docs";
 import type {
   ChangelogConfig,
@@ -540,7 +542,7 @@ function buildAgentSpec({
       pagePattern: `/${normalizedEntry}/{slug}.md`,
       rootPage: `/${normalizedEntry}.md`,
       apiPattern: `${DEFAULT_DOCS_API_ROUTE}?format=markdown&path={slug}`,
-      resolutionOrder: ["agent.md", "Agent blocks", "page markdown"],
+      resolutionOrder: ["agent.md", "agent audience projection", "shared page markdown"],
     },
     agentContract: {
       enabled: true,
@@ -1311,85 +1313,6 @@ function stripCommentsAndStrings(content: string): string {
   return result;
 }
 
-function resolveAgentMdxContent(content: string, audience: "human" | "agent"): string {
-  const lines = content.split("\n");
-  const output: string[] = [];
-  let fenceMarker: string | null = null;
-  let agentDepth = 0;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    const fenceMatch = trimmed.match(/^(`{3,}|~{3,})/);
-
-    if (fenceMatch) {
-      if (!fenceMarker) {
-        fenceMarker = fenceMatch[1];
-      } else if (trimmed.startsWith(fenceMarker)) {
-        fenceMarker = null;
-      }
-
-      if (audience === "agent" || agentDepth === 0) {
-        output.push(line);
-      }
-      continue;
-    }
-
-    if (!fenceMarker) {
-      if (/^<Agent(?:\s[^>]*)?\/>$/.test(trimmed)) {
-        continue;
-      }
-
-      const singleLineMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>([\s\S]*?)<\/Agent>\s*$/);
-      if (singleLineMatch) {
-        if (audience === "agent" && singleLineMatch[2]) {
-          output.push(`${singleLineMatch[1]}${singleLineMatch[2]}`);
-        }
-        continue;
-      }
-
-      const openMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>\s*$/);
-      if (openMatch) {
-        agentDepth += 1;
-        continue;
-      }
-
-      const openWithContentMatch = line.match(/^(\s*)<Agent(?:\s[^>]*)?>(.*)$/);
-      if (openWithContentMatch) {
-        agentDepth += 1;
-        if (audience === "agent" && openWithContentMatch[2]) {
-          output.push(`${openWithContentMatch[1]}${openWithContentMatch[2]}`);
-        }
-        continue;
-      }
-
-      const closeWithContentMatch = line.match(/^(.*)<\/Agent>\s*$/);
-      if (closeWithContentMatch && agentDepth > 0) {
-        if (audience === "agent" && closeWithContentMatch[1]) {
-          output.push(closeWithContentMatch[1]);
-        }
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-
-      if (/^<\/Agent>\s*$/.test(trimmed) && agentDepth > 0) {
-        agentDepth = Math.max(0, agentDepth - 1);
-        continue;
-      }
-    }
-
-    if (agentDepth > 0 && audience === "human") {
-      continue;
-    }
-
-    output.push(line);
-  }
-
-  return output
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 function stripMdx(content: string): string {
   return content
     .replace(/^(import|export)\s.*$/gm, "")
@@ -1462,6 +1385,23 @@ function isHiddenFolderIndexPageDir(dir: string): boolean {
   }
 }
 
+function readAudienceAgentDoc(dir: string) {
+  const agentPath = path.join(dir, "agent.md");
+  if (!fs.existsSync(agentPath)) return undefined;
+
+  try {
+    const raw = stripGeneratedAgentProvenance(fs.readFileSync(agentPath, "utf-8"));
+    const { content } = matter(raw);
+    const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
+    return {
+      agentContent: stripMdx(agentRawContent),
+      agentRawContent,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 function scanDocsDir(
   docsDir: string,
   entry: string,
@@ -1501,8 +1441,9 @@ function scanDocsDir(
             "Documentation";
           const description = data.description as string | undefined;
           const { content: fileContent } = matter(raw);
-          const rawContent = resolveAgentMdxContent(fileContent, "human");
-          const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
+          const rawContent = resolveDocsAudienceMdxContent(fileContent, "human");
+          const agentRawContent = resolveDocsAudienceMdxContent(fileContent, "agent");
+          const agentDoc = readAudienceAgentDoc(dir);
           const content = stripMdx(rawContent);
           const baseUrl = publicDocsRoute(publicPath, slugParts);
           const url = withLangInUrl(baseUrl, locale);
@@ -1519,6 +1460,7 @@ function scanDocsDir(
             sourcePath: pageSource.replace(/\\/g, "/"),
             lastModified: fs.statSync(pageSource).mtime.toISOString(),
             locale,
+            ...agentDoc,
           });
         }
       } catch {
@@ -1590,8 +1532,9 @@ function scanChangelogDir(
 
       const title = (data.title as string) || name.replace(/-/g, " ");
       const description = data.description as string | undefined;
-      const rawContent = resolveAgentMdxContent(fileContent, "human");
-      const agentRawContent = resolveAgentMdxContent(fileContent, "agent");
+      const rawContent = resolveDocsAudienceMdxContent(fileContent, "human");
+      const agentRawContent = resolveDocsAudienceMdxContent(fileContent, "agent");
+      const agentDoc = readAudienceAgentDoc(entryDir);
       const content = stripMdx(rawContent);
       const url = withLangInUrl(publicDocsRoute(publicPath, [changelogPath, name]), locale);
       const tags = Array.isArray(data.tags)
@@ -1611,6 +1554,7 @@ function scanChangelogDir(
         type: "changelog",
         version: typeof data.version === "string" ? data.version : undefined,
         tags,
+        ...agentDoc,
       });
     } catch {
       // skip unreadable files

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -494,7 +494,7 @@ agent:
     });
   });
 
-  it("ignores Agent-only content when computing reading time", () => {
+  it("uses the human audience projection when computing reading time", () => {
     mkdirSync(join(tmpDir, "app", "docs", "agent-safe"), { recursive: true });
     writeFileSync(
       join(tmpDir, "app", "docs", "agent-safe", "page.mdx"),
@@ -507,9 +507,15 @@ agent:
         "",
         "Short human summary.",
         "",
+        "<Human>",
+        "Visible guidance adds exactly ten useful words for human readers here.",
+        "</Human>",
+        "",
         "<Agent>",
         "These extra machine-only instructions should not count toward visible reading time even if they are verbose and packed with many additional words for testing purposes.",
         "</Agent>",
+        "",
+        '<Audience only="agent">More agent-only words must remain excluded from the visible estimate.</Audience>',
       ].join("\n"),
       "utf-8",
     );
@@ -526,7 +532,7 @@ agent:
 
     expect(props).toBeTruthy();
     expect(props?.readingTimeMap).toMatchObject({
-      "/docs/agent-safe": 1,
+      "/docs/agent-safe": 2,
     });
   });
 

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -11,7 +11,7 @@ import {
   normalizePageAgentFrontmatter,
   renderDocsPageStructuredDataJson,
   resolveChangelogConfig,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolveDocsAnalyticsConfig,
   resolveDocsMetadataBaseUrl,
   resolvePageSidebarFolderIndexBehavior,
@@ -570,7 +570,7 @@ function buildReadingTimeMap(
     if (fs.existsSync(pagePath)) {
       const source = fs.readFileSync(pagePath, "utf-8");
       const { data, content } = matter(source);
-      const humanContent = resolveDocsAgentMdxContent(content, "human");
+      const humanContent = resolveDocsAudienceMdxContent(content, "human");
       const minutes = resolvePageReadingTime(data as PageFrontmatter, humanContent, options);
 
       if (typeof minutes === "number") {

--- a/packages/fumadocs/src/index.ts
+++ b/packages/fumadocs/src/index.ts
@@ -98,6 +98,7 @@ export { withLangInUrl } from "./i18n.js";
 // ─── Core types (re-exported for convenience) ─────────────────────────
 export type {
   DocsConfig,
+  DocsContentAudience,
   ChangelogConfig,
   ChangelogFrontmatter,
   DocsTheme,
@@ -137,7 +138,8 @@ export {
   CodeBlockTabsTrigger,
   Pre,
 } from "fumadocs-ui/components/codeblock";
-export { Agent, CodeGroup } from "./mdx.js";
+export { Agent, Audience, CodeGroup, Human } from "./mdx.js";
+export type { AgentProps, AudienceProps, CodeGroupProps, HumanProps } from "./mdx.js";
 export { HoverLink } from "./hover-link.js";
 export type { HoverLinkProps } from "./hover-link.js";
 export { Prompt } from "./prompt.js";

--- a/packages/fumadocs/src/mdx.test.ts
+++ b/packages/fumadocs/src/mdx.test.ts
@@ -4,13 +4,53 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { getMDXComponents } from "./mdx.js";
 
 describe("getMDXComponents", () => {
-  it("includes the Agent primitive by default without user registration", () => {
+  it("includes audience primitives by default without user registration", () => {
     const components = getMDXComponents();
 
     expect(typeof components.Agent).toBe("function");
+    expect(typeof components.Human).toBe("function");
+    expect(typeof components.Audience).toBe("function");
 
     const AgentComponent = components.Agent as (props: { children?: unknown }) => unknown;
+    const HumanComponent = components.Human as React.ComponentType<{
+      children?: React.ReactNode;
+    }>;
+    const AudienceComponent = components.Audience as React.ComponentType<{
+      only: "human" | "agent";
+      children?: React.ReactNode;
+    }>;
+
     expect(AgentComponent({ children: "hidden agent-only context" })).toBeNull();
+    expect(
+      renderToStaticMarkup(React.createElement(HumanComponent, null, "visible human-only context")),
+    ).toContain("visible human-only context");
+    expect(
+      renderToStaticMarkup(
+        React.createElement(AudienceComponent, { only: "human" }, "visible human context"),
+      ),
+    ).toContain("visible human context");
+    expect(
+      renderToStaticMarkup(
+        React.createElement(AudienceComponent, { only: "agent" }, "hidden agent context"),
+      ),
+    ).toBe("");
+  });
+
+  it("renders Audience children as shared content when only is invalid", () => {
+    const components = getMDXComponents();
+    const AudienceComponent = components.Audience as React.ComponentType<{
+      only?: string;
+      children?: React.ReactNode;
+    }>;
+
+    const html = renderToStaticMarkup(
+      React.createElement(AudienceComponent, { only: "unknown" }, "shared fallback"),
+    );
+
+    expect(html).toContain("shared fallback");
+    expect(
+      renderToStaticMarkup(React.createElement(AudienceComponent, null, "missing-value fallback")),
+    ).toContain("missing-value fallback");
   });
 
   it("includes a Mintlify-compatible CodeGroup primitive by default without user registration", () => {

--- a/packages/fumadocs/src/mdx.ts
+++ b/packages/fumadocs/src/mdx.ts
@@ -37,7 +37,12 @@ import {
   type PromptProps,
 } from "./prompt.js";
 import { extractPromptText } from "./prompt-text.js";
-import { type CodeBlockCopyData, type DocsTheme } from "@farming-labs/docs";
+import {
+  type CodeBlockCopyData,
+  type DocsContentAudience,
+  type DocsTheme,
+  resolveDocsAudienceExposure,
+} from "@farming-labs/docs";
 
 function Table(props: React.ComponentPropsWithoutRef<"table">) {
   return React.createElement(
@@ -49,8 +54,34 @@ function Table(props: React.ComponentPropsWithoutRef<"table">) {
   );
 }
 
-function Agent(_props: { children?: React.ReactNode }) {
-  return null;
+export interface AgentProps {
+  children?: React.ReactNode;
+}
+
+export interface HumanProps {
+  children?: React.ReactNode;
+}
+
+export interface AudienceProps {
+  only: DocsContentAudience;
+  children?: React.ReactNode;
+}
+
+function renderAudience(only: unknown, audience: DocsContentAudience, children: React.ReactNode) {
+  if (!resolveDocsAudienceExposure(only, audience)) return null;
+  return React.createElement(React.Fragment, null, children);
+}
+
+function Agent({ children }: AgentProps) {
+  return renderAudience("agent", "human", children);
+}
+
+function Human({ children }: HumanProps) {
+  return renderAudience("human", "human", children);
+}
+
+function Audience({ only, children }: AudienceProps) {
+  return renderAudience(only, "human", children);
 }
 
 type ReactElementProps = Record<string, unknown> & {
@@ -271,8 +302,10 @@ const extendedMdxComponents = {
   img: MDXImg,
   table: Table,
   Agent,
+  Audience,
   CodeGroup,
   HoverLink,
+  Human,
   Prompt,
   Tab,
   Tabs,
@@ -399,10 +432,12 @@ export function getMDXComponents<T extends Record<string, unknown> = Record<stri
 
 export {
   Agent,
+  Audience,
   CodeGroup,
   defaultMdxComponents,
   extendedMdxComponents,
   HoverLink,
+  Human,
   Prompt,
   Tab,
   Tabs,

--- a/packages/nuxt/src/content.ts
+++ b/packages/nuxt/src/content.ts
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
@@ -95,8 +95,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
 
       const raw = fs.readFileSync(full, "utf-8");
       const { data, content } = matter(raw);
-      const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-      const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+      const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+      const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
       const related = normalizeDocsRelated(data.related);
 
       const baseName = name.replace(/\.(md|mdx|svx)$/, "");
@@ -150,9 +150,10 @@ function readAgentDoc(dir: string) {
 
   const raw = fs.readFileSync(agentPath, "utf-8");
   const { content } = matter(raw);
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdown(content),
-    agentRawContent: content,
+    agentContent: stripMarkdown(agentRawContent),
+    agentRawContent,
   };
 }
 

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
@@ -597,7 +597,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAgentMdxContent(content, "human");
+  let result = resolveDocsAudienceMdxContent(content, "human");
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -54,7 +54,7 @@ import {
   renderDocsSkillDocument,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
@@ -488,8 +488,8 @@ function searchIndexFromMap(
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+    const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
     const related = normalizeDocsRelated(data.related);
     const agentDoc = isIdx ? readAgentDocFromMap(contentMap, dirPrefix, slug) : undefined;
     const title =
@@ -530,9 +530,10 @@ function readAgentDocFromMap(contentMap: ContentFileMap, dirPrefix: string, slug
   if (!raw) return undefined;
 
   const { content } = matter(stripGeneratedAgentProvenance(raw));
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdownText(content),
-    agentRawContent: content,
+    agentContent: stripMarkdownText(agentRawContent),
+    agentRawContent,
   };
 }
 
@@ -760,7 +761,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
     const readingTime = resolvePageReadingTime(data, humanRawContent, {
       enabledByDefault: readingTimeOptions.enabled,
       wordsPerMinute: readingTimeOptions.wordsPerMinute,

--- a/packages/svelte/src/content.ts
+++ b/packages/svelte/src/content.ts
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
@@ -95,8 +95,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
 
       const raw = fs.readFileSync(full, "utf-8");
       const { data, content } = matter(raw);
-      const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-      const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+      const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+      const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
       const related = normalizeDocsRelated(data.related);
 
       const baseName = name.replace(/\.(md|mdx|svx)$/, "");
@@ -150,9 +150,10 @@ function readAgentDoc(dir: string) {
 
   const raw = fs.readFileSync(agentPath, "utf-8");
   const { content } = matter(raw);
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdown(content),
-    agentRawContent: content,
+    agentContent: stripMarkdown(agentRawContent),
+    agentRawContent,
   };
 }
 

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -9,7 +9,7 @@
  *   - Tables, lists, inline formatting, headings with anchor IDs
  */
 
-import { resolveDocsAgentMdxContent, type DocsTheme } from "@farming-labs/docs";
+import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
@@ -597,7 +597,7 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAgentMdxContent(content, "human");
+  let result = resolveDocsAudienceMdxContent(content, "human");
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -64,7 +64,7 @@ import {
   renderDocsSkillDocument,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
@@ -513,8 +513,8 @@ function searchIndexFromMap(
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+    const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
     const related = normalizeDocsRelated(data.related);
     const agentDoc = isIdx ? readAgentDocFromMap(contentMap, dirPrefix, slug) : undefined;
     const title =
@@ -555,9 +555,10 @@ function readAgentDocFromMap(contentMap: ContentFileMap, dirPrefix: string, slug
   if (!raw) return undefined;
 
   const { content } = matter(stripGeneratedAgentProvenance(raw));
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdownText(content),
-    agentRawContent: content,
+    agentContent: stripMarkdownText(agentRawContent),
+    agentRawContent,
   };
 }
 
@@ -783,7 +784,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
     const readingTime = resolvePageReadingTime(data, humanRawContent, {
       enabledByDefault: readingTimeOptions.enabled,
       wordsPerMinute: readingTimeOptions.wordsPerMinute,

--- a/packages/tanstack-start/src/content.ts
+++ b/packages/tanstack-start/src/content.ts
@@ -12,7 +12,7 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
@@ -88,8 +88,8 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
 
       const raw = fs.readFileSync(full, "utf-8");
       const { data, content } = matter(raw);
-      const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-      const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+      const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+      const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
       const related = normalizeDocsRelated(data.related);
 
       const baseName = name.replace(/\.(md|mdx)$/, "");
@@ -142,9 +142,10 @@ function readAgentDoc(dir: string) {
 
   const raw = fs.readFileSync(agentPath, "utf-8");
   const { content } = matter(raw);
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdown(content),
-    agentRawContent: content,
+    agentContent: stripMarkdown(agentRawContent),
+    agentRawContent,
   };
 }
 

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -34,7 +34,7 @@ import {
   renderDocsSkillDocument,
   readDocsSitemapManifestFromContentMap,
   stripGeneratedAgentProvenance,
-  resolveDocsAgentMdxContent,
+  resolveDocsAudienceMdxContent,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
@@ -439,8 +439,8 @@ function searchIndexFromMap(
 
     const raw = contentMap[key];
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
-    const pageAgentRawContent = resolveDocsAgentMdxContent(content, "agent");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
+    const pageAgentRawContent = resolveDocsAudienceMdxContent(content, "agent");
     const related = normalizeDocsRelated(data.related);
     const slug = isIdx ? segments.join("/") : [...segments, base].join("/");
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
@@ -488,9 +488,10 @@ function readAgentDocFromMap(contentMap: ContentFileMap, dirPrefix: string, slug
   if (!raw) return undefined;
 
   const { content } = matter(stripGeneratedAgentProvenance(raw));
+  const agentRawContent = resolveDocsAudienceMdxContent(content, "agent");
   return {
-    agentContent: stripMarkdownText(content),
-    agentRawContent: content,
+    agentContent: stripMarkdownText(agentRawContent),
+    agentRawContent,
   };
 }
 
@@ -754,7 +755,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     }
 
     const { data, content } = matter(raw);
-    const humanRawContent = resolveDocsAgentMdxContent(content, "human");
+    const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
     const readingTime = resolvePageReadingTime(data, humanRawContent, {
       enabledByDefault: readingTimeOptions.enabled,
       wordsPerMinute: readingTimeOptions.wordsPerMinute,
@@ -794,7 +795,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       url: currentUrl,
       title,
       description,
-      rawContent: content,
+      rawContent: humanRawContent,
       readingTime,
       readingTimeFormat: readingTimeOptions.format,
       sourcePath: toSourcePath(ctx.contentDirRel, relPath, rootDir),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -202,10 +202,25 @@ Default behavior:
 - successful markdown page responses append a `## Sitemap` footer that links to the configured markdown sitemap routes
 - missing markdown pages return actionable markdown with HTTP `404`, closest-match suggestions, recovery instructions, discovery links, and sitemap links
 - very high-confidence missing markdown slugs redirect to the closest `.md` page instead of returning a recovery body
-- embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI and are included in the markdown fallback
+- content outside audience wrappers is shared; no `docs.config` flag is required
+- embedded `<Agent>...</Agent>` and `<Audience only="agent">...</Audience>` blocks stay hidden in
+  rendered HTML and public search, and are included in the agent projection
+- embedded `<Human>...</Human>` and `<Audience only="human">...</Audience>` blocks stay in rendered
+  HTML and public search, and are removed from the agent projection
+- Markdown routes, Ask AI, MCP, `llms-full.txt`, and static agent exports use the agent projection;
+  compact `llms.txt` links point to agent-projected Markdown, while sitemaps contain route metadata
+  rather than page bodies
+- `<Agent>` remains an optional agent-only shorthand and `<Human>` is the human-only shorthand;
+  both have a fixed audience, so `docs review` reports and ignores an `only` prop
+- use `<Audience only="human">` or `<Audience only="agent">` when you prefer the explicit form
+- invalid or missing `Audience.only` values remain shared rather than being silently discarded
+- dynamic `Audience.only` expressions and spread props are unsupported because static exports
+  cannot resolve them; use a static literal and rely on `docs review` to report dynamic declarations
+- audience filtering is representation shaping, not authentication or authorization; never place
+  secrets or private data in an audience block or `agent.md`
 - if a page folder has `agent.md`, that file becomes the markdown response for that page
-- if `agent.md` is missing, the markdown response falls back to the normal page markdown
-- page frontmatter `related` is rendered into a comma-separated machine-readable markdown metadata line beside `Description` for normal page markdown and embedded `<Agent>` fallback
+- if `agent.md` is missing, the markdown response uses the agent audience projection of shared page content
+- page frontmatter `related` is rendered into a comma-separated machine-readable markdown metadata line beside `Description` for normal page markdown and audience-projected fallback
 - page frontmatter `agent` can define a structured task contract; valid fields are normalized into markdown frontmatter, a deterministic `## Agent Contract` section, search/Ask AI context, and Schema.org `HowTo` JSON-LD
 - structured agent contract fields are `task`, `outcome`, `appliesTo`, `prerequisites`, `files`, `commands`, `sideEffects`, `verification`, `rollback`, and `failureModes`; all are optional and `agent.tokenBudget` remains backward compatible
 - `docs review` reports malformed and unknown structured fields (with closest-name suggestions such as `verfication` → `verification`) and suggests missing outcomes, verification, or rollback guidance without breaking runtime page delivery
@@ -228,17 +243,25 @@ app/docs/getting-started/agent-ready-docs/
   agent.md
 ```
 
-Embedded agent-context example:
+Embedded audience-context example:
 
 ```mdx
 # Quickstart
 
 Human-facing instructions.
 
+<Human>
+Use the highlighted dashboard control shown below.
+</Human>
+
 <Agent>
 You are an implementation agent.
 Keep the scaffolded paths and commands aligned with the actual project structure.
 </Agent>
+
+<Audience only="agent">
+Run the verification command and require exit code 0.
+</Audience>
 ```
 
 Related-page frontmatter example:

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -43,7 +43,11 @@ Eleven built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-bor
 
 ### Built-in UI features
 
-- **MDX components** — built-ins like `Callout`, `Tabs`, and `HoverLink` are available without imports.
+- **MDX components** — built-ins like `Callout`, `Tabs`, `HoverLink`, `Agent`, `Human`, and
+  `Audience` are available without imports. Content is shared by default. Use `<Agent>` or
+  `<Audience only="agent">` for agent-only context, and `<Human>` or
+  `<Audience only="human">` for human-only context. Keep `Audience.only` static and avoid spread
+  props; `docs review` reports declarations that static agent outputs cannot resolve consistently.
 - **Page feedback** — enable with `feedback: true` or `feedback: { enabled: true, onFeedback() {} }`.
 - **Agent discovery spec** — agents should call `/.well-known/agent.json`, fall back to `/.well-known/agent`, and use `/api/docs/agent/spec` as the canonical framework route. The spec discovers site identity, locale config, capability flags, search, markdown routes, JSON-LD structured data support, `llms.txt` routes, OpenAPI schema discovery when `apiReference` is enabled, sitemap routes, `robots.route`, generated/root `AGENTS.md`, root `skill.md` route, Skills CLI install metadata, MCP config, and feedback endpoints generated from `docs.config`.
 - **Generated AGENTS.md** — `GET /AGENTS.md`, `GET /.well-known/AGENTS.md`, and `GET /api/docs?format=agents` return coding-agent instructions by default. A root `AGENTS.md` or `AGENT.md` overrides the generated fallback; use `docs agents generate` for static exports.
@@ -53,7 +57,12 @@ Eleven built-in theme entrypoints: `fumadocs` (default), `darksharp`, `pixel-bor
 - **Page actions** — enable with `pageActions.copyMarkdown` and `pageActions.openDocs`.
 - **Built-in changelog pages (Next.js)** — enable `changelog` to publish a release feed from dated MDX entries.
 - **Built-in MCP server** — enabled by default at `/mcp` and `/.well-known/mcp`, backed by `/api/docs/mcp`, and for local stdio tools. Next.js wires rewrites with `withDocs()`; TanStack Start/SvelteKit/Astro/Nuxt scaffold one public forwarder each. Opt out with `mcp: false` or `mcp: { enabled: false }`.
-- **Machine-readable markdown routes** — `/docs.md` and `/docs/<slug>.md` return agent-ready markdown in Next.js and in the generated TanStack Start, SvelteKit, Astro, and Nuxt forwarding layer. Next.js also returns the same markdown from `/docs/<slug>` when the request sends an unambiguous `Accept: text/markdown`; mixed headers containing an HTML-capable range should use the exact `.md` URL or API format route. Markdown responses start with YAML frontmatter for `title`, optional `description`, `canonical_url`, `markdown_url`, and `last_updated` when a freshness date is known. Use embedded `<Agent>...</Agent>` blocks inside `page.mdx` when the normal page only needs extra machine context; add a sibling `agent.md` when the whole machine-readable page should be overridden. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`. Page frontmatter `related` appears as a comma-separated machine-readable markdown metadata line beside `Description` unless a sibling `agent.md` fully overrides the page.
+- **Machine-readable markdown routes** — `/docs.md` and `/docs/<slug>.md` return agent-ready markdown in Next.js and in the generated TanStack Start, SvelteKit, Astro, and Nuxt forwarding layer. Next.js also returns the same markdown from `/docs/<slug>` when the request sends an unambiguous `Accept: text/markdown`; mixed headers containing an HTML-capable range should use the exact `.md` URL or API format route. Markdown responses start with YAML frontmatter for `title`, optional `description`, `canonical_url`, `markdown_url`, and `last_updated` when a freshness date is known. Use embedded `<Agent>...</Agent>` or `<Audience only="agent">...</Audience>` blocks inside `page.mdx` when the normal page only needs extra machine context. Use `<Human>` or `<Audience only="human">` to keep presentation-only content out of agent context, and add a sibling `agent.md` when the whole machine-readable page should be overridden. The shared docs API also supports `GET /api/docs?format=markdown&path=<slug>`. Page frontmatter `related` appears as a comma-separated machine-readable markdown metadata line beside `Description` unless a sibling `agent.md` fully overrides the page.
+- **Audience projection** — rendered HTML and public search use the human projection; Markdown,
+  Ask AI, MCP, `llms-full.txt`, and static agent exports use the agent projection. Compact
+  `llms.txt` contains discovery links to agent-projected Markdown, and sitemaps contain route
+  metadata only. Audience filtering is not authentication, so never place secrets in an audience
+  block or `agent.md`.
 
 ### MCP quick test
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -366,7 +366,8 @@ Use `agent compact` when you want shorter page-level machine docs without hand-w
 What it does:
 
 - resolves the same machine-readable page the runtime already uses: `agent.md`, then the agent
-  audience projection (`Agent`, `Human`, and `Audience` blocks), then shared page content
+  audience projection (which excludes `<Human>` and `<Audience only="human">` content), then
+  shared page content
 - compresses that document with the Docs Cloud compression API
 - creates missing sibling `agent.md` files and overwrites existing ones
 - makes the written `agent.md` the new source for `.md` routes, docs API markdown output, and MCP

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -309,7 +309,8 @@ pnpm exec docs agent export --public
 The command scans the configured content once and writes the complete bundle to `public/`, or to
 SvelteKit's `static/` directory:
 
-- a `.md` file for every resolved docs page, using `agent.md`, then `Agent` blocks, then page MDX
+- a `.md` file for every resolved docs page, using `agent.md`, then the page's agent audience
+  projection, then shared page MDX
 - root, entry-scoped, well-known, and configured section `llms.txt` and `llms-full.txt` files
 - `/.well-known/agent.json` plus the extensionless discovery alias
 - `/skill.md`, its well-known alias, and `/skills/docs/SKILL.md`
@@ -364,8 +365,8 @@ Use `agent compact` when you want shorter page-level machine docs without hand-w
 
 What it does:
 
-- resolves the same machine-readable page the runtime already uses: `agent.md`, then `Agent`
-  blocks, then normal page markdown
+- resolves the same machine-readable page the runtime already uses: `agent.md`, then the agent
+  audience projection (`Agent`, `Human`, and `Audience` blocks), then shared page content
 - compresses that document with the Docs Cloud compression API
 - creates missing sibling `agent.md` files and overwrites existing ones
 - makes the written `agent.md` the new source for `.md` routes, docs API markdown output, and MCP

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -349,9 +349,15 @@ No separate config flag is required for machine-readable page markdown.
 - Successful markdown page responses append a `## Sitemap` footer that links agents back to the configured markdown sitemap routes
 - Missing markdown pages return actionable markdown with HTTP `404`, closest-match suggestions, recovery instructions, discovery links, and sitemap links
 - Very high-confidence missing slugs redirect to the closest `.md` page
-- Embedded `<Agent>...</Agent>` blocks stay hidden in the normal UI but are included in the `.md` fallback and MCP `read_page`
-- When a page folder has `agent.md`, that file is returned instead of the normal page markdown
-- Page frontmatter `related` is rendered as a comma-separated markdown metadata line beside `Description` when the page uses normal markdown or embedded `<Agent>` fallback, so agents can discover adjacent pages without scraping the UI. A sibling `agent.md` remains the page-content override; include any `Related:` line manually inside `agent.md` when needed.
+- Content is shared by default. `<Agent>` and `<Audience only="agent">` add agent-only content;
+  `<Human>` and `<Audience only="human">` add human-only content. Rendered HTML and public search
+  use the human projection, while Markdown, Ask AI, MCP, `llms-full.txt`, and static agent exports
+  use the agent projection. Compact `llms.txt` and sitemaps contain discovery/route metadata rather
+  than page bodies.
+- `Audience.only` must be a static `"human"` or `"agent"` literal. `docs review` reports dynamic
+  expressions and spread props because build-time exports cannot resolve them consistently.
+- When a page folder has `agent.md`, that file is returned instead of the audience-projected page source
+- Page frontmatter `related` is rendered as a comma-separated markdown metadata line beside `Description` when the page uses normal markdown or an audience-projected fallback, so agents can discover adjacent pages without scraping the UI. A sibling `agent.md` remains the page-content override; include any `Related:` line manually inside `agent.md` when needed.
 
 <Callout type="info" title="Markdown via content negotiation">
   You can keep the canonical docs URL and ask for markdown with an HTTP header:

--- a/website/app/docs/customization/agent-primitive/agent.md
+++ b/website/app/docs/customization/agent-primitive/agent.md
@@ -5,21 +5,49 @@ You are reading the machine-oriented override for `/docs/customization/agent-pri
 Use this page when you need the page-level authoring contract for agent-facing docs in
 `@farming-labs/docs`.
 
-## The Two Primitives
+## Audience Controls
 
 1. `Agent`
    - Embed `<Agent>...</Agent>` inside `page.mdx`
    - Hidden in the normal docs UI
-   - Included in `.md` output and MCP fallback when there is no sibling `agent.md`
+   - Included in agent-projected output when there is no sibling `agent.md`
 
-2. `agent.md`
+2. `Human`
+   - Embed `<Human>...</Human>` inside `page.mdx`
+   - Included in rendered HTML and public search
+   - Removed from agent-projected output
+
+3. `Audience`
+   - Use `<Audience only="agent">...</Audience>` as the explicit form of `Agent`
+   - Use `<Audience only="human">...</Audience>` as the explicit form of `Human`
+   - Only static `"agent"` and `"human"` values are supported; `docs review` reports dynamic values and spread props
+   - Invalid or missing values remain shared rather than being silently deleted
+
+4. `agent.md`
    - Place a sibling `agent.md` beside `page.mdx`
    - Becomes the full machine-readable output for that page
    - Preferred by MCP `read_page("/docs/customization/agent-primitive")`
 
+Content without an audience wrapper is shared. `Agent` remains an optional shorthand and does not
+support `only="human"`; use `Human` or `Audience` for human-only content.
+
+## Projection Contract
+
+Use the human projection for rendered docs HTML and public docs search. Use the agent projection
+for Markdown routes and API responses, Ask AI retrieval/context, MCP, `llms-full.txt`, and static
+agent exports. The compact `llms.txt` file contains discovery metadata and links to agent-projected
+Markdown rather than page bodies. Sitemaps contain route metadata rather than page bodies, so
+audience blocks do not appear in them.
+
+Audience filtering is content shaping, not authentication or authorization. Do not put secrets or
+private data in any audience block or `agent.md`; machine-readable routes and source files can be
+public.
+
 ## When To Choose Which
 
 - Choose `Agent` when the human page should stay canonical and only needs extra machine context
+- Choose `Human` when a visual explanation or UI note should not consume agent context
+- Choose `Audience` when one explicit component is easier to scan than two shorthands
 - Choose `agent.md` when agents need a shorter, stricter, or more operational document
 
 ## Automation
@@ -27,8 +55,8 @@ Use this page when you need the page-level authoring contract for agent-facing d
 If the team wants to generate or refresh page-level `agent.md` files automatically, use
 `docs agent compact`.
 
-- it resolves the same page-level machine document with this order: `agent.md`, embedded `Agent`
-  blocks, then page markdown
+- it resolves the same page-level machine document with this order: `agent.md`, the agent
+  projection of audience-aware page markdown, then shared page markdown
 - it writes sibling `agent.md` files that become the new `.md`, docs API, and MCP source
 - it is useful when authors start with `<Agent>` blocks and later want a shorter, fully
   machine-focused document
@@ -48,10 +76,10 @@ pnpm exec docs agent compact --all
 - API route: `/api/docs?format=markdown&path=customization/agent-primitive`
 - MCP read target: `/docs/customization/agent-primitive`
 
-After adding or changing page-level primitives, see [the CLI docs](/docs/cli) and the `Doctor`
+After adding or changing page-level audience controls, see [the CLI docs](/docs/cli) and the `Doctor`
 section for the audit workflow. Use it to confirm the machine-facing layer is actually discoverable
-and to watch the `Explicit agent-friendly pages` metric improve as more routes gain `<Agent>`
-blocks or sibling `agent.md` files.
+and to watch the explicit audience coverage improve as more routes gain audience blocks or sibling
+`agent.md` files.
 
 ## Let Agents Discover The Spec
 
@@ -158,7 +186,7 @@ Install them with:
 npx skills add farming-labs/docs
 ```
 
-Use the page-level primitives in this doc when the context belongs to a single route.
+Use the page-level audience controls in this doc when the context belongs to a single route.
 Use a skill when the task spans multiple pages or product areas such as:
 
 - setup and installation
@@ -172,5 +200,6 @@ Relevant skills in this repo include `getting-started`, `cli`, `configuration`, 
 
 ## Authoring Reminder
 
-Do not duplicate whole pages into `<Agent>` blocks. Keep `Agent` additive and concise.
+Do not duplicate whole pages into `<Agent>` blocks. Keep `Agent` additive and concise. Use `Human`
+for UI-only explanation, and leave content unwrapped when it serves both audiences.
 Use `agent.md` when the machine-readable page needs to diverge substantially.

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -1,16 +1,23 @@
 ---
 title: "Agent Primitive"
-description: "Author page-level agent context, generated AGENTS.md instructions, and machine-readable route discovery."
+description: "Author human- and agent-specific page context, generated AGENTS.md instructions, and machine-readable route discovery."
 icon: "bot"
 order: 5.65
 ---
 
 # Agent Primitive
 
-`@farming-labs/docs` gives you two page-level primitives for agent-facing documentation:
+`@farming-labs/docs` gives you optional page-level audience controls for agent-friendly
+documentation:
 
-- `<Agent>...</Agent>` inside `page.mdx` for additive machine-only context
+- `<Agent>...</Agent>` inside `page.mdx` for additive agent-only context
+- `<Human>...</Human>` for presentation or explanation that only belongs in human-facing output
+- `<Audience only="agent">...</Audience>` or `<Audience only="human">...</Audience>` when you
+  prefer one explicit component
 - `agent.md` beside `page.mdx` for a full machine-readable override
+
+Content outside these wrappers remains shared by both audiences. Existing `<Agent>` blocks keep
+working unchanged, and you never need to add one when the same content serves both audiences well.
 
 The same page model also powers the built-in machine-readable routes:
 
@@ -62,14 +69,75 @@ The same page model also powers the built-in machine-readable routes:
 </Callout>
 
 Use `Agent` when the human page is already mostly correct and just needs a little extra implementation
-context. Use `agent.md` when the entire machine-readable page should be more operational, more
-structured, or fully different from the visible UI page.
+context. Use `Human` to remove UI-only explanation from agent context, or use `Audience` for either
+direction with one explicit API. Use `agent.md` when the entire machine-readable page should be
+more operational, more structured, or fully different from the visible UI page.
 
 <Callout type="info" title="Built in by default">
-  `Agent` is already part of the default MDX component map. You can write `<Agent>` directly in any
-  docs page without adding it to `docs.config.ts`, `mdx-components.tsx`, or a custom components map.
-  If you intentionally build your own MDX map from scratch, import it from `@farming-labs/theme` or
-  `@farming-labs/theme/mdx`.
+  `Agent`, `Human`, and `Audience` are already part of the default MDX component map. You can use
+  them directly in any docs page without adding them to `docs.config.ts`, `mdx-components.tsx`, or
+  a custom components map. If you intentionally build your own MDX map from scratch, import them
+  from `@farming-labs/theme` or `@farming-labs/theme/mdx`.
+</Callout>
+
+## Choose An Audience
+
+The short components and the explicit component are equivalent:
+
+```mdx title="page.mdx"
+# Deploy the app
+
+This setup applies to every reader.
+
+<Human>
+Use the dashboard screenshot below to find the deployment button.
+</Human>
+
+<Agent>
+Run `pnpm deploy`, then verify that the command exits with code 0.
+</Agent>
+
+<Audience only="human">
+This is the explicit form of `Human`.
+</Audience>
+
+<Audience only="agent">
+This is the explicit form of `Agent`.
+</Audience>
+```
+
+Use whichever authoring style reads best on the page. `<Agent>` remains the concise, optional
+shorthand for agent-only context, while `<Human>` is the human-only shorthand. Both shorthands have
+a fixed audience, so an `only` prop is ignored and `docs review` reports it. Use `<Audience>` when
+you want the explicit `only="human"` or `only="agent"` form. `Audience.only` accepts exactly
+`"human"` or `"agent"`. Use a static literal (a quoted prop or static quoted MDX expression).
+Runtime expressions such as `only={currentAudience}` and spread props such as
+`{...audienceProps}` are unsupported; `docs review` reports them because exports cannot resolve
+them consistently. An invalid or missing value is preserved as shared content instead of being
+silently dropped.
+
+The framework resolves the same audience policy before each content surface consumes the page:
+
+| Surface | Projection |
+| ------- | ---------- |
+| Rendered docs HTML | Human |
+| Public docs search | Human |
+| Markdown routes and the markdown API format | Agent |
+| Ask AI retrieval and context | Agent |
+| MCP search, context, and page reads | Agent |
+| `llms.txt` | Discovery metadata and links; linked Markdown uses the agent projection |
+| `llms-full.txt` page bodies | Agent |
+| Static agent exports | Agent |
+| XML and Markdown sitemaps | Route metadata only; page-body audience blocks are not included |
+
+This keeps visual instructions out of agent context and implementation-only instructions out of
+the rendered page and public search without maintaining separate copies of the entire page.
+
+<Callout type="warning" title="Audience filtering is not access control">
+  Audience wrappers shape a representation; they do not authenticate a reader or protect a secret.
+  Source files and machine-readable routes can still be public. Never put credentials, private
+  customer data, internal-only URLs, or other sensitive values inside `Agent`, `Human`, `Audience`,
+  or `agent.md`. Put protected documentation behind real authorization.
 </Callout>
 
 ## Use `Agent` For Additive Context
@@ -170,8 +238,8 @@ machine-readable page for one or more routes and write a sibling `agent.md` auto
 It uses the same resolution order as the runtime:
 
 - existing `agent.md`
-- hidden `Agent` blocks
-- normal page markdown
+- the agent projection of audience-aware page markdown
+- shared page markdown
 
 That makes it a good fit when you want to start with additive `<Agent>` context and later freeze a
 shorter, more operational machine page.
@@ -191,11 +259,11 @@ The visible UI page still renders `page.mdx`. Only the machine-readable surface 
 
 ## Audit The Agent Surface
 
-After you add `<Agent>` blocks, `agent.md`, `AGENTS.md`, `skill.md`, or discovery endpoints, use the
+After you add audience blocks, `agent.md`, `AGENTS.md`, `skill.md`, or discovery endpoints, use the
 [Doctor section of the CLI docs](/docs/cli#doctor) to audit whether the machine-facing layer is
 actually wired and visible the way you expect.
 
-That is the quickest follow-up after authoring page-level primitives. If you add an `Agent` block
+That is the quickest follow-up after authoring page-level controls. If you add an agent-only block
 or sibling `agent.md`, the doctor output should reflect stronger explicit agent-friendly page
 coverage instead of only looking correct in the UI.
 
@@ -290,13 +358,15 @@ also accepted as a compatibility alias.
 ## Choosing Between Them
 
 - Use `Agent` when the normal page should stay the source of truth and you only need extra machine context
+- Use `Human` when prose or visuals only help the rendered page and would add noise to agent context
+- Use `Audience` when you prefer an explicit `only="human"` or `only="agent"` prop
 - Use `agent.md` when the machine-readable page should become its own focused document
-- Use both patterns page-by-page; you do not need a global config flag to turn them on
+- Mix these patterns page-by-page; shared content needs no wrapper or global config flag
 
 ## Page Primitives Vs Skills
 
-`Agent` and `agent.md` are page-scoped primitives. They are the right fit when the machine context
-belongs to a single docs route.
+`Agent`, `Human`, `Audience`, and `agent.md` are page-scoped authoring controls. They are the right
+fit when audience-specific context belongs to a single docs route.
 
 Use `/AGENTS.md` when a coding agent needs site-level operating instructions for this repo or docs
 deployment. Use `/skill.md` when an agent needs a concise installable-skill style guide for this
@@ -305,7 +375,7 @@ workflows, such as setup, CLI usage, theme creation, page actions, or deeper con
 
 In practice, the two features work well together:
 
-- use `Agent` or `agent.md` to make one page more useful to agents
+- use audience wrappers or `agent.md` to tailor one page without duplicating its shared content
 - use skills when the knowledge should be bundled as a reusable workflow outside a single page
 
 This repo already publishes skills under `skills/farming-labs/`. Install them with:

--- a/website/app/docs/customization/components/page.mdx
+++ b/website/app/docs/customization/components/page.mdx
@@ -99,11 +99,41 @@ MDX without imports or `docs.config.ts` registration:
 - `img` — images
 - `blockquote` — blockquotes
 - `hr` — horizontal rules
+- `Agent` — optional shorthand for content that only appears in agent-projected output
+- `Human` — shorthand for content that only appears in human-projected output
+- `Audience` — explicit audience wrapper with `only="human"` or `only="agent"`
 - `HoverLink` — hover-triggered popover link card with title, description, and CTA
 - `Prompt` — reusable AI prompt card with copy/open actions
 - `Tab`, `Tabs` — tabbed content
 - `CodeGroup` — Mintlify-compatible tabbed code groups powered by the built-in code block UI
 - `Callout` — callout/admonition boxes
+
+### Example: Tailor content by audience
+
+Audience wrappers are built in, so they do not need to be registered in `docs.config.ts`:
+
+```mdx title="page.mdx"
+Shared setup instructions.
+
+<Human>Use the highlighted control in the screenshot.</Human>
+
+<Agent>Run `pnpm verify` and require exit code 0.</Agent>
+
+<Audience only="human">This is the explicit form of `Human`.</Audience>
+
+<Audience only="agent">This is the explicit form of `Agent`.</Audience>
+```
+
+Rendered HTML and public search use the human projection. Markdown, Ask AI, MCP, `llms-full.txt`,
+and static agent exports use the agent projection; compact `llms.txt` links point to that Markdown.
+Sitemaps contain route metadata rather than page bodies. Content outside a wrapper is shared, and
+`<Agent>` remains entirely optional. Keep `Audience.only` as a static literal and do not pass
+audience props through a spread; `docs review` reports declarations that static outputs cannot
+resolve consistently.
+
+These wrappers are not authentication or authorization. Never place secrets in them. See
+[Agent Primitive](/docs/customization/agent-primitive) for the complete surface matrix and
+`agent.md` override behavior.
 
 ### Example: Use `CodeGroup`
 

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -154,14 +154,14 @@ A declarative config file is hard to break. An AI can add `ai: { enabled: true }
 ## Compact Page-Level Agent Docs
 
 The framework already gives agents clean page-level markdown through `.md` routes, canonical URLs
-with `Signature-Agent` in Next.js, hidden `<Agent>...</Agent>` blocks, and sibling `agent.md` files.
+with `Signature-Agent` in Next.js, audience-aware page blocks, and sibling `agent.md` files.
 When you want that machine-readable layer to be even tighter, use `docs agent compact`.
 
 The command resolves the same page contract the runtime already uses:
 
 - existing `agent.md`
-- embedded `Agent` blocks
-- normal page markdown
+- the agent audience projection of `Agent`, `Human`, and `Audience` blocks
+- shared page content
 
 Then it sends that resolved document to the Docs Cloud compression API and writes a sibling
 `agent.md` file for the page.

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -160,7 +160,7 @@ When you want that machine-readable layer to be even tighter, use `docs agent co
 The command resolves the same page contract the runtime already uses:
 
 - existing `agent.md`
-- the agent audience projection of `Agent`, `Human`, and `Audience` blocks
+- the agent audience projection, which excludes `<Human>` and `<Audience only="human">` content
 - shared page content
 
 Then it sends that resolved document to the Docs Cloud compression API and writes a sibling


### PR DESCRIPTION
## Summary

- keep `Agent` as an optional agent-only shorthand and add `Human` plus explicit `Audience only="human|agent"` authoring
- apply one shared exposure policy to rendered HTML, reading time, Markdown, public search, Ask AI, MCP, llms output, sitemaps, and static exports across every adapter
- add authoring diagnostics for missing, invalid, dynamic, spread, and ignored shorthand audience props
- preserve shared content and literal MDX/code contexts with adversarial parser coverage for JSX, Svelte, frontmatter, comments, raw elements, regexes, links, and fences
- document the surface matrix and clarify that audience shaping is public representation, not authentication or authorization

## Verification

- core docs: 774 tests, typecheck, and build
- Fumadocs: 148 tests, typecheck, CSS bundle build, and package build
- Next adapter: 88 tests and build
- Astro, Nuxt, SvelteKit, TanStack Start, and Next adapter typechecks/builds
- website production build: 57 static pages
- repository formatting and diff checks
- lint: 0 errors (43 existing warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add audience-aware docs authoring and rendering across all adapters. Introduces `Human` and `Audience` MDX primitives, keeps `Agent`, and applies one projection policy to HTML, search, Ask, MCP, `llms.txt`, sitemaps, exports, and reading time.

- New Features
  - Unified resolver: `resolveDocsAudienceMdxContent` with `resolveDocsAudienceExposure`; keep `resolveDocsAgentMdxContent` for compat.
  - Built-ins in `fumadocs`: `Agent`, `Human`, and `Audience` (no imports). Reading time uses the human projection.
  - Search builds separate human/agent indexes; Ask/Context and MCP explicitly use the agent projection (MCP supports `audience: "agent"`). `llms-full.txt` now uses agent content at runtime.
  - CLI export includes audience-projected fields: `content/rawContent`, `agentContent/agentRawContent`, and fallback variants for downstream tools.
  - `docs review` surfaces audience issues (missing/invalid/dynamic/spread) and doctor reports “Audience-tailored” coverage; human-only primitives count as tailored coverage without usefulness credit.
  - Added `@mdx-js/mdx` to power robust audience parsing.

- Migration
  - Prefer `resolveDocsAudienceMdxContent`; `resolveDocsAgentMdxContent` stays exported for compatibility.
  - Keep `Audience.only` static (`"human"` or `"agent"`); dynamic or spread props are flagged in `docs review`.
  - No config flag required. Content outside audience wrappers is shared by both projections.

<sup>Written for commit 0357822f7c62512624d3aa427ce3df552138cdec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

