### PR TITLE
fix: complete website related-page coverage

### DIFF
--- a/website/app/docs/customization/analytics/page.mdx
+++ b/website/app/docs/customization/analytics/page.mdx
@@ -3,6 +3,11 @@ title: "Analytics"
 description: "Track product and usage events from docs, search, AI, feedback, agent, and MCP routes"
 icon: "chart-no-axes-column"
 order: 5.64
+related:
+  - /docs/customization/observability
+  - /docs/customization/telemetry
+  - /docs/cloud/analytics
+  - /docs/customization/ai-chat
 agent:
   tokenBudget: 900
 ---

--- a/website/app/docs/customization/colors/page.mdx
+++ b/website/app/docs/customization/colors/page.mdx
@@ -3,6 +3,11 @@ title: "Colors"
 description: "Override any color token from config"
 icon: "palette"
 order: 5.1
+related:
+  - /docs/customization/typography
+  - /docs/themes
+  - /docs/themes/creating-themes
+  - /docs/configuration
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/customization/llms-txt/page.mdx
+++ b/website/app/docs/customization/llms-txt/page.mdx
@@ -3,6 +3,12 @@ title: "llms.txt"
 description: "Auto-generate llms.txt and llms-full.txt for LLM-friendly documentation"
 icon: "bot"
 order: 5.8
+related:
+  - /docs/customization/sitemaps
+  - /docs/customization/agent-primitive
+  - /docs/customization/mcp
+  - /docs/guides/agent-friendly-docs
+  - /docs/cli
 agent:
   tokenBudget: 1100
 ---

--- a/website/app/docs/customization/observability/page.mdx
+++ b/website/app/docs/customization/observability/page.mdx
@@ -3,6 +3,11 @@ title: "Observability"
 description: "Trace Ask AI and MCP runs with span IDs, timing, status, previews, errors, and callbacks"
 icon: "activity"
 order: 5.65
+related:
+  - /docs/customization/analytics
+  - /docs/customization/ai-chat
+  - /docs/customization/mcp
+  - /docs/configuration
 agent:
   tokenBudget: 900
 ---

--- a/website/app/docs/customization/page.mdx
+++ b/website/app/docs/customization/page.mdx
@@ -3,6 +3,12 @@ title: "Customization"
 description: "Colors, typography, sidebar, components, analytics, telemetry, observability, agent primitives, robots.txt, OG images, AI chat, and page actions"
 icon: "settings"
 order: 5
+related:
+  - /docs/configuration
+  - /docs/themes
+  - /docs/customization/components
+  - /docs/customization/agent-primitive
+  - /docs/customization/ai-chat
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/customization/sidebar/page.mdx
+++ b/website/app/docs/customization/sidebar/page.mdx
@@ -3,6 +3,11 @@ title: "Sidebar"
 description: "Title, icons, collapsible groups, and styling"
 icon: "layers"
 order: 5.3
+related:
+  - /docs/configuration
+  - /docs/customization/components
+  - /docs/customization/colors
+  - /docs/themes
 agent:
   tokenBudget: 1000
 ---

--- a/website/app/docs/customization/typography/page.mdx
+++ b/website/app/docs/customization/typography/page.mdx
@@ -3,6 +3,11 @@ title: "Typography"
 description: "Fonts, heading sizes, weights, and spacing"
 icon: "file"
 order: 5.2
+related:
+  - /docs/customization/colors
+  - /docs/themes
+  - /docs/themes/creating-themes
+  - /docs/configuration
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/colorful/page.mdx
+++ b/website/app/docs/themes/colorful/page.mdx
@@ -3,6 +3,11 @@ title: "Colorful"
 description: "Warm amber accent with Inter typography and a clean layout"
 icon: "rainbow"
 order: 4.4
+related:
+  - /docs/themes
+  - /docs/customization/colors
+  - /docs/customization/typography
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/command-grid/page.mdx
+++ b/website/app/docs/themes/command-grid/page.mdx
@@ -3,6 +3,11 @@ title: "Command Grid"
 description: "Mono-first paper-grid theme inspired by the better-cmdk landing page"
 icon: "grid2x2"
 order: 4.8
+related:
+  - /docs/themes
+  - /docs/customization/colors
+  - /docs/customization/typography
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/concrete/page.mdx
+++ b/website/app/docs/themes/concrete/page.mdx
@@ -3,6 +3,11 @@ title: "Concrete"
 description: "Brutalist poster-style theme with offset shadows and square corners"
 icon: "square"
 order: 4.75
+related:
+  - /docs/themes
+  - /docs/themes/hardline
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/darkbold/page.mdx
+++ b/website/app/docs/themes/darkbold/page.mdx
@@ -3,6 +3,11 @@ title: "DarkBold"
 description: "Pure monochrome design with Geist typography and clean minimalism"
 icon: "bold"
 order: 4.6
+related:
+  - /docs/themes
+  - /docs/customization/typography
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/darksharp/page.mdx
+++ b/website/app/docs/themes/darksharp/page.mdx
@@ -3,6 +3,11 @@ title: "Darksharp"
 description: "All-black theme with sharp corners"
 icon: "triangle"
 order: 4.2
+related:
+  - /docs/themes
+  - /docs/themes/pixel-border
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/default/page.mdx
+++ b/website/app/docs/themes/default/page.mdx
@@ -3,6 +3,11 @@ title: "Default"
 description: "Clean, neutral palette with standard border radius"
 icon: "circle"
 order: 4.1
+related:
+  - /docs/themes
+  - /docs/customization/colors
+  - /docs/customization/typography
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/greentree/page.mdx
+++ b/website/app/docs/themes/greentree/page.mdx
@@ -3,6 +3,11 @@ title: "GreenTree"
 description: "Mintlify-inspired theme with emerald green accent and Inter typography"
 icon: "treePine"
 order: 4.55
+related:
+  - /docs/themes
+  - /docs/themes/shiny
+  - /docs/customization/colors
+  - /docs/customization/typography
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/hardline/page.mdx
+++ b/website/app/docs/themes/hardline/page.mdx
@@ -3,6 +3,11 @@ title: "Hardline"
 description: "Hard-edge theme with square corners and strong borders"
 icon: "square"
 order: 4.8
+related:
+  - /docs/themes
+  - /docs/themes/concrete
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/ledger/page.mdx
+++ b/website/app/docs/themes/ledger/page.mdx
@@ -3,6 +3,11 @@ title: "Ledger"
 description: "Stripe Docs-inspired theme with tabbed navigation, blue-violet actions, and deep code panels"
 icon: "dollarSign"
 order: 4.85
+related:
+  - /docs/themes
+  - /docs/themes/threadline
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/pixel-border/page.mdx
+++ b/website/app/docs/themes/pixel-border/page.mdx
@@ -3,6 +3,11 @@ title: "Pixel Border"
 description: "Inspired by better-auth.com — refined dark UI with visible borders"
 icon: "grid2x2"
 order: 4.3
+related:
+  - /docs/themes
+  - /docs/themes/darksharp
+  - /docs/customization/colors
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/shiny/page.mdx
+++ b/website/app/docs/themes/shiny/page.mdx
@@ -3,6 +3,11 @@ title: "Shiny"
 description: "Clerk-inspired theme with purple accents and a polished light/dark design"
 icon: "sparkles"
 order: 4.5
+related:
+  - /docs/themes
+  - /docs/themes/greentree
+  - /docs/customization/colors
+  - /docs/customization/typography
 agent:
   tokenBudget: 750
 ---

--- a/website/app/docs/themes/threadline/page.mdx
+++ b/website/app/docs/themes/threadline/page.mdx
@@ -3,6 +3,11 @@ title: "Threadline"
 description: "Compact neutral theme with right-aligned page actions"
 icon: "bot"
 order: 4.75
+related:
+  - /docs/themes
+  - /docs/customization/page-actions
+  - /docs/customization/typography
+  - /docs/themes/creating-themes
 agent:
   tokenBudget: 750
 ---


### PR DESCRIPTION
## Summary

- add task-relevant `related` frontmatter to the 19 website pages that lacked it
- connect customization pages to their configuration and adjacent feature guides
- connect every built-in theme page to the theme index, customization guidance, and the closest comparable preset

## Why

Only 24 of 43 website pages exposed related-page metadata. Agents and readers landing on the remaining customization and theme pages had no structured next-step routes.

## Impact

Website related-page coverage increases from 24/43 (56%) to 43/43 (100%). All 192 configured related links resolve to existing docs routes, with no self-links or duplicates.

## Validation

- `pnpm exec docs doctor --agent --config docs.config.tsx`: 98%, 21/21 golden tasks
- direct related-route audit: 43/43 pages covered; 0 broken, self, or duplicate links
- scoped `docs review`: no related-coverage findings
- `pnpm format:check`
- `pnpm lint` (0 errors; existing warnings only)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added task‑relevant `related` frontmatter to missing docs so readers and agents get clear next steps from customization and theme pages. Coverage increases from 24/43 to 43/43 with all links resolving.

- **Bug Fixes**
  - Added `related` links to 19 pages (customization and themes), connecting to config, adjacent guides, the theme index, and comparable presets.
  - Audited 192 links: no broken, self, or duplicate links.

<sup>Written for commit e6576f13e6839da08488597df3f2a133e11135cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

