### PR TITLE
fix: import docs config in TanStack agent forwarder

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "serialize-javascript": "^7.0.3",
       "shell-quote@<=1.8.4": "1.9.0",
       "svgo": "^4.0.1",
-      "fast-uri": "3.1.2",
+      "fast-uri": "3.1.3",
       "hono": "4.12.25",
       "rollup": "^4.59.0",
       "tar": "^7.5.19",

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -408,12 +408,19 @@ describe("api reference route templates", () => {
     expect(out).toContain("GET: handler");
   });
 
-  it("creates a single TanStack public docs forwarder", () => {
-    const out = tanstackDocsPublicRouteTemplate(false, "src/routes/$.ts", "docs");
+  it.each([
+    ["path aliases", true, 'import { docsServer } from "@/lib/docs.server";'],
+    ["relative paths", false, 'import { docsServer } from "../lib/docs.server";'],
+  ])("creates a single TanStack public docs forwarder with %s", (_, useAlias, serverImport) => {
+    const out = tanstackDocsPublicRouteTemplate(useAlias, "src/routes/$.ts", "docs");
     expect(out).toContain('createFileRoute("/$")');
     expect(out).toContain("isDocsPublicGetRequest");
     expect(out).toContain("isDocsMcpRequest");
-    expect(out).toContain('from "../lib/docs.server"');
+    expect(out).toContain(serverImport);
+    expect(out).toContain('import docsConfig from "../../docs.config";');
+    expect(out).toContain("sitemap: docsConfig.sitemap");
+    expect(out).toContain("llms: docsConfig.llmsTxt");
+    expect(out).toContain("robots: docsConfig.robots");
     expect(out).toContain("docsServer.MCP.OPTIONS");
     expect(out).toContain("OPTIONS: async");
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE, OPTIONS"');

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1175,6 +1175,7 @@ export function tanstackDocsPublicRouteTemplate(
 import { createFileRoute } from "@tanstack/react-router";
 import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
 import { docsServer } from "${serverImport}";
+import docsConfig from "${tanstackDocsConfigImport(filePath)}";
 
 const docsEntry = ${JSON.stringify(entry)};
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   serialize-javascript: ^7.0.3
   shell-quote@<=1.8.4: 1.9.0
   svgo: ^4.0.1
-  fast-uri: 3.1.2
+  fast-uri: 3.1.3
   hono: 4.12.25
   rollup: ^4.59.0
   tar: ^7.5.19
@@ -4813,8 +4813,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11225,7 +11225,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12323,7 +12323,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,16 +85,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.4.8(@types/node@22.19.11)(@vercel/functions@3.7.1(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.1)(jiti@2.7.0)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))(ws@8.21.0)
       '@farming-labs/astro':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -106,13 +106,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -155,13 +155,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -210,16 +210,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -238,16 +238,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -275,13 +275,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0


### PR DESCRIPTION
## What

- Import the root docs configuration in the generated TanStack public forwarder.
- Cover alias and relative server imports in the template regression test.
- Assert the generated sitemap, llms.txt, and robots options remain config-backed.

## Why

The generated src/routes/$.ts used docsConfig without declaring it, so new TanStack projects could fail typechecking or building.

## Impact

Generated TanStack public agent routes now compile and retain their configured discovery behavior.

## Checks

- Template tests: 77 passed
- @farming-labs/docs typecheck
- Targeted format and lint checks
- Frozen lockfile validation
- git diff --check

## Shared CI repairs

Current main bumped example packages to 0.2.59 without syncing the lockfile. CI also began flagging the newly published high-severity fast-uri advisory (GHSA-4c8g-83qw-93j6). This PR carries both shared repairs as separate dependency commits so frozen installs and the security audit can run. Once one fix PR merges, the duplicate dependency diffs drop from the others.
