### PR TITLE
fix: improve docs review command confidence

### DIFF
--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -808,6 +808,168 @@ pnpm run test -- --filter missing-workspace
     });
   });
 
+  it("resolves named and path selectors from an enclosing package-manager workspace", () => {
+    const workspaceRoot = path.join(rootDir, "monorepo");
+    const docsRoot = path.join(workspaceRoot, "website");
+    const packageRoot = path.join(workspaceRoot, "packages", "app");
+    mkdirSync(docsRoot, { recursive: true });
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(path.join(workspaceRoot, ".git"), "gitdir: fixture\n", "utf-8");
+    writeFileSync(
+      path.join(workspaceRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - website\n  - packages/*\n",
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(docsRoot, "package.json"),
+      JSON.stringify({ name: "website", scripts: { dev: "next dev" } }),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "@acme/app", scripts: { check: "tsc --noEmit" } }),
+      "utf-8",
+    );
+
+    const report = analyzeAgentUsefulness({
+      rootDir: docsRoot,
+      pages: [
+        {
+          ...page(
+            "nested-workspace",
+            `# Workspace commands
+
+\`\`\`bash
+pnpm --filter @acme/app check
+pnpm --filter ./packages/app check
+pnpm --filter @acme/app test
+\`\`\``,
+          ),
+          actionable: false,
+        },
+      ],
+    });
+
+    expect(
+      report.findings
+        .filter((finding) => finding.code === "command-script-missing")
+        .map((finding) => finding.command),
+    ).toEqual(["pnpm --filter @acme/app test"]);
+    expect(report.findings.map((finding) => finding.code)).not.toContain("command-unverified");
+    expect(report.metrics.commands).toEqual({
+      total: 3,
+      healthy: 2,
+      unhealthy: 1,
+      unverified: 0,
+    });
+  });
+
+  it("does not resolve selectors from a workspace outside the nearest Git boundary", () => {
+    const outerRoot = path.join(rootDir, "outer");
+    const repositoryRoot = path.join(outerRoot, "repository");
+    const docsRoot = path.join(repositoryRoot, "website");
+    const unrelatedPackageRoot = path.join(outerRoot, "packages", "outside");
+    mkdirSync(docsRoot, { recursive: true });
+    mkdirSync(unrelatedPackageRoot, { recursive: true });
+    writeFileSync(
+      path.join(outerRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - repository/website\n  - packages/*\n",
+      "utf-8",
+    );
+    writeFileSync(path.join(repositoryRoot, ".git"), "gitdir: fixture\n", "utf-8");
+    writeFileSync(
+      path.join(docsRoot, "package.json"),
+      JSON.stringify({ name: "website", scripts: { dev: "next dev" } }),
+      "utf-8",
+    );
+    writeFileSync(
+      path.join(unrelatedPackageRoot, "package.json"),
+      JSON.stringify({ name: "@outside/app", scripts: { check: "tsc --noEmit" } }),
+      "utf-8",
+    );
+
+    const report = analyzeAgentUsefulness({
+      rootDir: docsRoot,
+      pages: [
+        {
+          ...page(
+            "bounded-workspace",
+            `# Workspace boundary
+
+\`\`\`bash
+pnpm --filter @outside/app check
+\`\`\``,
+          ),
+          actionable: false,
+        },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.code)).toContain("command-unverified");
+    expect(report.metrics.commands).toEqual({
+      total: 1,
+      healthy: 0,
+      unhealthy: 0,
+      unverified: 1,
+    });
+  });
+
+  it("recognizes constrained probes and agent setup commands without executing them", () => {
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        {
+          ...page(
+            "static-command-confidence",
+            `# Static command confidence
+
+\`\`\`bash
+curl -fsSL "https://docs.example.com/docs.md" -H "Accept: text/markdown"
+curl -X POST "https://docs.example.com/api/feedback" -H "content-type: application/json" -d '{"outcome":"implemented"}'
+curl "https://docs.example.com/search?q=agent&format=markdown"
+cd generated-app
+export DOCS_API_KEY=example
+test "docs" = "docs"
+echo "shell ok"
+echo "operators such as && and > stay literal when quoted"
+npx skills add farming-labs/docs
+claude mcp add-json farming-labs-docs '{"type":"http","url":"https://docs.example.com/mcp"}'
+pnpm exec docs mcp setup --deployment <id>
+curl --imaginary "https://docs.example.com"
+npx skills add not-a-repository
+npx mystery-tool run build
+claude mcp add-json farming-labs-docs '{"type":"http","url":"not-a-url"}'
+echo "first" && mystery-tool
+echo first > output.txt
+\`\`\``,
+          ),
+          actionable: false,
+        },
+      ],
+    });
+    const unverified = report.findings
+      .filter((finding) => finding.code === "command-unverified")
+      .map((finding) => finding.command);
+
+    expect(unverified).toEqual(
+      expect.arrayContaining([
+        'claude mcp add-json farming-labs-docs \'{"type":"http","url":"not-a-url"}\'',
+        'echo "first" && mystery-tool',
+        "echo first > output.txt",
+        'curl --imaginary "https://docs.example.com"',
+        "npx skills add not-a-repository",
+        "npx mystery-tool run build",
+      ]),
+    );
+    expect(unverified).toHaveLength(6);
+    expect(report.metrics.commands).toEqual({
+      total: 17,
+      healthy: 11,
+      unhealthy: 0,
+      unverified: 6,
+    });
+  });
+
   it("skips prompted console output and marks unknown command forms as unverified", () => {
     const report = analyzeAgentUsefulness({
       rootDir,

--- a/packages/docs/src/agent-usefulness.ts
+++ b/packages/docs/src/agent-usefulness.ts
@@ -424,6 +424,80 @@ const PACKAGE_MANAGER_OPTIONS_WITH_VALUES = new Set([
   "-w",
 ]);
 
+const CURL_OPTIONS_WITH_VALUES = new Set([
+  "--cacert",
+  "--cert",
+  "--connect-timeout",
+  "--data",
+  "--data-ascii",
+  "--data-binary",
+  "--data-raw",
+  "--data-urlencode",
+  "--form",
+  "--header",
+  "--json",
+  "--key",
+  "--max-time",
+  "--output",
+  "--request",
+  "--resolve",
+  "--retry",
+  "--retry-delay",
+  "--url",
+  "--user",
+  "--user-agent",
+]);
+
+const CURL_OPTIONS_WITHOUT_VALUES = new Set([
+  "--compressed",
+  "--fail",
+  "--fail-with-body",
+  "--head",
+  "--include",
+  "--insecure",
+  "--location",
+  "--show-error",
+  "--silent",
+  "--verbose",
+]);
+
+const CURL_SHORT_OPTIONS_WITH_VALUES = new Set(["A", "d", "F", "H", "o", "u", "X"]);
+const CURL_SHORT_OPTIONS_WITHOUT_VALUES = new Set(["f", "I", "i", "k", "L", "s", "S", "v"]);
+const TEST_UNARY_OPERATORS = new Set([
+  "-b",
+  "-c",
+  "-d",
+  "-e",
+  "-f",
+  "-g",
+  "-h",
+  "-L",
+  "-n",
+  "-p",
+  "-r",
+  "-S",
+  "-s",
+  "-t",
+  "-u",
+  "-w",
+  "-x",
+  "-z",
+]);
+const TEST_BINARY_OPERATORS = new Set([
+  "=",
+  "==",
+  "!=",
+  "-ef",
+  "-eq",
+  "-ge",
+  "-gt",
+  "-le",
+  "-lt",
+  "-ne",
+  "-nt",
+  "-ot",
+]);
+
 interface AgentContextScope {
   id: number;
   name: DocsAudienceMdxTag["name"];
@@ -522,7 +596,8 @@ export function analyzeAgentUsefulness(
     ...DEFAULT_DOCS_COMMANDS,
     ...(options.knownDocsCommands ?? []),
   ]);
-  const packageManifests = readProjectPackageManifests(rootDir);
+  const workspaceRoot = findEnclosingWorkspaceRoot(rootDir);
+  const packageManifests = readProjectPackageManifests(workspaceRoot);
   const pages = options.pages.map((page) => analyzePage(page));
   const findings: AgentUsefulnessFinding[] = [];
   const unhealthyCommandKeys = new Set<string>();
@@ -615,6 +690,7 @@ export function analyzeAgentUsefulness(
         packageManager,
         knownDocsCommands,
         packageManifests,
+        workspaceRoot,
       });
       if (commandAnalysis.status === "unhealthy") unhealthyCommandKeys.add(commandKey);
       if (commandAnalysis.status === "unverified") unverifiedCommandKeys.add(commandKey);
@@ -952,6 +1028,7 @@ function analyzeCommand(options: {
   packageManager?: string;
   knownDocsCommands: Set<string>;
   packageManifests: Map<string, ProjectPackageManifest>;
+  workspaceRoot: string;
 }): CommandAnalysis {
   const findings: AgentUsefulnessFinding[] = [];
   let verificationEstablished = false;
@@ -986,6 +1063,18 @@ function analyzeCommand(options: {
     return commandAnalysis(findings);
   }
 
+  if (hasUnsupportedShellControlSyntax(executableCommand)) {
+    findings.push(
+      commandFinding(options, {
+        code: "command-unverified",
+        severity: "suggestion",
+        message:
+          "Compound commands, redirections, and shell expansions are not executed or inferred; this command is unverified.",
+      }),
+    );
+    return commandAnalysis(findings);
+  }
+
   const tokens = tokenizeShellCommand(executableCommand);
   const commandPackageManager = readCommandPackageManager(tokens);
   const expectedPackageManager =
@@ -1010,6 +1099,7 @@ function analyzeCommand(options: {
     workspaceSelection,
     options.packageManifests,
     options.rootDir,
+    options.workspaceRoot,
   );
   if (workspaceResolution.status === "unresolved") {
     const selectors = workspaceSelection.selectors.length
@@ -1075,7 +1165,13 @@ function analyzeCommand(options: {
     }
   }
 
-  if (isStaticallyKnownPackageManagerCommand(tokens) || isVersionProbe(tokens)) {
+  if (
+    isStaticallyKnownPackageManagerCommand(tokens) ||
+    isVersionProbe(tokens) ||
+    isStaticallyValidCurlCommand(tokens) ||
+    isStaticallyValidShellBuiltin(tokens, resolvedCwd, options.rootDir) ||
+    isStaticallyValidAgentToolCommand(tokens)
+  ) {
     verificationEstablished = true;
   }
 
@@ -1415,8 +1511,89 @@ function detectPackageManager(rootDir: string): "npm" | "pnpm" | "yarn" | "bun" 
   return name as "npm" | "pnpm" | "yarn" | "bun" | undefined;
 }
 
+function findEnclosingWorkspaceRoot(startDir: string): string {
+  const repositoryBoundary = findNearestGitBoundary(startDir);
+  let current = startDir;
+  let traversed = 0;
+  while (true) {
+    if (
+      existsSync(path.join(current, "pnpm-workspace.yaml")) ||
+      existsSync(path.join(current, "pnpm-workspace.yml"))
+    ) {
+      return current;
+    }
+
+    const packageJson = readJsonFile(path.join(current, "package.json"));
+    const workspaces = packageJson?.workspaces;
+    if (
+      Array.isArray(workspaces) ||
+      (workspaces !== null && typeof workspaces === "object" && !Array.isArray(workspaces))
+    ) {
+      return current;
+    }
+
+    if (current === repositoryBoundary || (!repositoryBoundary && traversed >= 12)) {
+      return startDir;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return startDir;
+    current = parent;
+    traversed += 1;
+  }
+}
+
+function findNearestGitBoundary(startDir: string): string | undefined {
+  let current = startDir;
+  while (true) {
+    if (existsSync(path.join(current, ".git"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
 function normalizeShellCommand(command: string): string {
   return command.trim().replace(/^\$\s*/, "");
+}
+
+function hasUnsupportedShellControlSyntax(command: string): boolean {
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index] ?? "";
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === "<") {
+      const placeholder = /^<[A-Za-z0-9._-]+>/.exec(command.slice(index))?.[0];
+      if (placeholder) {
+        index += placeholder.length - 1;
+        continue;
+      }
+    }
+    if (
+      ["&", "|", ";", "<", ">", "`", "\n", "\r"].includes(character) ||
+      (character === "$" && command[index + 1] === "(")
+    ) {
+      return true;
+    }
+  }
+
+  return Boolean(quote || escaped);
 }
 
 function tokenizeShellCommand(command: string): string[] {
@@ -1596,10 +1773,190 @@ function isVersionProbe(tokens: string[]): boolean {
   );
 }
 
+function isStaticallyValidCurlCommand(tokens: string[]): boolean {
+  if (tokens[0] !== "curl") return false;
+  let urls = 0;
+  let parseOptions = true;
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index] ?? "";
+    if (parseOptions && token === "--") {
+      parseOptions = false;
+      continue;
+    }
+
+    if (parseOptions && token.startsWith("--")) {
+      const equalsIndex = token.indexOf("=");
+      const option = equalsIndex >= 0 ? token.slice(0, equalsIndex) : token;
+      const inlineValue = equalsIndex >= 0 ? token.slice(equalsIndex + 1) : undefined;
+      if (CURL_OPTIONS_WITHOUT_VALUES.has(option)) {
+        if (inlineValue !== undefined) return false;
+        continue;
+      }
+      if (!CURL_OPTIONS_WITH_VALUES.has(option)) return false;
+
+      const value = inlineValue ?? tokens[index + 1];
+      if (!value || (!inlineValue && value.startsWith("-"))) return false;
+      if (inlineValue === undefined) index += 1;
+      if (!isValidCurlOptionValue(option, value)) return false;
+      if (option === "--url") urls += 1;
+      continue;
+    }
+
+    if (parseOptions && token.startsWith("-") && token !== "-") {
+      const shortOptions = token.slice(1);
+      if (!shortOptions) return false;
+      let consumed = false;
+
+      for (let offset = 0; offset < shortOptions.length; offset += 1) {
+        const option = shortOptions[offset] ?? "";
+        if (CURL_SHORT_OPTIONS_WITHOUT_VALUES.has(option)) continue;
+        if (!CURL_SHORT_OPTIONS_WITH_VALUES.has(option)) return false;
+
+        const inlineValue = shortOptions.slice(offset + 1);
+        const value = inlineValue || tokens[index + 1];
+        if (!value || (!inlineValue && value.startsWith("-"))) return false;
+        if (!inlineValue) index += 1;
+        if (!isValidCurlOptionValue(`-${option}`, value)) return false;
+        consumed = true;
+        break;
+      }
+
+      if (
+        consumed ||
+        [...shortOptions].every((item) => CURL_SHORT_OPTIONS_WITHOUT_VALUES.has(item))
+      ) {
+        continue;
+      }
+      return false;
+    }
+
+    if (!isHttpUrl(token)) return false;
+    urls += 1;
+  }
+
+  return urls > 0;
+}
+
+function isValidCurlOptionValue(option: string, value: string): boolean {
+  if (option === "--url") return isHttpUrl(value);
+  if (option === "--request" || option === "-X") return /^[A-Z]+$/i.test(value);
+  if (option === "--header" || option === "-H") return /^[^:\s][^:]*:\s*.*$/.test(value);
+  if (option === "--connect-timeout" || option === "--max-time") {
+    return /^\d+(?:\.\d+)?$/.test(value);
+  }
+  if (option === "--retry" || option === "--retry-delay") return /^\d+$/.test(value);
+  return value.length > 0;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isStaticallyValidShellBuiltin(tokens: string[], cwd: string, rootDir: string): boolean {
+  const command = tokens[0];
+  const args = tokens.slice(1);
+
+  if (command === "echo") return true;
+  if (command === "printf") return args.length > 0;
+  if (command === "pwd") return args.every((argument) => argument === "-L" || argument === "-P");
+  if (command === "export" || command === "unset") {
+    if (args.length === 0) return false;
+    return args.every((argument) =>
+      command === "export"
+        ? /^[A-Za-z_][A-Za-z0-9_]*(?:=.*)?$/.test(argument)
+        : /^[A-Za-z_][A-Za-z0-9_]*$/.test(argument),
+    );
+  }
+  if (command === "test") return isValidTestExpression(args);
+  if (command === "[") return args.at(-1) === "]" && isValidTestExpression(args.slice(0, -1));
+  if (command !== "cd" || args.length !== 1) return false;
+
+  const target = args[0] ?? "";
+  if (!target || target === "-" || path.isAbsolute(target) || /[$*?[\]{}]/.test(target)) {
+    return false;
+  }
+  return isPathInside(rootDir, path.resolve(cwd, target));
+}
+
+function isValidTestExpression(args: string[]): boolean {
+  if (args[0] === "!") return args.length > 1 && isValidTestExpression(args.slice(1));
+  if (args.length === 1) return true;
+  if (args.length === 2) return TEST_UNARY_OPERATORS.has(args[0] ?? "");
+  return args.length === 3 && TEST_BINARY_OPERATORS.has(args[1] ?? "");
+}
+
+function isStaticallyValidAgentToolCommand(tokens: string[]): boolean {
+  return isStaticallyValidSkillsCommand(tokens) || isStaticallyValidClaudeMcpCommand(tokens);
+}
+
+function isStaticallyValidSkillsCommand(tokens: string[]): boolean {
+  const invocation = unwrapDownloadRunner(tokens);
+  if (!invocation || !/^skills(?:@(?:latest|\d+(?:\.\d+){0,2}))?$/.test(invocation[0] ?? "")) {
+    return false;
+  }
+  if (invocation.length !== 3 || invocation[1] !== "add") return false;
+
+  const source = invocation[2] ?? "";
+  if (/^https:\/\/(?:www\.)?github\.com\/[^/\s]+\/[^/\s]+(?:\.git)?(?:#[^\s]+)?$/.test(source)) {
+    return true;
+  }
+  return /^@?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#[A-Za-z0-9._/-]+)?$/.test(source);
+}
+
+function unwrapDownloadRunner(tokens: string[]): string[] | undefined {
+  const runner = tokens[0];
+  if (runner === "skills") return tokens;
+  if (runner === "npx" || runner === "pnpx" || runner === "bunx") return tokens.slice(1);
+  if (runner === "npm" && tokens[1] === "exec" && tokens[2] === "--") return tokens.slice(3);
+  if (
+    (runner === "pnpm" || runner === "yarn" || runner === "bun") &&
+    ["dlx", "x"].includes(tokens[1] ?? "")
+  ) {
+    return tokens.slice(2);
+  }
+  return undefined;
+}
+
+function isStaticallyValidClaudeMcpCommand(tokens: string[]): boolean {
+  if (
+    tokens.length !== 5 ||
+    tokens[0] !== "claude" ||
+    tokens[1] !== "mcp" ||
+    tokens[2] !== "add-json" ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(tokens[3] ?? "")
+  ) {
+    return false;
+  }
+
+  try {
+    const config = JSON.parse(tokens[4] ?? "") as Record<string, unknown>;
+    if (!config || typeof config !== "object" || Array.isArray(config)) return false;
+    if (config.type === "http" || config.type === "sse") {
+      return typeof config.url === "string" && isHttpUrl(config.url);
+    }
+    if (config.type !== "stdio" || typeof config.command !== "string" || !config.command.trim()) {
+      return false;
+    }
+    return (
+      config.args === undefined ||
+      (Array.isArray(config.args) && config.args.every((argument) => typeof argument === "string"))
+    );
+  } catch {
+    return false;
+  }
+}
+
 function resolveWorkspaceSelection(
   selection: WorkspaceSelection,
   manifests: Map<string, ProjectPackageManifest>,
   rootDir: string,
+  workspaceRoot: string,
 ): WorkspaceResolution {
   if (!selection.requested) return { status: "none", manifests: [] };
   if (selection.selectors.length === 0) return { status: "unresolved", manifests: [] };
@@ -1617,9 +1974,11 @@ function resolveWorkspaceSelection(
       continue;
     }
 
-    const selectorPath = path.resolve(rootDir, selector);
-    const pathManifest = [...manifests.values()].find(
-      (manifest) => path.resolve(manifest.directory) === selectorPath,
+    const selectorPaths = Array.from(
+      new Set([path.resolve(rootDir, selector), path.resolve(workspaceRoot, selector)]),
+    );
+    const pathManifest = [...manifests.values()].find((manifest) =>
+      selectorPaths.includes(path.resolve(manifest.directory)),
     );
     if (!pathManifest) return { status: "unresolved", manifests: [] };
     resolved.push(pathManifest);

--- a/skills/farming-labs/cli/SKILL.md
+++ b/skills/farming-labs/cli/SKILL.md
@@ -708,10 +708,13 @@ What it checks:
 - configured golden tasks for retrieval, citations, version selection, answers, examples, and budgets
 - generated `agent.md` freshness and `agent.compact` defaults
 
-Command checks never execute arbitrary commands from docs. Golden evaluations default to the local
-`mcp-context` surface and make no implicit model, network, or runtime-execution request. Configure
-them under `agent.evaluations.tasks`; when no tasks exist, doctor reports the suite as `unmeasured`
-and awards no usefulness credit.
+Command checks never execute arbitrary commands from docs or make network requests. They resolve
+package scripts from an enclosing workspace and statically recognize constrained `curl` probes,
+safe shell built-ins, Agent Skills installation, and Claude MCP JSON setup commands. Unknown
+binaries, unsupported options, compound shell expressions, and unresolved selectors remain
+unverified. Golden evaluations default to the local `mcp-context` surface and make no implicit
+model, network, or runtime-execution request. Configure them under `agent.evaluations.tasks`; when
+no tasks exist, doctor reports the suite as `unmeasured` and awards no usefulness credit.
 
 Use `surface: "configured-search"` to measure the actual search provider or
 `surface: "ask-ai-context"` to measure the production Ask AI context path. Non-simple search, the

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -582,10 +582,12 @@ What it checks:
 - configured golden tasks for retrieval, citations, version selection, answers, examples, and budgets
 - generated `agent.md` freshness and `agent.compact` defaults
 
-Command health is a static check: the doctor validates package-manager usage, package scripts,
-working directories, and known docs CLI commands without executing arbitrary snippets from the
-documentation. Workspace selectors that cannot be resolved safely are reported as unverified and
-do not receive healthy-command credit. Corpus checks compare every docs page, so copying the same
+Command health is a static check: the doctor validates package-manager usage, package scripts
+(including selectors resolved from an enclosing workspace), working directories, known docs CLI
+commands, constrained HTTP probes, safe shell built-ins, and supported Agent Skills or Claude MCP
+setup forms without executing arbitrary snippets or making network requests. Unknown binaries,
+unsupported options, compound shell expressions, and unresolved selectors stay unverified and do
+not receive healthy-command credit. Corpus checks compare every docs page, so copying the same
 plausible-looking Agent template onto many pages no longer increases the score.
 
 Golden tasks are configured under `agent.evaluations.tasks`. When none are configured, the doctor

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -909,10 +909,13 @@ export default defineDocs({
 
 `agentContext` is corpus-aware: it detects exact duplicates, repeated boilerplate, generic Agent
 blocks, missing prerequisites/results/recovery, and ambiguous framework or version guidance.
-`commandHealth` inspects commands without running them. `configConfidence` reports when
-`docs.config` could only be read through partial static parsing, while `agentSurfaceDrift` compares
-resolved configuration, discovery metadata, structured contracts, MCP tools, routes, and the
-public config schema. `goldenTasks` reports both failed evaluations and an unmeasured task suite.
+`commandHealth` inspects commands without running them or making network requests. It resolves
+package scripts from an enclosing workspace and recognizes constrained HTTP probes, safe shell
+built-ins, and supported Agent Skills or Claude MCP setup forms; unknown or compound commands stay
+unverified. `configConfidence` reports when `docs.config` could only be read through partial static
+parsing, while `agentSurfaceDrift` compares resolved configuration, discovery metadata, structured
+contracts, MCP tools, routes, and the public config schema. `goldenTasks` reports both failed
+evaluations and an unmeasured task suite.
 
 Set `review: false` to opt out of review and workflow generation.
 

--- a/website/app/docs/guides/adapter-agent-conformance/page.mdx
+++ b/website/app/docs/guides/adapter-agent-conformance/page.mdx
@@ -114,7 +114,6 @@ requiring the useful recovery document in either response.
 Run the relevant adapter test and core typecheck before publishing:
 
 ```bash title="terminal"
-pnpm --filter @farming-labs/docs build
-pnpm --filter @farming-labs/svelte test
+pnpm --filter @farming-labs/docs test adapter-agent-conformance.test.ts
 pnpm --filter @farming-labs/svelte typecheck
 ```


### PR DESCRIPTION
## Summary

- resolve package scripts from the nearest Git-bounded workspace when docs live in a nested app
- statically validate constrained `curl` probes, safe shell built-ins, Agent Skills installs, and Claude MCP JSON setup without executing commands or making network requests
- keep malformed options, compound shell expressions, unknown binaries, and unresolved selectors unverified
- replace the stale Svelte package test example with the real adapter-conformance test

## Why

Docs Review could verify package-manager and framework CLI commands, but it treated 31 valid website commands as unknown. It also scanned only below the docs app, so monorepo workspace selectors could not be checked and one stale script stayed hidden.

## Impact

Website command confidence improves from 262/293 healthy with 31 unverified to 292/292 healthy with no unverified or unhealthy commands. The new validators remain syntax-only and conservative.

## Validation

- 928 `@farming-labs/docs` package tests
- 36 focused agent-usefulness tests
- website analyzer: 292/292 healthy, 0 unverified, 0 unhealthy
- package typecheck
- `pnpm format:check`
- `pnpm lint` (0 errors; existing warnings only)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Docs Review command confidence by resolving workspace scripts and adding syntax-only validators for safe command forms. This converts 31 previously unverified website commands to verified, raising health from 262/293 to 292/292 without executing commands or making network requests.

- **New Features**
  - Resolve package scripts and `pnpm --filter` selectors from the nearest Git-bounded workspace; ignore selectors outside the boundary.
  - Add static validation for constrained `curl` probes, safe shell built-ins (`cd`, `echo`, `test`, `export`, `printf`, `pwd`, `unset`), Agent Skills installs (`skills`, `npx skills`), and `claude mcp add-json`.
  - Mark compound shell expressions, redirections, shell expansions, malformed options, unknown binaries, and unresolved selectors as unverified.
  - Replace the stale example with the real adapter-conformance test and update docs in `@farming-labs/docs` and `@farming-labs/svelte` pages to reflect the static checks.

<sup>Written for commit 3d031ba9b6c9158edcd079fb78bc918678e37b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

