### PR TITLE
fix: advertise markdown negotiation in framework adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "serialize-javascript": "^7.0.3",
       "shell-quote@<=1.8.4": "1.9.0",
       "svgo": "^4.0.1",
-      "fast-uri": "3.1.2",
+      "fast-uri": "3.1.3",
       "hono": "4.12.25",
       "rollup": "^4.59.0",
       "tar": "^7.5.19",

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -1047,7 +1047,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       robots: config.robots,
       openapi: openapiDiscovery,
       markdown: {
-        acceptHeader: false,
+        acceptHeader: true,
       },
     } as any;
     if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE } from "./agent.js";
 import type { DocsAgentAdapter } from "./agent-conformance.js";
 import { runDocsAgentConformance } from "./agent-conformance.js";
 
@@ -48,6 +49,21 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
 
     expect(report.cases.filter((result) => !result.passed)).toEqual([]);
     expect(report.passed).toBe(true);
+
+    const discoveryUrl = new URL(
+      DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
+      "https://docs.example.com",
+    );
+    const discoveryResponse = await server.GET({
+      request: new Request(discoveryUrl),
+      url: discoveryUrl,
+    });
+    await expect(discoveryResponse.json()).resolves.toMatchObject({
+      markdown: {
+        enabled: true,
+        acceptHeader: "text/markdown",
+      },
+    });
 
     const indexUrl = new URL("/.well-known/agent-skills/index.json", "https://docs.example.com");
     const indexResponse = await server.GET({

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -1037,7 +1037,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       robots: config.robots,
       openapi: openapiDiscovery,
       markdown: {
-        acceptHeader: false,
+        acceptHeader: true,
       },
     } as any;
     if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -1059,7 +1059,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       robots: config.robots,
       openapi: openapiDiscovery,
       markdown: {
-        acceptHeader: false,
+        acceptHeader: true,
       },
     } as any;
     if (isDocsStandardsDiscoveryRequest(event.url, { apiRoute: discoveryApiRoute })) {

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -1007,7 +1007,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       robots: config.robots,
       openapi: openapiDiscovery,
       markdown: {
-        acceptHeader: false,
+        acceptHeader: true,
       },
     } as any;
     if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   serialize-javascript: ^7.0.3
   shell-quote@<=1.8.4: 1.9.0
   svgo: ^4.0.1
-  fast-uri: 3.1.2
+  fast-uri: 3.1.3
   hono: 4.12.25
   rollup: ^4.59.0
   tar: ^7.5.19
@@ -4813,8 +4813,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11225,7 +11225,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12323,7 +12323,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,16 +85,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.4.8(@types/node@22.19.11)(@vercel/functions@3.7.1(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.1)(jiti@2.7.0)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))(ws@8.21.0)
       '@farming-labs/astro':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -106,13 +106,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -155,13 +155,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -210,16 +210,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -238,16 +238,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -275,13 +275,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0


### PR DESCRIPTION
## What

- Advertise Accept: text/markdown support from Astro, Nuxt, SvelteKit, and TanStack Start.
- Add a cross-adapter discovery regression assertion.

## Why

All four adapters already negotiate Markdown successfully, but their agent discovery documents explicitly reported that capability as unavailable.

## Impact

Agents can trust discovery metadata and select the canonical Markdown representation consistently across adapters.

## Checks

- Adapter conformance: 8 passed
- Core plus Astro, Nuxt, SvelteKit, and TanStack Start typechecks
- Targeted format and lint checks
- Frozen lockfile validation
- git diff --check

## Shared CI repairs

Current main bumped example packages to 0.2.59 without syncing the lockfile. CI also began flagging the newly published high-severity fast-uri advisory (GHSA-4c8g-83qw-93j6). This PR carries both shared repairs as separate dependency commits so frozen installs and the security audit can run. Once one fix PR merges, the duplicate dependency diffs drop from the others.
