### PR TITLE
fix: make website agent context useful

### DIFF
--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -42,9 +42,21 @@ agent:
 # CLI
 
 <Agent>
-Use this page when the user asks about this topic: Scaffold, upgrade, export static Agent Bundles, compact agent docs, validate code blocks, generate sitemaps and robots.txt, sync search, and run MCP.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Choose the CLI workflow before changing files. For a published release use
+`pnpm dlx @farming-labs/docs <command>`; use `pnpm exec docs <command>` only after the project has
+installed its dependencies. For a non-interactive fresh scaffold, use
+`init --template <framework> --name <dir>`; omit `--name` to be prompted. Plain `init` asks whether
+to modify the current app or create a fresh project.
+
+After a mutating command, run `pnpm exec docs doctor --agent`; the expected result is a loaded
+`docs.config.ts`, `docs.config.tsx`, or `src/lib/docs.config.ts` with no hard failure for an enabled
+agent surface. For SvelteKit or Astro, append `--config src/lib/docs.config.ts`. Prefer `--dry-run`
+for upgrade or compaction previews and `--check` for generated agent bundles, sitemaps, robots, or
+AGENTS files where the command documents that flag.
+
+If `pnpm` cannot find `docs`, install dependencies or switch to the published `pnpm dlx` form. If
+the wrong config is loaded, return to the project root or pass the command's documented
+`--config <path>` option; do not copy flags between unrelated subcommands.
 </Agent>
 
 The `@farming-labs/docs` CLI has a few main jobs:

--- a/website/app/docs/contributing/page.mdx
+++ b/website/app/docs/contributing/page.mdx
@@ -46,9 +46,19 @@ agent:
 # Contributing
 
 <Agent>
-Use this page when the user asks about this topic: How to contribute to @farming-labs/docs.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Start by reading the repository `AGENTS.md` and the matching file under
+`skills/farming-labs/*/SKILL.md`, then branch from `main` with a focused `fix/`, `feat/`, or `chore/`
+name. Install the pinned workspace dependencies from the repository root and keep edits inside the
+smallest affected package, example, or `website/app/docs/` page set.
+
+For a documentation preview, run `pnpm --dir website dev` and open the changed route. Core or
+theme work may also require `pnpm build`; adapter agent-surface changes must run the shared
+conformance test described at `/docs/guides/adapter-agent-conformance`. The expected handoff is a
+clean, intentional diff with formatting, type checks, and the smallest relevant tests passing.
+
+If a package test passes but another adapter regresses, run the shared conformance tests and the
+affected adapter type check before review. If formatting touches unrelated files, remove those
+mechanical changes instead of including them in the pull request.
 </Agent>
 
 Thanks for your interest in contributing to **@farming-labs/docs**. This guide explains how to report issues, propose changes, and submit pull requests.
@@ -107,7 +117,7 @@ Please be respectful and constructive. We aim to keep the community welcoming an
    ```
 5. **Run the docs site** (from repo root):
    ```bash title="terminal"
-   pnpm --filter website dev
+   pnpm --dir website dev
    ```
    Then open [http://localhost:3000](http://localhost:3000) to preview.
 6. **Make your changes** — Keep edits focused; doc-only and small fixes are welcome.

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -43,9 +43,15 @@ agent:
 # Ask AI
 
 <Agent>
-Use this page when the user asks about this topic: Add a RAG-powered AI chat to your documentation.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Configure top-level `ai` in `docs.config.ts` or `docs.config.tsx`, and keep provider credentials in
+environment variables. Next.js reads `OPENAI_API_KEY` directly; TanStack Start, SvelteKit, and Astro
+pass the server-only value through `src/lib/docs.server.ts`, while Nuxt reads it through Nitro.
+
+Set `ai.useMcp: true` only when Ask AI should retrieve with `search_docs` from `mcp.route` (default
+`/api/docs/mcp`). Success means a question answered by a known page streams and cites that page. If
+the answer has no citation, check the search provider, `ai.maxResults`, MCP endpoint, and the page's
+machine-readable content. Move credential-bearing requests behind the same-origin docs API when the
+browser reports authentication or CORS errors; `staticExport: true` intentionally hides Ask AI.
 </Agent>
 
 Add a built-in AI chat that lets users ask questions about your documentation. The AI searches relevant pages, builds context, and streams a response from any OpenAI-compatible LLM.

--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -10,9 +10,15 @@ agent:
 # Analytics
 
 <Agent>
-Use this page when the user asks about this topic: Track product and usage events from docs, search, AI, feedback, agent, and MCP routes.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Top-level `analytics` records product usage, not step-level agent traces. `analytics: true` writes
+events with the `[@farming-labs/docs:analytics]` prefix; `analytics.onEvent` forwards normalized
+`DocsAnalyticsEvent` objects to a custom destination.
+
+Leave `analytics.includeInputs` false unless the project has consent and a retention policy; paths,
+counts, status, durations, and model IDs remain available without raw queries or questions. Verify
+the integration by triggering a page, search, Ask AI, Markdown, or MCP action and checking its exact
+event type and `source`. Retrieval, model, or tool spans inside one request belong to
+`observability` instead.
 </Agent>
 
 Use `analytics` when you want to understand how people and agents use your docs. It emits

--- a/website/app/docs/customization/colors/page.mdx
+++ b/website/app/docs/customization/colors/page.mdx
@@ -10,9 +10,14 @@ agent:
 # Colors
 
 <Agent>
-Use this page when the user asks about this topic: Override any color token from config.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Theme color overrides live under `theme(...).ui.colors` in `docs.config.ts` or `docs.config.tsx`;
+only the required keys belong there, without replacing the preset CSS for one token. Each value must
+be a valid CSS color and maps to its documented `--color-fd-*` variable, such as `primary` to
+`--color-fd-primary`.
+
+Verify that the target variable changes while omitted tokens still come from the preset in light and
+dark mode. If an override produces the wrong theme behavior, omitting that key restores the preset
+default; the replacement value can be valid hex, rgb, hsl, or oklch.
 </Agent>
 
 Override any color token directly from your config. Colors are mapped to `--color-fd-*` CSS variables at runtime.

--- a/website/app/docs/customization/components/page.mdx
+++ b/website/app/docs/customization/components/page.mdx
@@ -43,9 +43,17 @@ agent:
 # Components
 
 <Agent>
-Use this page when the user asks about this topic: Override built-in or add custom MDX components.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+For Next.js or TanStack Start, create the React component and register its exact case-sensitive name
+under top-level `components` in `docs.config.ts[x]`; MDX can then use that name without an import.
+Astro, SvelteKit, and Nuxt use their adapter-native component registration instead. Use
+`theme.ui.components` only to change default props for a built-in; a top-level entry such as
+`components.HoverLink` replaces that component across the React-rendered docs pages.
+
+Build the docs app and render one MDX page with the documented props while confirming existing
+built-ins still work. If MDX reports an undefined component, check its export and registration name
+and restart the dev server. If JSX makes the config fail to parse, rename `docs.config.ts` to
+`docs.config.tsx`. Remove a built-in override to restore the previous component; when removing a
+custom component, remove its MDX usages too.
 </Agent>
 
 Pass custom React components that become available in **all MDX files** — no imports needed.

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -10,9 +10,15 @@ agent:
 # llms.txt
 
 <Agent>
-Use this page when the user asks about this topic: Auto-generate llms.txt and llms-full.txt for LLM-friendly documentation.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+`llmsTxt` is enabled by default. Verify `/llms.txt`, `/llms-full.txt`, their `/.well-known/` aliases,
+and the `format=llms` or `format=llms-full` docs API responses before adding route files.
+`llmsTxt.baseUrl` corrects the generated origin, `llmsTxt.sections` divides a large corpus, and
+`llmsTxt.maxChars` limits compact output.
+
+Static deployment uses `pnpm exec docs agent export --public`; committed output is checked with
+`pnpm exec docs agent export --check`. A native `public/llms.txt` (or SvelteKit `static/llms.txt`)
+intentionally wins over generated fallback content, so that file is the first place to inspect or
+delete when runtime configuration appears to have no effect.
 </Agent>
 
 Serve <HoverLink href="https://llmstxt.org" title="llms.txt" description="An open convention for exposing website content to language models in a predictable, crawlable text format." linkLabel="Read the llms.txt spec" external><code>llms.txt</code></HoverLink> content through your existing docs API and the default public aliases. It is enabled by default.

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -61,9 +61,17 @@ agent:
 # MCP Server
 
 <Agent>
-Use this page when the user asks about this topic: Expose your docs as MCP tools and resources over stdio, /mcp, or /.well-known/mcp.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+MCP is enabled and public by default: `/mcp` and `/.well-known/mcp` forward to the canonical
+`/api/docs/mcp` handler. Add `mcp.security.authenticate` only for private docs; return a principal to
+continue or `null` for `401`. Add `mcp.security.protectedResource.authorizationServers` and scopes
+only when OAuth-aware clients need RFC 9728 discovery.
+
+Run `pnpm exec docs doctor --agent`, then initialize a client and call `list_docs` followed by
+`read_page` for a known route. A `404` can mean MCP is disabled, static export omitted the server
+route, or the canonical handler and public forwarder are missing or disagree; use doctor output to
+distinguish them. Repeated `401` responses mean the callback is not returning a valid principal;
+`403` with `insufficient_scope` means the principal lacks a configured required scope. Local-only
+clients can avoid HTTP routing with `pnpm exec docs mcp`.
 </Agent>
 
 `@farming-labs/docs` can expose your docs as a built-in MCP server, so AI clients can search the docs, read pages, list sections, inspect code examples, and understand config options without scraping HTML.

--- a/website/app/docs/customization/observability/page.mdx
+++ b/website/app/docs/customization/observability/page.mdx
@@ -10,9 +10,15 @@ agent:
 # Observability
 
 <Agent>
-Use this page when the user asks about this topic: Trace Ask AI and MCP runs with span IDs, timing, status, previews, errors, and callbacks.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Top-level `observability` covers steps inside Ask AI and MCP runs. `observability: true` writes the
+`[@farming-labs/docs:observability]` stream; its console mode shows local traces, while
+`observability.onEvent` forwards `DocsObservabilityEvent` objects.
+
+Verify one trace contains a shared `traceId`, child `spanId` values, status, and `durationMs`, with
+Ask AI lifecycle events or `tool.call`/`tool.result` for MCP. Built-in previews exclude raw user
+text; separate raw `input` fields are omitted unless `includeInputs` is enabled. If only `page_view`,
+`search_query`, `api_ai_request`, or `mcp_tool` appears, inspect `analytics.onEvent`; those are usage
+events rather than runtime spans.
 </Agent>
 
 Use `observability` when you need step-level visibility into agent runtime behavior. It emits

--- a/website/app/docs/customization/og-images/page.mdx
+++ b/website/app/docs/customization/og-images/page.mdx
@@ -41,9 +41,15 @@ agent:
 # OG Images
 
 <Agent>
-Use this page when the user asks about this topic: Dynamic and static Open Graph images for docs - how they work, what context is passed, and how the docs website generates them.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+For Next.js dynamic previews, set `og.enabled`, `og.type: "dynamic"`, and `og.endpoint` in
+`docs.config.ts`, then implement `GET` in `app/api/og/route.tsx` when the response contains JSX.
+Read the `title` and `description` query parameters and return a 1200x630 image. For a reliable
+per-page override, set explicit `openGraph` and `twitter` frontmatter.
+
+Fetch a representative page's absolute `og:image` URL and require HTTP 200 with an image content
+type. If a dynamic image is stale, hard-refresh or add a cache-busting query. If rendering throws,
+limit the route to fonts, layout, and CSS supported by `ImageResponse`; restore the previous `og`
+config and remove the new route or static image to roll back.
 </Agent>
 
 Open Graph (OG) images are the preview images shown when your docs pages are shared on social platforms, Slack, or messaging apps. This guide explains how the framework supports **dynamic** (generated per page) and **static** (per-page image file) OG images, what data your image generator receives, and how the docs website implements dynamic OG.

--- a/website/app/docs/customization/page-actions/page.mdx
+++ b/website/app/docs/customization/page-actions/page.mdx
@@ -41,9 +41,16 @@ agent:
 # Page Actions
 
 <Agent>
-Use this page when the user asks about this topic: Add "Open in LLM" and "Copy Markdown" buttons to your doc pages.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Edit top-level `pageActions` in `docs.config.ts` or `docs.config.tsx`. Enable
+`copyMarkdown` for clipboard output and `openDocs` for provider links; prefer
+`openDocs.target: "markdown"` so the prompt receives the current machine-readable page. Configure
+top-level `github` before using the `github` target or `{githubUrl}` template value.
+
+First verify the page's `.md` route, then copy Markdown and open every configured provider from that
+page. If copying returns HTML or an empty body, repair the Markdown route rather than the button. If
+a provider URL contains an unresolved token, use only the documented template placeholders and
+check the required `github.url`. To remove both actions, delete `pageActions` or set both
+`copyMarkdown: false` and `openDocs: false`.
 </Agent>
 
 Page actions are buttons rendered above or below the page title. They let users interact with page content — copy it as Markdown, or open it in an LLM provider like ChatGPT or Claude.

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -10,9 +10,15 @@ agent:
 # Customization
 
 <Agent>
-Use this page when the user asks about this topic: Colors, typography, sidebar, components, analytics, telemetry, observability, agent primitives, robots.txt, OG images, AI chat, and page actions.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Treat this page as a configuration router. Visual tokens and built-in default props belong under
+`theme.ui`, replacement MDX components use top-level `components`, and runtime features use
+top-level `ai`, `analytics`, `telemetry`, `observability`, `mcp`, `llmsTxt`, `sitemap`, and
+`pageActions` in `docs.config.ts`.
+
+The linked feature page is the source of truth because each option has different defaults and
+verification steps. A layout or CSS file is unnecessary for an option documented as config-only. A
+committed crawl policy comes from `pnpm exec docs robots generate`; audience-specific page content
+follows the Agent Primitive workflow.
 </Agent>
 
 Everything is customizable from `docs.config.ts`. No CSS files to edit, no layout files to create.

--- a/website/app/docs/customization/typography/page.mdx
+++ b/website/app/docs/customization/typography/page.mdx
@@ -10,9 +10,15 @@ agent:
 # Typography
 
 <Agent>
-Use this page when the user asks about this topic: Fonts, heading sizes, weights, and spacing.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Font families live at `theme.ui.typography.font.style.sans` and `.mono`; `h1` through `h4`, `body`,
+and `small` accept the documented `size`, `weight`, `lineHeight`, and `letterSpacing` fields in
+`docs.config.ts` or `docs.config.tsx`.
+
+For Next.js Google Fonts, CSS variables originate in `app/layout.tsx`; their generated variable
+classes belong on `<body>`, and the typography config references those exact names. Verify the
+computed sans and mono families on the rendered page. If the fallback font remains, check that the
+body class includes both font variables and that the config spelling matches before changing type
+sizes or weights.
 </Agent>
 
 Control fonts, heading sizes, weights, line heights, and letter spacing — all from config.

--- a/website/app/docs/guides/docs-json/page.mdx
+++ b/website/app/docs/guides/docs-json/page.mdx
@@ -16,9 +16,21 @@ agent:
 # docs.json
 
 <Agent>
-Use this page when the user asks about this topic: How the shared docs.json contract separates docs structure from Docs Cloud services.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Treat `docs.json` as a serializable repository contract. Keep `$schema`, `version`, `docs.mode`,
+`docs.runtime`, and `docs.root` explicit; use `content.docsRoot` and `content.apiReferenceRoot` for
+content locations. Only JSON-safe Cloud settings such as `cloud.analytics`, `cloud.publish`,
+`cloud.ai`, and hosted publication state belong here. Keep theme helpers and callbacks such as
+`analytics.onEvent` in `docs.config.ts`, CSS imports in the framework stylesheet, and secret values
+in environment variables. `docs.json` may name an environment variable but must not contain its
+secret value.
+
+For a config-backed Cloud project, `pnpm dlx @farming-labs/docs cloud sync` materializes the
+generated `docs.json`, which should describe the intended framework or frameworkless root without a
+raw API key. For SvelteKit or Astro, the command needs `--config src/lib/docs.config.ts`.
+`cloud.enabled: false` retains the local contract while disabling Cloud operations; otherwise the
+field is normally omitted. If the JSON drifts from executable config, regenerate and review it
+rather than hand-copying function-valued options. A frameworkless `pnpm exec docs dev` preview
+currently uses the Next.js runtime even though `docs.runtime` remains explicit for future runtimes.
 </Agent>
 
 Use `docs.json` when you want a repo-level contract for frameworkless docs or for connecting

--- a/website/app/docs/guides/page.mdx
+++ b/website/app/docs/guides/page.mdx
@@ -17,9 +17,17 @@ agent:
 # Guides
 
 <Agent>
-Use this page when the user asks about this topic: Long-form playbooks for building docs that work well for humans, IDEs, and agents.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Route the task to one playbook before proposing an implementation. Choose
+`/docs/guides/agent-friendly-docs` for page contracts, audience projections, discovery, validation,
+and compaction; choose `/docs/guides/docs-json` for `docs.mode`, `docs.runtime`, repo roots, and the
+JSON-safe `cloud` layer. Adapter maintainers should use
+`/docs/guides/adapter-agent-conformance` and require its versioned report to contain no failed
+cases.
+
+These guides explain end-to-end decisions, not every option type. When the selected workflow needs
+an exact `defineDocs()` field, verify it against `/docs/reference`; when it needs CLI flags, use
+`/docs/cli`. If the requested outcome cannot be verified by the chosen guide, switch to the linked
+specialized page instead of combining unrelated configuration shapes.
 </Agent>
 
 These are the longer, more opinionated walkthroughs in the docs. They sit on top of the reference pages and show how to use `@farming-labs/docs` in a way that feels coherent end to end, not just technically correct.

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -43,9 +43,19 @@ agent:
 # API Reference
 
 <Agent>
-Use this page when the user asks about this topic: Complete reference for all configuration options.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Before changing configuration, inspect the existing `defineDocs()` call and select the exact
+exported `DocsConfig` field or nested type documented below. Preserve the framework's config path:
+`docs.config.ts[x]` for Next.js, TanStack Start, and Nuxt, or `src/lib/docs.config.ts` for SvelteKit
+and Astro. The non-Next adapters can configure `contentDir` and `nav` explicitly, while Next.js
+derives its content tree from `app/{entry}/`.
+
+When MCP `get_config_schema` publishes the option, compare its type and default; otherwise verify
+against the installed exported types and matching-version reference. Then run
+`pnpm exec docs doctor --agent` for the resolved capability and discovery fields it audits. For
+SvelteKit or Astro, append `--config src/lib/docs.config.ts`. If TypeScript rejects the documented
+shape, first align all `@farming-labs/*` package versions and rename the config to `.tsx` when it
+contains JSX. If diagnostics and public discovery disagree, restore the previous value and repair
+the adapter route or stale static export before enabling the capability again.
 </Agent>
 
 Complete reference for every option in `docs.config.ts`. All types are exported from `@farming-labs/docs`.

--- a/website/app/docs/themes/colorful/page.mdx
+++ b/website/app/docs/themes/colorful/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Colorful Theme
 
 <Agent>
-Use this page when the user asks about this topic: Warm amber accent with Inter typography and a clean layout.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Apply this preset with `colorful` from `@farming-labs/theme/colorful`, `theme: colorful()` in `docs.config.ts`, and `@import "@farming-labs/theme/colorful/css"` in `app/global.css`.
+Check for the amber `hsl(40, 96%, 40%)` primary, 768px content width, and directional TOC; the documented overrides are `ui.colors.primary` and `ui.layout.contentWidth`.
+If the config compiles but those defaults are absent, make the CSS subpath match the `colorful` factory before changing theme tokens.
 </Agent>
 
 A warm, vibrant theme with an amber primary accent, Inter typography, and directional TOC styling.

--- a/website/app/docs/themes/command-grid/page.mdx
+++ b/website/app/docs/themes/command-grid/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Command Grid Theme
 
 <Agent>
-Use this page when the user asks about this topic: Mono-first paper-grid theme inspired by the better-cmdk landing page.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Choose Command Grid by importing `commandGrid` from `@farming-labs/theme/command-grid`, calling `commandGrid()` in the `theme` field, and loading `@farming-labs/theme/command-grid/css` globally.
+Verify the paper-grid light background, mono-first UI, `0px` radius, 900px content area, and 304px sidebar; customize only the shown `ui.colors.accent` or `ui.layout.sidebarWidth` when answering from this page.
+A plain ungridded result usually means the `/command-grid/css` entrypoint is missing or paired with a different factory.
 </Agent>
 
 A mono-first preset with a paper-grid light mode, lead-toned dark mode, sharper borders, and calmer surfaces inspired by the better-cmdk landing page.

--- a/website/app/docs/themes/concrete/page.mdx
+++ b/website/app/docs/themes/concrete/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Concrete Theme
 
 <Agent>
-Use this page when the user asks about this topic: Brutalist poster-style theme with offset shadows and square corners.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Concrete pairs `concrete` from `@farming-labs/theme/concrete` with `theme: concrete()` and the global CSS import `@farming-labs/theme/concrete/css`.
+The expected result is the `#ff5b31` primary, offset-shadow poster styling, `0px` corners, an 896px content width, and a 316px sidebar; this page documents `ui.colors.primary` and `ui.layout.sidebarWidth` overrides.
+If only the config changes and the brutalist surfaces do not appear, restore the matching `/concrete/css` import rather than recreating its CSS.
 </Agent>
 
 A louder brutalist-style preset with poster typography, offset shadows, square corners, and bold contrast.

--- a/website/app/docs/themes/creating-themes/page.mdx
+++ b/website/app/docs/themes/creating-themes/page.mdx
@@ -51,9 +51,9 @@ import { WebsiteThemePrompt } from "@/components/website-theme-prompt";
 # Creating Your Own Theme
 
 <Agent>
-Use this page when the user asks about this topic: Step-by-step guide to building, publishing, and sharing custom themes.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Build reusable presets with `createTheme` from `@farming-labs/docs`, give each one a unique `name`, and call its factory as `theme: myTheme()` inside `defineDocs()`. In contrast, pass the `DocsTheme` instance from `extendTheme()` as `theme: myTheme` without calling it.
+Validate the production build plus navigation, search, code, callouts, and tables. Config-only themes need no custom CSS; when a package ships custom CSS, export it as `./css` and import it from the consumer's global stylesheet.
+For an unstyled config-only theme, verify that the intended factory or extended instance reaches `defineDocs()`. For a package that only fails for consumers, verify `.` and, when present, `./css` in `package.json` exports against the packed artifact.
 </Agent>
 
 Everything starts with `createTheme()`. No CSS required — just a config object.

--- a/website/app/docs/themes/darkbold/page.mdx
+++ b/website/app/docs/themes/darkbold/page.mdx
@@ -10,9 +10,9 @@ agent:
 # DarkBold Theme
 
 <Agent>
-Use this page when the user asks about this topic: Pure monochrome design with Geist typography and clean minimalism.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+DarkBold uses `darkbold` from `@farming-labs/theme/darkbold`, `theme: darkbold()` in `docs.config.ts`, and `@farming-labs/theme/darkbold/css` in the global stylesheet.
+Validate the monochrome `#000` primary, Geist/Geist Mono fonts, and tighter H1–H3 letter spacing; supported examples override `ui.colors.primary` and `ui.typography.font.h1`.
+If the site retains another preset's colors or type scale, correct the `/darkbold/css` entrypoint before adding typography overrides.
 </Agent>
 
 A pure monochrome design inspired by <HoverLink href="https://vercel.com/docs" title="Vercel Docs" description="Vercel's documentation style pairs crisp monochrome UI, Geist typography, and compact spacing across technical content." linkLabel="Visit Vercel Docs" external>Vercel</HoverLink> — featuring Geist typography, tight letter-spacing, and clean minimalism.

--- a/website/app/docs/themes/darksharp/page.mdx
+++ b/website/app/docs/themes/darksharp/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Darksharp Theme
 
 <Agent>
-Use this page when the user asks about this topic: All-black theme with sharp corners.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Activate Darksharp with `darksharp` from `@farming-labs/theme/darksharp`, `theme: darksharp()`, and `@import "@farming-labs/theme/darksharp/css"` in `app/global.css`.
+Confirm the neutral light palette, pure-black dark-mode background, near-white dark-mode primary, sharp low-radius chrome, and the factory's 768px/280px content-sidebar defaults; the page demonstrates a `ui.colors.primary` override.
+If the preset styling is absent in both color modes, verify that `darksharp()` is paired with the `/darksharp/css` entrypoint before adding overrides.
 </Agent>
 
 An all-black theme with `rounded-none` styling — clean, minimal, and sharp.
@@ -38,11 +38,11 @@ export default defineDocs({
 
 | Property      | Value                  |
 | ------------- | ---------------------- |
-| Primary       | Near-white             |
-| Background    | `#000000` (pure black) |
-| Border radius | `0px` (no rounding)    |
-| Content width | 860px                  |
-| Sidebar width | 286px                  |
+| Primary       | Near-white in dark mode               |
+| Background    | Neutral light, `#000000` in dark mode |
+| Border radius | Sharp / low-radius                    |
+| Content width | 768px                                 |
+| Sidebar width | 280px                                 |
 
 ## Customizing
 

--- a/website/app/docs/themes/default/page.mdx
+++ b/website/app/docs/themes/default/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Default Theme
 
 <Agent>
-Use this page when the user asks about this topic: Clean, neutral palette with standard border radius.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+`fumadocs`, available from either `@farming-labs/theme` or `@farming-labs/theme/default`, pairs `theme: fumadocs()` with the separate `@farming-labs/theme/default/css` entrypoint.
+The factory declares indigo/white config defaults, standard radii, a 768px content width, and a 280px sidebar; the stylesheet and color mode determine the final computed palette. `ui.colors.primary` and `ui.layout.contentWidth` are documented overrides.
+If the factory resolves but styling is absent, verify the `/default/css` import and inspect the computed `--color-fd-*` variables before adding more overrides.
 </Agent>
 
 The default Fumadocs theme with a neutral color palette and standard border radii.

--- a/website/app/docs/themes/greentree/page.mdx
+++ b/website/app/docs/themes/greentree/page.mdx
@@ -10,9 +10,9 @@ agent:
 # GreenTree Theme
 
 <Agent>
-Use this page when the user asks about this topic: Mintlify-inspired theme with emerald green accent and Inter typography.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+GreenTree's exact pairing is `greentree` from `@farming-labs/theme/greentree`, `theme: greentree()`, and `@farming-labs/theme/greentree/css` in `app/global.css`.
+Success is an emerald `#0D9373` accent with Inter typography, a compact 240px sidebar, and a 56px header; use the shown `ui.colors.primary` and `ui.layout.sidebarWidth` overrides for variations.
+If the layout stays at another preset's dimensions, check the exact lowercase `greentree` export and its matching CSS subpath.
 </Agent>
 
 Inspired by <HoverLink href="https://mintlify.com/docs" title="Mintlify Docs" description="A hosted docs platform known for compact navigation, clean typography, and strong product-doc presentation." linkLabel="Visit Mintlify" external>Mintlify</HoverLink> — a clean, modern design with an emerald green accent, Inter typography, and a compact sidebar.

--- a/website/app/docs/themes/hardline/page.mdx
+++ b/website/app/docs/themes/hardline/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Hardline Theme
 
 <Agent>
-Use this page when the user asks about this topic: Hard-edge theme with square corners and strong borders.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Select the original hard-edge preset with `hardline` from `@farming-labs/theme/hardline`, `theme: hardline()`, and the global import `@farming-labs/theme/hardline/css`.
+Look for the `#ffd335` primary, square `0px` corners, bold borders, 860px content width, and 300px sidebar after rendering a docs page.
+Use `concrete` instead when the requirement is explicitly poster-like brutalism; if Hardline looks unstyled, repair the `/hardline/css` pairing rather than substituting Concrete tokens.
 </Agent>
 
 `hardline()` is the original hard-edge preset: square corners, bold borders, and sharp high-contrast surfaces.

--- a/website/app/docs/themes/ledger/page.mdx
+++ b/website/app/docs/themes/ledger/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Ledger Theme
 
 <Agent>
-Use this page when the user asks about this topic: Stripe Docs-inspired theme with tabbed navigation, blue-violet actions, and deep code panels.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Apply Ledger through `ledger` from `@farming-labs/theme/ledger`, `theme: ledger()`, and `@import "@farming-labs/theme/ledger/css"` in the global CSS file.
+Inspect tab-like navigation, pill search controls, deep navy code blocks in dark mode, the `#5f6cf6` light-mode primary, and the 820px/292px content-sidebar layout; documented adjustments include `ui.colors.primary`, `ui.layout.sidebarWidth`, and `ui.layout.tocWidth`.
+If the product-doc shell is missing, first align the `/ledger/css` entrypoint with the `ledger()` factory.
 </Agent>
 
 A product-docs preset inspired by <HoverLink href="https://docs.stripe.com/" title="Stripe Docs" description="Stripe's documentation uses compact navigation, strong search affordances, crisp product links, and dark code examples." linkLabel="Visit Stripe Docs" external>Stripe Docs</HoverLink>, with neutral branding for @farming-labs/docs projects.

--- a/website/app/docs/themes/page.mdx
+++ b/website/app/docs/themes/page.mdx
@@ -45,9 +45,9 @@ agent:
 # Themes
 
 <Agent>
-Use this page when the user asks about this topic: Built-in themes and how to create your own.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Select the factory and package subpath as a pair—for example, `pixelBorder` from `@farming-labs/theme/pixel-border` with `theme: pixelBorder()`—then import the matching `@farming-labs/theme/pixel-border/css` globally.
+Test navigation, code blocks, callouts, and tables after switching presets. Use `createTheme()` for a reusable custom factory and `extendTheme()` to derive a theme from an existing preset.
+If config builds but visuals do not change, repair the CSS entrypoint; if the factory cannot be resolved, copy its exact export and import path from the built-in themes table.
 </Agent>
 
 @farming-labs/docs ships with twelve built-in theme entrypoints. Each is a preset factory function that you pass to `defineDocs()`. `hardline` stays as the original hard-edge preset, `concrete` is the louder brutalist variant, `command-grid` is the mono-first paper-grid preset inspired by the better-cmdk landing page, `ledger` brings a Stripe Docs-inspired product documentation shell, and `threadline` adds compact neutral chrome for chat and agent docs.

--- a/website/app/docs/themes/pixel-border/page.mdx
+++ b/website/app/docs/themes/pixel-border/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Pixel Border Theme
 
 <Agent>
-Use this page when the user asks about this topic: Inspired by better-auth.com - refined dark UI with visible borders.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Pixel Border's required trio is `pixelBorder` from `@farming-labs/theme/pixel-border`, `theme: pixelBorder()`, and the CSS entrypoint `@farming-labs/theme/pixel-border/css`.
+Verify the `hsl(0 0% 2%)` dark background, visible borders, `0px` radius, and active sidebar indicator; a `ui.colors.primary` override must flow to sidebar text, the indicator bar, TOC state, and links.
+When the primary value changes but the bordered sidebar does not, restore the `/pixel-border/css` import before targeting component selectors manually.
 </Agent>
 
 Inspired by <HoverLink href="https://better-auth.com" title="better-auth" description="An authentication framework site with a sharp dark docs aesthetic, visible borders, and strong contrast-driven layout." linkLabel="Visit better-auth" external>better-auth.com</HoverLink> — a clean dark UI with visible borders, pixel-perfect spacing, and a refined sidebar. The active sidebar indicator and text use your primary color.

--- a/website/app/docs/themes/shiny/page.mdx
+++ b/website/app/docs/themes/shiny/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Shiny Theme
 
 <Agent>
-Use this page when the user asks about this topic: Clerk-inspired theme with purple accents and a polished light/dark design.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Shiny pairs `shiny` from `@farming-labs/theme/shiny` with `theme: shiny()` and `@farming-labs/theme/shiny/css` after Tailwind in `app/global.css`.
+Confirm the purple `hsl(256, 100%, 64%)` primary, polished light/dark surfaces, 280px sidebar, and 64px header; the local examples permit `ui.colors.primary` and `ui.layout.sidebarWidth` changes.
+If those dimensions apply without the polished surfaces, verify the `/shiny/css` package export is present rather than copying Clerk-specific styles.
 </Agent>
 
 Inspired by <HoverLink href="https://clerk.com/docs" title="Clerk Docs" description="Clerk's documentation combines polished product styling, strong hierarchy, and approachable auth-focused guides." linkLabel="Visit Clerk Docs" external>Clerk</HoverLink> — a clean, polished UI with purple accents and a professional light/dark design.

--- a/website/app/docs/themes/threadline/page.mdx
+++ b/website/app/docs/themes/threadline/page.mdx
@@ -10,9 +10,9 @@ agent:
 # Threadline Theme
 
 <Agent>
-Use this page when the user asks about this topic: compact neutral theme with page-action defaults.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Both `threadline` and `threadlinePageActions` come from `@farming-labs/theme/threadline`; their config fields are `theme: threadline()` and `pageActions: threadlinePageActions`, with styles from `@farming-labs/theme/threadline/css`.
+Verify the 48px header, compact Geist typography, 944px content width, and ghost-style action menu. The GitHub provider additionally requires top-level `github.url` in `docs.config.ts`.
+For a missing GitHub action, `github.url` is the relevant recovery; for an absent compact shell, the `/threadline/css` import is the relevant check.
 </Agent>
 
 A compact neutral preset for chat, agent, and product documentation. It uses a 48px header, compact Geist typography, muted shadcn surfaces, and ghost-style page actions for dense, readable docs.
@@ -59,7 +59,7 @@ The GitHub action needs top-level `github` config so the theme can resolve `{git
 | Background    | `oklch(1 0 0)` (light), `oklch(0.145 0 0)` (dark) |
 | Border        | `oklch(0.922 0 0)`                     |
 | Border radius | `0.625rem`                             |
-| Content width | 912px                                  |
+| Content width | 944px                                  |
 | Sidebar width | 260px                                  |
 | TOC width     | 224px                                  |
 | Header height | 48px                                   |

--- a/website/app/docs/token-efficiency/page.mdx
+++ b/website/app/docs/token-efficiency/page.mdx
@@ -51,9 +51,19 @@ agent:
 # Token Efficiency
 
 <Agent>
-Use this page when the user asks about this topic: How @farming-labs/docs keeps your project lean for AI-assisted development - without sacrificing flexibility.
-Keep answers grounded in the exact options, routes, commands, and examples documented here.
-If the request moves beyond this page, point to the closest related docs instead of inventing config.
+Measure retrieval before compacting. Set per-page `agent.tokenBudget` in `page.mdx` and configure
+`agent.compact` in `docs.config.ts[x]`; keep the Docs Cloud key outside source control through
+`agent.compact.apiKeyEnv`. Preview writes with
+`pnpm exec docs agent compact --changed --dry-run`, then compact only pages whose task commands,
+constraints, expected results, and recovery steps remain recoverable. For SvelteKit or Astro,
+append `--config src/lib/docs.config.ts` to this command and the doctor command below.
+
+Run `pnpm exec docs doctor --agent` after compaction. Any configured golden tasks should still
+satisfy their source, citation, scope, example, and UTF-8 budget requirements. Remember that a
+generated sibling `agent.md` replaces only machine-readable page output; the rendered `page.mdx`
+remains unchanged. If a compacted result drops required evidence or lowers the relevant page below
+an overview, restore the prior `agent.md`, improve its contract and retrieval metadata, and rerun
+the task before raising compaction aggressiveness.
 </Agent>
 
 AI tools like Cursor, Copilot, and Claude read your project files to help you write code. Every file they read costs **tokens** — the units that determine response speed, API cost, and how much of your project fits in a single conversation.

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -316,7 +316,7 @@ export default defineDocs({
         {
           id: "prepare-monorepo-contribution",
           query:
-            "Contributing Pull requests fork farming-labs/docs branch from main install pnpm and run pnpm --filter website dev",
+            "Contributing Pull requests fork farming-labs/docs branch from main install pnpm and run pnpm --dir website dev",
           topK: 5,
           filters: { framework: "astro", version: "0.2.60" },
           expect: {
@@ -331,7 +331,7 @@ export default defineDocs({
                 language: "bash",
                 title: "terminal",
                 runnable: false,
-                includes: ["pnpm --filter website dev"],
+                includes: ["pnpm --dir website dev"],
                 verification: "present",
               },
             ],


### PR DESCRIPTION
## Summary

- replace repeated generic `<Agent>` blocks across 31 website pages with page-specific setup, verification, and recovery guidance
- correct command, adapter, config, and theme facts uncovered while validating the new context
- align the contribution golden task with the working website preview command

## Why

The website exposed 40 rendered agent blocks, but only 9 passed the usefulness checks. Of the rest, 29 were repeated boilerplate and 27 were generic enough to provide little operational value.

## Impact

All 40 agent blocks now pass specificity and non-repetition checks. The existing 21-page actionable-contract set remains stable, and every actionable page includes prerequisites, expected results, recovery guidance, applicability, and valid related-page coverage.

## Validation

- `pnpm exec docs doctor --agent --config docs.config.tsx`: 98% Agent-optimized
- agent context usefulness: 40/40 useful, 0 duplicate, 0 boilerplate, 0 generic
- agent task completeness: 21/21
- golden agent tasks: 21/21 passed, 98.7132/100 average
- `pnpm format:check`
- `pnpm lint` (0 errors; existing warnings only)
- `git diff --check`

The remaining doctor warning is generated `agent.md` compaction freshness, which is intentionally outside this context-quality PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced generic `<Agent>` blocks with page-specific guidance across the docs, making agent context actionable, non-duplicated, and verifiable. Also corrected CLI flags, config paths, and theme defaults, and aligned the golden task with the working website preview command.

- **Refactors**
  - Rewrote all website Agent blocks with concrete setup, expected results, and recovery steps; removed boilerplate and duplicates.
  - Standardized commands and flags by framework (prefer `pnpm dlx @farming-labs/docs` for releases; use `--config src/lib/docs.config.ts` for SvelteKit/Astro).
  - Updated theme pages to require factory+CSS entrypoint pairs and documented defaults; adjusted incorrect widths and token names.

- **Bug Fixes**
  - Switched website preview to `pnpm --dir website dev` and updated the golden task in `website/docs.config.tsx`.
  - Corrected facts for CLI, MCP public routes/auth, Ask AI vs `observability` vs `analytics`, `llms.txt` generation/precedence, and `pageActions`/GitHub requirements.
  - Clarified `docs.json` contract scope and Cloud sync; tightened compaction workflow and recovery guidance.

- **Validation**
  - `pnpm exec docs doctor --agent`: 98% agent-optimized; 40/40 useful, 0 duplicate.
  - Agent tasks: 21/21; golden tasks: 21/21 passed, avg 98.7132.
  - Format and lint pass (no new errors).

<sup>Written for commit a38659a85f023eaf49145b0d9f6d0ea12fea4d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

