### PR TITLE
feat: add agent-aware search

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -72,6 +72,7 @@ import {
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtRequest,
@@ -1283,13 +1284,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const searchStartedAt = Date.now();
+    const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
       search: resolveSearchRequestConfig(config.search, context.request.url),
+      audience,
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+      baseUrl: markdownMetadataBaseUrl || url.origin,
     });
     await emitDocsAnalyticsEvent(analytics, {
       type: "api_search",
@@ -1300,6 +1304,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       input: { query },
       properties: {
         queryLength: query.length,
+        audience,
         resultCount: results.length,
         pathname: url.searchParams.get("pathname") ?? undefined,
         durationMs: Math.max(0, Date.now() - searchStartedAt),

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -94,6 +94,23 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       entry: "docs",
       nav: { title: "Audience Docs" },
       mcp: true,
+      search: {
+        provider: "custom",
+        adapter: {
+          name: "stale-audience-index",
+          async search() {
+            return [
+              {
+                id: "stale-audience-hit",
+                url: "https://docs.example.com/docs",
+                content: "Audience",
+                description: "Agent indigo procedure.",
+                type: "page",
+              },
+            ];
+          },
+        },
+      },
       sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
       _preloadedContent: {
         "/docs/page.md": `---
@@ -112,14 +129,26 @@ Shared context.
     });
 
     async function get(path: string) {
-      const url = new URL(path, "https://docs.example.com");
+      const url = new URL(path, "https://preview.example.com");
       return server.GET({ request: new Request(url), url });
     }
 
     const humanSearch = await get("/api/docs?query=human%20coral%20walkthrough");
-    const agentSearch = await get("/api/docs?query=agent%20indigo%20procedure");
-    expect(await humanSearch.text()).toContain("Audience");
-    expect(await agentSearch.json()).toEqual([]);
+    const defaultAgentSearch = await get("/api/docs?query=agent%20indigo%20procedure");
+    const explicitAgentSearch = await get(
+      "/api/docs?query=agent%20indigo%20procedure&audience=agent",
+    );
+    const invalidAgentSearch = await get(
+      "/api/docs?query=agent%20indigo%20procedure&audience=Agent",
+    );
+    const humanSearchText = await humanSearch.text();
+    expect(humanSearchText).toContain("Human coral walkthrough");
+    expect(humanSearchText).not.toContain("Agent indigo procedure");
+    expect(await defaultAgentSearch.json()).toEqual([]);
+    const explicitAgentSearchText = await explicitAgentSearch.text();
+    expect(explicitAgentSearchText).toContain("Agent indigo procedure");
+    expect(explicitAgentSearchText).not.toContain("Human coral walkthrough");
+    expect(await invalidAgentSearch.json()).toEqual([]);
 
     const markdown = await (await get("/docs.md")).text();
     expect(markdown).toContain("Agent indigo procedure.");

--- a/packages/docs/src/agent-surface-drift.test.ts
+++ b/packages/docs/src/agent-surface-drift.test.ts
@@ -59,6 +59,10 @@ function healthyOptions(): AnalyzeAgentSurfaceDriftOptions {
       search: {
         enabled: true,
         endpoint: "/api/docs?query={query}",
+        agentEndpoint: "/api/docs?query={query}&audience=agent",
+        audienceParam: "audience",
+        defaultAudience: "human",
+        supportedAudiences: ["human", "agent"],
       },
       mcp: {
         enabled: true,
@@ -205,6 +209,10 @@ describe("agent surface drift", () => {
       search: {
         enabled: false,
         endpoint: "/wrong-search",
+        agentEndpoint: "/wrong-agent-search",
+        audienceParam: "target",
+        defaultAudience: "agent",
+        supportedAudiences: ["agent"],
       },
       mcp: {
         enabled: false,
@@ -244,6 +252,7 @@ describe("agent surface drift", () => {
         "search-enabled-mismatch",
         "search-capability-mismatch",
         "search-route-mismatch",
+        "search-audience-mismatch",
         "mcp-enabled-mismatch",
         "mcp-capability-mismatch",
         "mcp-route-mismatch",
@@ -265,6 +274,16 @@ describe("agent surface drift", () => {
       expected: "documented schema option",
       actual: "<missing>",
     });
+    expect(
+      issues
+        .filter((issue) => issue.code === "search-audience-mismatch")
+        .map((issue) => issue.path),
+    ).toEqual([
+      "search.agentEndpoint",
+      "search.audienceParam",
+      "search.defaultAudience",
+      "search.supportedAudiences",
+    ]);
     expect(issues.find((issue) => issue.path === "agentContract.fields.rollback")).toMatchObject({
       code: "agent-contract-field-missing",
     });

--- a/packages/docs/src/agent-surface-drift.ts
+++ b/packages/docs/src/agent-surface-drift.ts
@@ -48,6 +48,7 @@ export type AgentSurfaceDriftCode =
   | "search-enabled-mismatch"
   | "search-capability-mismatch"
   | "search-route-mismatch"
+  | "search-audience-mismatch"
   | "mcp-enabled-mismatch"
   | "mcp-capability-mismatch"
   | "mcp-route-mismatch"
@@ -301,6 +302,44 @@ export function analyzeAgentSurfaceDrift(
     "search.endpoint",
     options.expected.search.endpoint,
     "Discovery search.endpoint",
+  );
+  const expectedAgentSearchEndpoint =
+    options.expected.search.endpoint === null
+      ? null
+      : `${options.expected.search.endpoint}${
+          options.expected.search.endpoint.includes("?") ? "&" : "?"
+        }audience=agent`;
+  compareExpectedValue(
+    issues,
+    options.discovery,
+    "search-audience-mismatch",
+    "search.agentEndpoint",
+    expectedAgentSearchEndpoint,
+    "Discovery search.agentEndpoint",
+  );
+  compareExpectedValue(
+    issues,
+    options.discovery,
+    "search-audience-mismatch",
+    "search.audienceParam",
+    "audience",
+    "Discovery search.audienceParam",
+  );
+  compareExpectedValue(
+    issues,
+    options.discovery,
+    "search-audience-mismatch",
+    "search.defaultAudience",
+    "human",
+    "Discovery search.defaultAudience",
+  );
+  compareExpectedValue(
+    issues,
+    options.discovery,
+    "search-audience-mismatch",
+    "search.supportedAudiences",
+    ["human", "agent"],
+    "Discovery search.supportedAudiences",
   );
 
   compareExpectedValue(

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -367,6 +367,7 @@ describe("agent route helpers", () => {
         agentSkillsIndex: "/.well-known/agent-skills/index.json",
         agentSkillsArtifact: "/.well-known/agent-skills/{name}/SKILL.md",
         search: null,
+        agentSearch: null,
         askAi: null,
         llmsTxt: null,
         robots: null,
@@ -385,6 +386,11 @@ describe("agent route helpers", () => {
           status: "disabled",
           reason: "static-export",
           provider: "algolia",
+          routes: { human: null, agent: null },
+          agentEndpoint: null,
+          audienceParam: "audience",
+          defaultAudience: "human",
+          supportedAudiences: ["human", "agent"],
         },
         ai: {
           status: "disabled",
@@ -463,13 +469,24 @@ describe("agent route helpers", () => {
       agents: "/api/internal/docs?format=agents",
       skill: "/api/internal/docs?format=skill",
       search: "/api/internal/docs?query={query}",
+      agentSearch: "/api/internal/docs?query={query}&audience=agent",
       askAi: "/api/internal/docs",
       openapi: "/api/internal/docs?format=openapi",
     });
     expect(diagnostics.features).toMatchObject({
       config: { route: "/api/internal/docs?format=config" },
       diagnostics: { route: "/api/internal/docs?format=diagnostics" },
-      search: { route: "/api/internal/docs?query={query}" },
+      search: {
+        route: "/api/internal/docs?query={query}",
+        routes: {
+          human: "/api/internal/docs?query={query}",
+          agent: "/api/internal/docs?query={query}&audience=agent",
+        },
+        agentEndpoint: "/api/internal/docs?query={query}&audience=agent",
+        audienceParam: "audience",
+        defaultAudience: "human",
+        supportedAudiences: ["human", "agent"],
+      },
       ai: { route: "/api/internal/docs" },
       apiReference: { routes: { openapi: "/api/internal/docs?format=openapi" } },
       agents: { routes: { api: "/api/internal/docs?format=agents" } },
@@ -1246,7 +1263,7 @@ describe("agent route helpers", () => {
     expect(document).toContain("[Missing Pages](/docs/missing-pages.md)");
     expect(document).toContain("`/docs/missing/page.md`");
     expect(document).toContain("`/.well-known/agent.json`");
-    expect(document).toContain("`/api/docs?query={query}`");
+    expect(document).toContain("`/api/docs?query={query}&audience=agent`");
     expect(document).toContain("`/api/docs?format=markdown&path=missing/page`");
     expect(document).toContain("`/docs-map/sitemap.md`");
     expect(document).toContain("`/docs-map/.well-known/sitemap.md`");
@@ -1261,9 +1278,9 @@ describe("agent route helpers", () => {
       pages: [],
     });
     expect(customRouteDocument).toContain("`/api/internal/docs?agent=spec`");
-    expect(customRouteDocument).toContain("`/api/internal/docs?query={query}`");
+    expect(customRouteDocument).toContain("`/api/internal/docs?query={query}&audience=agent`");
     expect(customRouteDocument).toContain("`/api/internal/docs?format=markdown&path=unknown`");
-    expect(customRouteDocument).not.toContain("`/api/docs?query={query}`");
+    expect(customRouteDocument).not.toContain("`/api/docs?query={query}&audience=agent`");
   });
 
   it("resolves high-confidence markdown recovery redirects", () => {
@@ -1831,6 +1848,7 @@ After`;
     expect(document).toContain("/.well-known/agent-skills/{name}/SKILL.md");
     expect(document).toContain("/robots.txt");
     expect(document).toContain("/api/docs?format=skill");
+    expect(document).toContain("/api/docs?query={query}&audience=agent");
     expect(document).toContain("OpenAPI schema: /api/docs?format=openapi");
     expect(document).toContain("API reference: /api-reference");
     expect(document).toContain("npx skills add farming-labs/docs");
@@ -1887,6 +1905,7 @@ After`;
     expect(document).toContain("/.well-known/agent-skills/index.json");
     expect(document).toContain("/.well-known/agent-skills/{name}/SKILL.md");
     expect(document).toContain("/api/docs?format=agents");
+    expect(document).toContain("/api/docs?query={query}&audience=agent");
     expect(document).toContain("/api/docs?format=openapi");
     expect(document).toContain("npx @farming-labs/docs@latest upgrade --latest");
     expect(document).toContain("npx skills add farming-labs/docs");
@@ -1945,6 +1964,17 @@ After`;
       "shared page markdown",
     ]);
     expect(spec.llms.publicTxt).toBe("/llms.txt");
+    expect(spec.search).toEqual({
+      enabled: true,
+      endpoint: "/api/docs?query={query}",
+      agentEndpoint: "/api/docs?query={query}&audience=agent",
+      method: "GET",
+      queryParam: "query",
+      localeParam: "lang",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
+    });
     expect(spec.agents).toEqual({
       enabled: true,
       file: "AGENTS.md",
@@ -2076,6 +2106,12 @@ After`;
     expect(spec.sitemap.xml.api).toBe("/api/internal/docs?format=sitemap-xml");
     expect(spec.sitemap.markdown.api).toBe("/api/internal/docs?format=sitemap-md");
     expect(spec.search.endpoint).toBe("/api/internal/docs?query={query}");
+    expect(spec.search).toMatchObject({
+      agentEndpoint: "/api/internal/docs?query={query}&audience=agent",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
+    });
     expect(spec.agents.api).toBe("/api/internal/docs?format=agents");
     expect(spec.skills.api).toBe("/api/internal/docs?format=skill");
     expect(spec.skills.discovery).toMatchObject({
@@ -2091,7 +2127,7 @@ After`;
     });
 
     const generatedSkill = renderDocsSkillDocument(options);
-    expect(generatedSkill).toContain("/api/internal/docs?query={query}");
+    expect(generatedSkill).toContain("/api/internal/docs?query={query}&audience=agent");
     expect(generatedSkill).toContain("/api/internal/docs?format=agents");
     expect(generatedSkill).toContain("/api/internal/docs?format=skill");
     expect(generatedSkill).toContain("/api/internal/docs?format=openapi");

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -412,6 +412,10 @@ export interface DocsDiagnosticsFeature {
   reason?: string;
   route?: string | null;
   routes?: Record<string, string | null>;
+  agentEndpoint?: string | null;
+  audienceParam?: string;
+  defaultAudience?: "human" | "agent";
+  supportedAudiences?: Array<"human" | "agent">;
   provider?: string;
   mode?: string;
   transport?: "GET" | "POST" | "GET/HEAD" | "GET/POST";
@@ -437,6 +441,7 @@ export interface DocsDiagnostics {
     agents: string;
     skill: string;
     search: string | null;
+    agentSearch: string | null;
     askAi: string | null;
     mcp: string | null;
     llmsTxt: string | null;
@@ -885,6 +890,7 @@ export function buildDocsDiagnostics(
       agents: apiQueryRoute("format=agents"),
       skill: apiQueryRoute("format=skill"),
       search: search.enabled ? apiQueryRoute("query={query}") : null,
+      agentSearch: search.enabled ? apiQueryRoute("query={query}&audience=agent") : null,
       askAi: ai.enabled ? apiRoute : null,
       mcp: mcp.enabled ? mcp.route : null,
       llmsTxt: llms.enabled ? DEFAULT_LLMS_TXT_ROUTE : null,
@@ -921,6 +927,14 @@ export function buildDocsDiagnostics(
         status: search.enabled ? "enabled" : "disabled",
         reason: search.reason,
         route: search.enabled ? apiQueryRoute("query={query}") : null,
+        routes: {
+          human: search.enabled ? apiQueryRoute("query={query}") : null,
+          agent: search.enabled ? apiQueryRoute("query={query}&audience=agent") : null,
+        },
+        agentEndpoint: search.enabled ? apiQueryRoute("query={query}&audience=agent") : null,
+        audienceParam: "audience",
+        defaultAudience: "human",
+        supportedAudiences: ["human", "agent"],
         provider: search.provider,
         transport: "GET",
       },
@@ -2840,7 +2854,7 @@ export function renderDocsMarkdownNotFound({
     `- API catalog: \`${DEFAULT_API_CATALOG_ROUTE}\``,
     `- Agent Skills index: \`${DEFAULT_AGENT_SKILLS_INDEX_ROUTE}\``,
     `- Agent instructions: \`${DEFAULT_AGENTS_MD_ROUTE}\``,
-    `- Search endpoint: \`${resolvedApiRoute}?query={query}\``,
+    `- Agent search endpoint: \`${resolvedApiRoute}?query={query}&audience=agent\``,
     `- Docs index markdown: \`/${normalizedEntry}.md\``,
     `- Requested markdown API route: \`${requestedApiRoute}\``,
   );
@@ -3152,8 +3166,8 @@ function appendDocsSearchStartLine(
   if (!context.searchEnabled) return;
   lines.push(
     variant === "skill"
-      ? `- Search with ${context.apiRoute}?query={query} when you do not know the page.`
-      : `- Search with ${context.apiRoute}?query={query} when the route is unknown.`,
+      ? `- Search with ${context.apiRoute}?query={query}&audience=agent when you do not know the page.`
+      : `- Search with ${context.apiRoute}?query={query}&audience=agent when the route is unknown.`,
   );
 }
 
@@ -3767,9 +3781,13 @@ export function buildDocsAgentDiscoverySpec({
     search: {
       enabled: searchEnabled,
       endpoint: apiQueryRoute("query={query}"),
+      agentEndpoint: apiQueryRoute("query={query}&audience=agent"),
       method: "GET",
       queryParam: "query",
       localeParam: "lang",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
     },
     agents: {
       enabled: true,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -303,6 +303,7 @@ export {
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   performDocsSearch,
+  resolveDocsSearchAudience,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -3015,6 +3015,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
 
   it("uses the shared search adapter pipeline for search_docs", async () => {
     const rootDir = createTempDocsProject();
+    const seenAudiences: string[] = [];
     const source = createFilesystemDocsMcpSource({
       rootDir,
       entry: "docs",
@@ -3029,15 +3030,21 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
         provider: "custom",
         adapter: {
           name: "custom-search",
-          async search(_query, context) {
+          async search(query, context) {
+            seenAudiences.push(`${query.audience}:${context.audience}`);
             const installationPage = context.pages.find(
               (page) => page.url === "/docs/installation",
             );
             expect(installationPage?.content).toContain("Run pnpm install.");
             expect(installationPage?.content).not.toContain("--frozen-lockfile");
-            expect(context.documents.map((document) => document.content).join(" ")).toContain(
-              "--frozen-lockfile",
-            );
+            const searchableContent = context.documents
+              .map((document) => document.content)
+              .join(" ");
+            if (query.audience === "agent") {
+              expect(searchableContent).toContain("--frozen-lockfile");
+            } else {
+              expect(searchableContent).toContain("Run pnpm install");
+            }
             return [
               {
                 id: "custom-hit",
@@ -3109,6 +3116,12 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
     expect(searchPayload.result?.content?.[0]?.text).toContain('"id": "custom-hit"');
     expect(searchPayload.result?.content?.[0]?.text).toContain("/docs/installation");
     expect(searchPayload.result?.content?.[0]?.text).not.toContain("Custom search result");
+
+    const humanSearchPayload = await parseMcpPayload<{
+      result?: { content?: Array<{ text?: string }> };
+    }>(await callMcpTool(handlers, "search_docs", { query: "install", audience: "human" }));
+    expect(humanSearchPayload.result?.content?.[0]?.text).toContain("/docs/installation");
+    expect(seenAudiences).toEqual(["agent:agent", "human:human"]);
   });
 
   it("falls back to simple search for self-referential MCP search configs", async () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -1789,6 +1789,7 @@ const searchDocsInputSchema = z.object({
   query: z.string().trim().min(1),
   limit: z.number().int().min(1).max(25).optional(),
   locale: z.string().min(1).optional(),
+  audience: z.enum(["human", "agent"]).optional(),
 });
 
 const readPageInputSchema = z.object({
@@ -3050,9 +3051,10 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         outputSchema: searchDocsOutputSchema,
         annotations: { readOnlyHint: true },
       },
-      async ({ query, limit, locale }) => {
+      async ({ query, limit, locale, audience }) => {
         const startedAt = nowMs();
         const resolvedLimit = limit ?? 10;
+        const resolvedAudience = audience ?? "agent";
         const trace = createDocsAgentTraceContext("mcp.tool.search_docs");
         const callSpanId = createDocsAgentTraceId("span");
         await emitDocsAgentTraceEvent(options.observability, {
@@ -3064,7 +3066,12 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           startedAt: trace.startedAt,
           status: "started",
           locale,
-          inputPreview: { queryLength: query.length, limit: resolvedLimit, locale },
+          inputPreview: {
+            queryLength: query.length,
+            limit: resolvedLimit,
+            locale,
+            audience: resolvedAudience,
+          },
           metadata: { tool: "search_docs" },
         });
 
@@ -3074,7 +3081,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             pages: toSearchSourcePages(pages),
             query,
             search: toolSearchConfig ?? true,
-            audience: "agent",
+            audience: resolvedAudience,
             locale,
             siteTitle: options.source.siteTitle,
             limit: resolvedLimit,
@@ -3089,11 +3096,15 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
               tool: "search_docs",
               queryLength: query.length,
               limit: resolvedLimit,
+              audience: resolvedAudience,
               resultCount: results.length,
               durationMs: elapsed,
             },
           });
-          trackMcpTool("search_docs", { locale, resultCount: results.length });
+          trackMcpTool("search_docs", {
+            locale,
+            resultCount: results.length,
+          });
           await emitDocsAgentTraceEvent(options.observability, {
             type: "tool.result",
             source: "mcp",

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -8,6 +8,7 @@ import {
   createMcpSearchAdapter,
   createTypesenseSearchAdapter,
   performDocsSearch,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
 } from "./search.js";
 
@@ -217,6 +218,42 @@ export const auth = betterAuth({});
 });
 
 describe("performDocsSearch", () => {
+  it.each([
+    [undefined, "human"],
+    [null, "human"],
+    ["", "human"],
+    ["human", "human"],
+    ["Agent", "human"],
+    ["bot", "human"],
+    ["agent", "agent"],
+  ] as const)("resolves the %s audience query value to %s", (value, expected) => {
+    expect(resolveDocsSearchAudience(value)).toBe(expected);
+  });
+
+  it("auto-forwards MCP audience only to the same-origin default search tool", () => {
+    expect(
+      resolveSearchRequestConfig(
+        { provider: "mcp", endpoint: "/api/docs/mcp" },
+        "https://docs.example.com/api/docs",
+      ),
+    ).toMatchObject({
+      endpoint: "https://docs.example.com/api/docs/mcp",
+      forwardAudience: true,
+    });
+    expect(
+      resolveSearchRequestConfig(
+        { provider: "mcp", endpoint: "https://remote.example/mcp" },
+        "https://docs.example.com/api/docs",
+      ),
+    ).toMatchObject({ forwardAudience: false });
+    expect(
+      resolveSearchRequestConfig(
+        { provider: "mcp", endpoint: "/api/docs/mcp", toolName: "custom_search" },
+        "https://docs.example.com/api/docs",
+      ),
+    ).toMatchObject({ forwardAudience: false });
+  });
+
   it("keeps public search human-only while allowing explicit agent retrieval", async () => {
     const audiencePages = [
       {
@@ -508,6 +545,8 @@ Customize the loading UI.
         name: "custom",
         async search(query, context) {
           expect(query.query).toBe("install");
+          expect(query.audience).toBe("human");
+          expect(context.audience).toBe("human");
           expect(context.documents.length).toBeGreaterThan(0);
           return [
             {
@@ -531,6 +570,175 @@ Customize the loading UI.
         type: "page",
       },
     ]);
+  });
+
+  it("projects raw audience blocks before passing documents to custom adapters", async () => {
+    const seen: string[] = [];
+    const adapter = createCustomSearchAdapter({
+      name: "audience-aware-custom",
+      async search(query, context) {
+        seen.push(`${query.audience}:${context.audience}:${context.documents[0]?.content ?? ""}`);
+        return [];
+      },
+    });
+    const sourcePages = [
+      {
+        title: "Audience projection",
+        url: "/docs/audience-projection",
+        content:
+          "Shared context. <Human>Human coral token.</Human> <Agent>Agent indigo token.</Agent>",
+      },
+    ];
+
+    await performDocsSearch({ pages: sourcePages, query: "token", search: adapter });
+    await performDocsSearch({
+      pages: sourcePages,
+      query: "token",
+      audience: "agent",
+      search: adapter,
+    });
+
+    expect(seen[0]).toContain("human:human:Shared context. Human coral token.");
+    expect(seen[0]).not.toContain("Agent indigo token");
+    expect(seen[1]).toContain("agent:agent:Shared context. Agent indigo token.");
+    expect(seen[1]).not.toContain("Human coral token");
+  });
+
+  it("replaces stale local provider snippets with the selected human projection", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Audience-safe search",
+          url: "/docs/audience-safe-search",
+          content: "Shared setup. Human coral walkthrough.",
+          rawContent: "# Audience-safe search\n\nShared setup. Human coral walkthrough.",
+          agentFallbackContent: "Shared setup. Agent indigo procedure.",
+          agentFallbackRawContent:
+            "# Audience-safe search\n\nShared setup. Agent indigo procedure.",
+        },
+      ],
+      query: "shared setup",
+      search: createCustomSearchAdapter({
+        name: "stale-agent-index",
+        async search() {
+          return [
+            {
+              id: "stale-hit",
+              url: "/docs/audience-safe-search",
+              content: "Audience-safe search",
+              description: "Shared setup. Agent indigo procedure.",
+              type: "page",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results.find((result) => result.id === "stale-hit")?.description).toContain(
+      "Human coral walkthrough",
+    );
+    expect(JSON.stringify(results)).not.toContain("Agent indigo procedure");
+  });
+
+  it("does not turn cross-audience provider hits into false-positive local results", async () => {
+    const sourcePages = [
+      {
+        title: "Audience-safe filtering",
+        url: "/docs/audience-safe-filtering",
+        content: "Shared setup. Human coral walkthrough.",
+        rawContent: "# Audience-safe filtering\n\nShared setup. Human coral walkthrough.",
+        agentFallbackContent: "Shared setup. Agent indigo procedure.",
+        agentFallbackRawContent:
+          "# Audience-safe filtering\n\nShared setup. Agent indigo procedure.",
+      },
+    ];
+    const staleProvider = createCustomSearchAdapter({
+      name: "cross-audience-index",
+      async search(query) {
+        return [
+          {
+            id: `stale-${query.audience}`,
+            url: "/docs/audience-safe-filtering",
+            content: "Audience-safe filtering",
+            type: "page",
+          },
+        ];
+      },
+    });
+
+    await expect(
+      performDocsSearch({
+        pages: sourcePages,
+        query: "indigo",
+        search: staleProvider,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      performDocsSearch({
+        pages: sourcePages,
+        query: "coral",
+        audience: "agent",
+        search: staleProvider,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("falls back to current human content when a provider returns a stale absolute anchor", async () => {
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Current search guide",
+          url: "/docs/current-search-guide",
+          content: `Current amber workflow. ${"Detailed human guidance. ".repeat(30)}`,
+          rawContent: `# Current search guide\n\nCurrent amber workflow. ${"Detailed human guidance. ".repeat(30)}`,
+          agentFallbackContent: "Agent violet workflow.",
+          agentFallbackRawContent: "# Current search guide\n\nAgent violet workflow.",
+        },
+      ],
+      query: "amber",
+      baseUrl: "https://docs.example.com",
+      search: createCustomSearchAdapter({
+        name: "stale-anchor-index",
+        async search() {
+          return [
+            {
+              id: "removed-anchor",
+              url: "https://docs.example.com/docs/current-search-guide#removed",
+              content: "Current search guide — Removed",
+              description: "Agent violet workflow.",
+              type: "heading",
+              section: "Removed",
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results.some((result) => result.url === "/docs/current-search-guide")).toBe(true);
+    expect(JSON.stringify(results)).toContain("Current amber workflow");
+    expect(JSON.stringify(results)).not.toContain("Agent violet workflow");
+    expect(
+      Math.max(...results.map((result) => result.description?.length ?? 0)),
+    ).toBeLessThanOrEqual(160);
+  });
+
+  it("fails remote MCP human projection closed when audience forwarding is not enabled", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const results = await performDocsSearch({
+        pages,
+        query: "configure",
+        search: {
+          provider: "mcp",
+          endpoint: "https://remote.example/mcp",
+        },
+      });
+
+      expect(results[0]?.url).toBe("/docs/installation#quickstart");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("falls back to simple search when a custom adapter throws", async () => {
@@ -635,6 +843,13 @@ Customize the loading UI.
       const searchCall = vi.mocked(globalThis.fetch).mock.calls[1]?.[1];
       expect(searchCall?.headers).toBeDefined();
       expect(searchCall?.headers).not.toHaveProperty("mcp-session-id");
+      expect(JSON.parse(String(searchCall?.body))).toMatchObject({
+        params: {
+          arguments: {
+            audience: "agent",
+          },
+        },
+      });
     } finally {
       globalThis.fetch = originalFetch;
       vi.restoreAllMocks();
@@ -684,6 +899,23 @@ Your page is now available at \`/docs/my-page\`.
     expect(results[0]?.description).not.toContain("```");
     expect(results[0]?.description).not.toContain("`");
     expect(results[0]?.description).not.toContain("|");
+  });
+
+  it("keeps snippets bounded when the matching query itself is long", async () => {
+    const longQuery = `agent-${"projection-".repeat(24)}token`;
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Long query",
+          url: "/docs/long-query",
+          content: `Prefix ${longQuery} suffix`,
+        },
+      ],
+      query: longQuery,
+      limit: 1,
+    });
+
+    expect(results[0]?.description?.length).toBeLessThanOrEqual(160);
   });
 
   it("ignores question stopwords and punctuation when ranking natural-language queries", async () => {
@@ -1573,6 +1805,9 @@ describe("remote search adapters", () => {
         section: undefined,
       },
     ]);
+    expect(
+      JSON.parse(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]?.body)),
+    ).not.toHaveProperty("params.arguments.audience");
   });
 
   it("attempts independently bounded MCP session cleanup after caller abort", async () => {

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -1789,7 +1789,7 @@ describe("remote search adapters", () => {
       endpoint: "https://docs.example.com/api/docs/mcp",
     });
 
-    const results = await adapter.search({ query: "install", limit: 5 }, {
+    const results = await adapter.search({ query: "install", limit: 5, audience: "agent" }, {
       pages: [],
       documents: [],
     } as DocsSearchAdapterContext);
@@ -1808,6 +1808,72 @@ describe("remote search adapters", () => {
     expect(
       JSON.parse(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]?.body)),
     ).not.toHaveProperty("params.arguments.audience");
+  });
+
+  it("fails direct MCP searches closed when the default human audience cannot be forwarded", async () => {
+    const adapter = createMcpSearchAdapter({
+      provider: "mcp",
+      endpoint: "https://docs.example.com/api/docs/mcp",
+    });
+
+    await expect(
+      adapter.search({ query: "install", limit: 5 }, {
+        pages: [],
+        documents: [],
+      } as DocsSearchAdapterContext),
+    ).rejects.toThrow(
+      "MCP human-projection search requires forwardAudience: true on an audience-aware tool.",
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards human for direct MCP searches that omit audience", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              serverInfo: { name: "docs-mcp", version: "1.0.0" },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: { content: [{ type: "text", text: JSON.stringify({ results: [] }) }] },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    const adapter = createMcpSearchAdapter({
+      provider: "mcp",
+      endpoint: "https://docs.example.com/api/docs/mcp",
+      forwardAudience: true,
+    });
+
+    await adapter.search({ query: "install", limit: 5 }, {
+      pages: [],
+      documents: [],
+    } as DocsSearchAdapterContext);
+
+    expect(JSON.parse(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]?.body))).toMatchObject({
+      params: { arguments: { audience: "human" } },
+    });
   });
 
   it("attempts independently bounded MCP session cleanup after caller abort", async () => {
@@ -1860,7 +1926,7 @@ describe("remote search adapters", () => {
         provider: "mcp",
         endpoint: "https://docs.example.com/api/docs/mcp",
       });
-      const request = adapter.search({ query: "install", limit: 5 }, {
+      const request = adapter.search({ query: "install", limit: 5, audience: "agent" }, {
         pages: [],
         documents: [],
         signal: callerController.signal,

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -20,10 +20,11 @@ import {
   renderPageAgentContractMarkdown,
   upsertPageAgentContractMarkdown,
 } from "./agent-contract.js";
-import type { DocsContentAudience } from "./audience.js";
+import { resolveDocsAudienceMdxContent, type DocsContentAudience } from "./audience.js";
 import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;
+const MAX_SEARCH_SNIPPET_CHARS = 160;
 const DEFAULT_MCP_PROTOCOL_VERSION = "2025-11-25";
 const MCP_SESSION_CLEANUP_TIMEOUT_MS = 1_000;
 const syncedIndexes = new Set<string>();
@@ -222,15 +223,7 @@ function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
 }
 
 function getAskAIPageContent(page: DocsSearchSourcePage): string {
-  return upsertPageAgentContractMarkdown(
-    page.agentRawContent ??
-      page.agentFallbackRawContent ??
-      page.agentContent ??
-      page.agentFallbackContent ??
-      page.rawContent ??
-      page.content,
-    page.agent,
-  )
+  return upsertPageAgentContractMarkdown(getPageAudienceRawContent(page, "agent"), page.agent)
     .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
     .replace(PAGE_AGENT_CONTRACT_END_MARKER, "")
     .replace(/^\r?\n+/, "");
@@ -534,32 +527,37 @@ function mergeSearchResults(
   return results;
 }
 
-function buildAgentProjectionSearchResults(
+function buildAudienceProjectionSearchResults(
   documents: readonly DocsSearchDocument[],
+  query: string,
 ): DocsSearchResult[] {
-  return documents.map((document) => ({
-    id: document.id,
-    url: document.url,
-    content: document.section ? `${document.title} — ${document.section}` : document.title,
-    description: document.content || document.description,
-    type: document.type,
-    section: document.section,
-  }));
+  return documents.map((document) => {
+    const score = scoreDocument(query, document);
+    return {
+      id: document.id,
+      url: document.url,
+      content: document.section ? `${document.title} — ${document.section}` : document.title,
+      description: cleanSearchResultText(buildSnippet(document, query) ?? document.description),
+      type: document.type,
+      score,
+      section: document.section,
+    };
+  });
 }
 
-function sanitizeExternalAgentSearchResults(
+function sanitizeExternalAudienceSearchResults(
   results: DocsSearchResult[],
-  localAgentResults: DocsSearchResult[],
+  localAudienceResults: DocsSearchResult[],
   baseUrl?: string,
   strictExternalOrigins = false,
   preserveUnmatched?: (result: DocsSearchResult) => boolean,
 ): DocsSearchResult[] {
   const localByKey = new Map(
-    localAgentResults.map((result) => [getSearchResultKey(result), result] as const),
+    localAudienceResults.map((result) => [getSearchResultKey(result), result] as const),
   );
   const localPageResults = new Map<string, DocsSearchResult>();
 
-  for (const result of localAgentResults) {
+  for (const result of localAudienceResults) {
     const pageUrl = normalizeUrlPathname(result.url);
     const existing = localPageResults.get(pageUrl);
     if (!existing || result.type === "page") localPageResults.set(pageUrl, result);
@@ -597,60 +595,108 @@ function sanitizeExternalAgentSearchResults(
   });
 }
 
-function shouldPreserveUnmatchedMcpResult(options: {
+function shouldPreserveUnmatchedExternalResult(options: {
   result: DocsSearchResult;
   localPagePaths: ReadonlySet<string>;
   baseUrl?: string;
-  strictExternalOrigins: boolean;
 }): boolean {
-  const { result, localPagePaths, baseUrl, strictExternalOrigins } = options;
+  const { result, localPagePaths, baseUrl } = options;
   const path = normalizeUrlPathname(result.url);
   const rawUrl = result.url.trim();
   const explicitScheme = rawUrl.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
   if (explicitScheme && explicitScheme !== "http" && explicitScheme !== "https") return false;
   const explicitlyHosted = /^[a-z][a-z\d+.-]*:/iu.test(rawUrl) || /^[\\/]{2}/u.test(rawUrl);
-  if (!strictExternalOrigins) return explicitlyHosted || !localPagePaths.has(path);
-  if (!explicitlyHosted) return !localPagePaths.has(path);
-  if (!baseUrl) return true;
+  const knownLocalPath = localPagePaths.has(path);
+  if (!explicitlyHosted) return !knownLocalPath;
+  if (!baseUrl) return !knownLocalPath;
   try {
     if (new URL(result.url, baseUrl).origin !== new URL(baseUrl).origin) return true;
   } catch {
     return false;
   }
-  return !localPagePaths.has(path);
+  return !knownLocalPath;
 }
 
 function getPageAudienceRawContent(
   page: DocsSearchSourcePage,
   audience: DocsContentAudience,
 ): string {
-  if (audience === "agent") {
-    return (
-      page.agentRawContent ??
-      page.agentFallbackRawContent ??
-      page.agentContent ??
-      page.agentFallbackContent ??
-      page.rawContent ??
-      page.content
-    );
-  }
+  const source =
+    audience === "agent"
+      ? (page.agentRawContent ??
+        page.agentFallbackRawContent ??
+        page.agentContent ??
+        page.agentFallbackContent ??
+        page.rawContent ??
+        page.content)
+      : (page.rawContent ?? page.content);
 
-  return page.rawContent ?? page.content;
+  return resolveDocsAudienceMdxContent(source, audience);
 }
 
 function getPageAudienceSearchText(
   page: DocsSearchSourcePage,
   audience: DocsContentAudience,
 ): string {
-  if (audience === "agent") {
-    return (
-      page.agentContent ??
-      page.agentFallbackContent ??
-      stripMarkdownText(getPageAudienceRawContent(page, audience))
-    );
+  return stripMarkdownText(getPageAudienceRawContent(page, audience));
+}
+
+function isLocalProviderResult(
+  result: DocsSearchResult,
+  baseUrl?: string,
+  strictExternalOrigins = false,
+): boolean {
+  const rawUrl = result.url.trim();
+  const explicitScheme = rawUrl.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
+  if (explicitScheme && explicitScheme !== "http" && explicitScheme !== "https") return false;
+  const explicitlyHosted = /^[a-z][a-z\d+.-]*:/iu.test(rawUrl) || /^[\\/]{2}/u.test(rawUrl);
+  if (!explicitlyHosted) return true;
+  if (!baseUrl) return !strictExternalOrigins;
+
+  try {
+    return new URL(result.url, baseUrl).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+function hasOppositeAudienceEvidence(options: {
+  result: DocsSearchResult;
+  pages: DocsSearchSourcePage[];
+  query: string;
+  audience: DocsContentAudience;
+  baseUrl?: string;
+  strictExternalOrigins?: boolean;
+}): boolean {
+  const { result, pages, query, audience, baseUrl, strictExternalOrigins } = options;
+  if (!isLocalProviderResult(result, baseUrl, strictExternalOrigins)) return false;
+
+  const pagePath = normalizeUrlPathname(result.url);
+  const page = pages.find((candidate) => normalizeUrlPathname(candidate.url) === pagePath);
+  if (!page) return false;
+  if (scoreDocument(query, pageToSearchDocument(page, audience)) > 0) return false;
+
+  const oppositeAudience = audience === "agent" ? "human" : "agent";
+  if (scoreDocument(query, pageToSearchDocument(page, oppositeAudience)) > 0) return true;
+
+  const evidence = cleanSearchResultText(result.description);
+  if (!evidence) return false;
+  const selectedTokens = new Set(tokenizeSearchQuery(getPageAudienceSearchText(page, audience)));
+  const oppositeTokens = new Set(
+    tokenizeSearchQuery(getPageAudienceSearchText(page, oppositeAudience)),
+  );
+  const evidenceTokens = [...new Set(tokenizeSearchQuery(evidence))];
+  let selectedOnlyMatches = 0;
+  let oppositeOnlyMatches = 0;
+
+  for (const token of evidenceTokens) {
+    const inSelected = selectedTokens.has(token);
+    const inOpposite = oppositeTokens.has(token);
+    if (inSelected && !inOpposite) selectedOnlyMatches += 1;
+    if (inOpposite && !inSelected) oppositeOnlyMatches += 1;
   }
 
-  return page.content || stripMarkdownText(getPageAudienceRawContent(page, audience));
+  return oppositeOnlyMatches > selectedOnlyMatches;
 }
 
 function pageToSearchDocument(
@@ -919,7 +965,7 @@ function scoreDocument(query: string, document: DocsSearchDocument): number {
   }
 
   if (matchedWords === words.length && words.length > 1) score += 20;
-  if (document.type === "heading" && hasDistinctSection) score += 6;
+  if (score > 0 && document.type === "heading" && hasDistinctSection) score += 6;
 
   return score;
 }
@@ -932,7 +978,7 @@ function buildSnippet(document: DocsSearchDocument, query: string): string | und
   ].filter(Boolean);
 
   for (const source of sources) {
-    if (!q) return source.slice(0, 160);
+    if (!q) return clampSearchSnippet(source);
 
     const idx = source.toLowerCase().indexOf(q);
     if (idx === -1) continue;
@@ -941,10 +987,15 @@ function buildSnippet(document: DocsSearchDocument, query: string): string | und
     const end = Math.min(source.length, idx + q.length + 96);
     const prefix = start > 0 ? "..." : "";
     const suffix = end < source.length ? "..." : "";
-    return `${prefix}${source.slice(start, end).trim()}${suffix}`;
+    return clampSearchSnippet(`${prefix}${source.slice(start, end).trim()}${suffix}`);
   }
 
-  return sources[0]?.slice(0, 160);
+  return sources[0] ? clampSearchSnippet(sources[0]) : undefined;
+}
+
+function clampSearchSnippet(value: string): string {
+  if (value.length <= MAX_SEARCH_SNIPPET_CHARS) return value;
+  return `${value.slice(0, MAX_SEARCH_SNIPPET_CHARS - 3).trimEnd()}...`;
 }
 
 function cleanSearchResultText(value?: string): string | undefined {
@@ -1386,12 +1437,25 @@ export function resolveSearchRequestConfig(
     return search;
   }
 
-  if (/^https?:\/\//i.test(search.endpoint) || !requestUrl) return search;
+  if (!requestUrl) return search;
+
+  const resolvedEndpoint = new URL(search.endpoint, requestUrl);
+  const usesDefaultSearchTool = (search.toolName ?? "search_docs") === "search_docs";
+  const isSameOrigin = resolvedEndpoint.origin === new URL(requestUrl).origin;
 
   return {
     ...search,
-    endpoint: new URL(search.endpoint, requestUrl).toString(),
+    endpoint: resolvedEndpoint.toString(),
+    forwardAudience: search.forwardAudience ?? (usesDefaultSearchTool && isSameOrigin),
   };
+}
+
+/**
+ * Resolve the public search audience without allowing malformed values to opt into agent content.
+ * Human search remains the default for omitted, legacy, and unknown query values.
+ */
+export function resolveDocsSearchAudience(value: string | null | undefined): DocsContentAudience {
+  return value === "agent" ? "agent" : "human";
 }
 
 export function resolveAskAISearchRequestConfig(options: {
@@ -1436,7 +1500,14 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
       const endpoint = resolveMcpEndpoint(config.endpoint);
       const protocolVersion = config.protocolVersion ?? DEFAULT_MCP_PROTOCOL_VERSION;
       const toolName = config.toolName ?? "search_docs";
+      const forwardAudience = config.forwardAudience === true;
       const baseHeaders = config.headers ?? {};
+
+      if (query.audience === "human" && !forwardAudience) {
+        throw new Error(
+          "MCP human-projection search requires forwardAudience: true on an audience-aware tool.",
+        );
+      }
 
       const initializeResponse = await fetch(endpoint, {
         method: "POST",
@@ -1488,6 +1559,7 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
                 query: query.query,
                 limit: query.limit ?? config.maxResults ?? DEFAULT_SEARCH_LIMIT,
                 locale: query.locale,
+                ...(forwardAudience && query.audience ? { audience: query.audience } : {}),
               },
             },
           }),
@@ -1750,11 +1822,12 @@ export async function performDocsSearch(options: {
   const search = normalizeDocsSearchConfig(options.search);
   if (!search.enabled) return [];
 
-  const audience = options.audience ?? "human";
+  const audience = resolveDocsSearchAudience(options.audience);
   const documents = buildDocsSearchDocuments(options.pages, search.chunking, audience);
   const context: DocsSearchAdapterContext = {
     pages: options.pages,
     documents,
+    audience,
     locale: options.locale,
     pathname: options.pathname,
     siteTitle: options.siteTitle,
@@ -1766,6 +1839,7 @@ export async function performDocsSearch(options: {
     limit: options.limit ?? search.maxResults,
     locale: options.locale,
     pathname: options.pathname,
+    audience,
   };
 
   try {
@@ -1775,47 +1849,67 @@ export async function performDocsSearch(options: {
         ? {
             ...context,
             documents: buildDocsSearchDocuments(options.pages, search.chunking, "human"),
+            audience: "human" as const,
           }
         : context;
     await maybeSyncSearchIndex(adapter, search, syncContext);
     const results = await adapter.search(query, context);
     if (search.provider === "simple") return results;
 
-    const localAudienceResults =
-      audience === "agent" ? await createSimpleSearchAdapter().search(query, context) : [];
-    const localAgentProjectionResults =
-      audience === "agent" ? buildAgentProjectionSearchResults(documents) : [];
+    const localAudienceProjectionResults = buildAudienceProjectionSearchResults(
+      documents,
+      options.query,
+    );
     const localPagePaths = new Set(options.pages.map((page) => normalizeUrlPathname(page.url)));
-    // External providers may expose a human index, so local-page snippets must
-    // be replaced with the local agent projection. MCP can also return pages
-    // outside this docs corpus; preserve those agent-native remote results.
-    const safeAdapterResults =
-      audience !== "agent"
-        ? results
-        : sanitizeExternalAgentSearchResults(
-            results,
-            localAgentProjectionResults,
-            options.baseUrl,
-            options.strictExternalOrigins,
-            search.provider === "mcp"
-              ? (result) =>
-                  shouldPreserveUnmatchedMcpResult({
-                    result,
-                    localPagePaths,
-                    baseUrl: options.baseUrl,
-                    strictExternalOrigins: options.strictExternalOrigins === true,
-                  })
-              : undefined,
-          );
+    // External indexes can be stale or built for a different audience. Replace
+    // every local-page hit with the selected local projection before returning it.
+    // Human search preserves provider-only pages for backwards compatibility;
+    // agent search preserves them only for MCP, whose search_docs results may
+    // intentionally include a remote corpus.
+    const preserveUnmatched =
+      audience === "human" || search.provider === "mcp"
+        ? (result: DocsSearchResult) =>
+            shouldPreserveUnmatchedExternalResult({
+              result,
+              localPagePaths,
+              baseUrl: options.baseUrl,
+            })
+        : undefined;
+    // Provider ranking may be semantic, so lexical query overlap is not required.
+    // Fail closed only when a local snippet contains distinctive evidence from
+    // the opposite projection and none from the selected one.
+    const audienceSafeAdapterResults = results.filter(
+      (result) =>
+        !hasOppositeAudienceEvidence({
+          result,
+          pages: options.pages,
+          query: options.query,
+          audience,
+          baseUrl: options.baseUrl,
+          strictExternalOrigins: options.strictExternalOrigins,
+        }),
+    );
+    const safeAdapterResults = sanitizeExternalAudienceSearchResults(
+      audienceSafeAdapterResults,
+      localAudienceProjectionResults,
+      options.baseUrl,
+      options.strictExternalOrigins,
+      preserveUnmatched,
+    );
 
     if (options.supplementExternalResults === false) {
       return safeAdapterResults.slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
     }
+    const shouldSupplementWithLocalSearch =
+      audience === "agent" || results.length === 0 || safeAdapterResults.length < results.length;
+    const simpleAudienceResults = shouldSupplementWithLocalSearch
+      ? await createSimpleSearchAdapter().search(query, context)
+      : [];
     const combinedResults = mergeSearchResults(
       [
         buildExactPageSearchResults(options.query, options.pages, audience),
         safeAdapterResults,
-        localAudienceResults,
+        simpleAudienceResults,
       ],
       audience === "agent"
         ? (result) => getAskAIResultKey(result, options.baseUrl, options.strictExternalOrigins)

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -1501,9 +1501,10 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
       const protocolVersion = config.protocolVersion ?? DEFAULT_MCP_PROTOCOL_VERSION;
       const toolName = config.toolName ?? "search_docs";
       const forwardAudience = config.forwardAudience === true;
+      const audience = resolveDocsSearchAudience(query.audience);
       const baseHeaders = config.headers ?? {};
 
-      if (query.audience === "human" && !forwardAudience) {
+      if (audience === "human" && !forwardAudience) {
         throw new Error(
           "MCP human-projection search requires forwardAudience: true on an audience-aware tool.",
         );
@@ -1559,7 +1560,7 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
                 query: query.query,
                 limit: query.limit ?? config.maxResults ?? DEFAULT_SEARCH_LIMIT,
                 locale: query.locale,
-                ...(forwardAudience && query.audience ? { audience: query.audience } : {}),
+                ...(forwardAudience ? { audience } : {}),
               },
             },
           }),

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -79,6 +79,7 @@ export {
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   performDocsSearch,
+  resolveDocsSearchAudience,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1556,11 +1556,15 @@ export interface DocsSearchQuery {
   limit?: number;
   locale?: string;
   pathname?: string;
+  /** Requested content projection. Omitted callers retain the human-search default. */
+  audience?: "human" | "agent";
 }
 
 export interface DocsSearchAdapterContext {
   pages: DocsSearchSourcePage[];
   documents: DocsSearchDocument[];
+  /** Resolved content projection supplied to this adapter. */
+  audience?: "human" | "agent";
   locale?: string;
   pathname?: string;
   siteTitle?: string;
@@ -1652,6 +1656,12 @@ export interface McpDocsSearchConfig {
    * MCP tool name used for search. Defaults to `search_docs`.
    */
   toolName?: string;
+  /**
+   * Forward the resolved human/agent projection as the tool's `audience` argument.
+   * HTTP request resolution enables this for same-origin `search_docs` routes.
+   * Remote and custom tools must opt in explicitly after supporting the argument.
+   */
+  forwardAudience?: boolean;
   /**
    * Override the MCP protocol version header when needed.
    */

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -690,8 +690,8 @@ export default defineDocs({
     const customMissingMarkdownText = await customMissingMarkdown.text();
     expect(customMissingMarkdown.status).toBe(404);
     expect(customMissingMarkdownText).toContain("/api/internal/docs?agent=spec");
-    expect(customMissingMarkdownText).toContain("/api/internal/docs?query={query}");
-    expect(customMissingMarkdownText).not.toContain("/api/docs?query={query}");
+    expect(customMissingMarkdownText).toContain("/api/internal/docs?query={query}&audience=agent");
+    expect(customMissingMarkdownText).not.toContain("/api/docs?query={query}&audience=agent");
 
     const skillApi = await GET(new Request("http://localhost/api/docs?format=skill"));
     const skillApiText = await skillApi.text();
@@ -701,6 +701,7 @@ export default defineDocs({
     expect(skillApiText).toContain("# Alias Docs Skill");
     expect(skillApiText).toContain("/docs.md");
     expect(skillApiText).toContain("/.well-known/agent.json");
+    expect(skillApiText).toContain("/api/docs?query={query}&audience=agent");
 
     for (const path of ["/skill.md", "/.well-known/skill.md"]) {
       const response = await GET(new Request(`http://localhost${path}`));
@@ -713,6 +714,7 @@ export default defineDocs({
     const customSkillText = await customSkill.text();
     expect(customSkill.status).toBe(200);
     expect(customSkillText).toContain("/api/internal/docs?format=skill");
+    expect(customSkillText).toContain("/api/internal/docs?query={query}&audience=agent");
     expect(customSkillText).not.toContain("/api/docs?format=skill");
 
     const agentsApi = await GET(new Request("http://localhost/api/docs?format=agents"));
@@ -723,6 +725,7 @@ export default defineDocs({
     expect(agentsApiText).toContain("Site: Alias Docs");
     expect(agentsApiText).toContain("/AGENTS.md");
     expect(agentsApiText).toContain("/api/docs?format=agents");
+    expect(agentsApiText).toContain("/api/docs?query={query}&audience=agent");
 
     for (const path of [
       "/AGENTS.md",
@@ -740,6 +743,7 @@ export default defineDocs({
     const customAgentsText = await customAgents.text();
     expect(customAgents.status).toBe(200);
     expect(customAgentsText).toContain("/api/internal/docs?format=agents");
+    expect(customAgentsText).toContain("/api/internal/docs?query={query}&audience=agent");
     expect(customAgentsText).not.toContain("/api/docs?format=agents");
   });
 
@@ -1541,6 +1545,24 @@ Search should not return this hidden agent-only zebra token.
 
     const { GET } = createDocsAPI({
       entry: "docs",
+      sitemap: { enabled: true, baseUrl: "https://docs.example.com" },
+      search: {
+        provider: "custom",
+        adapter: {
+          name: "stale-audience-index",
+          async search() {
+            return [
+              {
+                id: "stale-audience-hit",
+                url: "https://docs.example.com/docs",
+                content: "Introduction",
+                description: "Search should not return this hidden agent-only zebra token.",
+                type: "page",
+              },
+            ];
+          },
+        },
+      },
     });
 
     const response = await GET(
@@ -1561,6 +1583,26 @@ Search should not return this hidden agent-only zebra token.
       description?: string;
     }>;
     expect(humanPayload.some((result) => result.content.includes("Introduction"))).toBe(true);
+
+    const agentResponse = await GET(
+      new Request("http://localhost/api/docs?query=agent-only%20zebra%20token&audience=agent"),
+    );
+    const agentPayload = (await agentResponse.json()) as Array<{
+      content: string;
+      description?: string;
+    }>;
+    expect(agentPayload.some((result) => result.content.includes("Introduction"))).toBe(true);
+    expect(JSON.stringify(agentPayload)).not.toContain("human-only coral token");
+
+    const invalidAudienceResponse = await GET(
+      new Request("http://localhost/api/docs?query=agent-only%20zebra%20token&audience=Agent"),
+    );
+    const invalidAudiencePayload = (await invalidAudienceResponse.json()) as Array<{
+      content: string;
+      description?: string;
+    }>;
+    expect(JSON.stringify(invalidAudiencePayload)).not.toContain("agent-only zebra token");
+    expect(JSON.stringify(invalidAudiencePayload)).toContain("human-only coral token");
   });
 
   it("serves markdown through the default docs api route, including Agent blocks and preferring agent.md when present", async () => {
@@ -2705,7 +2747,7 @@ description: "Start building quickly"
     expect(notFoundDocument).toContain("## Closest Matches");
     expect(notFoundDocument).toContain("[Quickstart](/docs/guides/quickstart.md)");
     expect(notFoundDocument).toContain("`/.well-known/agent.json`");
-    expect(notFoundDocument).toContain("`/api/docs?query={query}`");
+    expect(notFoundDocument).toContain("`/api/docs?query={query}&audience=agent`");
     expect(notFoundDocument).toContain("`/sitemap.md`");
     expect(notFoundDocument).toContain("## Sitemap");
 
@@ -2941,9 +2983,13 @@ description: "Start building quickly"
     expect(spec.search).toEqual({
       enabled: true,
       endpoint: "/api/docs?query={query}",
+      agentEndpoint: "/api/docs?query={query}&audience=agent",
       method: "GET",
       queryParam: "query",
       localeParam: "lang",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
     });
     expect(spec.robots).toEqual({
       enabled: true,
@@ -3160,6 +3206,7 @@ description: "Start building quickly"
         config: "/api/docs?format=config",
         diagnostics: "/api/docs?format=diagnostics",
         search: "/api/docs?query={query}",
+        agentSearch: "/api/docs?query={query}&audience=agent",
         askAi: "/api/docs",
       },
       features: {
@@ -3167,6 +3214,14 @@ description: "Start building quickly"
           status: "enabled",
           provider: "algolia",
           transport: "GET",
+          routes: {
+            human: "/api/docs?query={query}",
+            agent: "/api/docs?query={query}&audience=agent",
+          },
+          agentEndpoint: "/api/docs?query={query}&audience=agent",
+          audienceParam: "audience",
+          defaultAudience: "human",
+          supportedAudiences: ["human", "agent"],
         },
         ai: {
           status: "enabled",
@@ -3276,7 +3331,15 @@ description: "Start building quickly"
       llms: Record<string, string | boolean>;
       agents: Record<string, unknown>;
       openapi: Record<string, unknown>;
-      search: { enabled: boolean; endpoint: string; method: string };
+      search: {
+        enabled: boolean;
+        endpoint: string;
+        agentEndpoint: string;
+        method: string;
+        audienceParam: string;
+        defaultAudience: string;
+        supportedAudiences: string[];
+      };
       robots: { enabled: boolean; route: string; defaultRoute: string };
       structuredData: Record<string, unknown>;
       skills: {
@@ -3367,7 +3430,11 @@ description: "Start building quickly"
     expect(spec.search).toMatchObject({
       enabled: false,
       endpoint: "/api/docs?query={query}",
+      agentEndpoint: "/api/docs?query={query}&audience=agent",
       method: "GET",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
     });
     expect(spec.robots).toEqual({
       enabled: true,
@@ -4442,6 +4509,11 @@ Welcome to the docs.
 
       expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe("http://localhost/api/docs/mcp");
       expect(vi.mocked(globalThis.fetch).mock.calls[1]?.[0]).toBe("http://localhost/api/docs/mcp");
+      expect(
+        JSON.parse(String(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]?.body)),
+      ).toMatchObject({
+        params: { arguments: { audience: "human" } },
+      });
     } finally {
       globalThis.fetch = originalFetch;
       vi.restoreAllMocks();
@@ -4717,12 +4789,14 @@ Welcome to the docs.
         Authorization: "Bearer docs-mcp-token",
         "mcp-session-id": "remote-session-1",
       });
-      expect(JSON.parse(String(toolInit?.body))).toMatchObject({
+      const toolBody = JSON.parse(String(toolInit?.body));
+      expect(toolBody).toMatchObject({
         method: "tools/call",
         params: {
           name: "custom_search_docs",
         },
       });
+      expect(toolBody).not.toHaveProperty("params.arguments.audience");
 
       const upstreamInit = vi.mocked(globalThis.fetch).mock.calls[3]?.[1];
       const upstreamBody = JSON.parse(String(upstreamInit?.body)) as {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -103,6 +103,7 @@ import {
   formatDocsAskAIPackageHints,
   performDocsSearch,
   resolveAskAISearchRequestConfig,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
 } from "@farming-labs/docs";
 import type {
@@ -692,9 +693,13 @@ function buildAgentSpec({
     search: {
       enabled: searchEnabled,
       endpoint: `${apiRoute}?query={query}`,
+      agentEndpoint: `${apiRoute}?query={query}&audience=agent`,
       method: "GET",
       queryParam: "query",
       localeParam: "lang",
+      audienceParam: "audience",
+      defaultAudience: "human",
+      supportedAudiences: ["human", "agent"],
     },
     agents: {
       enabled: true,
@@ -2065,7 +2070,9 @@ function renderSkillDocument({
   );
 
   if (searchEnabled) {
-    lines.push(`- Search with ${apiRoute}?query={query} when you do not know the page.`);
+    lines.push(
+      `- Search with ${apiRoute}?query={query}&audience=agent when you do not know the page.`,
+    );
   }
 
   if (openapi.enabled && openapiUrl) {
@@ -2258,7 +2265,7 @@ function renderAgentsDocument({
   }
 
   if (searchEnabled) {
-    lines.push(`- Search with ${apiRoute}?query={query} when the route is unknown.`);
+    lines.push(`- Search with ${apiRoute}?query={query}&audience=agent when the route is unknown.`);
   }
 
   if (openapi.enabled && openapiUrl) {
@@ -4610,13 +4617,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       }
 
       const searchStartedAt = Date.now();
+      const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
       const results = await performDocsSearch({
         pages: getIndexes(ctx),
         query,
         search: resolveSearchRequestConfig(searchConfig, request.url),
+        audience,
         locale: ctx.locale,
         pathname: url.searchParams.get("pathname") ?? undefined,
         siteTitle: llmsConfig.siteTitle ?? "Documentation",
+        baseUrl: markdownMetadataBaseUrl || url.origin,
       });
       await emitDocsAnalyticsEvent(analytics, {
         type: "api_search",
@@ -4628,6 +4638,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         properties: {
           ...requestAnalyticsProperties,
           queryLength: query.length,
+          audience,
           resultCount: results.length,
           pathname: url.searchParams.get("pathname") ?? undefined,
           durationMs: Math.max(0, Date.now() - searchStartedAt),

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -62,6 +62,7 @@ import {
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtRequest,
@@ -1273,13 +1274,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const searchStartedAt = Date.now();
+    const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
       search: resolveSearchRequestConfig(config.search, context.request.url),
+      audience,
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+      baseUrl: markdownMetadataBaseUrl || url.origin,
     });
     await emitDocsAnalyticsEvent(analytics, {
       type: "api_search",
@@ -1290,6 +1294,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       input: { query },
       properties: {
         queryLength: query.length,
+        audience,
         resultCount: results.length,
         pathname: url.searchParams.get("pathname") ?? undefined,
         durationMs: Math.max(0, Date.now() - searchStartedAt),

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -72,6 +72,7 @@ import {
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtRequest,
@@ -1295,13 +1296,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const searchStartedAt = Date.now();
+    const audience = resolveDocsSearchAudience(event.url.searchParams.get("audience"));
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
       search: resolveSearchRequestConfig(config.search, event.request.url),
+      audience,
       locale: ctx.locale,
       pathname: event.url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+      baseUrl: markdownMetadataBaseUrl || event.url.origin,
     });
     await emitDocsAnalyticsEvent(analytics, {
       type: "api_search",
@@ -1312,6 +1316,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       input: { query },
       properties: {
         queryLength: query.length,
+        audience,
         resultCount: results.length,
         pathname: event.url.searchParams.get("pathname") ?? undefined,
         durationMs: Math.max(0, Date.now() - searchStartedAt),

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -42,6 +42,7 @@ import {
   resolveDocsAgentFeedbackRequest,
   resolvePageSidebarFolderIndexBehavior,
   resolveAskAISearchRequestConfig,
+  resolveDocsSearchAudience,
   resolveSearchRequestConfig,
   resolveDocsI18n,
   resolveDocsLlmsTxtRequest,
@@ -1243,13 +1244,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     }
 
     const searchStartedAt = Date.now();
+    const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const results = await performDocsSearch({
       pages: getSearchIndex(ctx),
       query,
       search: resolveSearchRequestConfig(config.search, event.request.url),
+      audience,
       locale: ctx.locale,
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
+      baseUrl: markdownMetadataBaseUrl || url.origin,
     });
     await emitDocsAnalyticsEvent(analytics, {
       type: "api_search",
@@ -1260,6 +1264,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       input: { query },
       properties: {
         queryLength: query.length,
+        audience,
         resultCount: results.length,
         pathname: url.searchParams.get("pathname") ?? undefined,
         durationMs: Math.max(0, Date.now() - searchStartedAt),

--- a/skills/farming-labs/README.md
+++ b/skills/farming-labs/README.md
@@ -29,6 +29,7 @@ Useful routes:
 - Robots: `http://127.0.0.1:3000/robots.txt` after running `docs robots generate`
 - MCP: `http://127.0.0.1:3000/mcp` or `http://127.0.0.1:3000/.well-known/mcp`
 - Search API: `http://127.0.0.1:3000/api/docs?query=session`
+- Agent-projected search: `http://127.0.0.1:3000/api/docs?query=session&audience=agent`
 - Docs API markdown: `http://127.0.0.1:3000/api/docs?format=markdown&path=quickstart`
 - Agent feedback schema: `http://127.0.0.1:3000/api/docs/agent/feedback/schema`
 - Public markdown page with embedded `Agent` block (Next.js): `http://127.0.0.1:3000/docs/quickstart.md`

--- a/skills/farming-labs/configuration/SKILL.md
+++ b/skills/farming-labs/configuration/SKILL.md
@@ -746,6 +746,17 @@ adapter with section-based chunking.
 search: true,
 ```
 
+The HTTP search route is audience-aware while remaining backward compatible:
+
+- `GET /api/docs?query=<query>` returns the human projection (shared content plus `Human` content)
+- `GET /api/docs?query=<query>&audience=agent` opts into the agent projection (shared content plus
+  `Agent` content)
+- `audience=human`, an omitted value, or any value other than the exact lowercase `agent` stays on
+  the human projection
+
+Audience selection shapes public search content; it is not authentication or authorization. Never
+put secrets or private data in an audience block.
+
 Built-in provider options:
 
 - `simple` — zero-config docs search
@@ -818,8 +829,16 @@ search: createCustomSearchAdapter({
 Important notes:
 
 - `chunking.strategy` defaults to `"section"` and can be changed to `"page"`
+- custom adapters receive the resolved projection as `query.audience` and `context.audience`; the
+  `context.documents` supplied to the request use that same projection
+- custom adapters should apply `query.audience` while filtering and ranking provider results
 - Typesense and Algolia can sync the index on first request when `adminApiKey` is present
+- hosted Typesense and Algolia index sync remains human-projected; agent searches are projected at
+  request time and do not replace the public index with agent-only text
 - `provider: "mcp"` supports relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints
+- same-origin MCP `search_docs` routes receive the resolved `audience`; remote endpoints and custom
+  tool names must set `forwardAudience: true` after their input schema supports that argument;
+  human-projection requests fall back to local search until then
 - if `provider: "mcp"` points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally so the route does not recurse forever
 - On custom/manual Next routes, pass the full config into `createDocsAPI(docsConfig)`
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want to push external indexes from the CLI instead of waiting for the first request
@@ -830,6 +849,8 @@ Testing tip:
 - The Next example under `examples/next` is the easiest place to verify provider-backed search.
 - Set `DOCS_SEARCH_PROVIDER=typesense`, `algolia`, or `mcp`, restart the app, and query
   `/api/docs?query=...` to confirm the active backend.
+- Query `/api/docs?query=...&audience=agent` to verify the agent projection without changing the
+  human-default search contract.
 
 ---
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -604,6 +604,16 @@ export default defineDocs({
 });
 ```
 
+The same route supports two content projections. `GET /api/docs?query=<query>` remains the human
+default and searches shared plus human-only content. Use the exact lowercase
+`GET /api/docs?query=<query>&audience=agent` form to search shared plus agent-only content.
+`audience=human`, an omitted value, and invalid values all stay on the human projection.
+
+<Callout type="warning" title="Audience is not access control">
+  The query parameter selects a public content projection; it does not authenticate or authorize
+  the caller. Never place secrets or private data in audience-specific docs content.
+</Callout>
+
 Use an object when you want to switch providers or tune indexing behavior:
 
 ### Simple search
@@ -727,9 +737,17 @@ Notes:
 
 - `search: false` disables search entirely
 - `chunking.strategy` defaults to `"section"` and can be changed to `"page"` for one-document-per-page indexing
+- custom adapters receive the resolved value as `query.audience` and `context.audience`, and
+  `context.documents` uses the matching content projection
+- custom adapters should apply `query.audience` while filtering and ranking provider results
 - Typesense and Algolia can sync documents automatically on the first search request when `adminApiKey` is present
+- hosted index sync remains human-projected; requesting `audience=agent` does not replace the public
+  index with agent-only text
 - Use `pnpm dlx @farming-labs/docs search sync --typesense` or `--algolia` when you want manual indexing as a CLI step
 - `provider: "mcp"` can target a relative route like `/mcp` or `/.well-known/mcp` or an absolute remote MCP endpoint
+- same-origin MCP `search_docs` routes receive the resolved `audience`; remote endpoints and custom
+  tool names must set `forwardAudience: true` after supporting that argument; human-projection
+  requests fall back to local search until then
 - when MCP search points at the same site's relative MCP route, the MCP `search_docs` tool falls back to built-in simple search to avoid recursive loops
 - If you use a custom Next.js docs API route, import `createDocsAPI` from `@farming-labs/next/api` and pass the whole config: `createDocsAPI(docsConfig)`
 - Search requires the docs API route; with `staticExport: true` the UI is hidden because there is no server route

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -162,7 +162,8 @@ The framework resolves the same audience policy before each content surface cons
 | Surface | Projection |
 | ------- | ---------- |
 | Rendered docs HTML | Human |
-| Public docs search | Human |
+| Search API without `audience=agent` | Human |
+| Search API with exact `audience=agent` | Agent |
 | Markdown routes and the markdown API format | Agent |
 | Ask AI retrieval and context | Agent |
 | MCP search, context, and page reads | Agent |
@@ -232,7 +233,8 @@ Recommended bootstrap flow:
 1. Fetch `/.well-known/agent.json`, then fall back to `/.well-known/agent`.
 2. Read `spec.skills.route` or `spec.skills.wellKnown` when you want the concise site skill.
 3. Use `spec.markdown.pagePattern`, `spec.markdown.acceptHeader`, or `spec.markdown.signatureAgentHeader` to read relevant docs pages as markdown.
-4. Use `spec.search.endpoint` when you need to find the right page first.
+4. Use `spec.search.agentEndpoint` when you need to find the right page first. Older discovery
+   documents can be handled by adding `&audience=agent` to `spec.search.endpoint`.
 5. Use `spec.sitemap.markdown.route` for the semantic docs map and `spec.sitemap.xml.route` for canonical freshness when sitemap is enabled.
 6. Fetch `spec.robots.route` when you need to confirm crawler and AI-agent access policy.
 7. Use `spec.mcp.wellKnownEndpoint` or `spec.mcp.publicEndpoint` when available, otherwise `spec.mcp.endpoint`, when MCP is enabled and your environment supports MCP.
@@ -400,6 +402,12 @@ The generated spec includes `agentSpecDefault: "/.well-known/agent.json"` and
 `agentSpecFallback: "/.well-known/agent"` so downstream integrations do not need to hard-code the
 preference themselves. It also includes `robots.route` so agents can find the static crawl policy
 without guessing.
+
+The `search` object keeps `endpoint` as the backward-compatible human-default URL and adds
+`agentEndpoint` for agent-projected retrieval. It also declares `audienceParam: "audience"`,
+`defaultAudience: "human"`, and `supportedAudiences: ["human", "agent"]`. Only the exact lowercase
+`audience=agent` value opts into shared plus agent-only content; this is projection rather than an
+authorization boundary.
 
 The custom manifest remains supported and advertises the standards routes through
 `apiCatalog` and `skills.discovery`. Discovery responses also include an `api-catalog` HTTP

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -840,6 +840,17 @@ export default defineDocs({
 });
 ```
 
+`GET /api/docs?query=<query>` searches the human projection by default. The exact lowercase
+`audience=agent` query parameter selects the agent projection:
+
+```text
+GET /api/docs?query=installation&audience=agent
+```
+
+The human projection contains shared plus human-only content; the agent projection contains shared
+plus agent-only content. `audience=human`, a missing value, and invalid values all resolve to human.
+This is content projection, not authentication or authorization.
+
 Built-in providers:
 
 - `simple` — zero-config docs search with section chunking
@@ -988,7 +999,11 @@ export default defineDocs({
 ### `DocsSearchAdapter`
 
 Custom adapters receive normalized source pages and chunked search documents so you can focus on
-retrieval and ranking instead of rebuilding the docs scan pipeline.
+retrieval and ranking instead of rebuilding the docs scan pipeline. `DocsSearchQuery.audience` and
+`DocsSearchAdapterContext.audience` are both `"human" | "agent"` and contain the resolved request
+projection; `context.documents` is projected to match. Hosted index synchronization always uses
+the human projection. Custom adapters should apply `query.audience` while filtering and ranking
+provider results.
 
 ```ts title="search-adapter.ts"
 import type { DocsSearchAdapter } from "@farming-labs/docs";
@@ -1026,8 +1041,13 @@ Notes:
 
 - `search: false` disables search entirely
 - Search requires the docs API route; static export hides the UI because there is no server route
+- `GET /api/docs?query=...` remains human by default; only exact `audience=agent` opts into agent
+  content
 - On Next.js, generated routes from `withDocs()` pass `docsConfig` directly into `createDocsAPI`
 - MCP-backed search works with relative endpoints like `/mcp` or `/.well-known/mcp` and absolute remote endpoints like `https://docs.example.com/mcp`
+- same-origin MCP `search_docs` routes receive the resolved `audience`; set `forwardAudience: true`
+  only when a remote endpoint or custom tool supports the same argument; human-projection requests
+  fall back to local search until then
 - If MCP-backed search points at the same relative MCP route, the built-in `search_docs` tool falls back to simple search internally to avoid recursive loops
 - On custom/manual Next routes, import `createDocsAPI` from `@farming-labs/next/api` and pass the whole config: `createDocsAPI(docsConfig)`
 


### PR DESCRIPTION
## Summary

- keep `GET /api/docs?query=...` human-projected by default and add exact `audience=agent` opt-in across Next/Fumadocs, TanStack Start, SvelteKit, Astro, and Nuxt
- propagate typed audience context through custom search adapters and MCP while keeping hosted index sync human-projected
- sanitize stale provider results against the selected local projection, reject opposite-audience hits, bound snippets, and recover safely from stale anchors or incompatible remote MCP tools
- advertise the human and agent endpoints through discovery, diagnostics, generated agent instructions, and drift checks
- document the public projection contract, adapter responsibilities, and the fact that audience selection is not authentication

## Compatibility and safety

- omitted, `human`, mixed-case, and unknown audience values resolve to `human`
- the legacy discovery `search.endpoint` remains unchanged; `search.agentEndpoint` is additive
- same-origin `search_docs` routes receive the audience automatically; remote/custom tools opt in with `forwardAudience: true`
- canonical metadata origins are used when sanitizing provider results from preview or proxy deployments

## Verification

- 1,179 tests passed across `docs`, `fumadocs`, `next`, and `nuxt`
- typechecks passed for `docs`, `fumadocs`, `next`, `tanstack-start`, `svelte`, `astro`, and `nuxt`
- builds passed for all affected packages
- formatting passed
- lint passed with zero errors (existing warnings remain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds audience-aware search with an explicit agent opt-in. Human remains the default for `GET /api/docs?query=...`; use `audience=agent` to search the agent projection across `@astro`, `@fumadocs`, `@tanstack-start`, `@sveltekit`, and `@nuxt`. Direct MCP searches now default to the human projection and only forward audience when enabled.

- **New Features**
  - Public API: `GET /api/docs?query=<q>` defaults to human; only exact `audience=agent` selects agent. Added `resolveDocsSearchAudience`.
  - Adapters: `DocsSearchQuery.audience` and `DocsSearchAdapterContext.audience` added; `context.documents` match the projection. MCP adapter defaults to human and forwards audience only when `forwardAudience: true`.
  - Safety: Replace stale provider snippets with the selected projection, block opposite-audience hits, clamp snippets to 160 chars, and recover from stale anchors using `baseUrl`.
  - Discovery/Diagnostics: Added `search.agentEndpoint`, `search.audienceParam`, `search.defaultAudience`, and `search.supportedAudiences`; features include per-audience routes.

- **Migration**
  - Keep using `GET /api/docs?query=...` for human; use `&audience=agent` when you need agent content.
  - If using MCP on a remote endpoint or custom tool, set `forwardAudience: true` after the tool supports an `audience` argument; otherwise human requests fail closed.

<sup>Written for commit 52f9e74dbeb326a006f954709e404b38c27785e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

