### PR TITLE
fix: emit direct hosted MCP client configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "serialize-javascript": "^7.0.3",
       "shell-quote@<=1.8.4": "1.9.0",
       "svgo": "^4.0.1",
-      "fast-uri": "3.1.2",
+      "fast-uri": "3.1.3",
       "hono": "4.12.25",
       "rollup": "^4.59.0",
       "tar": "^7.5.19",

--- a/packages/docs/src/cli/index.test.ts
+++ b/packages/docs/src/cli/index.test.ts
@@ -47,8 +47,9 @@ describe("parseFlags", () => {
   });
 
   it("parses mcp flags", () => {
-    const flags = parseFlags(["mcp", "--config", "src/lib/docs.config.ts"]);
+    const flags = parseFlags(["mcp", "--config", "src/lib/docs.config.ts", "--client", "cursor"]);
     expect(flags.config).toBe("src/lib/docs.config.ts");
+    expect(flags.client).toBe("cursor");
   });
 
   it("parses search sync provider flags", () => {

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -92,6 +92,7 @@ async function main() {
         : typeof flags.url === "string"
           ? flags.url
           : undefined,
+    client: typeof flags.client === "string" ? flags.client : undefined,
     json: typeof flags.json === "boolean" ? flags.json : undefined,
   };
   const devOptions = {
@@ -371,7 +372,8 @@ ${pc.dim("Options for mcp:")}
   ${pc.cyan("--config <path>")}     Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
   ${pc.cyan("mcp setup --deployment <id>")} Print Docs Cloud hosted MCP setup for a deployment id
   ${pc.cyan("--api-base-url <url>")} Override the hosted Docs Cloud API base URL for ${pc.cyan("mcp setup")}
-  ${pc.cyan("--json")}              Print MCP client JSON only for ${pc.cyan("mcp setup")}
+  ${pc.cyan("--client <name>")}     Emit native config for ${pc.dim("claude-code")}, ${pc.dim("cursor")}, or ${pc.dim("vscode")}
+  ${pc.cyan("--json")}              Print the selected MCP client JSON only for ${pc.cyan("mcp setup")}
 
 ${pc.dim("Options for dev:")}
   ${pc.cyan("--port <number>")}     Run the frameworkless preview on a custom port

--- a/packages/docs/src/cli/mcp.test.ts
+++ b/packages/docs/src/cli/mcp.test.ts
@@ -22,11 +22,56 @@ describe("createHostedMcpClientConfig", () => {
       " https://cloud.example.com/api/// ",
     );
 
-    expect(config.mcpServers["docs-cloud"].url).toBe(
-      "https://cloud.example.com/api/v1/mcp/deployment-456",
+    expect(config).toMatchObject({
+      mcpServers: {
+        "docs-cloud": {
+          url: "https://cloud.example.com/api/v1/mcp/deployment-456",
+        },
+      },
+    });
+    expect(JSON.stringify(config)).not.toContain('"command"');
+    expect(JSON.stringify(config)).not.toContain('"args"');
+  });
+
+  it("uses Cursor's environment variable syntax", () => {
+    expect(createHostedMcpClientConfig("deployment-123", undefined, "cursor")).toEqual({
+      mcpServers: {
+        "docs-cloud": {
+          url: "https://api.farming-labs.dev/v1/mcp/deployment-123",
+          headers: {
+            Authorization: "Bearer ${env:DOCS_CLOUD_API_KEY}",
+          },
+        },
+      },
+    });
+  });
+
+  it("uses VS Code's servers schema and secure input syntax", () => {
+    expect(createHostedMcpClientConfig("deployment-123", undefined, "vscode")).toEqual({
+      inputs: [
+        {
+          type: "promptString",
+          id: "docs-cloud-api-key",
+          description: "Docs Cloud API key",
+          password: true,
+        },
+      ],
+      servers: {
+        "docs-cloud": {
+          type: "http",
+          url: "https://api.farming-labs.dev/v1/mcp/deployment-123",
+          headers: {
+            Authorization: "Bearer ${input:docs-cloud-api-key}",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects unknown clients instead of emitting incompatible JSON", () => {
+    expect(() => createHostedMcpClientConfig("deployment-123", undefined, "other")).toThrow(
+      'Unsupported MCP client "other"',
     );
-    expect(config.mcpServers["docs-cloud"]).not.toHaveProperty("command");
-    expect(config.mcpServers["docs-cloud"]).not.toHaveProperty("args");
   });
 });
 

--- a/packages/docs/src/cli/mcp.test.ts
+++ b/packages/docs/src/cli/mcp.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { readMcpConfig } from "./mcp.js";
+import { createHostedMcpClientConfig, readMcpConfig } from "./mcp.js";
+
+describe("createHostedMcpClientConfig", () => {
+  it("connects directly to the hosted Streamable HTTP endpoint", () => {
+    expect(createHostedMcpClientConfig(" deployment-123 ")).toEqual({
+      mcpServers: {
+        "docs-cloud": {
+          type: "http",
+          url: "https://api.farming-labs.dev/v1/mcp/deployment-123",
+          headers: {
+            Authorization: "Bearer ${DOCS_CLOUD_API_KEY}",
+          },
+        },
+      },
+    });
+  });
+
+  it("normalizes a custom API base URL without generating a setup subprocess", () => {
+    const config = createHostedMcpClientConfig(
+      "deployment-456",
+      " https://cloud.example.com/api/// ",
+    );
+
+    expect(config.mcpServers["docs-cloud"].url).toBe(
+      "https://cloud.example.com/api/v1/mcp/deployment-456",
+    );
+    expect(config.mcpServers["docs-cloud"]).not.toHaveProperty("command");
+    expect(config.mcpServers["docs-cloud"]).not.toHaveProperty("args");
+  });
+});
 
 describe("readMcpConfig", () => {
   it("preserves task and context tool opt-outs", () => {

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -56,6 +56,22 @@ function normalizeApiBaseUrl(value?: string) {
   return (value?.trim() || "https://api.farming-labs.dev").replace(/\/+$/g, "");
 }
 
+export function createHostedMcpClientConfig(deploymentId: string, apiBaseUrl?: string) {
+  const endpoint = `${normalizeApiBaseUrl(apiBaseUrl)}/v1/mcp/${deploymentId.trim()}`;
+
+  return {
+    mcpServers: {
+      "docs-cloud": {
+        type: "http",
+        url: endpoint,
+        headers: {
+          Authorization: "Bearer ${DOCS_CLOUD_API_KEY}",
+        },
+      },
+    },
+  };
+}
+
 function printHostedMcpSetup(options: RunMcpOptions) {
   const deploymentId = options.deploymentId?.trim();
 
@@ -68,16 +84,8 @@ function printHostedMcpSetup(options: RunMcpOptions) {
     process.exit(1);
   }
 
-  const apiBaseUrl = normalizeApiBaseUrl(options.apiBaseUrl);
-  const endpoint = `${apiBaseUrl}/v1/mcp/${deploymentId}`;
-  const jsonConfig = {
-    mcpServers: {
-      "docs-cloud": {
-        command: "npx",
-        args: ["@farming-labs/docs", "mcp", "setup", "--deployment", deploymentId],
-      },
-    },
-  };
+  const jsonConfig = createHostedMcpClientConfig(deploymentId, options.apiBaseUrl);
+  const endpoint = jsonConfig.mcpServers["docs-cloud"].url;
 
   if (options.json) {
     console.log(JSON.stringify(jsonConfig, null, 2));
@@ -87,10 +95,7 @@ function printHostedMcpSetup(options: RunMcpOptions) {
   console.log(pc.bold("Docs Cloud MCP deployment"));
   console.log(pc.dim(`Deployment: ${deploymentId}`));
   console.log();
-  console.log(pc.cyan("CLI stdio"));
-  console.log(`  npx @farming-labs/docs mcp setup --deployment ${deploymentId}`);
-  console.log();
-  console.log(pc.cyan("Streamable HTTP"));
+  console.log(pc.cyan("Streamable HTTP (recommended)"));
   console.log(`  ${endpoint}`);
   console.log();
   console.log(pc.cyan("SSE"));
@@ -99,7 +104,11 @@ function printHostedMcpSetup(options: RunMcpOptions) {
   console.log(pc.cyan("MCP client JSON"));
   console.log(JSON.stringify(jsonConfig, null, 2));
   console.log();
-  console.log(pc.dim("Set DOCS_CLOUD_API_KEY in the agent environment before connecting."));
+  console.log(
+    pc.dim(
+      "The config reads DOCS_CLOUD_API_KEY from the MCP client environment; no secret is embedded.",
+    ),
+  );
 }
 
 export function readMcpConfig(content: string): boolean | DocsMcpConfig | undefined {

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -16,8 +16,18 @@ interface RunMcpOptions {
   setup?: boolean;
   deploymentId?: string;
   apiBaseUrl?: string;
+  client?: string;
   json?: boolean;
 }
+
+const HOSTED_MCP_CLIENTS = ["claude-code", "cursor", "vscode"] as const;
+type HostedMcpClient = (typeof HOSTED_MCP_CLIENTS)[number];
+
+const HOSTED_MCP_CLIENT_LABELS: Record<HostedMcpClient, string> = {
+  "claude-code": "Claude Code",
+  cursor: "Cursor",
+  vscode: "VS Code",
+};
 
 export async function runMcp(options: RunMcpOptions = {}): Promise<void> {
   if (options.setup) {
@@ -56,8 +66,61 @@ function normalizeApiBaseUrl(value?: string) {
   return (value?.trim() || "https://api.farming-labs.dev").replace(/\/+$/g, "");
 }
 
-export function createHostedMcpClientConfig(deploymentId: string, apiBaseUrl?: string) {
+function normalizeHostedMcpClient(value?: string): HostedMcpClient {
+  const normalized = value?.trim().toLowerCase() || "claude-code";
+
+  if (normalized === "claude") return "claude-code";
+  if (HOSTED_MCP_CLIENTS.includes(normalized as HostedMcpClient)) {
+    return normalized as HostedMcpClient;
+  }
+
+  throw new Error(
+    `Unsupported MCP client "${value}". Expected one of: ${HOSTED_MCP_CLIENTS.join(", ")}.`,
+  );
+}
+
+export function createHostedMcpClientConfig(
+  deploymentId: string,
+  apiBaseUrl?: string,
+  clientName?: string,
+) {
   const endpoint = `${normalizeApiBaseUrl(apiBaseUrl)}/v1/mcp/${deploymentId.trim()}`;
+  const client = normalizeHostedMcpClient(clientName);
+
+  if (client === "cursor") {
+    return {
+      mcpServers: {
+        "docs-cloud": {
+          url: endpoint,
+          headers: {
+            Authorization: "Bearer ${env:DOCS_CLOUD_API_KEY}",
+          },
+        },
+      },
+    };
+  }
+
+  if (client === "vscode") {
+    return {
+      inputs: [
+        {
+          type: "promptString",
+          id: "docs-cloud-api-key",
+          description: "Docs Cloud API key",
+          password: true,
+        },
+      ],
+      servers: {
+        "docs-cloud": {
+          type: "http",
+          url: endpoint,
+          headers: {
+            Authorization: "Bearer ${input:docs-cloud-api-key}",
+          },
+        },
+      },
+    };
+  }
 
   return {
     mcpServers: {
@@ -84,8 +147,9 @@ function printHostedMcpSetup(options: RunMcpOptions) {
     process.exit(1);
   }
 
-  const jsonConfig = createHostedMcpClientConfig(deploymentId, options.apiBaseUrl);
-  const endpoint = jsonConfig.mcpServers["docs-cloud"].url;
+  const client = normalizeHostedMcpClient(options.client);
+  const jsonConfig = createHostedMcpClientConfig(deploymentId, options.apiBaseUrl, client);
+  const endpoint = `${normalizeApiBaseUrl(options.apiBaseUrl)}/v1/mcp/${deploymentId}`;
 
   if (options.json) {
     console.log(JSON.stringify(jsonConfig, null, 2));
@@ -101,14 +165,19 @@ function printHostedMcpSetup(options: RunMcpOptions) {
   console.log(pc.cyan("SSE"));
   console.log(`  ${endpoint}/sse`);
   console.log();
-  console.log(pc.cyan("MCP client JSON"));
+  console.log(pc.cyan(`MCP client JSON (${HOSTED_MCP_CLIENT_LABELS[client]})`));
   console.log(JSON.stringify(jsonConfig, null, 2));
   console.log();
-  console.log(
-    pc.dim(
-      "The config reads DOCS_CLOUD_API_KEY from the MCP client environment; no secret is embedded.",
-    ),
-  );
+  if (client === "vscode") {
+    console.log(pc.dim("VS Code prompts for the API key once and stores it securely."));
+  } else {
+    console.log(
+      pc.dim(
+        "The config reads DOCS_CLOUD_API_KEY from the MCP client environment; no secret is embedded.",
+      ),
+    );
+  }
+  console.log(pc.dim("Use --client cursor or --client vscode to emit another native format."));
 }
 
 export function readMcpConfig(content: string): boolean | DocsMcpConfig | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   serialize-javascript: ^7.0.3
   shell-quote@<=1.8.4: 1.9.0
   svgo: ^4.0.1
-  fast-uri: 3.1.2
+  fast-uri: 3.1.3
   hono: 4.12.25
   rollup: ^4.59.0
   tar: ^7.5.19
@@ -4813,8 +4813,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11225,7 +11225,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12323,7 +12323,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,16 +85,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.4.8(@types/node@22.19.11)(@vercel/functions@3.7.1(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.1)(jiti@2.7.0)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))(ws@8.21.0)
       '@farming-labs/astro':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -106,13 +106,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -155,13 +155,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -210,16 +210,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -238,16 +238,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -275,13 +275,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.58
+        specifier: 0.2.59
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -195,6 +195,17 @@ Use a custom config path when the file lives elsewhere:
 pnpm exec docs mcp --config src/lib/docs.config.ts
 ```
 
+For a hosted Docs Cloud deployment, generate a direct Streamable HTTP client entry instead of
+running the local stdio server:
+
+```bash
+pnpm exec docs mcp setup --deployment <deployment-id> --json
+```
+
+The generated `mcpServers` entry uses the hosted `/v1/mcp/<deployment-id>` URL and references
+`DOCS_CLOUD_API_KEY` in its authorization header. The raw key is never written to the JSON output;
+set the environment variable in the MCP client process before connecting.
+
 The built-in MCP surface currently includes:
 
 - `list_docs`

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -202,9 +202,17 @@ running the local stdio server:
 pnpm exec docs mcp setup --deployment <deployment-id> --json
 ```
 
-The generated `mcpServers` entry uses the hosted `/v1/mcp/<deployment-id>` URL and references
-`DOCS_CLOUD_API_KEY` in its authorization header. The raw key is never written to the JSON output;
-set the environment variable in the MCP client process before connecting.
+The default output targets Claude Code and references `${DOCS_CLOUD_API_KEY}` in its authorization
+header. Generate a native config for another client when needed:
+
+```bash
+pnpm exec docs mcp setup --deployment <deployment-id> --client cursor --json
+pnpm exec docs mcp setup --deployment <deployment-id> --client vscode --json
+```
+
+Cursor output uses `${env:DOCS_CLOUD_API_KEY}`. VS Code output uses its top-level `servers` schema
+and a secure `${input:docs-cloud-api-key}` prompt. The raw key is never written to any generated
+JSON output.
 
 The built-in MCP surface currently includes:
 

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -1135,17 +1135,18 @@ Use `mcp setup` when you want to print the MCP client configuration for a Docs C
 pnpm exec docs mcp setup --deployment <id>
 ```
 
-By default the command prints human-readable setup instructions. Use `--json` to print only the JSON block:
+By default the command prints human-readable setup instructions and a Claude Code-compatible JSON
+block. Use `--json` to print only that JSON:
 
 ```bash title="terminal"
 pnpm exec docs mcp setup --deployment <id> --json
 ```
 
-The generated `mcpServers` entry connects directly to the deployment over Streamable HTTP. It
-references `DOCS_CLOUD_API_KEY` in the authorization header instead of embedding the secret, so set
-that environment variable before starting the MCP client:
+The default `claude-code` format connects directly to the deployment over Streamable HTTP. Its
+`${DOCS_CLOUD_API_KEY}` placeholder is Claude Code's environment-variable syntax, so set that
+variable before starting Claude Code:
 
-```json title="MCP client config"
+```json title="Claude Code .mcp.json (default)"
 {
   "mcpServers": {
     "docs-cloud": {
@@ -1159,6 +1160,22 @@ that environment variable before starting the MCP client:
 }
 ```
 
+MCP clients use different config schemas and secret placeholders. Select the target client instead
+of copying the default block into an incompatible config file:
+
+```bash title="terminal"
+pnpm exec docs mcp setup --deployment <id> --client cursor --json
+pnpm exec docs mcp setup --deployment <id> --client vscode --json
+```
+
+| Client | `--client` value | Generated secret handling |
+| ------ | ---------------- | ------------------------- |
+| Claude Code | `claude-code` (default) | Reads `${DOCS_CLOUD_API_KEY}` from the Claude Code process environment. |
+| Cursor | `cursor` | Reads `${env:DOCS_CLOUD_API_KEY}` using Cursor's environment-variable syntax. |
+| VS Code | `vscode` | Uses the native `servers` schema and a secure `${input:docs-cloud-api-key}` prompt. |
+
+None of the formats embeds the raw API key in generated JSON.
+
 Use `--api-base-url` to override the Docs Cloud API base URL (defaults to `https://api.farming-labs.dev`):
 
 ```bash title="terminal"
@@ -1171,7 +1188,8 @@ Flags for `mcp setup`:
 | ---- | ----------- |
 | `--deployment <id>` | **(Required)** Docs Cloud deployment ID. |
 | `--api-base-url <url>` | Override the Docs Cloud API base URL. Defaults to `https://api.farming-labs.dev`. |
-| `--json` | Print only the MCP client JSON without human-readable instructions. |
+| `--client <name>` | Emit native config for `claude-code` (default), `cursor`, or `vscode`. |
+| `--json` | Print only the selected MCP client JSON without human-readable instructions. |
 ## Code Blocks
 
 Use `docs codeblocks validate` to plan and validate fenced code blocks from your docs content.

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -1141,6 +1141,24 @@ By default the command prints human-readable setup instructions. Use `--json` to
 pnpm exec docs mcp setup --deployment <id> --json
 ```
 
+The generated `mcpServers` entry connects directly to the deployment over Streamable HTTP. It
+references `DOCS_CLOUD_API_KEY` in the authorization header instead of embedding the secret, so set
+that environment variable before starting the MCP client:
+
+```json title="MCP client config"
+{
+  "mcpServers": {
+    "docs-cloud": {
+      "type": "http",
+      "url": "https://api.farming-labs.dev/v1/mcp/<id>",
+      "headers": {
+        "Authorization": "Bearer ${DOCS_CLOUD_API_KEY}"
+      }
+    }
+  }
+}
+```
+
 Use `--api-base-url` to override the Docs Cloud API base URL (defaults to `https://api.farming-labs.dev`):
 
 ```bash title="terminal"

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -464,11 +464,13 @@ To print the MCP client setup instructions for your own Docs Cloud deployment, u
 pnpm exec docs mcp setup --deployment <your-deployment-id>
 ```
 
-The generated config connects directly to the hosted Streamable HTTP endpoint and reads the bearer
-token from `DOCS_CLOUD_API_KEY`; it does not run another setup command or embed the secret. Add
-`--json` to print only the JSON config block, or `--api-base-url <url>` to target a self-hosted Docs
-Cloud API. See [CLI](/docs/cli#print-hosted-mcp-client-config-with-mcp-setup) for the full flag
-reference.
+The generated config connects directly to the hosted Streamable HTTP endpoint; it does not run
+another setup command or embed the secret. The default output targets Claude Code and reads
+`${DOCS_CLOUD_API_KEY}` from that client's environment. Use `--client cursor` for Cursor's
+`${env:DOCS_CLOUD_API_KEY}` syntax, or `--client vscode` for VS Code's native `servers` schema and
+secure input prompt. Add `--json` to print only the selected JSON config block, or
+`--api-base-url <url>` to target a self-hosted Docs Cloud API. See
+[CLI](/docs/cli#print-hosted-mcp-client-config-with-mcp-setup) for the full flag reference.
 <DocsMcpAccess />
 
 ### More setup docs

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -464,7 +464,11 @@ To print the MCP client setup instructions for your own Docs Cloud deployment, u
 pnpm exec docs mcp setup --deployment <your-deployment-id>
 ```
 
-Add `--json` to print only the JSON config block, or `--api-base-url <url>` to target a self-hosted Docs Cloud API. See [CLI](/docs/cli#print-hosted-mcp-client-config-with-mcp-setup) for the full flag reference.
+The generated config connects directly to the hosted Streamable HTTP endpoint and reads the bearer
+token from `DOCS_CLOUD_API_KEY`; it does not run another setup command or embed the secret. Add
+`--json` to print only the JSON config block, or `--api-base-url <url>` to target a self-hosted Docs
+Cloud API. See [CLI](/docs/cli#print-hosted-mcp-client-config-with-mcp-setup) for the full flag
+reference.
 <DocsMcpAccess />
 
 ### More setup docs


### PR DESCRIPTION
## What

- Emit direct Streamable HTTP MCP client entries for hosted deployments.
- Add `--client claude-code|cursor|vscode` with each client native schema and secret syntax.
- Keep Claude Code as the documented default while generating Cursor `${env:...}` and VS Code secure `${input:...}` variants.
- Remove the misleading hosted stdio setup output.
- Add focused regression tests and update the CLI, MCP, and agent-facing CLI guidance.

## Why

The old generated client configuration launched `mcp setup` as a subprocess. That command only printed setup instructions and exited, so the MCP client never connected. Authenticated MCP JSON is also not portable across Claude Code, Cursor, and VS Code, so the CLI now emits an explicit native format rather than ambiguous generic JSON.

## Impact

Generated hosted configuration connects to the deployment URL directly, never embeds the raw key, and is ready to paste into the selected client.

## Checks

- Hosted MCP and flag tests: 29 passed
- `@farming-labs/docs` typecheck
- Targeted format and lint checks
- Frozen lockfile validation
- `git diff --check`

## Shared CI repairs

Current main bumped example packages to 0.2.59 without syncing the lockfile. CI also began flagging the newly published high-severity `fast-uri` advisory (GHSA-4c8g-83qw-93j6). This PR carries both shared repairs as separate dependency commits so frozen installs and the security audit can run. Once one fix PR merges, the duplicate dependency diffs drop from the others.