### PR TITLE
fix: `tsx` docs config evaluation

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -60,7 +60,7 @@
     "@scalar/core": "^0.4.3",
     "@vercel/sandbox": "^2.0.0",
     "gray-matter": "^4.0.3",
-    "jiti": "^2.6.1",
+    "jiti": "^2.7.0",
     "picocolors": "^1.1.1",
     "zod": "^4.3.6"
   },

--- a/packages/docs/src/cli/config.test.ts
+++ b/packages/docs/src/cli/config.test.ts
@@ -221,6 +221,109 @@ describe("loadDocsConfigModuleResult", () => {
     );
   });
 
+  it("evaluates a TSX config with JSX-valued options", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-config-loader-"));
+    tempDirs.push(rootDir);
+    writeFileSync(
+      join(rootDir, "docs.config.tsx"),
+      `export default {
+  entry: "guide",
+  nav: {
+    title: <span data-kind="docs-title">Agent-ready docs</span>,
+  },
+  pageActions: {
+    custom: <button type="button">Copy context</button>,
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const result = await loadDocsConfigModuleResult(rootDir, undefined, { silent: true });
+
+    expect(result).toMatchObject({
+      status: "evaluated",
+      path: join(rootDir, "docs.config.tsx"),
+      config: {
+        entry: "guide",
+        nav: {
+          title: {
+            type: "span",
+            props: {
+              "data-kind": "docs-title",
+              children: "Agent-ready docs",
+            },
+          },
+        },
+        pageActions: {
+          custom: {
+            type: "button",
+            props: {
+              type: "button",
+              children: "Copy context",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("resolves project tsconfig paths for a nested TSX config", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-config-loader-"));
+    tempDirs.push(rootDir);
+    mkdirSync(join(rootDir, "config"), { recursive: true });
+    mkdirSync(join(rootDir, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "@/*": ["src/*"] },
+        },
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(rootDir, "src", "components", "agent-icon.tsx"),
+      `export function AgentIcon() {
+  return <svg data-agent-icon="true" />;
+}
+`,
+      "utf-8",
+    );
+    writeFileSync(
+      join(rootDir, "config", "docs.config.tsx"),
+      `import { AgentIcon } from "@/components/agent-icon";
+
+export default {
+  entry: "guide",
+  pageActions: {
+    custom: <AgentIcon />,
+  },
+};
+`,
+      "utf-8",
+    );
+
+    const result = await loadDocsConfigModuleResult(rootDir, "config/docs.config.tsx", {
+      silent: true,
+    });
+
+    expect(result).toMatchObject({
+      status: "evaluated",
+      path: join(rootDir, "config", "docs.config.tsx"),
+      config: {
+        entry: "guide",
+        pageActions: {
+          custom: {
+            type: expect.any(Function),
+            props: {},
+          },
+        },
+      },
+    });
+  });
+
   it.each([
     ["an array", "export default [];\n"],
     ["an array beside named exports", "export const helper = true;\nexport default [];\n"],

--- a/packages/docs/src/cli/config.ts
+++ b/packages/docs/src/cli/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import type { DocsConfig } from "../types.js";
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
@@ -403,6 +403,24 @@ function isPlainDocsConfig(value: unknown): value is DocsConfig {
   return prototype === Object.prototype || prototype === null;
 }
 
+function resolveDocsConfigTsconfigPath(rootDir: string, configPath: string): string | false {
+  const projectRoot = resolve(rootDir);
+  let currentDir = dirname(configPath);
+
+  while (true) {
+    const tsconfigPath = join(currentDir, "tsconfig.json");
+    if (existsSync(tsconfigPath)) return tsconfigPath;
+    if (currentDir === projectRoot) return false;
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) return false;
+
+    const relativeParent = relative(projectRoot, parentDir);
+    if (relativeParent === ".." || relativeParent.startsWith(`..${sep}`)) return false;
+    currentDir = parentDir;
+  }
+}
+
 /**
  * Load docs.config with an explicit confidence signal for diagnostics.
  * Existing callers can keep using `loadDocsConfigModule`, which preserves the
@@ -421,6 +439,10 @@ export async function loadDocsConfigModuleResult(
       moduleCache: false,
       fsCache: false,
       interopDefault: false,
+      jsx: {
+        runtime: "automatic",
+      },
+      tsconfigPaths: resolveDocsConfigTsconfigPath(rootDir, configPath),
     });
 
     const loaded = await jiti.import(configPath);

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -763,12 +763,14 @@ Allow: /
     expect(report.checks.find((check) => check.id === "skill")?.status).toBe("pass");
   });
 
-  it("detects agent.compact in static config parsing when feedback.agent appears first", async () => {
+  it("detects agent.compact in static config parsing after module evaluation fails", async () => {
     writePackageJson(tmpDir, "doctor-static-agent", { next: "16.0.0" });
 
     writeFileSync(
       path.join(tmpDir, "docs.config.tsx"),
-      `export default {
+      `throw new Error("force static fallback");
+
+export default {
   entry: "docs",
   nav: {
     title: <span>Docs</span>,
@@ -2186,8 +2188,8 @@ Choose the entry, content directory, and theme defaults.
     expect(report.checks.find((check) => check.id === "feedback")?.status).toBe("pass");
   });
 
-  it("warns and awards partial credit when the site doctor uses static config parsing", async () => {
-    writePackageJson(tmpDir, "doctor-human-static-config", { next: "16.0.0" });
+  it("fully evaluates a TSX config with a JSX-valued navigation title", async () => {
+    writePackageJson(tmpDir, "doctor-human-tsx-config", { next: "16.0.0" });
     writeFileSync(
       path.join(tmpDir, "docs.config.tsx"),
       `export default {
@@ -2204,10 +2206,11 @@ Choose the entry, content directory, and theme defaults.
     const report = await inspectHumanReadiness();
 
     expect(report.checks.find((check) => check.id === "config")).toMatchObject({
-      status: "warn",
-      score: 2,
+      status: "pass",
+      score: 10,
       maxScore: 10,
-      recommendation: expect.stringContaining("Fix docs.config module evaluation"),
+      detail: expect.stringContaining("evaluated the config module"),
+      recommendation: undefined,
     });
   });
 

--- a/packages/docs/src/cli/review.test.ts
+++ b/packages/docs/src/cli/review.test.ts
@@ -107,11 +107,45 @@ description: Docs page
     });
   });
 
+  it("evaluates a TSX config before resolving review settings", async () => {
+    writeFileSync(
+      join(tmpDir, "docs.config.tsx"),
+      `const reviewBadge = <span data-review="disabled">Review disabled</span>;
+
+export default {
+  entry: "docs",
+  nav: { title: reviewBadge },
+  pageActions: {
+    custom: <button type="button">Copy context</button>,
+  },
+  review: reviewBadge.props["data-review"] === "disabled" ? false : true,
+};
+`,
+      "utf-8",
+    );
+    process.chdir(tmpDir);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const report = await runReview({ json: true });
+
+    expect(report).toMatchObject({
+      status: "disabled",
+      score: null,
+      findings: [],
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      status: "disabled",
+      score: null,
+    });
+  });
+
   it("prints project-wide findings when no docs file changed", async () => {
     mkdirSync(join(tmpDir, "app", "docs"), { recursive: true });
     writeFileSync(
       join(tmpDir, "docs.config.tsx"),
-      `export default {
+      `throw new Error("force static fallback");
+
+export default {
   entry: "docs",
   nav: { title: <span>Docs</span> },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,8 +381,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       jiti:
-        specifier: ^2.6.1
-        version: 2.6.1
+        specifier: ^2.7.0
+        version: 2.7.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -407,7 +407,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/fumadocs:
     dependencies:
@@ -5391,10 +5391,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -10425,7 +10421,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.19.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.30.2
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -10435,7 +10431,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.19.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.31.1
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -10957,14 +10953,6 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -11590,7 +11578,7 @@ snapshots:
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 1.0.0
@@ -11607,7 +11595,7 @@ snapshots:
       dotenv: 17.3.1
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -12974,8 +12962,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jiti@2.6.1: {}
 
   jiti@2.7.0: {}
 
@@ -16023,23 +16009,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.19.11
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.31.1
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
   vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.28.1
@@ -16068,33 +16037,6 @@ snapshots:
   vitefu@1.1.3(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
       vite: 7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  vitest@4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.11
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
## What changed

- enable Jiti's automatic JSX runtime when evaluating `docs.config.tsx`
- resolve the nearest project `tsconfig.json` so aliases such as `@/*` work from nested configs
- upgrade the direct Jiti dependency to the version that supports TypeScript path resolution
- add loader, Doctor, and Review regressions for JSX-valued settings and aliased TSX imports

## Why

Doctor and Review recognized `.tsx` config files but evaluated them without JSX or project path-alias support. Valid configs therefore fell back to static parsing, lowering confidence and preventing resolved config, discovery, and schema drift checks from running.

## Impact

Valid TSX configs now receive full evaluated-config diagnostics. Static fallback remains available for genuine evaluation failures.

Dogfooding this repository's `website/docs.config.tsx` now produces:

- config: 10/10
- config loading confidence: 5/5
- discovery/config/schema drift: 10/10

## Verification

- focused config/Doctor/Review tests: 72 passed
- full `@farming-labs/docs` suite: 780 passed
- package typecheck
- package build
- oxlint and formatting checks
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TSX docs config evaluation by enabling automatic JSX runtime and tsconfig path alias resolution. Doctor and Review now fully evaluate `.tsx` configs with JSX and `@/*` imports.

- **Bug Fixes**
  - Enable automatic JSX runtime when evaluating `docs.config.tsx`.
  - Resolve nearest `tsconfig.json` so TypeScript path aliases (e.g., `@/*`) work in nested configs.
  - Doctor/Review now evaluate TSX configs; static parsing is used only on real evaluation failures.
  - Added regression tests for JSX-valued settings and aliased TSX imports.

- **Dependencies**
  - Upgrade `jiti` to `^2.7.0` for TypeScript path resolution support.

<sup>Written for commit 7092b8c8923dd1044a160921274232dfb9c5cfed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

