### PR TITLE
fix: restore production agent discovery endpoints

### DIFF
--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -17,7 +17,13 @@ permissions:
 
 jobs:
   smoke:
-    if: github.event_name != 'deployment_status' || github.event.deployment_status.state == 'success'
+    # The docs-website preview project is intentionally protected by Vercel SSO.
+    # The public docs-cloud preview exercises the same site, while scheduled and
+    # manual runs continue to verify the production origin.
+    if: >-
+      github.event_name != 'deployment_status' ||
+      (github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment != 'Preview – docs-website')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -1,0 +1,37 @@
+name: Agent surface smoke
+
+on:
+  deployment_status:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Deployment origin to test
+        required: false
+        default: https://docs.farming-labs.dev
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    if: github.event_name != 'deployment_status' || github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DOCS_SMOKE_BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.environment_url || inputs.base_url || 'https://docs.farming-labs.dev' }}
+      DOCS_SMOKE_EXPECT_SKILLS: ask-ai,cli,configuration,creating-themes,getting-started,page-actions
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test the smoke validator
+        run: node --test scripts/smoke-agent-surfaces.test.mjs
+
+      - name: Smoke-test deployed agent surfaces
+        run: node scripts/smoke-agent-surfaces.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Run Next adapter tests
+        run: pnpm --filter @farming-labs/next test
+
+      - name: Run Fumadocs theme tests
+        run: pnpm --filter @farming-labs/theme test
+
+      - name: Test deployed agent surface smoke validator
+        run: pnpm test:smoke-agent-surfaces
+
       - name: Run Nuxt adapter tests
         run: pnpm --filter @farming-labs/nuxt test
   security-audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Build Next adapter test dependencies
+        run: pnpm --filter @farming-labs/theme build
+
       - name: Run Next adapter tests
         run: pnpm --filter @farming-labs/next test
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "try:init": "pnpm --filter @farming-labs/docs run build && cd examples/next && node ../../packages/docs/dist/cli/index.mjs init",
     "dev": "pnpm --filter example-next dev",
     "examples:version": "node scripts/set-examples-version.mjs",
+    "smoke:agent-surfaces": "node scripts/smoke-agent-surfaces.mjs",
+    "test:smoke-agent-surfaces": "node --test scripts/smoke-agent-surfaces.test.mjs",
     "test": "pnpm --filter @farming-labs/docs run test",
     "typecheck": "pnpm --filter @farming-labs/docs run build && pnpm --filter './packages/*' run typecheck",
     "release": "bumpp",

--- a/packages/docs/src/agent-skills-server-async.test.ts
+++ b/packages/docs/src/agent-skills-server-async.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const fail = () => {
+    throw new Error("promise-based resolver used a synchronous filesystem API");
+  };
+  return {
+    ...actual,
+    existsSync: fail,
+    lstatSync: fail,
+    readFileSync: fail,
+    readdirSync: fail,
+    realpathSync: fail,
+    statSync: fail,
+  };
+});
+
+vi.mock("node:zlib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:zlib")>();
+  return {
+    ...actual,
+    gzipSync: () => {
+      throw new Error("promise-based resolver used synchronous compression");
+    },
+  };
+});
+
+import { resolveConfiguredAgentSkills } from "./agent-skills-server.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("asynchronous configured Agent Skill resolution", () => {
+  it("uses asynchronous filesystem and compression APIs for runtime publishing", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "docs-agent-skills-async-"));
+    temporaryRoots.push(root);
+    const skillDir = path.join(root, "skills", "runtime-safe");
+    await mkdir(path.join(skillDir, "references"), { recursive: true });
+    await writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: runtime-safe\ndescription: Publish without blocking runtime I/O.\n---\n",
+      "utf8",
+    );
+    await writeFile(path.join(skillDir, "references", "guide.md"), "# Guide\n", "utf8");
+
+    const [skill] = await resolveConfiguredAgentSkills("skills", {
+      rootDir: root,
+      workspaceRoot: root,
+    });
+
+    expect(skill.type).toBe("archive");
+    expect(skill.files.map((file) => file.path)).toEqual(["SKILL.md", "references/guide.md"]);
+  });
+});

--- a/packages/docs/src/agent-skills-server.test.ts
+++ b/packages/docs/src/agent-skills-server.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveConfiguredAgentSkills } from "./agent-skills-server.js";
+import {
+  resolveConfiguredAgentSkills,
+  resolveConfiguredAgentSkillsSync,
+} from "./agent-skills-server.js";
 
 const temporaryRoots: string[] = [];
 
@@ -78,6 +81,23 @@ describe("configured Agent Skills", () => {
     expect(skills[0].digest).toBe(`sha256:${skills[0].sha256}`);
   });
 
+  it("creates the same deterministic build-time snapshot through the synchronous API", async () => {
+    const root = createWorkspace();
+    const directory = writeSkill(root, "build-time");
+    mkdirSync(path.join(directory, "references"));
+    writeFileSync(path.join(directory, "references", "guide.md"), "# Guide\n", "utf8");
+
+    const synchronous = resolveConfiguredAgentSkillsSync("skills", { rootDir: root });
+    const asynchronous = await resolveConfiguredAgentSkills("skills", { rootDir: root });
+
+    expect(synchronous).toEqual(asynchronous);
+    expect(synchronous[0].type).toBe("archive");
+    expect(synchronous[0].files.map((file) => file.path)).toEqual([
+      "SKILL.md",
+      "references/guide.md",
+    ]);
+  });
+
   it("creates deterministic archives with safe companion files and binary assets", async () => {
     const root = createWorkspace();
     const directory = writeSkill(root, "with-files");
@@ -129,6 +149,9 @@ describe("configured Agent Skills", () => {
     await expect(
       resolveConfiguredAgentSkills(path.join(outside, "skills"), { rootDir: root }),
     ).rejects.toThrow("escapes the workspace");
+    expect(() =>
+      resolveConfiguredAgentSkillsSync(path.join(outside, "skills"), { rootDir: root }),
+    ).toThrow("escapes the workspace");
   });
 
   it("requires the frontmatter name to match the skill directory", async () => {

--- a/packages/docs/src/agent-skills-server.ts
+++ b/packages/docs/src/agent-skills-server.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 import type { DocsAgentSkillsInput } from "./types.js";
 import {
+  buildDocsPublishedAgentSkill,
   DEFAULT_AGENT_SKILLS_ROUTE_PREFIX,
-  resolveDocsPublishedAgentSkill,
   type DocsPublishedAgentSkill,
   type DocsPublishedAgentSkillFile,
 } from "./standards-discovery.js";
@@ -316,17 +316,14 @@ function createDeterministicTarGzip(files: DocsPublishedAgentSkillFile[]): Uint8
   return archive;
 }
 
-async function publishSkillDocument(skillPath: string): Promise<DocsPublishedAgentSkill> {
+function publishSkillDocument(skillPath: string): DocsPublishedAgentSkill {
   const skillDir = path.dirname(skillPath);
   const skillDocument = readFileSync(skillPath, "utf8");
   const skillDocumentBytes = Buffer.byteLength(skillDocument, "utf8");
   if (skillDocumentBytes > MAX_FILE_BYTES) {
     throw new Error(`Agent Skill SKILL.md exceeds ${MAX_FILE_BYTES} bytes: ${skillPath}`);
   }
-  const base = await resolveDocsPublishedAgentSkill({
-    preferredDocument: skillDocument,
-    fallbackDocument: skillDocument,
-  });
+  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument));
   if (base.name !== path.basename(skillDir)) {
     throw new Error(
       `Agent Skill frontmatter name "${base.name}" must match its directory "${path.basename(skillDir)}".`,
@@ -351,11 +348,11 @@ async function publishSkillDocument(skillPath: string): Promise<DocsPublishedAge
   };
 }
 
-/** Resolve and safely package all project skills configured through `agent.skills`. */
-export async function resolveConfiguredAgentSkills(
+/** Resolve and safely package all project skills configured through `agent.skills` synchronously. */
+export function resolveConfiguredAgentSkillsSync(
   input: DocsAgentSkillsInput | undefined,
   options: ResolveConfiguredAgentSkillsOptions = {},
-): Promise<DocsPublishedAgentSkill[]> {
+): DocsPublishedAgentSkill[] {
   const configuredPaths = normalizeConfiguredPaths(input);
   if (configuredPaths.length === 0) return [];
 
@@ -376,7 +373,7 @@ export async function resolveConfiguredAgentSkills(
     );
   }
 
-  const published = await Promise.all([...documents].sort().map(publishSkillDocument));
+  const published = [...documents].sort().map(publishSkillDocument);
   const names = new Set<string>();
   for (const skill of published) {
     if (names.has(skill.name))
@@ -384,4 +381,12 @@ export async function resolveConfiguredAgentSkills(
     names.add(skill.name);
   }
   return published.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** Resolve configured skills while preserving the original promise-based public API. */
+export async function resolveConfiguredAgentSkills(
+  input: DocsAgentSkillsInput | undefined,
+  options: ResolveConfiguredAgentSkillsOptions = {},
+): Promise<DocsPublishedAgentSkill[]> {
+  return resolveConfiguredAgentSkillsSync(input, options);
 }

--- a/packages/docs/src/agent-skills-server.ts
+++ b/packages/docs/src/agent-skills-server.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { access, lstat, readFile, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
-import { gzipSync } from "node:zlib";
+import { gzip, gzipSync } from "node:zlib";
 import type { DocsAgentSkillsInput } from "./types.js";
 import {
   buildDocsPublishedAgentSkill,
@@ -43,6 +44,32 @@ function findWorkspaceRoot(rootDir: string): string {
   }
 }
 
+async function pathExists(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findWorkspaceRootAsync(rootDir: string): Promise<string> {
+  const resolvedRoot = await realpath(rootDir);
+  let current = resolvedRoot;
+  for (;;) {
+    if (
+      (await pathExists(path.join(current, ".git"))) ||
+      (await pathExists(path.join(current, "pnpm-workspace.yaml"))) ||
+      (await pathExists(path.join(current, "pnpm-workspace.yml")))
+    ) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return resolvedRoot;
+    current = parent;
+  }
+}
+
 function normalizeConfiguredPaths(input: DocsAgentSkillsInput | undefined): string[] {
   if (!input) return [];
   const value =
@@ -67,6 +94,25 @@ function resolveSafeConfiguredPath(
     throw new Error(`Configured Agent Skill paths may not be symlinks: ${configuredPath}`);
   }
   const resolved = realpathSync(candidate);
+  if (!isInside(workspaceRoot, resolved)) {
+    throw new Error(`Agent Skill symlink escapes the workspace: ${configuredPath}`);
+  }
+  return resolved;
+}
+
+async function resolveSafeConfiguredPathAsync(
+  configuredPath: string,
+  rootDir: string,
+  workspaceRoot: string,
+): Promise<string> {
+  const candidate = path.resolve(rootDir, configuredPath);
+  if (!(await pathExists(candidate))) {
+    throw new Error(`Configured Agent Skill path does not exist: ${configuredPath}`);
+  }
+  if ((await lstat(candidate)).isSymbolicLink()) {
+    throw new Error(`Configured Agent Skill paths may not be symlinks: ${configuredPath}`);
+  }
+  const resolved = await realpath(candidate);
   if (!isInside(workspaceRoot, resolved)) {
     throw new Error(`Agent Skill symlink escapes the workspace: ${configuredPath}`);
   }
@@ -128,6 +174,67 @@ function collectSkillDocuments(
     } else if (entry.isDirectory() || entry.isFile()) {
       if (entry.isDirectory() || entry.name === "SKILL.md") {
         collectSkillDocuments(entryPath, workspaceRoot, results, visited, depth + 1);
+      }
+    } else {
+      throw new Error(`Unsafe filesystem entry in Agent Skill collection: ${entryPath}`);
+    }
+  }
+}
+
+async function collectSkillDocumentsAsync(
+  candidate: string,
+  workspaceRoot: string,
+  results: Set<string>,
+  visited: Set<string>,
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_COLLECTION_DEPTH) {
+    throw new Error(`Agent Skill collection exceeds ${MAX_COLLECTION_DEPTH} directory levels.`);
+  }
+  const resolved = await realpath(candidate);
+  if (!isInside(workspaceRoot, resolved)) {
+    throw new Error(`Agent Skill symlink escapes the workspace: ${candidate}`);
+  }
+  if (visited.has(resolved)) return;
+  visited.add(resolved);
+
+  const info = await stat(resolved);
+  if (info.isFile()) {
+    if (path.basename(resolved) !== "SKILL.md") {
+      throw new Error(`Agent Skill file must be named SKILL.md: ${candidate}`);
+    }
+    results.add(resolved);
+    return;
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`Agent Skill path must be a regular file or directory: ${candidate}`);
+  }
+
+  const directSkill = path.join(resolved, "SKILL.md");
+  if (await pathExists(directSkill)) {
+    const directInfo = await lstat(directSkill);
+    if (!directInfo.isFile() || directInfo.isSymbolicLink()) {
+      throw new Error(`Agent Skill SKILL.md must be a non-symlink regular file: ${directSkill}`);
+    }
+    results.add(directSkill);
+    return;
+  }
+
+  const entries = await readdir(resolved, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (
+      IGNORED_COLLECTION_DIRECTORIES.has(entry.name) ||
+      entry.name.startsWith(".") ||
+      COMPANION_DIRECTORIES.has(entry.name)
+    ) {
+      continue;
+    }
+    const entryPath = path.join(resolved, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Agent Skill collections may not contain symlinks: ${entryPath}`);
+    } else if (entry.isDirectory() || entry.isFile()) {
+      if (entry.isDirectory() || entry.name === "SKILL.md") {
+        await collectSkillDocumentsAsync(entryPath, workspaceRoot, results, visited, depth + 1);
       }
     } else {
       throw new Error(`Unsafe filesystem entry in Agent Skill collection: ${entryPath}`);
@@ -261,6 +368,70 @@ function readCompanionFiles(
   return files;
 }
 
+async function readCompanionFilesAsync(
+  skillDir: string,
+  name: string,
+  rootSkillBytes: number,
+): Promise<DocsPublishedAgentSkillFile[]> {
+  const files: DocsPublishedAgentSkillFile[] = [];
+  let totalBytes = rootSkillBytes;
+
+  async function visit(absoluteDir: string, relativeDir: string, depth = 0): Promise<void> {
+    if (depth > MAX_COLLECTION_DEPTH) {
+      throw new Error(
+        `Agent Skill companion tree exceeds ${MAX_COLLECTION_DEPTH} levels: ${skillDir}`,
+      );
+    }
+    const entries = await readdir(absoluteDir, { withFileTypes: true });
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const absolutePath = path.join(absoluteDir, entry.name);
+      const relativePath = path.posix.join(relativeDir, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Agent Skill companion files may not be symlinks: ${absolutePath}`);
+      }
+      if (entry.isDirectory()) {
+        await visit(absolutePath, relativePath, depth + 1);
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new Error(`Unsafe filesystem entry in Agent Skill: ${absolutePath}`);
+      }
+      const executable = ((await stat(absolutePath)).mode & 0o111) !== 0;
+      const content = await readFile(absolutePath);
+      if (content.byteLength > MAX_FILE_BYTES) {
+        throw new Error(`Agent Skill file exceeds ${MAX_FILE_BYTES} bytes: ${absolutePath}`);
+      }
+      totalBytes += content.byteLength;
+      if (totalBytes > MAX_SKILL_BYTES || files.length >= MAX_FILES_PER_SKILL - 1) {
+        throw new Error(`Agent Skill exceeds safe publication limits: ${skillDir}`);
+      }
+      const mediaType = mediaTypeFor(relativePath);
+      const value = preserveFileBytes(content, mediaType);
+      const sha256 = hashBytes(value);
+      files.push({
+        path: relativePath,
+        url: encodeSkillFileUrl(name, relativePath),
+        mediaType,
+        content: value,
+        sha256,
+        digest: `sha256:${sha256}`,
+        executable,
+      });
+    }
+  }
+
+  for (const directory of [...COMPANION_DIRECTORIES].sort()) {
+    const absoluteDir = path.join(skillDir, directory);
+    if (!(await pathExists(absoluteDir))) continue;
+    const info = await lstat(absoluteDir);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new Error(`Agent Skill ${directory}/ must be a non-symlink directory: ${absoluteDir}`);
+    }
+    await visit(absoluteDir, directory);
+  }
+  return files;
+}
+
 function writeTarString(header: Uint8Array, offset: number, length: number, value: string): void {
   const encoded = Buffer.from(value, "utf8");
   if (encoded.byteLength > length)
@@ -289,7 +460,7 @@ function createTarHeader(name: string, size: number, executable: boolean): Uint8
   return header;
 }
 
-function createDeterministicTarGzip(files: DocsPublishedAgentSkillFile[]): Uint8Array {
+function createDeterministicTar(files: DocsPublishedAgentSkillFile[]): Uint8Array {
   const chunks: Uint8Array[] = [];
   let total = 0;
   for (const file of [...files].sort(compareSkillFilePath)) {
@@ -311,12 +482,31 @@ function createDeterministicTarGzip(files: DocsPublishedAgentSkillFile[]): Uint8
     tar.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  const archive = new Uint8Array(gzipSync(tar, { level: 9 }));
+  return tar;
+}
+
+function normalizeGzipArchive(content: Uint8Array): Uint8Array {
+  const archive = new Uint8Array(content);
   if (archive.byteLength > 9) archive[9] = 255;
   return archive;
 }
 
-function publishSkillDocument(skillPath: string): DocsPublishedAgentSkill {
+function createDeterministicTarGzip(files: DocsPublishedAgentSkillFile[]): Uint8Array {
+  return normalizeGzipArchive(gzipSync(createDeterministicTar(files), { level: 9 }));
+}
+
+function createDeterministicTarGzipAsync(
+  files: DocsPublishedAgentSkillFile[],
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    gzip(createDeterministicTar(files), { level: 9 }, (error, content) => {
+      if (error) reject(error);
+      else resolve(normalizeGzipArchive(content));
+    });
+  });
+}
+
+function publishSkillDocumentSync(skillPath: string): DocsPublishedAgentSkill {
   const skillDir = path.dirname(skillPath);
   const skillDocument = readFileSync(skillPath, "utf8");
   const skillDocumentBytes = Buffer.byteLength(skillDocument, "utf8");
@@ -348,6 +538,48 @@ function publishSkillDocument(skillPath: string): DocsPublishedAgentSkill {
   };
 }
 
+async function publishSkillDocumentAsync(skillPath: string): Promise<DocsPublishedAgentSkill> {
+  const skillDir = path.dirname(skillPath);
+  const skillDocument = await readFile(skillPath, "utf8");
+  const skillDocumentBytes = Buffer.byteLength(skillDocument, "utf8");
+  if (skillDocumentBytes > MAX_FILE_BYTES) {
+    throw new Error(`Agent Skill SKILL.md exceeds ${MAX_FILE_BYTES} bytes: ${skillPath}`);
+  }
+  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument));
+  if (base.name !== path.basename(skillDir)) {
+    throw new Error(
+      `Agent Skill frontmatter name "${base.name}" must match its directory "${path.basename(skillDir)}".`,
+    );
+  }
+  const companions = await readCompanionFilesAsync(skillDir, base.name, skillDocumentBytes);
+  const files = [...base.files, ...companions].sort(compareSkillFilePath);
+  if (companions.length === 0) return { ...base, files };
+
+  const content = await createDeterministicTarGzipAsync(files);
+  const sha256 = hashBytes(content);
+  return {
+    name: base.name,
+    type: "archive",
+    description: base.description,
+    url: `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(base.name)}.tar.gz`,
+    digest: `sha256:${sha256}`,
+    content,
+    sha256,
+    skillDocument,
+    files,
+  };
+}
+
+function validateAndSortSkills(published: DocsPublishedAgentSkill[]): DocsPublishedAgentSkill[] {
+  const names = new Set<string>();
+  for (const skill of published) {
+    if (names.has(skill.name))
+      throw new Error(`Duplicate configured Agent Skill name: ${skill.name}`);
+    names.add(skill.name);
+  }
+  return published.sort((left, right) => left.name.localeCompare(right.name));
+}
+
 /** Resolve and safely package all project skills configured through `agent.skills` synchronously. */
 export function resolveConfiguredAgentSkillsSync(
   input: DocsAgentSkillsInput | undefined,
@@ -373,20 +605,38 @@ export function resolveConfiguredAgentSkillsSync(
     );
   }
 
-  const published = [...documents].sort().map(publishSkillDocument);
-  const names = new Set<string>();
-  for (const skill of published) {
-    if (names.has(skill.name))
-      throw new Error(`Duplicate configured Agent Skill name: ${skill.name}`);
-    names.add(skill.name);
-  }
-  return published.sort((left, right) => left.name.localeCompare(right.name));
+  const published = [...documents].sort().map(publishSkillDocumentSync);
+  return validateAndSortSkills(published);
 }
 
-/** Resolve configured skills while preserving the original promise-based public API. */
+/** Resolve and package configured skills without blocking runtime filesystem or compression work. */
 export async function resolveConfiguredAgentSkills(
   input: DocsAgentSkillsInput | undefined,
   options: ResolveConfiguredAgentSkillsOptions = {},
 ): Promise<DocsPublishedAgentSkill[]> {
-  return resolveConfiguredAgentSkillsSync(input, options);
+  const configuredPaths = normalizeConfiguredPaths(input);
+  if (configuredPaths.length === 0) return [];
+
+  const rootDir = await realpath(options.rootDir ?? process.cwd());
+  const workspaceRoot =
+    options.workspaceRoot === undefined
+      ? await findWorkspaceRootAsync(rootDir)
+      : await realpath(options.workspaceRoot);
+  if (!isInside(workspaceRoot, rootDir)) {
+    throw new Error("Agent Skill rootDir must stay inside the configured workspace root.");
+  }
+
+  const documents = new Set<string>();
+  const visited = new Set<string>();
+  for (const configuredPath of configuredPaths) {
+    await collectSkillDocumentsAsync(
+      await resolveSafeConfiguredPathAsync(configuredPath, rootDir, workspaceRoot),
+      workspaceRoot,
+      documents,
+      visited,
+    );
+  }
+
+  const published = await Promise.all([...documents].sort().map(publishSkillDocumentAsync));
+  return validateAndSortSkills(published);
 }

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -84,8 +84,12 @@ export {
   resolveSearchRequestConfig,
 } from "./search.js";
 export { runDocsGoldenTasks } from "./agent-evals.js";
-export { resolveConfiguredAgentSkills } from "./agent-skills-server.js";
+export {
+  resolveConfiguredAgentSkills,
+  resolveConfiguredAgentSkillsSync,
+} from "./agent-skills-server.js";
 export type { ResolveConfiguredAgentSkillsOptions } from "./agent-skills-server.js";
+export { renderDocsAgentSkillsBundle } from "./agent-skills-vite.js";
 export type {
   DocsGoldenAnswerMetrics,
   DocsGoldenCitationMetrics,

--- a/packages/docs/src/standards-discovery.ts
+++ b/packages/docs/src/standards-discovery.ts
@@ -405,23 +405,11 @@ export async function sha256DocsDiscoveryContent(content: string | Uint8Array): 
   return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
 }
 
-/** Select a valid public skill and hash the exact bytes returned by its standards route. */
-export async function resolveDocsPublishedAgentSkill({
-  preferredDocument,
-  fallbackDocument,
-}: DocsPublishedAgentSkillOptions): Promise<DocsPublishedAgentSkill> {
-  const preferredMetadata = preferredDocument ? readAgentSkillFrontmatter(preferredDocument) : null;
-  const fallbackMetadata = readAgentSkillFrontmatter(fallbackDocument);
-  const content = preferredMetadata ? preferredDocument! : fallbackDocument;
-  const metadata = preferredMetadata ?? fallbackMetadata;
-
-  if (!metadata) {
-    throw new Error(
-      "The generated Agent Skills fallback must contain valid name and description frontmatter.",
-    );
-  }
-
-  const sha256 = await sha256DocsDiscoveryContent(content);
+function createDocsPublishedAgentSkill(
+  content: string,
+  metadata: { name: string; description: string },
+  sha256: string,
+): DocsPublishedAgentSkill {
   return {
     name: metadata.name,
     type: "skill-md",
@@ -442,6 +430,43 @@ export async function resolveDocsPublishedAgentSkill({
       },
     ],
   };
+}
+
+/** Build a published skill from an exact SKILL.md document and its precomputed SHA-256. */
+export function buildDocsPublishedAgentSkill(
+  document: string,
+  sha256: string,
+): DocsPublishedAgentSkill {
+  const metadata = readAgentSkillFrontmatter(document);
+  if (!metadata) {
+    throw new Error(
+      "The generated Agent Skills fallback must contain valid name and description frontmatter.",
+    );
+  }
+  if (!/^[a-f0-9]{64}$/.test(sha256)) {
+    throw new Error("Agent Skill SHA-256 must be a lowercase 64-character hexadecimal digest.");
+  }
+  return createDocsPublishedAgentSkill(document, metadata, sha256);
+}
+
+/** Select a valid public skill and hash the exact bytes returned by its standards route. */
+export async function resolveDocsPublishedAgentSkill({
+  preferredDocument,
+  fallbackDocument,
+}: DocsPublishedAgentSkillOptions): Promise<DocsPublishedAgentSkill> {
+  const preferredMetadata = preferredDocument ? readAgentSkillFrontmatter(preferredDocument) : null;
+  const fallbackMetadata = readAgentSkillFrontmatter(fallbackDocument);
+  const content = preferredMetadata ? preferredDocument! : fallbackDocument;
+  const metadata = preferredMetadata ?? fallbackMetadata;
+
+  if (!metadata) {
+    throw new Error(
+      "The generated Agent Skills fallback must contain valid name and description frontmatter.",
+    );
+  }
+
+  const sha256 = await sha256DocsDiscoveryContent(content);
+  return createDocsPublishedAgentSkill(content, metadata, sha256);
 }
 
 export function buildDocsAgentSkillsIndex(

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs, { chmodSync, mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { DocsAnalyticsEvent, DocsObservabilityEvent } from "@farming-labs/docs";
+import type {
+  DocsAnalyticsEvent,
+  DocsObservabilityEvent,
+  DocsPublishedAgentSkill,
+} from "@farming-labs/docs";
 import { createDocsAPI, createDocsMCPAPI } from "./docs-api.js";
 
 function createDeferredPromise<T = void>() {
@@ -36,6 +40,39 @@ async function parseMcpPayload<T>(response: Response): Promise<T> {
 
     return JSON.parse(payload) as T;
   }
+}
+
+function createPreloadedAgentSkill(): DocsPublishedAgentSkill {
+  const skillDocument = `---
+name: packaged-skill
+description: Use the skill bundled into the deployment.
+---
+
+# Packaged skill
+`;
+  const sha256 = createHash("sha256").update(skillDocument, "utf8").digest("hex");
+  const url = "/.well-known/agent-skills/packaged-skill/SKILL.md";
+
+  return {
+    name: "packaged-skill",
+    type: "skill-md",
+    description: "Use the skill bundled into the deployment.",
+    url,
+    digest: `sha256:${sha256}`,
+    content: skillDocument,
+    sha256,
+    skillDocument,
+    files: [
+      {
+        path: "SKILL.md",
+        url,
+        mediaType: "text/markdown",
+        content: skillDocument,
+        sha256,
+        digest: `sha256:${sha256}`,
+      },
+    ],
+  };
 }
 
 describe("createDocsMCPAPI", () => {
@@ -146,6 +183,45 @@ Welcome to the docs.
     );
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get("access-control-allow-origin")).toBe("http://localhost");
+  });
+
+  it("publishes preloaded Agent Skills through MCP without runtime filesystem access", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-mcp-preloaded-skills-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Introduction\n");
+
+    const { POST } = createDocsMCPAPI({
+      rootDir,
+      entry: "docs",
+      agent: { skills: "../runtime-skills-not-deployed" },
+      _preloadedAgentSkills: [createPreloadedAgentSkill()],
+    });
+    const response = await POST(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-protocol-version": "2025-11-25",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "resources/list",
+          params: {},
+        }),
+      }),
+    );
+    const payload = await parseMcpPayload<{
+      result?: { resources?: Array<{ uri?: string }> };
+    }>(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.result?.resources?.map((resource) => resource.uri)).toContain(
+      "docs://skills/packaged-skill/SKILL.md",
+    );
   });
 
   it("fails closed when the legacy constructor would drop source-configured MCP security", () => {
@@ -1405,6 +1481,64 @@ Use the product-specific workflow first.
         expect.objectContaining({ id: "portable", url: portable!.url }),
       ]),
     });
+  });
+
+  it("uses preloaded Agent Skills when deployment filesystem paths are unavailable", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-preloaded-skills-"));
+    tempDirs.push(rootDir);
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+
+    const runtimeOnlyAgent = {
+      skills: "../runtime-skills-not-deployed",
+    };
+    const catalogOnly = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      agent: runtimeOnlyAgent,
+    });
+    const catalog = await catalogOnly.GET(
+      new Request("https://docs.example.com/.well-known/api-catalog"),
+    );
+    expect(catalog.status).toBe(200);
+
+    const preloaded = createPreloadedAgentSkill();
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      agent: runtimeOnlyAgent,
+      _preloadedAgentSkills: [preloaded],
+    });
+
+    const indexResponse = await GET(
+      new Request("https://docs.example.com/.well-known/agent-skills/index.json"),
+    );
+    expect(indexResponse.status).toBe(200);
+    await expect(indexResponse.json()).resolves.toMatchObject({
+      skills: expect.arrayContaining([
+        {
+          name: preloaded.name,
+          type: preloaded.type,
+          description: preloaded.description,
+          url: preloaded.url,
+          digest: preloaded.digest,
+        },
+      ]),
+    });
+
+    const artifact = await GET(new Request(`https://docs.example.com${preloaded.url}`));
+    expect(artifact.status).toBe(200);
+    expect(await artifact.text()).toBe(preloaded.skillDocument);
+
+    for (const route of ["/.well-known/agent.json", "/api/docs/agent/spec"]) {
+      const response = await GET(new Request(`https://docs.example.com${route}`));
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        skills: {
+          published: expect.arrayContaining([expect.objectContaining({ name: preloaded.name })]),
+        },
+      });
+    }
   });
 
   it("serves legacy discovery HEAD without loading documents and records HEAD analytics", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -203,6 +203,8 @@ interface DocsAPIOptions {
   metadata?: DocsConfig["metadata"];
   /** Reusable skill publication and optional real A2A service metadata. */
   agent?: DocsConfig["agent"];
+  /** @internal Build-time Agent Skills snapshot supplied by framework adapters. */
+  _preloadedAgentSkills?: readonly DocsPublishedAgentSkill[];
 }
 
 interface DocsMCPAPIOptions {
@@ -217,6 +219,8 @@ interface DocsMCPAPIOptions {
   telemetry?: boolean | DocsTelemetryConfig;
   observability?: boolean | DocsObservabilityConfig;
   agent?: DocsConfig["agent"];
+  /** @internal Build-time Agent Skills snapshot supplied by framework adapters. */
+  _preloadedAgentSkills?: readonly DocsPublishedAgentSkill[];
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -3744,9 +3748,15 @@ function generateLlmsTxt(
  */
 export function createDocsAPI(options?: DocsAPIOptions) {
   const root = options?.rootDir ?? process.cwd();
-  const publishedAgentSkills = resolveConfiguredAgentSkills(options?.agent?.skills, {
-    rootDir: root,
-  });
+  let publishedAgentSkills: Promise<DocsPublishedAgentSkill[]> | undefined;
+  function getPublishedAgentSkills(): Promise<DocsPublishedAgentSkill[]> {
+    if (!publishedAgentSkills) {
+      publishedAgentSkills = Array.isArray(options?._preloadedAgentSkills)
+        ? Promise.resolve([...options._preloadedAgentSkills])
+        : resolveConfiguredAgentSkills(options?.agent?.skills, { rootDir: root });
+    }
+    return publishedAgentSkills;
+  }
   const entry = options?.entry ?? readEntry(root);
   const docsPath = normalizeDocsPublicPath(options?.docsPath ?? readDocsPath(root), entry);
   const analytics = options?.analytics;
@@ -4127,7 +4137,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       request,
       preferredSkillDocument: needsSkill ? readRootSkillDocument(root) : null,
       fallbackSkillDocument,
-      publishedSkills: await publishedAgentSkills,
+      publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: options?.agent?.a2a,
       origin: url.origin,
       entry,
@@ -4248,7 +4258,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
                   openapi: openapiDiscovery,
                 }),
               }),
-              ...(await publishedAgentSkills),
+              ...(await getPublishedAgentSkills()),
             ],
             agentCard: options?.agent?.a2a,
           }),
@@ -4818,6 +4828,15 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
     typeof options.nav?.title === "string" && options.nav.title.trim().length > 0
       ? options.nav.title
       : "Documentation";
+  let configuredAgentSkills: Promise<DocsPublishedAgentSkill[]> | undefined;
+  function getConfiguredAgentSkills(): Promise<DocsPublishedAgentSkill[]> {
+    if (!configuredAgentSkills) {
+      configuredAgentSkills = Array.isArray(options._preloadedAgentSkills)
+        ? Promise.resolve([...options._preloadedAgentSkills])
+        : resolveConfiguredAgentSkills(options.agent?.skills, { rootDir });
+    }
+    return configuredAgentSkills;
+  }
 
   const filesystemSource = createFilesystemDocsMcpSource({
     rootDir,
@@ -4829,7 +4848,7 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
   const source = {
     ...filesystemSource,
     async getSkills() {
-      const configured = await resolveConfiguredAgentSkills(options.agent?.skills, { rootDir });
+      const configured = await getConfiguredAgentSkills();
       const preferredDocument = readRootSkillDocument(rootDir);
       const fallbackDocument = `---\nname: docs\ndescription: Use the project documentation through MCP resources and tools.\n---\n\n# Documentation\n`;
       const rootSkill = await resolveDocsPublishedAgentSkill({

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -93,6 +93,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@babel/parser": "7.29.7",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^16.1.6",
@@ -107,6 +108,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@babel/types": "7.29.7",
     "@farming-labs/docs": "workspace:*",
     "@farming-labs/theme": "workspace:*",
     "@types/node": "^22.10.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -119,7 +119,7 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
-    "@farming-labs/docs": ">=0.0.1",
+    "@farming-labs/docs": ">=0.2.61",
     "@farming-labs/theme": ">=0.0.1",
     "next": ">=16.0.0",
     "react": ">=19.2.0",

--- a/packages/next/src/api.ts
+++ b/packages/next/src/api.ts
@@ -4,6 +4,7 @@ import {
   createDocsAPI as createThemeDocsAPI,
   createDocsMCPAPI as createThemeDocsMCPAPI,
 } from "@farming-labs/theme/api";
+import { bundledAgentSkills } from "@farming-labs/docs/agent-skills-bundle";
 import type {
   DocsCloudRouteHandlerOptions,
   DocsCloudServer,
@@ -188,7 +189,12 @@ export function createDocsAPI(
   cloudIntegration?: DocsAPICloudIntegration,
 ) {
   const rootDir = options.rootDir ?? inferNextProjectRootFromCaller();
-  const handlers = createThemeDocsAPI(rootDir ? { ...options, rootDir } : options);
+  const resolvedOptions = {
+    ...options,
+    ...(rootDir ? { rootDir } : {}),
+    _preloadedAgentSkills: options._preloadedAgentSkills ?? bundledAgentSkills,
+  };
+  const handlers = createThemeDocsAPI(resolvedOptions);
   const integration = resolveDocsCloudIntegration(cloudIntegration);
 
   if (!integration) return handlers;
@@ -222,5 +228,9 @@ export function createDocsAPI(
 
 export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
   const rootDir = options.rootDir ?? inferNextProjectRootFromCaller();
-  return createThemeDocsMCPAPI(rootDir ? { ...options, rootDir } : options);
+  return createThemeDocsMCPAPI({
+    ...options,
+    ...(rootDir ? { rootDir } : {}),
+    _preloadedAgentSkills: options._preloadedAgentSkills ?? bundledAgentSkills,
+  });
 }

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1478,37 +1478,174 @@ export default { mcp: sharedMcp };
     });
   });
 
-  it("traces configured Agent Skill collections for both docs and MCP routes", () => {
+  it("bundles configured Agent Skills for both docs and MCP production handlers", () => {
+    const projectDir = join(tmpDir, "website");
+    const projectSkillDir = join(projectDir, "skills", "one");
+    const sharedSkillDir = join(tmpDir, "shared-skills");
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - website\n", "utf8");
+    mkdirSync(join(projectDir, "app"), { recursive: true });
+    mkdirSync(projectSkillDir, { recursive: true });
+    mkdirSync(sharedSkillDir, { recursive: true });
     writeFileSync(
-      join(tmpDir, "docs.config.ts"),
-      `export default { entry: "docs", agent: { skills: { paths: ["skills/one", "../shared-skills"] } } };\n`,
+      join(projectSkillDir, "SKILL.md"),
+      `---\nname: one\ndescription: Use the first test skill.\n---\n\n# One\n`,
       "utf8",
     );
-    mkdirSync(join(tmpDir, "app"), { recursive: true });
-    process.chdir(tmpDir);
+    writeFileSync(
+      join(sharedSkillDir, "SKILL.md"),
+      `---\nname: shared-skills\ndescription: Use the shared test skill.\n---\n\n# Shared\n`,
+      "utf8",
+    );
+    writeFileSync(
+      join(projectDir, "docs.config.ts"),
+      `export default { entry: "docs", agent: { skills: { paths: ["skills/one", /* portable */ "../shared-skills",] } } };\n`,
+      "utf8",
+    );
+    process.chdir(projectDir);
 
     const nextConfig = withDocs({});
-    expect(nextConfig.outputFileTracingRoot).toBe(realpathSync(dirname(tmpDir)));
-    expect(nextConfig.outputFileTracingIncludes?.["/api/docs"]).toEqual(
+    const bundlePath = join(realpathSync(projectDir), ".docs", "agent-skills-bundle.mjs");
+    const bundle = readFileSync(bundlePath, "utf8");
+    const turbopackAliases = nextConfig.turbopack?.resolveAlias as Record<string, string>;
+    const webpackConfig = nextConfig.webpack?.({ resolve: { alias: {} }, module: { rules: [] } }, {
+      defaultLoaders: { babel: "babel-loader" },
+    } as Parameters<NonNullable<typeof nextConfig.webpack>>[1]);
+
+    expect(bundle).toContain('"name":"one"');
+    expect(bundle).toContain('"name":"shared-skills"');
+    expect(bundle).toContain('"sha256"');
+    expect(turbopackAliases["@farming-labs/docs/agent-skills-bundle"]).toBe(
+      "./.docs/agent-skills-bundle.mjs",
+    );
+    expect(webpackConfig.resolve.alias["@farming-labs/docs/agent-skills-bundle"]).toBe(bundlePath);
+    expect(nextConfig.outputFileTracingRoot).toBeUndefined();
+    expect(nextConfig.outputFileTracingIncludes?.["/api/docs"]).not.toEqual(
       expect.arrayContaining(["skills/one/**/*", "../shared-skills/**/*"]),
     );
-    expect(nextConfig.outputFileTracingIncludes?.["/api/docs/mcp"]).toEqual(
+    expect(nextConfig.outputFileTracingIncludes?.["/api/docs/mcp"]).not.toEqual(
       expect.arrayContaining(["skills/one/**/*", "../shared-skills/**/*"]),
     );
   });
 
-  it("fails loudly when configured Agent Skill paths cannot be traced", () => {
-    writeFileSync(
-      join(tmpDir, "docs.config.ts"),
-      `const skillPaths = ["skills/one"];
-export default { entry: "docs", agent: { skills: skillPaths } };
-`,
-      "utf8",
-    );
+  it("fails loudly when configured Agent Skill paths cannot be statically bundled", () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
 
-    expect(() => withDocs({})).toThrow("could not statically trace agent.skills");
+    for (const source of [
+      `const skillPaths = ["skills/one"];
+export default { entry: "docs", agent: { skills: skillPaths } };
+`,
+      `const sharedSkill = "skills/two";
+export default { entry: "docs", agent: { skills: ["skills/one", sharedSkill] } };
+`,
+      `const sharedSkills = ["skills/two"];
+export default { entry: "docs", agent: { skills: ["skills/one", ...sharedSkills] } };
+`,
+      `const suffix = "/one";
+export default { entry: "docs", agent: { skills: "skills" + suffix } };
+`,
+      `const shared = { paths: ["skills/two"] };
+export default { entry: "docs", agent: { skills: { paths: ["skills/one"], ...shared } } };
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: { paths: ["skills/one"], paths: ["skills/two"] } },
+};
+`,
+      `const key = "paths";
+export default { entry: "docs", agent: { skills: { [key]: ["skills/one"] } } };
+`,
+    ]) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+      expect(() => withDocs({})).toThrow("could not statically bundle agent.skills");
+    }
+
+    expect(existsSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"))).toBe(false);
+  });
+
+  it("fails closed when a composed agent config cannot be statically inspected", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    for (const source of [
+      `const agent = { skills: "skills/one" };
+export default { entry: "docs", agent };
+`,
+      `const shared = { agent: { skills: "skills/one" } };
+export default { entry: "docs", ...shared };
+`,
+      `const sharedAgent = { skills: "skills/one" };
+export default { entry: "docs", agent: sharedAgent };
+`,
+      `const sharedAgent = { skills: "skills/one" };
+export default { entry: "docs", agent: { ...sharedAgent } };
+`,
+      `const shared = { agent: { skills: "skills/two" } };
+export default { entry: "docs", agent: { skills: "skills/one" }, ...shared };
+`,
+      `const sharedAgent = { skills: "skills/two" };
+export default { entry: "docs", agent: { skills: "skills/one", ...sharedAgent } };
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: "skills/one" },
+  agent: { skills: "skills/two" },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: "skills/one", skills: "skills/two" },
+};
+`,
+      `const key = "agent";
+export default { entry: "docs", [key]: { skills: "skills/one" } };
+`,
+      `const key = "skills";
+export default { entry: "docs", agent: { [key]: "skills/one" } };
+`,
+    ]) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+      expect(() => withDocs({})).toThrow("could not statically determine agent.skills");
+    }
+  });
+
+  it("bundles skills from a live composed docs config", () => {
+    const skillDir = join(tmpDir, "skills", "live");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `const agent = { skills: "skills/live" };
+export default { entry: "docs", agent };
+`,
+      "utf8",
+    );
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: live\ndescription: Use the live composed skill.\n---\n\n# Live\n`,
+      "utf8",
+    );
+    process.chdir(tmpDir);
+
+    withDocs({}, { agent: { skills: "skills/live" } });
+
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      '"name":"live"',
+    );
+  });
+
+  it("fails the build when a configured Agent Skill is invalid", () => {
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs", agent: { skills: "skills/broken" } };\n`,
+      "utf8",
+    );
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    mkdirSync(join(tmpDir, "skills", "broken"), { recursive: true });
+    writeFileSync(join(tmpDir, "skills", "broken", "SKILL.md"), "# Missing frontmatter\n", "utf8");
+    process.chdir(tmpDir);
+
+    expect(() => withDocs({})).toThrow("valid name and description frontmatter");
   });
 
   it("reads a top-level contentDir even when nested config uses deeper indentation", () => {

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1547,11 +1547,6 @@ export default { entry: "docs", agent: { skills: "skills" + suffix } };
       `const shared = { paths: ["skills/two"] };
 export default { entry: "docs", agent: { skills: { paths: ["skills/one"], ...shared } } };
 `,
-      `export default {
-  entry: "docs",
-  agent: { skills: { paths: ["skills/one"], paths: ["skills/two"] } },
-};
-`,
       `const key = "paths";
 export default { entry: "docs", agent: { skills: { [key]: ["skills/one"] } } };
 `,
@@ -1563,7 +1558,7 @@ export default { entry: "docs", agent: { skills: { [key]: ["skills/one"] } } };
     expect(existsSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"))).toBe(false);
   });
 
-  it("fails closed when a composed agent config cannot be statically inspected", () => {
+  it("never silently omits statically present or ambiguous configured skill paths", () => {
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     process.chdir(tmpDir);
 
@@ -1574,6 +1569,36 @@ export default { entry: "docs", agent };
       `const shared = { agent: { skills: "skills/one" } };
 export default { entry: "docs", ...shared };
 `,
+      `export default { "ag\\u0065nt": { skills: "skills/one" } };
+`,
+      `export default { "ag\\u{65}nt": { skills: "skills/one" } };
+`,
+      `export default { "a\\gent": { skills: "skills/one" } };
+`,
+      String.raw`export default { "ag\
+ent": { skills: "skills/one" } };
+`,
+      `export default { ag\\u0065nt: { skills: "skills/one" } };
+`,
+      `export default { ag\\u{65}nt: { skills: "skills/one" } };
+`,
+      `export default { get agent() { return { skills: "skills/one" }; } };
+`,
+      `export default { get ["agent"]() { return { skills: "skills/one" }; } };
+`,
+      `export default { agent<T>() { return { skills: "skills/one" }; } };
+`,
+      `export default { agent /* comment */ : { skills: "skills/one" } };
+`,
+      `export default {
+  agent // comment
+  : { skills: "skills/one" },
+};
+`,
+      `// defineDocs({})
+const closingBrace = /}/;
+export default { agent: { skills: "skills/one" } };
+`,
       `const sharedAgent = { skills: "skills/one" };
 export default { entry: "docs", agent: sharedAgent };
 `,
@@ -1582,6 +1607,12 @@ export default { entry: "docs", agent: { ...sharedAgent } };
 `,
       `const shared = { agent: { skills: "skills/two" } };
 export default { entry: "docs", agent: { skills: "skills/one" }, ...shared };
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: "skills/one" },
+  get agent() { return { skills: "skills/two" }; },
+};
 `,
       `const sharedAgent = { skills: "skills/two" };
 export default { entry: "docs", agent: { skills: "skills/one", ...sharedAgent } };
@@ -1603,10 +1634,263 @@ export default { entry: "docs", [key]: { skills: "skills/one" } };
       `const key = "skills";
 export default { entry: "docs", agent: { [key]: "skills/one" } };
 `,
+      `export default { entry: "docs", agent: { "sk\\u0069lls": "skills/one" } };
+`,
+      `export default { entry: "docs", agent: { sk\\u0069lls: "skills/one" } };
+`,
+      `export default {
+  entry: "docs",
+  agent: { get skills() { return "skills/one"; } },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { get ["skills"]() { return "skills/one"; } },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills /* comment */ : "skills/one" },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: { "pa\\u0074hs": ["skills/one"] } },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: { get ["paths"]() { return ["skills/one"]; } } },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: { paths /* comment */ : ["skills/one"] } },
+};
+`,
+    ]) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+      expect(() => withDocs({})).toThrow();
+    }
+  });
+
+  it("recognizes deterministic Agent Skill syntax without falling back to filesystem errors", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    for (const name of ["one", "two"]) {
+      const skillDir = join(tmpDir, "skills", name);
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, "SKILL.md"),
+        `---\nname: ${name}\ndescription: Test ${name}.\n---\n\n# ${name}\n`,
+        "utf8",
+      );
+    }
+    process.chdir(tmpDir);
+
+    for (const [source, expectedName] of [
+      [`export default { "ag\\u0065nt": { skills: "skills/one" } };\n`, "one"],
+      [`export default { ag\\u0065nt: { skills: "skills/one" } };\n`, "one"],
+      [`export default { agent /* comment */ : { skills: "skills/one" } };\n`, "one"],
+      [`const closingBrace = /}/;\nexport default { agent: { skills: "skills/one" } };\n`, "one"],
+      [`export default { agent: { "sk\\u0069lls": "skills/one" } };\n`, "one"],
+      [
+        `export default {
+  agent: { skills: "skills/one" },
+  agent: { skills: "skills/two" },
+};
+`,
+        "two",
+      ],
+      [
+        `export default {
+  agent: { skills: "skills/one", skills: "skills/two" },
+};
+`,
+        "two",
+      ],
+      [
+        `export default {
+  agent: { skills: { paths: ["skills/one"], paths: ["skills/two"] } },
+};
+`,
+        "two",
+      ],
+    ] as const) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+
+      expect(() => withDocs({})).not.toThrow();
+      expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+        `"name":"${expectedName}"`,
+      );
+    }
+  });
+
+  it("accepts a literal agent config that overrides earlier composed properties", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+    for (const source of [
+      `const search = { search: { provider: "mcp" } };
+export default { entry: "docs", ...search, agent: { compact: { tokenBudget: 5_000 } } };
+`,
+      `export default {
+  get agent() { return { skills: "skills/ignored" }; },
+  agent: { compact: { tokenBudget: 5_000 } },
+};
+`,
+      `const key = "search";
+export default {
+  [key]: { provider: "mcp" },
+  agent: { compact: { tokenBudget: 5_000 } },
+};
+`,
+      `const shared = { agent: { skills: "skills/ignored" } };
+export default {
+  agent: { skills: "skills/ignored" },
+  ...shared,
+  agent: { compact: { tokenBudget: 5_000 } },
+};
+`,
+      `const shared = { skills: "skills/ignored" };
+export default {
+  agent: {
+    skills: "skills/ignored",
+    ...shared,
+    skills: [],
+  },
+};
+`,
+      `const shared = { paths: ["skills/ignored"] };
+export default {
+  agent: {
+    skills: {
+      paths: ["skills/ignored"],
+      ...shared,
+      paths: [],
+    },
+  },
+};
+`,
+    ]) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+
+      expect(() => withDocs({})).not.toThrow();
+    }
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      "const snapshot = [];",
+    );
+  });
+
+  it("parses a composed TSX defineDocs config when a literal agent overrides earlier properties", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+    writeFileSync(
+      join(tmpDir, "docs.config.tsx"),
+      `import { defineDocs } from "@farming-labs/docs";
+const condition = true;
+const search = { provider: "mcp" };
+export default defineDocs({
+  ...(condition ? { search } : {}),
+  agent: { compact: { tokenBudget: 5_000 } },
+  nav: { title: <div>Docs</div> },
+});
+`,
+      "utf8",
+    );
+
+    expect(() => withDocs({})).not.toThrow();
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      "const snapshot = [];",
+    );
+  });
+
+  it("parses TypeScript assertions and decorated declarations without enabling JSX", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `type DocsConfig = { agent: { skills: string[] } };
+function sealed(value: unknown) { return value; }
+@sealed
+class ConfigMarker {}
+export default <DocsConfig>{ agent: { skills: [] } };
+`,
+      "utf8",
+    );
+
+    expect(() => withDocs({})).not.toThrow();
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      "const snapshot = [];",
+    );
+  });
+
+  it("fails closed when an object prototype could provide agent or skills", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    for (const source of [
+      `export default { __proto__: { agent: { skills: "skills/one" } } };\n`,
+      `export default { agent: { __proto__: { skills: "skills/one" } } };\n`,
     ]) {
       writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
       expect(() => withDocs({})).toThrow("could not statically determine agent.skills");
     }
+  });
+
+  it("rejects defineDocs calls that are not bound to @farming-labs/docs", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    process.chdir(tmpDir);
+
+    for (const source of [
+      `function defineDocs(value: unknown) { return value; }
+export default defineDocs({ agent: { skills: "skills/one" } });
+`,
+      `import { defineDocs } from "unrelated-package";
+export default defineDocs({ agent: { skills: "skills/one" } });
+`,
+    ]) {
+      writeFileSync(join(tmpDir, "docs.config.ts"), source, "utf8");
+      expect(() => withDocs({})).toThrow("could not statically determine agent.skills");
+    }
+  });
+
+  it("uses an explicitly provided live agent value even when it is undefined", () => {
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `const shared = { entry: "docs" };
+export default { ...shared };
+`,
+      "utf8",
+    );
+    process.chdir(tmpDir);
+
+    expect(() => withDocs({}, { agent: undefined })).not.toThrow();
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      "const snapshot = [];",
+    );
+  });
+
+  it("keeps statically configured skills when a partial live config only overrides MCP", () => {
+    const skillDir = join(tmpDir, "skills", "one");
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "docs.config.ts"),
+      `export default { agent: { skills: "skills/one" } };\n`,
+      "utf8",
+    );
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: one\ndescription: Test one.\n---\n\n# One\n`,
+      "utf8",
+    );
+    process.chdir(tmpDir);
+
+    withDocs({}, { mcp: { enabled: false } });
+
+    expect(readFileSync(join(tmpDir, ".docs", "agent-skills-bundle.mjs"), "utf8")).toContain(
+      `"name":"one"`,
+    );
   });
 
   it("bundles skills from a live composed docs config", () => {

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1631,9 +1631,12 @@ export default { entry: "docs", agent: { skills: "skills/one", ...sharedAgent } 
       `const key = "agent";
 export default { entry: "docs", [key]: { skills: "skills/one" } };
 `,
+      `export default { entry: "docs", ["agent"]: { skills: "skills/one" } };
+`,
       `const key = "skills";
 export default { entry: "docs", agent: { [key]: "skills/one" } };
 `,
+      'export default { entry: "docs", agent: { [`skills`]: "skills/one" } };\n',
       `export default { entry: "docs", agent: { "sk\\u0069lls": "skills/one" } };
 `,
       `export default { entry: "docs", agent: { sk\\u0069lls: "skills/one" } };
@@ -1656,6 +1659,11 @@ export default { entry: "docs", agent: { [key]: "skills/one" } };
       `export default {
   entry: "docs",
   agent: { skills: { "pa\\u0074hs": ["skills/one"] } },
+};
+`,
+      `export default {
+  entry: "docs",
+  agent: { skills: { ["paths"]: ["skills/one"] } },
 };
 `,
       `export default {

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -30,7 +30,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative } from "node:path";
+import { dirname, extname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
@@ -52,6 +52,14 @@ import {
 } from "@farming-labs/docs/server";
 import matter from "gray-matter";
 import type { NextConfig } from "next";
+import { parse, type ParserPlugin } from "@babel/parser";
+import type {
+  Expression,
+  ObjectExpression,
+  ObjectMethod,
+  ObjectProperty,
+  Program,
+} from "@babel/types";
 
 /** Resolve Next.js App Router directory: prefer src/app when present, else app. */
 function getNextAppDir(root: string): string {
@@ -518,283 +526,213 @@ function readDocsConfigPath(root: string): string {
   return "docs.config.ts";
 }
 
-function skipStaticTrivia(source: string, start: number): number {
-  let cursor = start;
-  while (cursor < source.length) {
-    if (/\s/.test(source[cursor] ?? "")) {
-      cursor += 1;
-      continue;
-    }
-    if (source.startsWith("//", cursor)) {
-      const lineEnd = source.indexOf("\n", cursor + 2);
-      return lineEnd === -1 ? source.length : skipStaticTrivia(source, lineEnd + 1);
-    }
-    if (source.startsWith("/*", cursor)) {
-      const commentEnd = source.indexOf("*/", cursor + 2);
-      return commentEnd === -1 ? source.length : skipStaticTrivia(source, commentEnd + 2);
-    }
-    break;
+type StaticPropertyResolution =
+  | { status: "absent" }
+  | { status: "unknown" }
+  | { status: "value"; value: Expression };
+
+function unwrapStaticExpression(expression: Expression): Expression {
+  let current = expression;
+  while (
+    current.type === "ParenthesizedExpression" ||
+    current.type === "TSAsExpression" ||
+    current.type === "TSSatisfiesExpression" ||
+    current.type === "TSTypeAssertion" ||
+    current.type === "TSNonNullExpression" ||
+    current.type === "TSInstantiationExpression"
+  ) {
+    current = current.expression;
   }
-  return cursor;
+  return current;
 }
 
-function readStaticStringLiteral(
-  source: string,
-  start: number,
-): { value: string; end: number } | null {
-  const quote = source[start];
-  if (quote !== '"' && quote !== "'") return null;
-  let value = "";
+function readStaticPropertyName(property: ObjectMethod | ObjectProperty): string | undefined {
+  const key = unwrapStaticExpression(property.key as Expression);
 
-  for (let cursor = start + 1; cursor < source.length; cursor += 1) {
-    const char = source[cursor]!;
-    if (char === quote) return { value, end: cursor + 1 };
-    if (char === "\n" || char === "\r") return null;
-    if (char !== "\\") {
-      value += char;
-      continue;
-    }
-
-    const escaped = source[cursor + 1];
-    if (!escaped) return null;
-    const simpleEscapes: Record<string, string> = {
-      "0": "\0",
-      b: "\b",
-      f: "\f",
-      n: "\n",
-      r: "\r",
-      t: "\t",
-      v: "\v",
-      "\\": "\\",
-      '"': '"',
-      "'": "'",
-    };
-    if (escaped in simpleEscapes) {
-      value += simpleEscapes[escaped]!;
-      cursor += 1;
-      continue;
-    }
-    const digits = escaped === "x" ? 2 : escaped === "u" ? 4 : 0;
-    if (digits > 0) {
-      const hex = source.slice(cursor + 2, cursor + 2 + digits);
-      if (!new RegExp(`^[0-9a-fA-F]{${digits}}$`).test(hex)) return null;
-      value += String.fromCodePoint(Number.parseInt(hex, 16));
-      cursor += digits + 1;
-      continue;
-    }
-    return null;
+  if (!property.computed && key.type === "Identifier") return key.name;
+  if (key.type === "StringLiteral") return key.value;
+  if (key.type === "NumericLiteral") return String(key.value);
+  if (key.type === "BigIntLiteral") return key.value;
+  if (key.type === "TemplateLiteral" && key.expressions.length === 0) {
+    return key.quasis[0]?.value.cooked ?? undefined;
   }
-
-  return null;
+  return undefined;
 }
 
-function isStaticPropertyValueEnd(source: string, start: number): boolean {
-  const cursor = skipStaticTrivia(source, start);
-  return cursor === source.length || source[cursor] === ",";
-}
+function resolveStaticObjectProperty(
+  object: ObjectExpression,
+  key: string,
+): StaticPropertyResolution {
+  let resolution: StaticPropertyResolution = { status: "absent" };
 
-function readLiteralStringList(block: string, key: string): string[] | null {
-  const valueStart = findTopLevelPropertyValueIndex(block, key);
-  if (valueStart === undefined) return null;
-
-  const single = readStaticStringLiteral(block, valueStart);
-  if (single) return isStaticPropertyValueEnd(block, single.end) ? [single.value] : null;
-  if (block[valueStart] !== "[") return null;
-
-  const values: string[] = [];
-  let cursor = valueStart + 1;
-  while (cursor < block.length) {
-    cursor = skipStaticTrivia(block, cursor);
-    if (block[cursor] === "]") {
-      return isStaticPropertyValueEnd(block, cursor + 1) ? values : null;
+  for (const entry of object.properties) {
+    if (entry.type === "SpreadElement") {
+      resolution = { status: "unknown" };
+      continue;
     }
 
-    const item = readStaticStringLiteral(block, cursor);
-    if (!item) return null;
-    values.push(item.value);
-    cursor = skipStaticTrivia(block, item.end);
-    if (block[cursor] === "]") {
-      return isStaticPropertyValueEnd(block, cursor + 1) ? values : null;
+    const name = readStaticPropertyName(entry);
+    if (name === undefined) {
+      if (entry.computed) resolution = { status: "unknown" };
+      continue;
     }
-    if (block[cursor] !== ",") return null;
-    cursor += 1;
+    if (
+      name === "__proto__" &&
+      !entry.computed &&
+      entry.type === "ObjectProperty" &&
+      !entry.shorthand
+    ) {
+      if (resolution.status !== "value") resolution = { status: "unknown" };
+      continue;
+    }
+    if (name !== key) continue;
+
+    if (entry.type !== "ObjectProperty" || entry.shorthand) {
+      resolution = { status: "unknown" };
+      continue;
+    }
+
+    resolution = { status: "value", value: entry.value as Expression };
   }
 
-  return null;
+  return resolution;
 }
 
-function maskNestedObjectSource(block: string): string {
-  let objectDepth = 0;
-  let arrayDepth = 0;
-  let parenDepth = 0;
-  let inString: '"' | "'" | "`" | null = null;
-  let inLineComment = false;
-  let inBlockComment = false;
-  let escaped = false;
-  let result = "";
-
-  for (let index = 0; index < block.length; index += 1) {
-    const char = block[index]!;
-    const next = block[index + 1];
-    const atTopLevel = objectDepth === 0 && arrayDepth === 0 && parenDepth === 0;
-
-    if (inLineComment) {
-      if (char === "\n") inLineComment = false;
-      result += char === "\n" ? "\n" : " ";
-      continue;
-    }
-
-    if (inBlockComment) {
-      if (char === "*" && next === "/") {
-        inBlockComment = false;
-        result += "  ";
-        index += 1;
-      } else {
-        result += char === "\n" ? "\n" : " ";
-      }
-      continue;
-    }
-
-    if (inString) {
-      result += char === "\n" ? "\n" : " ";
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === inString) {
-        inString = null;
-      }
-      continue;
-    }
-
-    if (char === "/" && next === "/") {
-      inLineComment = true;
-      result += "  ";
-      index += 1;
-      continue;
-    }
-
-    if (char === "/" && next === "*") {
-      inBlockComment = true;
-      result += "  ";
-      index += 1;
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === "`") {
-      if (atTopLevel && char !== "`") {
-        const literal = readStaticStringLiteral(block, index);
-        if (literal) {
-          const isPropertyKey = block[skipStaticTrivia(block, literal.end)] === ":";
-          result += isPropertyKey
-            ? block.slice(index, literal.end)
-            : " ".repeat(literal.end - index);
-          index = literal.end - 1;
-          continue;
-        }
-      }
-      inString = char;
-      result += " ";
-      continue;
-    }
-
-    if (char === "{") objectDepth += 1;
-    else if (char === "}") objectDepth = Math.max(0, objectDepth - 1);
-    else if (char === "[") arrayDepth += 1;
-    else if (char === "]") arrayDepth = Math.max(0, arrayDepth - 1);
-    else if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-
-    result += atTopLevel ? char : " ";
-  }
-
-  return result;
-}
-
-function hasUnresolvedTopLevelProperty(block: string, key: string): boolean {
-  const visible = maskNestedObjectSource(block);
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return (
-    /(?:^|,)\s*\.\.\./s.test(visible) ||
-    /(?:^|,)\s*\[/s.test(visible) ||
-    new RegExp(`(?:^|,)\\s*${escapedKey}\\s*(?=,|$)`, "s").test(visible) ||
-    new RegExp(`["']${escapedKey}["']\\s*:`).test(visible)
+function hasDefineDocsImport(program: Program, localName: string): boolean {
+  return program.body.some(
+    (statement) =>
+      statement.type === "ImportDeclaration" &&
+      statement.importKind !== "type" &&
+      statement.source.value === "@farming-labs/docs" &&
+      statement.specifiers.some(
+        (specifier) =>
+          specifier.type === "ImportSpecifier" &&
+          specifier.importKind !== "type" &&
+          specifier.local.name === localName &&
+          specifier.imported.type === "Identifier" &&
+          specifier.imported.name === "defineDocs",
+      ),
   );
 }
 
-function hasDuplicateTopLevelProperty(block: string, key: string): boolean {
-  const visible = maskNestedObjectSource(block);
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return [...visible.matchAll(new RegExp(`(?:^|,)\\s*${escapedKey}\\s*:`, "gs"))].length > 1;
+function readDocsConfigRootObject(configPath: string, content: string): ObjectExpression {
+  let program: Program;
+  try {
+    const extension = extname(configPath).toLowerCase();
+    const syntaxPlugins: ParserPlugin[] =
+      extension === ".tsx"
+        ? ["typescript", "jsx", "decorators-legacy"]
+        : extension === ".ts"
+          ? ["typescript", "decorators-legacy"]
+          : extension === ".jsx"
+            ? ["jsx", "decorators-legacy"]
+            : ["decorators-legacy"];
+    program = parse(content, {
+      sourceType: "module",
+      sourceFilename: configPath,
+      plugins: syntaxPlugins,
+      createParenthesizedExpressions: true,
+    }).program;
+  } catch (error) {
+    throw new Error(
+      `withDocs could not parse ${configPath} while bundling Agent Skills: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const defaults = program.body.filter(
+    (statement) => statement.type === "ExportDefaultDeclaration",
+  );
+  if (defaults.length !== 1) {
+    throw new Error(
+      "withDocs could not statically determine agent.skills. Pass the live docs config as the second withDocs argument or use a literal agent object.",
+    );
+  }
+
+  let expression = unwrapStaticExpression(defaults[0]!.declaration as Expression);
+  if (expression.type === "CallExpression") {
+    const callee =
+      expression.callee.type === "V8IntrinsicIdentifier"
+        ? undefined
+        : unwrapStaticExpression(expression.callee);
+    const argument = expression.arguments[0];
+    if (
+      !callee ||
+      callee.type !== "Identifier" ||
+      !hasDefineDocsImport(program, callee.name) ||
+      !argument ||
+      argument.type === "SpreadElement" ||
+      argument.type === "ArgumentPlaceholder"
+    ) {
+      throw new Error(
+        "withDocs could not statically determine agent.skills. Pass the live docs config as the second withDocs argument or use a literal agent object.",
+      );
+    }
+    expression = unwrapStaticExpression(argument);
+  }
+
+  if (expression.type !== "ObjectExpression") {
+    throw new Error(
+      "withDocs could not statically determine agent.skills. Pass the live docs config as the second withDocs argument or use a literal agent object.",
+    );
+  }
+  return expression;
+}
+
+function readStaticStringPaths(expression: Expression): string[] | null {
+  const value = unwrapStaticExpression(expression);
+  if (value.type === "StringLiteral") return [value.value];
+  if (value.type !== "ArrayExpression") return null;
+
+  const paths: string[] = [];
+  for (const entry of value.elements) {
+    if (!entry || entry.type === "SpreadElement") {
+      return null;
+    }
+    const item = unwrapStaticExpression(entry);
+    if (item.type !== "StringLiteral") return null;
+    paths.push(item.value);
+  }
+  return paths;
 }
 
 function readAgentSkillPaths(root: string, configPath: string): string[] {
   const absoluteConfigPath = join(root, configPath);
   if (!existsSync(absoluteConfigPath)) return [];
+
   const content = readFileSync(absoluteConfigPath, "utf8");
-  const rootObject = extractRootObjectLiteral(content);
-  if (!rootObject) {
-    throw new Error(
-      "withDocs could not statically determine agent.skills. Pass the live docs config as the second withDocs argument or use a literal agent object.",
-    );
-  }
-  if (
-    hasUnresolvedTopLevelProperty(rootObject, "agent") ||
-    hasDuplicateTopLevelProperty(rootObject, "agent")
-  ) {
+  const rootObject = readDocsConfigRootObject(absoluteConfigPath, content);
+  const agent = resolveStaticObjectProperty(rootObject, "agent");
+  if (agent.status === "absent") return [];
+  if (agent.status === "unknown") {
     throw new Error(
       "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
     );
   }
-  const agentCursor = findTopLevelPropertyValueIndex(rootObject, "agent");
-  if (agentCursor === undefined) {
-    return [];
-  }
-  if (rootObject[agentCursor] !== "{") {
+
+  const agentValue = unwrapStaticExpression(agent.value);
+  if (agentValue.type !== "ObjectExpression") {
     throw new Error(
       "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
     );
   }
-  const agentEnd = findMatchingObjectEnd(rootObject, agentCursor);
-  if (agentEnd === undefined || !isStaticPropertyValueEnd(rootObject, agentEnd + 1)) {
-    throw new Error(
-      "withDocs could not parse the literal agent config while bundling Agent Skills.",
-    );
-  }
-  const agent = rootObject.slice(agentCursor + 1, agentEnd);
-  if (
-    hasUnresolvedTopLevelProperty(agent, "skills") ||
-    hasDuplicateTopLevelProperty(agent, "skills")
-  ) {
+
+  const skills = resolveStaticObjectProperty(agentValue, "skills");
+  if (skills.status === "absent") return [];
+  if (skills.status === "unknown") {
     throw new Error(
       "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
     );
   }
-  const skillsCursor = findTopLevelPropertyValueIndex(agent, "skills");
-  if (skillsCursor === undefined) {
-    return [];
+
+  const skillsValue = unwrapStaticExpression(skills.value);
+  let configured: string[] | null;
+  if (skillsValue.type === "ObjectExpression") {
+    const paths = resolveStaticObjectProperty(skillsValue, "paths");
+    configured = paths.status === "value" ? readStaticStringPaths(paths.value) : null;
+  } else {
+    configured = readStaticStringPaths(skillsValue);
   }
-  let skillsObject: string | undefined;
-  if (agent[skillsCursor] === "{") {
-    const skillsEnd = findMatchingObjectEnd(agent, skillsCursor);
-    if (skillsEnd === undefined || !isStaticPropertyValueEnd(agent, skillsEnd + 1)) {
-      throw new Error(
-        "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
-      );
-    }
-    skillsObject = agent.slice(skillsCursor + 1, skillsEnd);
-    if (
-      hasUnresolvedTopLevelProperty(skillsObject, "paths") ||
-      hasDuplicateTopLevelProperty(skillsObject, "paths")
-    ) {
-      throw new Error(
-        "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
-      );
-    }
-  }
-  const configured = skillsObject
-    ? readLiteralStringList(skillsObject, "paths")
-    : readLiteralStringList(agent, "skills");
+
   if (!configured) {
     throw new Error(
       "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
@@ -2436,9 +2374,9 @@ export function withDocs(
     );
   }
   const configuredAgentSkills =
-    docsConfig?.agent === undefined
+    docsConfig === undefined || !Object.hasOwn(docsConfig, "agent")
       ? readAgentSkillPaths(root, docsConfigPath)
-      : docsConfig.agent.skills;
+      : docsConfig.agent?.skills;
   const agentSkillsBundlePath = writeAgentSkillsBundle(root, configuredAgentSkills);
   const agentFeedback = readAgentFeedbackConfig(root);
   const docsConfigRelativeAlias =

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -549,7 +549,8 @@ function unwrapStaticExpression(expression: Expression): Expression {
 function readStaticPropertyName(property: ObjectMethod | ObjectProperty): string | undefined {
   const key = unwrapStaticExpression(property.key as Expression);
 
-  if (!property.computed && key.type === "Identifier") return key.name;
+  if (property.computed) return undefined;
+  if (key.type === "Identifier") return key.name;
   if (key.type === "StringLiteral") return key.value;
   if (key.type === "NumericLiteral") return String(key.value);
   if (key.type === "BigIntLiteral") return key.value;

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -30,7 +30,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve, sep as pathSeparator } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
@@ -45,7 +45,11 @@ import {
   DEFAULT_API_CATALOG_ROUTE,
   type DocsConfig,
 } from "@farming-labs/docs";
-import { ensureDocsReviewWorkflow } from "@farming-labs/docs/server";
+import {
+  ensureDocsReviewWorkflow,
+  renderDocsAgentSkillsBundle,
+  resolveConfiguredAgentSkillsSync,
+} from "@farming-labs/docs/server";
 import matter from "gray-matter";
 import type { NextConfig } from "next";
 
@@ -178,6 +182,8 @@ export default function HiddenChangelogSourceLayout() {
 
 const FILE_EXTS = ["tsx", "ts", "jsx", "js"];
 const INTERNAL_DOCS_CONFIG_ALIAS = "@farming-labs/next-internal-docs-config";
+const AGENT_SKILLS_BUNDLE_ALIAS = "@farming-labs/docs/agent-skills-bundle";
+const AGENT_SKILLS_BUNDLE_PATH = ".docs/agent-skills-bundle.mjs";
 const NEXT_PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DEFAULT_AGENT_SPEC_ROUTE = "/api/docs/agent/spec";
 const DEFAULT_AGENT_SPEC_WELL_KNOWN_ROUTE = "/.well-known/agent";
@@ -233,8 +239,12 @@ function resolvePackageSubpath(packageDir: string, relativePath: string): string
 
 function toTurbopackAliasPath(root: string, value: string): string {
   if (!isAbsolute(value)) return value;
-  const relativePath = relative(root, value);
-  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+  const relativePath = relative(root, value).replaceAll("\\", "/");
+  return relativePath === ".." || relativePath.startsWith("../")
+    ? relativePath
+    : relativePath.startsWith("./")
+      ? relativePath
+      : `./${relativePath}`;
 }
 
 const FUMADOCS_OPENAPI_PACKAGE_ALIAS =
@@ -508,58 +518,305 @@ function readDocsConfigPath(root: string): string {
   return "docs.config.ts";
 }
 
-function readLiteralStringList(block: string, key: string): string[] | null {
-  const cursor = findTopLevelPropertyValueIndex(block, key);
-  if (cursor === undefined) return null;
-  const value = block.slice(cursor);
-  const quoted = value.match(/^(["'])(.*?)\1/s);
-  if (quoted) return [quoted[2]];
-  if (!value.startsWith("[")) return null;
-  const end = value.indexOf("]");
-  if (end === -1) return null;
-  return [...value.slice(1, end).matchAll(/(["'])(.*?)\1/g)].map((match) => match[2]);
+function skipStaticTrivia(source: string, start: number): number {
+  let cursor = start;
+  while (cursor < source.length) {
+    if (/\s/.test(source[cursor] ?? "")) {
+      cursor += 1;
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const lineEnd = source.indexOf("\n", cursor + 2);
+      return lineEnd === -1 ? source.length : skipStaticTrivia(source, lineEnd + 1);
+    }
+    if (source.startsWith("/*", cursor)) {
+      const commentEnd = source.indexOf("*/", cursor + 2);
+      return commentEnd === -1 ? source.length : skipStaticTrivia(source, commentEnd + 2);
+    }
+    break;
+  }
+  return cursor;
 }
 
-function readAgentSkillTraceGlobs(root: string, configPath: string): string[] {
+function readStaticStringLiteral(
+  source: string,
+  start: number,
+): { value: string; end: number } | null {
+  const quote = source[start];
+  if (quote !== '"' && quote !== "'") return null;
+  let value = "";
+
+  for (let cursor = start + 1; cursor < source.length; cursor += 1) {
+    const char = source[cursor]!;
+    if (char === quote) return { value, end: cursor + 1 };
+    if (char === "\n" || char === "\r") return null;
+    if (char !== "\\") {
+      value += char;
+      continue;
+    }
+
+    const escaped = source[cursor + 1];
+    if (!escaped) return null;
+    const simpleEscapes: Record<string, string> = {
+      "0": "\0",
+      b: "\b",
+      f: "\f",
+      n: "\n",
+      r: "\r",
+      t: "\t",
+      v: "\v",
+      "\\": "\\",
+      '"': '"',
+      "'": "'",
+    };
+    if (escaped in simpleEscapes) {
+      value += simpleEscapes[escaped]!;
+      cursor += 1;
+      continue;
+    }
+    const digits = escaped === "x" ? 2 : escaped === "u" ? 4 : 0;
+    if (digits > 0) {
+      const hex = source.slice(cursor + 2, cursor + 2 + digits);
+      if (!new RegExp(`^[0-9a-fA-F]{${digits}}$`).test(hex)) return null;
+      value += String.fromCodePoint(Number.parseInt(hex, 16));
+      cursor += digits + 1;
+      continue;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function isStaticPropertyValueEnd(source: string, start: number): boolean {
+  const cursor = skipStaticTrivia(source, start);
+  return cursor === source.length || source[cursor] === ",";
+}
+
+function readLiteralStringList(block: string, key: string): string[] | null {
+  const valueStart = findTopLevelPropertyValueIndex(block, key);
+  if (valueStart === undefined) return null;
+
+  const single = readStaticStringLiteral(block, valueStart);
+  if (single) return isStaticPropertyValueEnd(block, single.end) ? [single.value] : null;
+  if (block[valueStart] !== "[") return null;
+
+  const values: string[] = [];
+  let cursor = valueStart + 1;
+  while (cursor < block.length) {
+    cursor = skipStaticTrivia(block, cursor);
+    if (block[cursor] === "]") {
+      return isStaticPropertyValueEnd(block, cursor + 1) ? values : null;
+    }
+
+    const item = readStaticStringLiteral(block, cursor);
+    if (!item) return null;
+    values.push(item.value);
+    cursor = skipStaticTrivia(block, item.end);
+    if (block[cursor] === "]") {
+      return isStaticPropertyValueEnd(block, cursor + 1) ? values : null;
+    }
+    if (block[cursor] !== ",") return null;
+    cursor += 1;
+  }
+
+  return null;
+}
+
+function maskNestedObjectSource(block: string): string {
+  let objectDepth = 0;
+  let arrayDepth = 0;
+  let parenDepth = 0;
+  let inString: '"' | "'" | "`" | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let escaped = false;
+  let result = "";
+
+  for (let index = 0; index < block.length; index += 1) {
+    const char = block[index]!;
+    const next = block[index + 1];
+    const atTopLevel = objectDepth === 0 && arrayDepth === 0 && parenDepth === 0;
+
+    if (inLineComment) {
+      if (char === "\n") inLineComment = false;
+      result += char === "\n" ? "\n" : " ";
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        result += "  ";
+        index += 1;
+      } else {
+        result += char === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+
+    if (inString) {
+      result += char === "\n" ? "\n" : " ";
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      result += "  ";
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      result += "  ";
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      if (atTopLevel && char !== "`") {
+        const literal = readStaticStringLiteral(block, index);
+        if (literal) {
+          const isPropertyKey = block[skipStaticTrivia(block, literal.end)] === ":";
+          result += isPropertyKey
+            ? block.slice(index, literal.end)
+            : " ".repeat(literal.end - index);
+          index = literal.end - 1;
+          continue;
+        }
+      }
+      inString = char;
+      result += " ";
+      continue;
+    }
+
+    if (char === "{") objectDepth += 1;
+    else if (char === "}") objectDepth = Math.max(0, objectDepth - 1);
+    else if (char === "[") arrayDepth += 1;
+    else if (char === "]") arrayDepth = Math.max(0, arrayDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+
+    result += atTopLevel ? char : " ";
+  }
+
+  return result;
+}
+
+function hasUnresolvedTopLevelProperty(block: string, key: string): boolean {
+  const visible = maskNestedObjectSource(block);
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (
+    /(?:^|,)\s*\.\.\./s.test(visible) ||
+    /(?:^|,)\s*\[/s.test(visible) ||
+    new RegExp(`(?:^|,)\\s*${escapedKey}\\s*(?=,|$)`, "s").test(visible) ||
+    new RegExp(`["']${escapedKey}["']\\s*:`).test(visible)
+  );
+}
+
+function hasDuplicateTopLevelProperty(block: string, key: string): boolean {
+  const visible = maskNestedObjectSource(block);
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return [...visible.matchAll(new RegExp(`(?:^|,)\\s*${escapedKey}\\s*:`, "gs"))].length > 1;
+}
+
+function readAgentSkillPaths(root: string, configPath: string): string[] {
   const absoluteConfigPath = join(root, configPath);
   if (!existsSync(absoluteConfigPath)) return [];
   const content = readFileSync(absoluteConfigPath, "utf8");
-  const agent = extractTopLevelObjectLiteral(content, "agent");
-  if (!agent) return [];
+  const rootObject = extractRootObjectLiteral(content);
+  if (!rootObject) {
+    throw new Error(
+      "withDocs could not statically determine agent.skills. Pass the live docs config as the second withDocs argument or use a literal agent object.",
+    );
+  }
+  if (
+    hasUnresolvedTopLevelProperty(rootObject, "agent") ||
+    hasDuplicateTopLevelProperty(rootObject, "agent")
+  ) {
+    throw new Error(
+      "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
+    );
+  }
+  const agentCursor = findTopLevelPropertyValueIndex(rootObject, "agent");
+  if (agentCursor === undefined) {
+    return [];
+  }
+  if (rootObject[agentCursor] !== "{") {
+    throw new Error(
+      "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
+    );
+  }
+  const agentEnd = findMatchingObjectEnd(rootObject, agentCursor);
+  if (agentEnd === undefined || !isStaticPropertyValueEnd(rootObject, agentEnd + 1)) {
+    throw new Error(
+      "withDocs could not parse the literal agent config while bundling Agent Skills.",
+    );
+  }
+  const agent = rootObject.slice(agentCursor + 1, agentEnd);
+  if (
+    hasUnresolvedTopLevelProperty(agent, "skills") ||
+    hasDuplicateTopLevelProperty(agent, "skills")
+  ) {
+    throw new Error(
+      "withDocs could not statically determine agent.skills from a composed agent config. Pass the live docs config as the second withDocs argument.",
+    );
+  }
   const skillsCursor = findTopLevelPropertyValueIndex(agent, "skills");
-  if (skillsCursor === undefined) return [];
-  const skillsObject =
-    agent[skillsCursor] === "{" ? extractObjectLiteral(agent, "skills") : undefined;
+  if (skillsCursor === undefined) {
+    return [];
+  }
+  let skillsObject: string | undefined;
+  if (agent[skillsCursor] === "{") {
+    const skillsEnd = findMatchingObjectEnd(agent, skillsCursor);
+    if (skillsEnd === undefined || !isStaticPropertyValueEnd(agent, skillsEnd + 1)) {
+      throw new Error(
+        "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
+      );
+    }
+    skillsObject = agent.slice(skillsCursor + 1, skillsEnd);
+    if (
+      hasUnresolvedTopLevelProperty(skillsObject, "paths") ||
+      hasDuplicateTopLevelProperty(skillsObject, "paths")
+    ) {
+      throw new Error(
+        "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
+      );
+    }
+  }
   const configured = skillsObject
     ? readLiteralStringList(skillsObject, "paths")
     : readLiteralStringList(agent, "skills");
   if (!configured) {
     throw new Error(
-      "withDocs could not statically trace agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
+      "withDocs could not statically bundle agent.skills. Use a literal path, a literal path array, or { paths: [...] } so configured skills are included in production.",
     );
   }
-  return configured.map((configuredPath) => {
-    const normalized = configuredPath.replace(/\\/g, "/").replace(/\/$/, "");
-    return normalized.endsWith("/SKILL.md") || normalized === "SKILL.md"
-      ? normalized
-      : `${normalized}/**/*`;
-  });
+  return configured;
 }
 
-function commonTracingRoot(root: string, globs: readonly string[]): string {
-  let common = resolve(root);
-  for (const glob of globs) {
-    const candidate = resolve(root, glob.replace(/\/\*\*\/\*$/, ""));
-    while (
-      relative(common, candidate) === ".." ||
-      relative(common, candidate).startsWith(`..${pathSeparator}`)
-    ) {
-      const parent = dirname(common);
-      if (parent === common) break;
-      common = parent;
-    }
+function writeAgentSkillsBundle(
+  root: string,
+  configuredSkills: NonNullable<DocsConfig["agent"]>["skills"],
+): string {
+  const bundlePath = join(root, AGENT_SKILLS_BUNDLE_PATH);
+  const skills = resolveConfiguredAgentSkillsSync(configuredSkills, { rootDir: root });
+  const source = `${GENERATED_BANNER}${renderDocsAgentSkillsBundle(skills)}`;
+
+  mkdirSync(dirname(bundlePath), { recursive: true });
+  if (!existsSync(bundlePath) || readFileSync(bundlePath, "utf8") !== source) {
+    writeFileSync(bundlePath, source, "utf8");
   }
-  return common;
+
+  return bundlePath;
 }
 
 /** Read the OG endpoint from docs.config.ts[x] (returns undefined if not set). */
@@ -2165,7 +2422,7 @@ function mergeDocsRedirects(
 
 export function withDocs(
   nextConfig: NextConfig = {},
-  docsConfig?: Pick<DocsConfig, "mcp">,
+  docsConfig?: Pick<DocsConfig, "agent" | "mcp">,
 ): NextConfig {
   const root = process.cwd();
   const workspaceRoot = findDocsWorkspaceRoot(root);
@@ -2178,11 +2435,11 @@ export function withDocs(
       `@farming-labs/next: mcp.security.protectedResource cannot be combined with Next.js basePath ${JSON.stringify(nextBasePath)} because RFC 9728 metadata must be hosted at origin-root well-known URLs. Host the protected docs app at the origin root or publish the metadata and MCP proxy at the edge.`,
     );
   }
-  const agentSkillTraceGlobs = readAgentSkillTraceGlobs(root, docsConfigPath);
-  if (agentSkillTraceGlobs.some((glob) => glob.startsWith("../"))) {
-    nextConfig.outputFileTracingRoot ??=
-      workspaceRoot ?? commonTracingRoot(root, agentSkillTraceGlobs);
-  }
+  const configuredAgentSkills =
+    docsConfig?.agent === undefined
+      ? readAgentSkillPaths(root, docsConfigPath)
+      : docsConfig.agent.skills;
+  const agentSkillsBundlePath = writeAgentSkillsBundle(root, configuredAgentSkills);
   const agentFeedback = readAgentFeedbackConfig(root);
   const docsConfigRelativeAlias =
     docsConfigPath.startsWith("./") || docsConfigPath.startsWith("../")
@@ -2436,6 +2693,7 @@ export function withDocs(
       ...(workspaceRoot ? createDocsWorkspaceAliases(root, workspaceRoot) : {}),
       ...existingResolveAlias,
       [INTERNAL_DOCS_CONFIG_ALIAS]: docsConfigRelativeAlias,
+      [AGENT_SKILLS_BUNDLE_ALIAS]: toTurbopackAliasPath(root, agentSkillsBundlePath),
       "fumadocs-openapi": toTurbopackAliasPath(root, FUMADOCS_OPENAPI_PACKAGE_ALIAS),
       "fumadocs-openapi/ui": toTurbopackAliasPath(root, FUMADOCS_OPENAPI_UI_ALIAS),
       "fumadocs-openapi/server": toTurbopackAliasPath(root, FUMADOCS_OPENAPI_SERVER_ALIAS),
@@ -2510,6 +2768,7 @@ export function withDocs(
       });
     }
     resolvedConfig.resolve.alias[INTERNAL_DOCS_CONFIG_ALIAS] = docsConfigAbsolutePath;
+    resolvedConfig.resolve.alias[AGENT_SKILLS_BUNDLE_ALIAS] = agentSkillsBundlePath;
     resolvedConfig.resolve.alias["fumadocs-openapi"] = FUMADOCS_OPENAPI_PACKAGE_ALIAS;
     resolvedConfig.resolve.alias["fumadocs-openapi/ui"] = FUMADOCS_OPENAPI_UI_ALIAS;
     resolvedConfig.resolve.alias["fumadocs-openapi/server"] = FUMADOCS_OPENAPI_SERVER_ALIAS;
@@ -2579,7 +2838,6 @@ export function withDocs(
         agentsTraceFile,
         agentTraceFile,
         sitemapManifestTraceFile,
-        ...agentSkillTraceGlobs,
       ]),
     ],
     [DEFAULT_MCP_ROUTE]: [
@@ -2587,7 +2845,6 @@ export function withDocs(
         ...(existingTracingIncludes[DEFAULT_MCP_ROUTE] ?? []),
         docsTraceGlob,
         skillTraceFile,
-        ...agentSkillTraceGlobs,
       ]),
     ],
   };

--- a/packages/next/tsdown.config.ts
+++ b/packages/next/tsdown.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
     "@farming-labs/theme/api",
     "@farming-labs/theme/client-hooks",
     "@next/mdx",
+    "@babel/parser",
     "@mdx-js/loader",
     "@mdx-js/react",
     "fumadocs-core",

--- a/packages/next/tsdown.config.ts
+++ b/packages/next/tsdown.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     "react-dom",
     "@/docs.config",
     "@farming-labs/docs",
+    "@farming-labs/docs/agent-skills-bundle",
     "@farming-labs/docs/client/react",
     "@farming-labs/docs/cloud/server",
     "@farming-labs/docs/server",

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -7,6 +7,10 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@farming-labs/docs/agent-skills-bundle": resolve(
+        rootDir,
+        "../docs/src/agent-skills-bundle.ts",
+      ),
       "@farming-labs/docs/client/react": resolve(rootDir, "../docs/src/client/react.ts"),
       "@farming-labs/docs/cloud/server": resolve(rootDir, "../docs/src/docs-cloud-server.ts"),
       "@farming-labs/docs/server": resolve(rootDir, "../docs/src/server.ts"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
 
   packages/next:
     dependencies:
+      '@babel/parser':
+        specifier: 7.29.7
+        version: 7.29.7
       '@mdx-js/loader':
         specifier: ^3.1.0
         version: 3.1.1
@@ -511,6 +514,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@babel/types':
+        specifier: 7.29.7
+        version: 7.29.7
       '@farming-labs/docs':
         specifier: workspace:*
         version: link:../docs

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -99,7 +99,73 @@ function parseExpectedSkillNames(value) {
   );
 }
 
-function createRequester({ baseUrl, fetchImpl, timeoutMs, attempts }) {
+function validateFinalResponseOrigin(response, requestedUrl, baseUrl) {
+  let finalUrl;
+  try {
+    finalUrl = new URL(response.url);
+  } catch {
+    throw new Error(
+      `${requestedUrl} returned an invalid final response URL: ${JSON.stringify(response.url)}`,
+    );
+  }
+  assert(
+    finalUrl.origin === baseUrl,
+    `${requestedUrl} redirected to cross-origin response ${finalUrl.origin}`,
+  );
+}
+
+async function readResponseBytes(response, requestedUrl, abortController, maxResponseBytes) {
+  const declaredLength = Number.parseInt(response.headers.get("content-length") ?? "0", 10);
+  if (Number.isFinite(declaredLength) && declaredLength > maxResponseBytes) {
+    const error = new Error(
+      `${requestedUrl} declared an unexpectedly large ${declaredLength}-byte response`,
+    );
+    abortController.abort(error);
+    try {
+      await response.body?.cancel(error);
+    } catch {
+      // The aborted fetch may already have errored its response stream.
+    }
+    throw error;
+  }
+
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      if (chunk.byteLength > maxResponseBytes - byteLength) {
+        const error = new Error(`${requestedUrl} returned more than ${maxResponseBytes} bytes`);
+        abortController.abort(error);
+        try {
+          await reader.cancel(error);
+        } catch {
+          // The aborted fetch may already have errored its response stream.
+        }
+        throw error;
+      }
+      chunks.push(chunk);
+      byteLength += chunk.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function createRequester({ baseUrl, fetchImpl, timeoutMs, attempts, maxResponseBytes }) {
   return async function request(target, init = {}, expectedStatuses = [200]) {
     const url = new URL(target, `${baseUrl}/`);
     const headers = new Headers(init.headers);
@@ -107,42 +173,42 @@ function createRequester({ baseUrl, fetchImpl, timeoutMs, attempts }) {
     headers.set("cache-control", "no-cache");
     headers.set("user-agent", "farming-labs-agent-surface-smoke/1.0");
 
-    let response;
+    let result;
     let requestError;
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
-      response = undefined;
+      result = undefined;
+      const abortController = new AbortController();
+      const timeout = setTimeout(() => {
+        abortController.abort(new Error(`${url} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
       try {
-        response = await fetchImpl(url, {
+        const response = await fetchImpl(url, {
           ...init,
           headers,
           redirect: "follow",
-          signal: AbortSignal.timeout(timeoutMs),
+          signal: abortController.signal,
         });
+        validateFinalResponseOrigin(response, url, baseUrl);
+        const bytes = await readResponseBytes(response, url, abortController, maxResponseBytes);
+        result = { bytes, response };
         if (response.status < 500 || attempt === attempts) break;
-        await response.arrayBuffer();
       } catch (error) {
         requestError = error;
+        if (!abortController.signal.aborted) abortController.abort(error);
         if (attempt === attempts) break;
+      } finally {
+        clearTimeout(timeout);
       }
       await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 500));
     }
 
-    if (!response) {
+    if (!result) {
       throw new Error(
         `${url} could not be fetched: ${requestError instanceof Error ? requestError.message : String(requestError)}`,
       );
     }
 
-    const declaredLength = Number.parseInt(response.headers.get("content-length") ?? "0", 10);
-    assert(
-      !Number.isFinite(declaredLength) || declaredLength <= MAX_RESPONSE_BYTES,
-      `${url} declared an unexpectedly large ${declaredLength}-byte response`,
-    );
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    assert(
-      bytes.byteLength <= MAX_RESPONSE_BYTES,
-      `${url} returned more than ${MAX_RESPONSE_BYTES} bytes`,
-    );
+    const { bytes, response } = result;
     if (!expectedStatuses.includes(response.status)) {
       const preview = responsePreview(bytes);
       throw new Error(
@@ -552,12 +618,18 @@ export async function runAgentSurfaceSmoke(options = {}) {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
   const expectedSkillNames = new Set(options.expectedSkillNames ?? []);
+  const maxResponseBytes = options.maxResponseBytes ?? MAX_RESPONSE_BYTES;
+  assert(
+    Number.isSafeInteger(maxResponseBytes) && maxResponseBytes > 0,
+    "Response size limit must be a positive safe integer",
+  );
   const log = options.log ?? console.log;
   const request = createRequester({
     baseUrl,
     fetchImpl: options.fetchImpl ?? globalThis.fetch,
     timeoutMs,
     attempts,
+    maxResponseBytes,
   });
   const recorder = createRecorder(log);
 

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -328,7 +328,10 @@ async function validateModernSkillArtifact(request, baseUrl, skill) {
     `${skill.url} HEAD returned the wrong content-type`,
   );
   assert(
-    head.response.headers.get("etag") === `"${skill.digest.slice("sha256:".length)}"`,
+    [
+      `"${skill.digest.slice("sha256:".length)}"`,
+      `W/"${skill.digest.slice("sha256:".length)}"`,
+    ].includes(head.response.headers.get("etag")),
     `${skill.url} HEAD did not expose the indexed digest as its ETag`,
   );
 }

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -1,0 +1,709 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_BASE_URL = "https://docs.farming-labs.dev";
+const AGENT_SKILLS_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+const API_CATALOG_PROFILE = "https://www.rfc-editor.org/info/rfc9727";
+const API_CATALOG_ROUTE = "/.well-known/api-catalog";
+const AGENT_SKILLS_INDEX_ROUTE = "/.well-known/agent-skills/index.json";
+const LEGACY_SKILLS_INDEX_ROUTE = "/.well-known/skills/index.json";
+const AGENT_CARD_ROUTE = "/.well-known/agent-card.json";
+const MCP_ROUTES = ["/mcp", "/.well-known/mcp"];
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_ATTEMPTS = 3;
+const MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function asRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parsePositiveInteger(value, fallback) {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeBaseUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid smoke-test base URL: ${JSON.stringify(value)}`);
+  }
+  assert(url.protocol === "http:" || url.protocol === "https:", "Base URL must use HTTP(S)");
+  assert(!url.username && !url.password, "Base URL must not contain credentials");
+  assert(url.pathname === "/" || url.pathname === "", "Base URL must not contain a path");
+  assert(!url.search && !url.hash, "Base URL must not contain a query or fragment");
+  return url.origin;
+}
+
+function mediaType(response) {
+  return (response.headers.get("content-type") ?? "").split(";", 1)[0].trim().toLowerCase();
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function responsePreview(bytes) {
+  return new TextDecoder().decode(bytes.slice(0, 300)).replace(/\s+/g, " ").trim();
+}
+
+function formatStatusExpectation(statuses) {
+  return statuses.length === 1 ? String(statuses[0]) : statuses.join(" or ");
+}
+
+function includesLinkRelation(response, relation) {
+  const link = response.headers.get("link") ?? "";
+  return new RegExp(
+    `(?:^|[,;]\\s*)rel=(?:"[^"]*\\b${relation}\\b[^"]*"|${relation})(?:[,;]|$)`,
+    "i",
+  ).test(link);
+}
+
+function encodePath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function validateSafeSkillPath(path) {
+  assert(isNonEmptyString(path), "Skill file path was empty");
+  assert(!path.startsWith("/"), `Skill file path must be relative: ${JSON.stringify(path)}`);
+  assert(
+    !path.split("/").some((segment) => !segment || segment === "." || segment === ".."),
+    `Skill file path was unsafe: ${JSON.stringify(path)}`,
+  );
+  assert(
+    path === "SKILL.md" || /^(?:references|scripts|assets)\//u.test(path),
+    `Skill file path was outside the portable skill surface: ${JSON.stringify(path)}`,
+  );
+}
+
+function parseExpectedSkillNames(value) {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
+}
+
+function createRequester({ baseUrl, fetchImpl, timeoutMs, attempts }) {
+  return async function request(target, init = {}, expectedStatuses = [200]) {
+    const url = new URL(target, `${baseUrl}/`);
+    const headers = new Headers(init.headers);
+    if (!headers.has("accept")) headers.set("accept", "*/*");
+    headers.set("cache-control", "no-cache");
+    headers.set("user-agent", "farming-labs-agent-surface-smoke/1.0");
+
+    let response;
+    let requestError;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      response = undefined;
+      try {
+        response = await fetchImpl(url, {
+          ...init,
+          headers,
+          redirect: "follow",
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (response.status < 500 || attempt === attempts) break;
+        await response.arrayBuffer();
+      } catch (error) {
+        requestError = error;
+        if (attempt === attempts) break;
+      }
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 500));
+    }
+
+    if (!response) {
+      throw new Error(
+        `${url} could not be fetched: ${requestError instanceof Error ? requestError.message : String(requestError)}`,
+      );
+    }
+
+    const declaredLength = Number.parseInt(response.headers.get("content-length") ?? "0", 10);
+    assert(
+      !Number.isFinite(declaredLength) || declaredLength <= MAX_RESPONSE_BYTES,
+      `${url} declared an unexpectedly large ${declaredLength}-byte response`,
+    );
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    assert(
+      bytes.byteLength <= MAX_RESPONSE_BYTES,
+      `${url} returned more than ${MAX_RESPONSE_BYTES} bytes`,
+    );
+    if (!expectedStatuses.includes(response.status)) {
+      const preview = responsePreview(bytes);
+      throw new Error(
+        `${url.pathname} expected status ${formatStatusExpectation(expectedStatuses)}, received ${response.status}${preview ? `: ${preview}` : ""}`,
+      );
+    }
+    return { bytes, response, url };
+  };
+}
+
+async function readJson(request, route, expectedStatuses = [200]) {
+  const result = await request(
+    route,
+    { headers: { accept: "application/json, application/linkset+json" } },
+    expectedStatuses,
+  );
+  const type = mediaType(result.response);
+  assert(
+    type === "application/json" || type.endsWith("+json"),
+    `${result.url.pathname} returned ${type || "no content-type"}, expected JSON`,
+  );
+  try {
+    return { ...result, json: JSON.parse(new TextDecoder().decode(result.bytes)) };
+  } catch {
+    throw new Error(`${result.url.pathname} did not return valid JSON`);
+  }
+}
+
+function validateManifest(json, route) {
+  const manifest = asRecord(json);
+  assert(manifest, `${route} did not return a JSON object`);
+  assert(manifest.version === "1", `${route} did not declare agent manifest version 1`);
+  assert(isNonEmptyString(manifest.name), `${route} did not declare a name`);
+
+  const capabilities = asRecord(manifest.capabilities);
+  const api = asRecord(manifest.api);
+  const apiCatalog = asRecord(manifest.apiCatalog);
+  const skills = asRecord(manifest.skills);
+  const discovery = asRecord(skills?.discovery);
+  const mcp = asRecord(manifest.mcp);
+  assert(capabilities?.agentSkillsDiscovery === true, `${route} did not enable skill discovery`);
+  assert(capabilities?.mcp === true, `${route} did not enable MCP`);
+  assert(
+    api?.agentSkillsIndex === AGENT_SKILLS_INDEX_ROUTE,
+    `${route} advertised the wrong skill index`,
+  );
+  assert(
+    api?.legacySkillsIndex === LEGACY_SKILLS_INDEX_ROUTE,
+    `${route} omitted legacy skill discovery`,
+  );
+  assert(apiCatalog?.enabled === true, `${route} did not enable the RFC 9727 API catalog`);
+  assert(
+    apiCatalog?.route === API_CATALOG_ROUTE,
+    `${route} advertised the wrong API catalog route`,
+  );
+  assert(
+    discovery?.schema === AGENT_SKILLS_SCHEMA,
+    `${route} advertised the wrong Agent Skills schema`,
+  );
+  assert(
+    discovery?.index === AGENT_SKILLS_INDEX_ROUTE,
+    `${route} advertised the wrong skill index`,
+  );
+  assert(
+    discovery?.legacyIndex === LEGACY_SKILLS_INDEX_ROUTE,
+    `${route} omitted the legacy skill index`,
+  );
+  assert(
+    Array.isArray(mcp?.publicEndpoints) &&
+      MCP_ROUTES.every((path) => mcp.publicEndpoints.includes(path)),
+    `${route} did not advertise both public MCP endpoints`,
+  );
+  return manifest;
+}
+
+async function validateApiCatalog(request) {
+  const catalog = await readJson(request, API_CATALOG_ROUTE);
+  assert(
+    mediaType(catalog.response) === "application/linkset+json",
+    `${API_CATALOG_ROUTE} did not return application/linkset+json`,
+  );
+  assert(
+    (catalog.response.headers.get("content-type") ?? "").includes(
+      `profile="${API_CATALOG_PROFILE}"`,
+    ),
+    `${API_CATALOG_ROUTE} did not declare the RFC 9727 profile`,
+  );
+  assert(
+    includesLinkRelation(catalog.response, "api-catalog"),
+    `${API_CATALOG_ROUTE} omitted its Link relation`,
+  );
+  const root = asRecord(catalog.json);
+  assert(
+    Array.isArray(root?.linkset) && root.linkset.length > 0,
+    `${API_CATALOG_ROUTE} had no linkset entries`,
+  );
+  const serialized = JSON.stringify(catalog.json);
+  for (const route of ["/.well-known/agent.json", AGENT_SKILLS_INDEX_ROUTE, "/api/docs"]) {
+    assert(serialized.includes(route), `${API_CATALOG_ROUTE} did not advertise ${route}`);
+  }
+
+  const head = await request(API_CATALOG_ROUTE, { method: "HEAD" });
+  assert(head.bytes.byteLength === 0, `${API_CATALOG_ROUTE} HEAD returned a body`);
+  assert(
+    mediaType(head.response) === "application/linkset+json",
+    `${API_CATALOG_ROUTE} HEAD returned the wrong content-type`,
+  );
+  assert(
+    (head.response.headers.get("content-type") ?? "").includes(`profile="${API_CATALOG_PROFILE}"`),
+    `${API_CATALOG_ROUTE} HEAD did not declare the RFC 9727 profile`,
+  );
+}
+
+function validateModernSkillIndex(json, expectedSkillNames) {
+  const root = asRecord(json);
+  assert(root?.$schema === AGENT_SKILLS_SCHEMA, "Agent Skills index declared the wrong schema");
+  assert(
+    Array.isArray(root.skills) && root.skills.length > 0,
+    "Agent Skills index did not publish any skills",
+  );
+
+  const seen = new Set();
+  const skills = root.skills.map((value) => {
+    const skill = asRecord(value);
+    assert(skill, "Agent Skills index contained a non-object entry");
+    assert(
+      isNonEmptyString(skill.name) && /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(skill.name),
+      "Agent Skills index contained an invalid name",
+    );
+    assert(!seen.has(skill.name), `Agent Skills index duplicated ${JSON.stringify(skill.name)}`);
+    seen.add(skill.name);
+    assert(isNonEmptyString(skill.description), `Agent Skill ${skill.name} had no description`);
+    assert(
+      skill.type === "skill-md" || skill.type === "archive",
+      `Agent Skill ${skill.name} had an invalid type`,
+    );
+    assert(isNonEmptyString(skill.url), `Agent Skill ${skill.name} had no artifact URL`);
+    assert(
+      /^sha256:[0-9a-f]{64}$/u.test(skill.digest),
+      `Agent Skill ${skill.name} had an invalid digest`,
+    );
+    return skill;
+  });
+
+  for (const name of expectedSkillNames) {
+    assert(
+      seen.has(name),
+      `Agent Skills index did not publish configured skill ${JSON.stringify(name)}`,
+    );
+  }
+  return skills;
+}
+
+async function validateModernSkillArtifact(request, baseUrl, skill) {
+  const artifactUrl = new URL(skill.url, `${baseUrl}/`);
+  assert(
+    artifactUrl.origin === baseUrl,
+    `Agent Skill ${skill.name} used a cross-origin artifact URL`,
+  );
+  assert(
+    artifactUrl.pathname.startsWith("/.well-known/agent-skills/"),
+    `Agent Skill ${skill.name} used an unexpected artifact path`,
+  );
+  const artifact = await request(artifactUrl);
+  const expectedType = skill.type === "archive" ? "application/gzip" : "text/markdown";
+  assert(
+    mediaType(artifact.response) === expectedType,
+    `${skill.url} returned the wrong content-type`,
+  );
+  assert(
+    `sha256:${sha256(artifact.bytes)}` === skill.digest,
+    `${skill.url} did not match its published digest`,
+  );
+  assert(
+    includesLinkRelation(artifact.response, "collection"),
+    `${skill.url} omitted its collection Link`,
+  );
+
+  const head = await request(artifactUrl, { method: "HEAD" });
+  assert(head.bytes.byteLength === 0, `${skill.url} HEAD returned a body`);
+  assert(
+    mediaType(head.response) === expectedType,
+    `${skill.url} HEAD returned the wrong content-type`,
+  );
+  assert(
+    head.response.headers.get("etag") === `"${skill.digest.slice("sha256:".length)}"`,
+    `${skill.url} HEAD did not expose the indexed digest as its ETag`,
+  );
+}
+
+function validateManifestPublishedSkills(manifest, modernNames, expectedSkillNames) {
+  const skills = asRecord(manifest.skills);
+  assert(Array.isArray(skills?.published), "Agent manifest did not include its published skills");
+  const files = [];
+  for (const value of skills.published) {
+    const skill = asRecord(value);
+    assert(
+      skill && isNonEmptyString(skill.name),
+      "Agent manifest contained an invalid published skill",
+    );
+    assert(
+      modernNames.has(skill.name),
+      `Agent manifest skill ${skill.name} was absent from the Agent Skills index`,
+    );
+    assert(
+      Array.isArray(skill.files) && skill.files.length > 0,
+      `Agent manifest skill ${skill.name} had no files`,
+    );
+    for (const rawFile of skill.files) {
+      const file = asRecord(rawFile);
+      assert(
+        file && isNonEmptyString(file.path),
+        `Agent manifest skill ${skill.name} had an invalid file`,
+      );
+      validateSafeSkillPath(file.path);
+      assert(
+        isNonEmptyString(file.url),
+        `Agent manifest file ${skill.name}/${file.path} had no URL`,
+      );
+      assert(
+        /^sha256:[0-9a-f]{64}$/u.test(file.digest),
+        `Agent manifest file ${skill.name}/${file.path} had an invalid digest`,
+      );
+      files.push({ ...file, name: skill.name });
+    }
+  }
+  const publishedNames = new Set(skills.published.map((value) => asRecord(value)?.name));
+  for (const name of expectedSkillNames) {
+    assert(
+      publishedNames.has(name),
+      `Agent manifest did not publish the configured file map for ${JSON.stringify(name)}`,
+    );
+  }
+  return files;
+}
+
+async function validateManifestSkillFile(request, baseUrl, file) {
+  const url = new URL(file.url, `${baseUrl}/`);
+  assert(
+    url.origin === baseUrl,
+    `Agent Skill file ${file.name}/${file.path} used a cross-origin URL`,
+  );
+  assert(
+    url.pathname.startsWith(`/.well-known/agent-skills/${encodeURIComponent(file.name)}/`),
+    `Agent Skill file ${file.name}/${file.path} used an unexpected URL`,
+  );
+  const result = await request(url);
+  assert(
+    `sha256:${sha256(result.bytes)}` === file.digest,
+    `Agent Skill file ${file.name}/${file.path} did not match its published digest`,
+  );
+}
+
+function validateLegacySkillIndex(json, modernNames) {
+  const root = asRecord(json);
+  assert(
+    Array.isArray(root?.skills) && root.skills.length > 0,
+    "Legacy skill index did not publish any skills",
+  );
+  const seen = new Set();
+  const files = [];
+  for (const value of root.skills) {
+    const skill = asRecord(value);
+    assert(skill && isNonEmptyString(skill.name), "Legacy skill index contained an invalid skill");
+    assert(!seen.has(skill.name), `Legacy skill index duplicated ${JSON.stringify(skill.name)}`);
+    seen.add(skill.name);
+    assert(
+      modernNames.has(skill.name),
+      `Legacy skill ${skill.name} was absent from the modern index`,
+    );
+    assert(
+      Array.isArray(skill.files) && skill.files.includes("SKILL.md"),
+      `Legacy skill ${skill.name} omitted SKILL.md`,
+    );
+    for (const path of skill.files) {
+      validateSafeSkillPath(path);
+      files.push({ name: skill.name, path });
+    }
+  }
+  assert(
+    modernNames.size === seen.size && [...modernNames].every((name) => seen.has(name)),
+    "Modern and legacy skill indexes did not publish the same skills",
+  );
+  return files;
+}
+
+async function validateLegacySkillFile(request, file, expectedDigests) {
+  const route = `/.well-known/skills/${encodeURIComponent(file.name)}/${encodePath(file.path)}`;
+  const result = await request(route);
+  if (file.path === "SKILL.md") {
+    assert(
+      mediaType(result.response) === "text/markdown",
+      `${route} returned the wrong content-type`,
+    );
+  }
+  const expectedDigest = expectedDigests.get(`${file.name}/${file.path}`);
+  if (expectedDigest) {
+    assert(
+      `sha256:${sha256(result.bytes)}` === expectedDigest,
+      `${route} did not match the modern skill file`,
+    );
+  }
+}
+
+function parseMcpResponse(response, bytes) {
+  const text = new TextDecoder().decode(bytes);
+  if (mediaType(response) === "application/json") {
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error("MCP initialize response did not contain valid JSON");
+    }
+  }
+
+  assert(
+    mediaType(response) === "text/event-stream",
+    "MCP initialize returned an unsupported content-type",
+  );
+  for (const event of text.split(/\r?\n\r?\n/u)) {
+    const data = event
+      .split(/\r?\n/u)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trimStart())
+      .join("\n");
+    if (!data) continue;
+    try {
+      const parsed = JSON.parse(data);
+      if (asRecord(parsed)?.id === 1) return parsed;
+    } catch {
+      // Ignore keepalives or non-JSON events while looking for the initialize response.
+    }
+  }
+  throw new Error("MCP event stream did not contain the initialize response");
+}
+
+async function validateMcp(request, route) {
+  const result = await request(route, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-protocol-version": MCP_PROTOCOL_VERSION,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "agent-surface-smoke", version: "1.0.0" },
+      },
+    }),
+  });
+  const payload = asRecord(parseMcpResponse(result.response, result.bytes));
+  assert(
+    payload?.jsonrpc === "2.0" && payload.id === 1,
+    `${route} returned an invalid JSON-RPC response`,
+  );
+  assert(!payload.error, `${route} rejected MCP initialize: ${JSON.stringify(payload.error)}`);
+  const initialized = asRecord(payload.result);
+  assert(asRecord(initialized?.serverInfo), `${route} initialize response omitted serverInfo`);
+  assert(
+    isNonEmptyString(initialized?.protocolVersion),
+    `${route} initialize response omitted protocolVersion`,
+  );
+}
+
+async function validateWellKnownText(request, route, expectedType, requiredText) {
+  const result = await request(route);
+  assert(mediaType(result.response) === expectedType, `${route} returned the wrong content-type`);
+  const text = new TextDecoder().decode(result.bytes);
+  assert(text.trim().length > 0, `${route} returned an empty document`);
+  if (requiredText)
+    assert(text.includes(requiredText), `${route} did not include ${JSON.stringify(requiredText)}`);
+}
+
+function createRecorder(log) {
+  const failures = [];
+  let passed = 0;
+  return {
+    failures,
+    get passed() {
+      return passed;
+    },
+    async check(label, callback) {
+      try {
+        const result = await callback();
+        passed += 1;
+        log(`✓ ${label}`);
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push({ label, message });
+        log(`✗ ${label}: ${message}`);
+        return undefined;
+      }
+    },
+  };
+}
+
+export async function runAgentSurfaceSmoke(options = {}) {
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const expectedSkillNames = new Set(options.expectedSkillNames ?? []);
+  const log = options.log ?? console.log;
+  const request = createRequester({
+    baseUrl,
+    fetchImpl: options.fetchImpl ?? globalThis.fetch,
+    timeoutMs,
+    attempts,
+  });
+  const recorder = createRecorder(log);
+
+  log(`Agent surface smoke test: ${baseUrl}`);
+
+  const manifest = await recorder.check("agent manifest /.well-known/agent.json", async () => {
+    const result = await readJson(request, "/.well-known/agent.json");
+    return validateManifest(result.json, "/.well-known/agent.json");
+  });
+  await Promise.all([
+    recorder.check("agent manifest /.well-known/agent", async () => {
+      const result = await readJson(request, "/.well-known/agent");
+      validateManifest(result.json, "/.well-known/agent");
+    }),
+    recorder.check("agent manifest /api/docs/agent/spec", async () => {
+      const result = await readJson(request, "/api/docs/agent/spec");
+      validateManifest(result.json, "/api/docs/agent/spec");
+    }),
+    recorder.check("RFC 9727 API catalog", () => validateApiCatalog(request)),
+  ]);
+
+  const modernIndex = await recorder.check("Agent Skills v0.2 index", async () => {
+    const result = await readJson(request, AGENT_SKILLS_INDEX_ROUTE);
+    const head = await request(AGENT_SKILLS_INDEX_ROUTE, { method: "HEAD" });
+    assert(head.bytes.byteLength === 0, `${AGENT_SKILLS_INDEX_ROUTE} HEAD returned a body`);
+    return validateModernSkillIndex(result.json, expectedSkillNames);
+  });
+  const modernNames = new Set((modernIndex ?? []).map((skill) => skill.name));
+  const expectedFileDigests = new Map(
+    (modernIndex ?? [])
+      .filter((skill) => skill.type === "skill-md")
+      .map((skill) => [`${skill.name}/SKILL.md`, skill.digest]),
+  );
+
+  if (modernIndex) {
+    await Promise.all(
+      modernIndex.map((skill) =>
+        recorder.check(`Agent Skill artifact ${skill.name}`, () =>
+          validateModernSkillArtifact(request, baseUrl, skill),
+        ),
+      ),
+    );
+  }
+
+  let manifestFiles = [];
+  if (manifest && modernIndex) {
+    const files = await recorder.check("agent manifest published-skill file map", async () =>
+      validateManifestPublishedSkills(manifest, modernNames, expectedSkillNames),
+    );
+    manifestFiles = files ?? [];
+    for (const file of manifestFiles) {
+      expectedFileDigests.set(`${file.name}/${file.path}`, file.digest);
+    }
+    await Promise.all(
+      manifestFiles.map((file) =>
+        recorder.check(`Agent Skill file ${file.name}/${file.path}`, () =>
+          validateManifestSkillFile(request, baseUrl, file),
+        ),
+      ),
+    );
+  }
+
+  const legacyFiles = await recorder.check("legacy Agent Skills index", async () => {
+    const result = await readJson(request, LEGACY_SKILLS_INDEX_ROUTE);
+    const head = await request(LEGACY_SKILLS_INDEX_ROUTE, { method: "HEAD" });
+    assert(head.bytes.byteLength === 0, `${LEGACY_SKILLS_INDEX_ROUTE} HEAD returned a body`);
+    return validateLegacySkillIndex(result.json, modernNames);
+  });
+  if (legacyFiles) {
+    await Promise.all(
+      legacyFiles.map((file) =>
+        recorder.check(`legacy Agent Skill file ${file.name}/${file.path}`, () =>
+          validateLegacySkillFile(request, file, expectedFileDigests),
+        ),
+      ),
+    );
+  }
+
+  await recorder.check("optional A2A agent card", async () => {
+    const advertised = isNonEmptyString(asRecord(manifest?.api)?.agentCard);
+    const result = advertised
+      ? await readJson(request, AGENT_CARD_ROUTE)
+      : await request(AGENT_CARD_ROUTE, {}, [404]);
+    if (advertised) {
+      const card = asRecord(result.json);
+      assert(
+        card && isNonEmptyString(card.name),
+        `${AGENT_CARD_ROUTE} returned an invalid A2A card`,
+      );
+    }
+  });
+
+  await Promise.all(
+    MCP_ROUTES.map((route) =>
+      recorder.check(`MCP initialize ${route}`, () => validateMcp(request, route)),
+    ),
+  );
+
+  await Promise.all([
+    recorder.check("well-known site skill", () =>
+      validateWellKnownText(request, "/.well-known/skill.md", "text/markdown", "name:"),
+    ),
+    recorder.check("well-known AGENTS.md", () =>
+      validateWellKnownText(request, "/.well-known/AGENTS.md", "text/markdown"),
+    ),
+    recorder.check("well-known AGENT.md", () =>
+      validateWellKnownText(request, "/.well-known/AGENT.md", "text/markdown"),
+    ),
+    recorder.check("well-known llms.txt", () =>
+      validateWellKnownText(request, "/.well-known/llms.txt", "text/plain"),
+    ),
+    recorder.check("well-known llms-full.txt", () =>
+      validateWellKnownText(request, "/.well-known/llms-full.txt", "text/plain"),
+    ),
+    recorder.check("well-known Markdown sitemap", () =>
+      validateWellKnownText(request, "/.well-known/sitemap.md", "text/markdown"),
+    ),
+  ]);
+
+  if (recorder.failures.length > 0) {
+    const error = new Error(
+      `${recorder.failures.length} agent surface smoke check${recorder.failures.length === 1 ? "" : "s"} failed`,
+    );
+    error.failures = recorder.failures;
+    throw error;
+  }
+
+  log(`Passed ${recorder.passed} agent surface smoke checks.`);
+  return { baseUrl, checks: recorder.passed, passed: true };
+}
+
+async function main() {
+  const baseUrl = process.argv[2] || process.env.DOCS_SMOKE_BASE_URL || DEFAULT_BASE_URL;
+  const expectedSkillNames = parseExpectedSkillNames(process.env.DOCS_SMOKE_EXPECT_SKILLS);
+  try {
+    await runAgentSurfaceSmoke({
+      baseUrl,
+      expectedSkillNames,
+      timeoutMs: parsePositiveInteger(process.env.DOCS_SMOKE_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+      attempts: parsePositiveInteger(process.env.DOCS_SMOKE_ATTEMPTS, DEFAULT_ATTEMPTS),
+    });
+  } catch (error) {
+    console.error(
+      `Agent surface smoke test failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isDirectExecution) await main();

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -158,7 +158,7 @@ function createFixtureFetch(options = {}) {
       return response(method, docsDocument, {
         contentType: "text/markdown; charset=utf-8",
         headers: {
-          etag: `"${docsDigest}"`,
+          etag: `W/"${docsDigest}"`,
           link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"`,
         },
       });

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -53,6 +53,7 @@ function response(method, body, options = {}) {
 
 function createFixtureFetch(options = {}) {
   const calls = [];
+  const streamState = { aborted: false, cancelled: false, pulls: 0 };
   const manifest = {
     version: "1",
     name: "@farming-labs/docs",
@@ -115,7 +116,7 @@ function createFixtureFetch(options = {}) {
     ],
   };
 
-  async function fixtureFetch(input, init = {}) {
+  async function fixtureResponse(input, init = {}) {
     const url = new URL(input);
     const method = init.method ?? "GET";
     calls.push({ method, pathname: url.pathname });
@@ -196,6 +197,30 @@ function createFixtureFetch(options = {}) {
       });
     }
 
+    if (url.pathname === "/.well-known/skill.md" && options.oversizedStream) {
+      init.signal?.addEventListener(
+        "abort",
+        () => {
+          streamState.aborted = true;
+        },
+        { once: true },
+      );
+      const body = new ReadableStream({
+        pull(controller) {
+          streamState.pulls += 1;
+          if (streamState.pulls > 100) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(new Uint8Array(48 * 1024));
+        },
+        cancel() {
+          streamState.cancelled = true;
+        },
+      });
+      return response(method, body, { contentType: "text/markdown; charset=utf-8" });
+    }
+
     const textRoutes = {
       "/.well-known/skill.md": ["text/markdown", docsDocument],
       "/.well-known/AGENTS.md": ["text/markdown", "# AGENTS.md\n"],
@@ -209,7 +234,18 @@ function createFixtureFetch(options = {}) {
     return response(method, "Not Found", { status: 404, contentType: "text/plain" });
   }
 
-  return { calls, fetch: fixtureFetch };
+  async function fixtureFetch(input, init = {}) {
+    const requestedUrl = new URL(input);
+    const result = await fixtureResponse(input, init);
+    const finalUrl =
+      options.crossOriginRedirectPath === requestedUrl.pathname
+        ? new URL(requestedUrl.pathname, "https://redirect.example.net").href
+        : requestedUrl.href;
+    Object.defineProperty(result, "url", { configurable: true, value: finalUrl });
+    return result;
+  }
+
+  return { calls, fetch: fixtureFetch, streamState };
 }
 
 test("smoke-checks deployed discovery, skills, MCP, and well-known aliases", async () => {
@@ -244,4 +280,46 @@ test("fails when an indexed Agent Skill artifact does not match its digest", asy
     }),
     /1 agent surface smoke check failed/u,
   );
+});
+
+test("fails when a followed redirect leaves the deployment origin", async () => {
+  const fixture = createFixtureFetch({
+    crossOriginRedirectPath: "/.well-known/agent-skills/docs/SKILL.md",
+  });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      assert.equal(error.failures.length, 1);
+      assert.match(error.failures[0].message, /redirected to cross-origin response/u);
+      return true;
+    },
+  );
+});
+
+test("aborts and cancels a response stream as soon as it exceeds the size cap", async () => {
+  const fixture = createFixtureFetch({ oversizedStream: true });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+      maxResponseBytes: 64 * 1024,
+    }),
+    (error) => {
+      assert.equal(error.failures.length, 1);
+      assert.match(error.failures[0].message, /returned more than 65536 bytes/u);
+      return true;
+    },
+  );
+  assert.equal(fixture.streamState.aborted, true);
+  assert.equal(fixture.streamState.cancelled, true);
+  assert(fixture.streamState.pulls < 10, "the oversized response was not fully consumed");
 });

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import { runAgentSurfaceSmoke } from "./smoke-agent-surfaces.mjs";
+
+const BASE_URL = "https://deployment.example.com";
+const AGENT_SKILLS_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+const API_CATALOG_PROFILE = "https://www.rfc-editor.org/info/rfc9727";
+const API_CATALOG_ROUTE = "/.well-known/api-catalog";
+const AGENT_SKILLS_INDEX_ROUTE = "/.well-known/agent-skills/index.json";
+const LEGACY_SKILLS_INDEX_ROUTE = "/.well-known/skills/index.json";
+
+const docsDocument = `---
+name: docs
+description: Use the site documentation.
+---
+
+# Documentation
+`;
+const portableDocument = `---
+name: portable
+description: Use the portable workflow.
+---
+
+# Portable workflow
+`;
+const portableArchive = new Uint8Array([31, 139, 8, 0, 1, 2, 3, 4]);
+
+function digest(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+const docsDigest = digest(docsDocument);
+const portableDocumentDigest = digest(portableDocument);
+const portableArchiveDigest = digest(portableArchive);
+
+function jsonResponse(method, value, options = {}) {
+  return response(method, `${JSON.stringify(value)}\n`, {
+    contentType: "application/json; charset=utf-8",
+    ...options,
+  });
+}
+
+function response(method, body, options = {}) {
+  const headers = new Headers(options.headers);
+  if (options.contentType) headers.set("content-type", options.contentType);
+  return new Response(method === "HEAD" ? null : body, {
+    status: options.status ?? 200,
+    headers,
+  });
+}
+
+function createFixtureFetch(options = {}) {
+  const calls = [];
+  const manifest = {
+    version: "1",
+    name: "@farming-labs/docs",
+    capabilities: { agentSkillsDiscovery: true, mcp: true },
+    api: {
+      agentSkillsIndex: AGENT_SKILLS_INDEX_ROUTE,
+      legacySkillsIndex: LEGACY_SKILLS_INDEX_ROUTE,
+    },
+    apiCatalog: { enabled: true, route: API_CATALOG_ROUTE },
+    skills: {
+      discovery: {
+        schema: AGENT_SKILLS_SCHEMA,
+        index: AGENT_SKILLS_INDEX_ROUTE,
+        legacyIndex: LEGACY_SKILLS_INDEX_ROUTE,
+      },
+      published: [
+        {
+          name: "portable",
+          type: "archive",
+          description: "Use the portable workflow.",
+          url: "/.well-known/agent-skills/portable.tar.gz",
+          digest: `sha256:${portableArchiveDigest}`,
+          files: [
+            {
+              path: "SKILL.md",
+              url: "/.well-known/agent-skills/portable/SKILL.md",
+              digest: `sha256:${portableDocumentDigest}`,
+            },
+          ],
+        },
+      ],
+    },
+    mcp: {
+      publicEndpoints: ["/mcp", "/.well-known/mcp"],
+    },
+  };
+  const modernIndex = {
+    $schema: AGENT_SKILLS_SCHEMA,
+    skills: [
+      {
+        name: "docs",
+        type: "skill-md",
+        description: "Use the site documentation.",
+        url: "/.well-known/agent-skills/docs/SKILL.md",
+        digest: `sha256:${docsDigest}`,
+      },
+      {
+        name: "portable",
+        type: "archive",
+        description: "Use the portable workflow.",
+        url: "/.well-known/agent-skills/portable.tar.gz",
+        digest: `sha256:${portableArchiveDigest}`,
+      },
+    ],
+  };
+  const legacyIndex = {
+    skills: [
+      { name: "docs", description: "Use the site documentation.", files: ["SKILL.md"] },
+      { name: "portable", description: "Use the portable workflow.", files: ["SKILL.md"] },
+    ],
+  };
+
+  async function fixtureFetch(input, init = {}) {
+    const url = new URL(input);
+    const method = init.method ?? "GET";
+    calls.push({ method, pathname: url.pathname });
+
+    if (
+      url.pathname === "/.well-known/agent.json" ||
+      url.pathname === "/.well-known/agent" ||
+      url.pathname === "/api/docs/agent/spec"
+    ) {
+      return jsonResponse(method, manifest);
+    }
+    if (url.pathname === API_CATALOG_ROUTE) {
+      return jsonResponse(
+        method,
+        {
+          linkset: [
+            {
+              anchor: `${BASE_URL}${API_CATALOG_ROUTE}`,
+              item: [{ href: `${BASE_URL}/api/docs` }],
+              "service-meta": [
+                { href: `${BASE_URL}/.well-known/agent.json` },
+                { href: `${BASE_URL}${AGENT_SKILLS_INDEX_ROUTE}` },
+              ],
+            },
+          ],
+        },
+        {
+          contentType: `application/linkset+json; profile="${API_CATALOG_PROFILE}"; charset=utf-8`,
+          headers: { link: `<${API_CATALOG_ROUTE}>; rel="api-catalog"` },
+        },
+      );
+    }
+    if (url.pathname === AGENT_SKILLS_INDEX_ROUTE) {
+      return jsonResponse(method, modernIndex);
+    }
+    if (url.pathname === LEGACY_SKILLS_INDEX_ROUTE) {
+      return jsonResponse(method, legacyIndex);
+    }
+    if (url.pathname === "/.well-known/agent-skills/docs/SKILL.md") {
+      return response(method, docsDocument, {
+        contentType: "text/markdown; charset=utf-8",
+        headers: {
+          etag: `"${docsDigest}"`,
+          link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"`,
+        },
+      });
+    }
+    if (url.pathname === "/.well-known/agent-skills/portable.tar.gz") {
+      return response(method, options.corruptArchive ? new Uint8Array([0]) : portableArchive, {
+        contentType: "application/gzip",
+        headers: {
+          etag: `"${portableArchiveDigest}"`,
+          link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"`,
+        },
+      });
+    }
+    if (url.pathname === "/.well-known/agent-skills/portable/SKILL.md") {
+      return response(method, portableDocument, { contentType: "text/markdown; charset=utf-8" });
+    }
+    if (url.pathname === "/.well-known/skills/docs/SKILL.md") {
+      return response(method, docsDocument, { contentType: "text/markdown; charset=utf-8" });
+    }
+    if (url.pathname === "/.well-known/skills/portable/SKILL.md") {
+      return response(method, portableDocument, { contentType: "text/markdown; charset=utf-8" });
+    }
+    if (url.pathname === "/.well-known/agent-card.json") {
+      return response(method, "Not Found", { status: 404, contentType: "text/plain" });
+    }
+    if (url.pathname === "/mcp" || url.pathname === "/.well-known/mcp") {
+      return jsonResponse(method, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          serverInfo: { name: "Fixture docs", version: "1.0.0" },
+        },
+      });
+    }
+
+    const textRoutes = {
+      "/.well-known/skill.md": ["text/markdown", docsDocument],
+      "/.well-known/AGENTS.md": ["text/markdown", "# AGENTS.md\n"],
+      "/.well-known/AGENT.md": ["text/markdown", "# AGENT.md\n"],
+      "/.well-known/llms.txt": ["text/plain", "# Documentation\n"],
+      "/.well-known/llms-full.txt": ["text/plain", "# Full documentation\n"],
+      "/.well-known/sitemap.md": ["text/markdown", "# Sitemap\n"],
+    };
+    const textRoute = textRoutes[url.pathname];
+    if (textRoute) return response(method, textRoute[1], { contentType: textRoute[0] });
+    return response(method, "Not Found", { status: 404, contentType: "text/plain" });
+  }
+
+  return { calls, fetch: fixtureFetch };
+}
+
+test("smoke-checks deployed discovery, skills, MCP, and well-known aliases", async () => {
+  const fixture = createFixtureFetch();
+  const result = await runAgentSurfaceSmoke({
+    attempts: 1,
+    baseUrl: BASE_URL,
+    expectedSkillNames: ["portable"],
+    fetchImpl: fixture.fetch,
+    log() {},
+  });
+
+  assert.equal(result.passed, true);
+  assert(
+    fixture.calls.some((call) => call.method === "HEAD" && call.pathname === API_CATALOG_ROUTE),
+  );
+  assert(fixture.calls.some((call) => call.method === "POST" && call.pathname === "/mcp"));
+  assert(
+    fixture.calls.some((call) => call.pathname === "/.well-known/agent-skills/portable/SKILL.md"),
+  );
+});
+
+test("fails when an indexed Agent Skill artifact does not match its digest", async () => {
+  const fixture = createFixtureFetch({ corruptArchive: true });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    /1 agent surface smoke check failed/u,
+  );
+});

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: cli
-description: @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews, run doctor audits and docs review checks, export static Agent Bundles, compact agent docs, validate code blocks, generate AGENTS.md, sitemaps, and robots.txt, sync search indexes, and run MCP. Use for init, deploy, upgrade, doctor, review, agent export, agent compact, codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp, and their flags. Covers framework detection and package managers.
+description: >-
+  @farming-labs/docs CLI — scaffold, upgrade, downgrade, deploy hosted Docs Cloud previews,
+  run doctor audits and docs review checks, export static Agent Bundles, compact agent docs,
+  validate code blocks, generate AGENTS.md, sitemaps, and robots.txt, sync search indexes, and
+  run MCP. Use for init, deploy, upgrade, doctor, review, agent export, agent compact,
+  codeblocks validate, agents generate, sitemap generate, robots generate, search sync, mcp,
+  and their flags. Covers framework detection and package managers.
 ---
 
 # @farming-labs/docs — CLI


### PR DESCRIPTION
## Summary

- Snapshot configured Agent Skills into the Next.js server bundle at build time instead of resolving monorepo-relative paths inside deployed functions.
- Make configured-skill resolution lazy and preloaded-first so API catalog requests never inherit unrelated filesystem failures.
- Serve the same snapshot through the agent manifest, modern and legacy skill indexes, skill artifacts, and MCP.
- Fail closed for composed skill configuration that cannot be statically proven, with a live docs-config escape hatch.
- Add a post-deployment smoke workflow covering manifests, RFC 9727 GET/HEAD, every published skill and hash, both MCP endpoints, and the remaining well-known resources.
- Run Next and Fumadocs discovery regressions in CI.

## Root cause

Next output tracing copied the configured skill files, but the deployed function did not contain the repository markers used to infer the workspace root. The runtime therefore treated website as the boundary, rejected ../skills/farming-labs, and the eagerly-created rejecting promise crashed all dependent discovery routes.

## Validation

- pnpm build
- core docs tests: 925 passed
- Fumadocs tests: 160 passed
- Next adapter tests: 108 passed
- pnpm typecheck
- pnpm lint (0 errors; existing warnings only)
- pnpm format:check
- standalone Next production build
- isolated standalone smoke: 37 agent surfaces passed, including /.well-known/agent.json, RFC 9727 API catalog, all skill artifacts and hashes, /mcp, and /.well-known/mcp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores production Agent discovery by bundling Agent Skills at build time and serving a preloaded snapshot across the agent card, skill indexes, artifacts, and MCP. Hardened bundling by statically parsing `docs.config.*` to include only provable skills and added a comprehensive smoke test for deployed surfaces.

- **Bug Fixes**
  - `@farming-labs/next` bundles `agent.skills` into `.docs/agent-skills-bundle.mjs` and aliases it as `@farming-labs/docs/agent-skills-bundle`. Both discovery and MCP now use this snapshot in production. It parses `docs.config.ts/tsx` with `@babel/parser` to extract literal `agent.skills` and fails closed for computed/spread/getter cases or prototype-influenced configs.
  - `@farming-labs/docs` adds a deterministic, synchronous skills resolver (`resolveConfiguredAgentSkillsSync`), `buildDocsPublishedAgentSkill` for exact SKILL.md hashing, and `renderDocsAgentSkillsBundle` to generate the snapshot. The async resolver uses async I/O only.
  - `@farming-labs/theme` prefers `_preloadedAgentSkills` for discovery and MCP so endpoints stay up even when runtime paths are missing.
  - Added a post-deploy smoke validator and workflow (on deployment status, schedule, and manual) that checks the agent card, RFC 9727 API catalog GET/HEAD, modern and legacy skill indexes and artifacts, both MCP endpoints, and other well-known routes. The validator accepts weak ETags on skill artifact HEAD responses and skips SSO-protected preview deployments. CI now runs Next adapter tests, theme tests, and the validator.

- **Migration**
  - `withDocs` now requires statically provable `agent.skills` (literal string, string array, or `{ paths: [...] }`) in `docs.config.*`. Dynamic/computed/spread keys, `__proto__` usage, or unbound `defineDocs` calls fail closed with a clear error.
  - To bundle a composed config, pass the live `agent` to `withDocs` as the second argument, e.g. `withDocs({}, { agent: { skills: "skills/..." } })`.

<sup>Written for commit cbe9134ab86a93875272579473d95bceb2e562cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->