### PR TITLE
fix: align non-Next discovery methods

### DIFF
--- a/examples/astro/src/lib/docs.server.ts
+++ b/examples/astro/src/lib/docs.server.ts
@@ -16,7 +16,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -2,10 +2,11 @@ import {
   isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
   isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
 } from "@farming-labs/docs";
 import type { MiddlewareHandler } from "astro";
 import config from "./lib/docs.config";
-import { GET, MCP } from "./lib/docs.server";
+import { GET, HEAD, POST, MCP } from "./lib/docs.server";
 
 const docsEntry = config.entry ?? "docs";
 
@@ -23,9 +24,17 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     });
   }
 
+  if (isDocsStandardsDiscoveryRequest(context.url, { apiRoute: config.cloud?.apiRoute })) {
+    if (method === "HEAD") return HEAD({ request: context.request });
+    if (method === "POST") return POST({ request: context.request });
+    return GET({ request: context.request });
+  }
+
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry)
+    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry, {
+      apiRoute: config.cloud?.apiRoute,
+    })
   ) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;
@@ -34,11 +43,14 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   if (
     (method === "GET" || method === "HEAD") &&
     isDocsPublicGetRequest(docsEntry, context.url, context.request, {
+      apiRoute: config.cloud?.apiRoute,
       sitemap: config.sitemap,
       llms: config.llmsTxt,
     })
   ) {
-    return GET({ request: context.request });
+    return method === "HEAD"
+      ? HEAD({ request: context.request })
+      : GET({ request: context.request });
   }
 
   return next();

--- a/examples/astro/src/pages/api/docs.ts
+++ b/examples/astro/src/pages/api/docs.ts
@@ -1,8 +1,12 @@
 import type { APIRoute } from "astro";
-import { GET as docsGET, POST as docsPOST } from "../../lib/docs.server";
+import { GET as docsGET, HEAD as docsHEAD, POST as docsPOST } from "../../lib/docs.server";
 
 export const GET: APIRoute = async ({ request }) => {
   return docsGET({ request });
+};
+
+export const HEAD: APIRoute = async ({ request }) => {
+  return docsHEAD({ request });
 };
 
 export const POST: APIRoute = async ({ request }) => {

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -1255,6 +1255,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | -------- | ---------------------------------------------------------- | ----------- |
 | `load`   | `({ pathname, locale? }) => Promise<DocsServerLoadResult>` | Loads docs page data and the sidebar tree for a pathname |
 | `GET`    | `({ request }) => Response`                                | Search / `llms.txt` endpoint handler |
+| `HEAD`   | `({ request }) => Promise<Response>`                       | Bodyless public-read handler |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
 
 ```ts title="src/lib/docs.server.ts"
@@ -1293,13 +1294,31 @@ function DocsIndexPage() {
 
 ```ts title="src/routes/api.docs.ts"
 import { createFileRoute } from "@tanstack/react-router";
+import { isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
+import docsConfig from "../../docs.config";
+
+async function handleUnsupportedDocsMethod(request: Request) {
+  if (
+    isDocsStandardsDiscoveryRequest(new URL(request.url), {
+      apiRoute: docsConfig.cloud?.apiRoute,
+    })
+  ) {
+    return docsServer.GET({ request });
+  }
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "GET, HEAD, POST" },
+  });
+}
 
 export const Route = createFileRoute("/api/docs")({
   server: {
     handlers: {
       GET: async ({ request }) => docsServer.GET({ request }),
+      HEAD: async ({ request }) => docsServer.HEAD({ request }),
       POST: async ({ request }) => docsServer.POST({ request }),
+      ANY: async ({ request }) => handleUnsupportedDocsMethod(request),
     },
   },
 });
@@ -1332,6 +1351,7 @@ import { createDocsServer } from "@farming-labs/svelte/server";
 | -------- | ------------------------------ | ------------------------------------------------- |
 | `load`   | `(event) => Promise<PageData>` | Layout load function (use in `+layout.server.js`) |
 | `GET`    | `(event) => Response`          | Search endpoint handler                           |
+| `HEAD`   | `(event) => Promise<Response>` | Bodyless public-read handler                      |
 | `POST`   | `(event) => Promise<Response>` | AI chat endpoint handler                          |
 
 ```ts title="src/lib/docs.server.ts"
@@ -1344,7 +1364,7 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx,svx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST } = createDocsServer({
+export const { load, GET, HEAD, POST } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });
@@ -1366,7 +1386,7 @@ Imported from `@farming-labs/svelte-theme`:
 
 ### `createDocsServer(config)`
 
-Same as SvelteKit — returns `{ load, GET, POST }`.
+Same as SvelteKit — returns `{ load, GET, HEAD, POST }`.
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -1385,6 +1405,7 @@ import { createDocsServer } from "@farming-labs/astro/server";
 | -------- | ----------------------------------------- | ----------------------------------------------------- |
 | `load`   | `(pathname: string) => Promise<PageData>` | Takes a URL pathname string, returns page data        |
 | `GET`    | `({ request }) => Response`               | Search endpoint handler for `GET /api/docs?query=...` |
+| `HEAD`   | `({ request }) => Promise<Response>`      | Bodyless public-read handler                          |
 | `POST`   | `({ request }) => Promise<Response>`      | AI chat endpoint handler with SSE streaming           |
 
 ```ts title="src/lib/docs.server.ts"
@@ -1397,7 +1418,7 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST } = createDocsServer({
+export const { load, GET, HEAD, POST } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/examples/next/app/docs/overview/agent.md
+++ b/examples/next/app/docs/overview/agent.md
@@ -1257,6 +1257,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | `GET`    | `({ request }) => Response`                                | Search / `llms.txt` endpoint handler |
 | `HEAD`   | `({ request }) => Promise<Response>`                       | Bodyless public-read handler |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
+| `MCP`    | `DocsMcpHttpHandlers`                                      | MCP HTTP transport handlers |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/tanstack-start/server";
@@ -1353,6 +1354,7 @@ import { createDocsServer } from "@farming-labs/svelte/server";
 | `GET`    | `(event) => Response`          | Search endpoint handler                           |
 | `HEAD`   | `(event) => Promise<Response>` | Bodyless public-read handler                      |
 | `POST`   | `(event) => Promise<Response>` | AI chat endpoint handler                          |
+| `MCP`    | `DocsMcpHttpHandlers`          | MCP HTTP transport handlers                       |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/svelte/server";
@@ -1364,7 +1366,7 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx,svx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, HEAD, POST } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });
@@ -1386,7 +1388,7 @@ Imported from `@farming-labs/svelte-theme`:
 
 ### `createDocsServer(config)`
 
-Same as SvelteKit — returns `{ load, GET, HEAD, POST }`.
+Same as SvelteKit — returns `{ load, GET, HEAD, POST, MCP }`.
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -1407,6 +1409,7 @@ import { createDocsServer } from "@farming-labs/astro/server";
 | `GET`    | `({ request }) => Response`               | Search endpoint handler for `GET /api/docs?query=...` |
 | `HEAD`   | `({ request }) => Promise<Response>`      | Bodyless public-read handler                          |
 | `POST`   | `({ request }) => Promise<Response>`      | AI chat endpoint handler with SSE streaming           |
+| `MCP`    | `DocsMcpHttpHandlers`                     | MCP HTTP transport handlers                           |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -1418,7 +1421,7 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, HEAD, POST } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/examples/sveltekit/src/hooks.server.js
+++ b/examples/sveltekit/src/hooks.server.js
@@ -2,9 +2,10 @@ import {
   isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
   isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
 } from "@farming-labs/docs";
 import config from "$lib/docs.config";
-import { GET, MCP } from "$lib/docs.server.js";
+import { GET, HEAD, POST, MCP } from "$lib/docs.server.js";
 
 const docsEntry = config.entry ?? "docs";
 
@@ -22,9 +23,17 @@ export async function handle({ event, resolve }) {
     });
   }
 
+  if (isDocsStandardsDiscoveryRequest(event.url, { apiRoute: config.cloud?.apiRoute })) {
+    if (method === "HEAD") return HEAD({ url: event.url, request: event.request });
+    if (method === "POST") return POST({ url: event.url, request: event.request });
+    return GET({ url: event.url, request: event.request });
+  }
+
   if (
     (method === "GET" || method === "HEAD") &&
-    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry)
+    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry, {
+      apiRoute: config.cloud?.apiRoute,
+    })
   ) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;
@@ -33,11 +42,14 @@ export async function handle({ event, resolve }) {
   if (
     (method === "GET" || method === "HEAD") &&
     isDocsPublicGetRequest(docsEntry, event.url, event.request, {
+      apiRoute: config.cloud?.apiRoute,
       sitemap: config.sitemap,
       llms: config.llmsTxt,
     })
   ) {
-    return GET({ url: event.url, request: event.request });
+    return method === "HEAD"
+      ? HEAD({ url: event.url, request: event.request })
+      : GET({ url: event.url, request: event.request });
   }
 
   return resolve(event);

--- a/examples/sveltekit/src/lib/docs.server.ts
+++ b/examples/sveltekit/src/lib/docs.server.ts
@@ -18,7 +18,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   ai: { apiKey: env.OPENAI_API_KEY, ...config.ai },
   _preloadedContent: contentFiles,

--- a/examples/sveltekit/src/routes/api/docs/+server.js
+++ b/examples/sveltekit/src/routes/api/docs/+server.js
@@ -1,1 +1,1 @@
-export { GET, POST } from "$lib/docs.server.js";
+export { GET, HEAD, POST } from "$lib/docs.server.js";

--- a/examples/tanstack-start/src/routes/$.ts
+++ b/examples/tanstack-start/src/routes/$.ts
@@ -1,5 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
+} from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
 import docsConfig from "../../docs.config";
 
@@ -20,14 +24,22 @@ async function handlePublicDocsRequest(request: Request) {
     });
   }
 
+  if (isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    if (method === "HEAD") return docsServer.HEAD({ request });
+    if (method === "POST") return docsServer.POST({ request });
+    return docsServer.GET({ request });
+  }
+
   if (
     (method === "GET" || method === "HEAD") &&
     isDocsPublicGetRequest(docsEntry, url, request, {
+      apiRoute: docsConfig.cloud?.apiRoute,
       sitemap: docsConfig.sitemap,
       llms: docsConfig.llmsTxt,
+      robots: docsConfig.robots,
     })
   ) {
-    return docsServer.GET({ request });
+    return method === "HEAD" ? docsServer.HEAD({ request }) : docsServer.GET({ request });
   }
 
   return new Response("Not Found", { status: 404 });
@@ -37,9 +49,11 @@ export const Route = createFileRoute("/$")({
   server: {
     handlers: {
       GET: async ({ request }) => handlePublicDocsRequest(request),
+      HEAD: async ({ request }) => handlePublicDocsRequest(request),
       POST: async ({ request }) => handlePublicDocsRequest(request),
       DELETE: async ({ request }) => handlePublicDocsRequest(request),
       OPTIONS: async ({ request }) => handlePublicDocsRequest(request),
+      ANY: async ({ request }) => handlePublicDocsRequest(request),
     },
   },
 });

--- a/examples/tanstack-start/src/routes/api.docs.ts
+++ b/examples/tanstack-start/src/routes/api.docs.ts
@@ -1,11 +1,26 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
+import docsConfig from "../../docs.config";
+
+async function handleUnsupportedDocsMethod(request: Request) {
+  const url = new URL(request.url);
+  if (isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    return docsServer.GET({ request });
+  }
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "GET, HEAD, POST" },
+  });
+}
 
 export const Route = createFileRoute("/api/docs")({
   server: {
     handlers: {
       GET: async ({ request }) => docsServer.GET({ request }),
+      HEAD: async ({ request }) => docsServer.HEAD({ request }),
       POST: async ({ request }) => docsServer.POST({ request }),
+      ANY: async ({ request }) => handleUnsupportedDocsMethod(request),
     },
   },
 });

--- a/examples/tanstack-start/src/routes/docs.$.tsx
+++ b/examples/tanstack-start/src/routes/docs.$.tsx
@@ -13,6 +13,11 @@ export const Route = createFileRoute("/docs/$")({
         if (isDocsPublicGetRequest("docs", url, request)) return docsServer.GET({ request });
         return undefined;
       },
+      HEAD: async ({ request }) => {
+        const url = new URL(request.url);
+        if (isDocsPublicGetRequest("docs", url, request)) return docsServer.HEAD({ request });
+        return undefined;
+      },
     },
   },
   loader: async ({ location }) => {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "rollup": "^4.59.0",
       "tar": "^7.5.19",
       "undici": "7.28.0",
+      "postcss": "8.5.15",
       "ws": "^8.21.0",
       "readdir-glob>minimatch": "^5.1.8",
       "glob@10>minimatch": "^9.0.7",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "rollup": "^4.59.0",
       "tar": "^7.5.19",
       "undici": "7.28.0",
-      "postcss": "8.5.15",
+      "postcss@<=8.5.11": "8.5.15",
       "ws": "^8.21.0",
       "readdir-glob>minimatch": "^5.1.8",
       "glob@10>minimatch": "^9.0.7",

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -45,7 +45,7 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -3,7 +3,7 @@
  *
  * `createDocsServer(config)` returns all the functions needed for
  * a complete docs site: `load` for getting page data, `GET` and `HEAD`
- * for public reads, and `POST` for AI chat.
+ * for public reads, `POST` for AI chat, and `MCP` for MCP transport.
  *
  * @example
  * ```ts
@@ -15,7 +15,7 @@
  *   query: "?raw", import: "default", eager: true,
  * }) as Record<string, string>;
  *
- * export const { load, GET, HEAD, POST } = createDocsServer({
+ * export const { load, GET, HEAD, POST, MCP } = createDocsServer({
  *   ...config,
  *   _preloadedContent: contentFiles,
  * });

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -2,8 +2,8 @@
  * Server-side helpers for Astro docs routes.
  *
  * `createDocsServer(config)` returns all the functions needed for
- * a complete docs site: `load` for getting page data, `GET` for search,
- * and `POST` for AI chat.
+ * a complete docs site: `load` for getting page data, `GET` and `HEAD`
+ * for public reads, and `POST` for AI chat.
  *
  * @example
  * ```ts
@@ -15,7 +15,7 @@
  *   query: "?raw", import: "default", eager: true,
  * }) as Record<string, string>;
  *
- * export const { load, GET, POST } = createDocsServer({
+ * export const { load, GET, HEAD, POST } = createDocsServer({
  *   ...config,
  *   _preloadedContent: contentFiles,
  * });
@@ -56,7 +56,6 @@ import {
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
   isDocsSkillRequest,
-  isDocsStandardsDiscoveryRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
   parseDocsAgentFeedbackData,
@@ -81,6 +80,7 @@ import {
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
   resolveDocsPublishedAgentSkill,
+  resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
@@ -221,6 +221,7 @@ export interface DocsServer {
     structuredData: string;
   }>;
   GET: (context: { request: Request }) => Promise<Response>;
+  HEAD: (context: { request: Request }) => Promise<Response>;
   POST: (context: { request: Request }) => Promise<Response>;
   MCP: DocsMcpHttpHandlers;
 }
@@ -603,9 +604,13 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const rootDir = path.resolve(
     ((config as Record<string, unknown>).rootDir as string | undefined) ?? process.cwd(),
   );
-  const publishedAgentSkills = Array.isArray(config._preloadedAgentSkills)
-    ? Promise.resolve(config._preloadedAgentSkills)
-    : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+  let publishedAgentSkills: ReturnType<typeof resolveConfiguredAgentSkills> | undefined;
+  function getPublishedAgentSkills() {
+    publishedAgentSkills ??= Array.isArray(config._preloadedAgentSkills)
+      ? Promise.resolve(config._preloadedAgentSkills)
+      : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+    return publishedAgentSkills;
+  }
   const i18n = resolveDocsI18n((config as Record<string, unknown>).i18n as any);
 
   const githubRaw = config.github;
@@ -988,11 +993,63 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       : null;
   }
 
+  function createDiscoveryOptions(origin: string, apiRoute: string) {
+    return {
+      origin,
+      entry,
+      apiRoute,
+      docsPath: config.docsPath,
+      apiCatalog: apiCatalogEnabled,
+      i18n,
+      search: config.search,
+      mcp: mcpConfig,
+      feedback: agentFeedbackDiscovery,
+      llms: {
+        enabled: llmsEnabled,
+        apiCatalog: apiCatalogEnabled,
+        baseUrl: llmsBaseUrl || undefined,
+        siteTitle: llmsTitle,
+        siteDescription: llmsDesc,
+        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
+        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
+      },
+      sitemap: config.sitemap,
+      robots: config.robots,
+      openapi: openapiDiscovery,
+      markdown: {
+        acceptHeader: true,
+      },
+    } as any;
+  }
+
+  async function resolveStandardsResponse(
+    request: Request,
+    url: URL,
+    discoveryOptions: ReturnType<typeof createDiscoveryOptions>,
+  ): Promise<Response | null> {
+    const resolved = resolveDocsStandardsDiscoveryRequest(url, {
+      apiRoute: discoveryOptions.apiRoute,
+    });
+    if (!resolved) return null;
+    const method = request.method.toUpperCase();
+    const needsSkill = (method === "GET" || method === "HEAD") && resolved.kind !== "api-catalog";
+
+    return createDocsStandardsDiscoveryResponse({
+      request,
+      ...discoveryOptions,
+      preferredSkillDocument: needsSkill ? readRootSkillDocument(preloaded, rootDir) : null,
+      fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
+      publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
+      agentCard: config.agent?.a2a,
+    });
+  }
+
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(context: { request: Request }): Promise<Response> {
     trackTelemetryRequest(context.request);
     const ctx = resolveContextFromRequest(context.request);
     const url = new URL(context.request.url);
+    const isHeadRequest = context.request.method.toUpperCase() === "HEAD";
     const requestApiRoute = resolveDocsRequestApiRoute(url, configuredApiRoute);
 
     if (isDocsConfigRequest(url)) {
@@ -1031,61 +1088,33 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const discoveryApiRoute = requestApiRoute;
-    const discoveryOptions = {
-      origin: url.origin,
-      entry,
-      apiRoute: discoveryApiRoute,
-      docsPath: config.docsPath,
-      apiCatalog: apiCatalogEnabled,
-      i18n,
-      search: config.search,
-      mcp: mcpConfig,
-      feedback: agentFeedbackDiscovery,
-      llms: {
-        enabled: llmsEnabled,
-        apiCatalog: apiCatalogEnabled,
-        baseUrl: llmsBaseUrl || undefined,
-        siteTitle: llmsTitle,
-        siteDescription: llmsDesc,
-        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
-        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-      },
-      sitemap: config.sitemap,
-      robots: config.robots,
-      openapi: openapiDiscovery,
-      markdown: {
-        acceptHeader: true,
-      },
-    } as any;
-    if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const standardsDiscoveryResponse = await createDocsStandardsDiscoveryResponse({
-        request: context.request,
-        ...discoveryOptions,
-        preferredSkillDocument: readRootSkillDocument(preloaded, rootDir),
-        fallbackSkillDocument: renderDocsSkillDocument(discoveryOptions),
-        publishedSkills: await publishedAgentSkills,
-        agentCard: config.agent?.a2a,
-      });
-      if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
-    }
+    const discoveryOptions = createDiscoveryOptions(url.origin, discoveryApiRoute);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      context.request,
+      url,
+      discoveryOptions,
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
       return new Response(
-        JSON.stringify(
-          buildDocsAgentDiscoverySpec({
-            ...discoveryOptions,
-            publishedSkills: [
-              await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : JSON.stringify(
+              buildDocsAgentDiscoverySpec({
+                ...discoveryOptions,
+                publishedSkills: [
+                  await resolveDocsPublishedAgentSkill({
+                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
+                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+                  }),
+                  ...(await getPublishedAgentSkills()),
+                ],
+                agentCard: config.agent?.a2a,
               }),
-              ...(await publishedAgentSkills),
-            ],
-            agentCard: config.agent?.a2a,
-          }),
-          null,
-          2,
-        ),
+              null,
+              2,
+            ),
         {
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -1103,6 +1132,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           status: 404,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      if (isHeadRequest) {
+        return new Response(null, {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
             "X-Robots-Tag": "noindex",
           },
         });
@@ -1135,13 +1174,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         });
       }
 
-      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
-        headers: {
-          "Content-Type": "application/schema+json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
-          "X-Robots-Tag": "noindex",
+      return new Response(
+        isHeadRequest ? null : JSON.stringify(agentFeedbackConfig.schema, null, 2),
+        {
+          headers: {
+            "Content-Type": "application/schema+json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
         },
-      });
+      );
     }
 
     if (
@@ -1149,7 +1191,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsAgentsFormat(url) === "agents"
     ) {
       return new Response(
-        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootAgentsDocument(preloaded, rootDir) ??
+              renderDocsAgentsDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1166,7 +1211,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsSkillFormat(url) === "skill"
     ) {
       return new Response(
-        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootSkillDocument(preloaded, rootDir) ??
+              renderDocsSkillDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1359,6 +1407,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   async function POST(context: { request: Request }): Promise<Response> {
     trackTelemetryRequest(context.request);
     const requestUrl = new URL(context.request.url);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      context.request,
+      requestUrl,
+      createDiscoveryOptions(
+        requestUrl.origin,
+        resolveDocsRequestApiRoute(requestUrl, configuredApiRoute),
+      ),
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
+
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
       if (agentFeedbackRequest.kind === "schema") {
@@ -1948,7 +2006,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           preferredDocument: readRootSkillDocument(preloaded, rootDir),
           fallbackDocument: renderDocsSkillDocument(skillOptions),
         });
-        return [rootSkill, ...(await publishedAgentSkills)];
+        return [rootSkill, ...(await getPublishedAgentSkills())];
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
@@ -1959,5 +2017,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     defaultName: mcpSiteTitle,
   });
 
-  return { load, GET, POST, MCP };
+  async function HEAD(context: { request: Request }): Promise<Response> {
+    const response = await GET(context);
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  return { load, GET, HEAD, POST, MCP };
 }

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -110,7 +110,7 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       },
     });
 
-    for (const method of ["POST", "PUT", "PATCH"]) {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
       for (const path of [
         DEFAULT_API_CATALOG_ROUTE,
         DEFAULT_AGENT_SKILLS_INDEX_ROUTE,
@@ -140,7 +140,7 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
         "/docs/page.md": "# Home\n",
       },
     });
-    for (const method of ["PUT", "PATCH"]) {
+    for (const method of ["PUT", "PATCH", "DELETE", "OPTIONS"]) {
       const url = new URL("/api/internal/docs?format=agent-skills", "https://docs.example.com");
       const response = await customRouteServer.GET({
         request: new Request(url, { method }),

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -1,9 +1,13 @@
 import { createHash } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE } from "./agent.js";
 import type { DocsAgentAdapter } from "./agent-conformance.js";
 import { runDocsAgentConformance } from "./agent-conformance.js";
-import { resolveDocsPublishedAgentSkill } from "./standards-discovery.js";
+import {
+  DEFAULT_AGENT_SKILLS_INDEX_ROUTE,
+  DEFAULT_API_CATALOG_ROUTE,
+  resolveDocsPublishedAgentSkill,
+} from "./standards-discovery.js";
 
 const adapters = [
   ["tanstack-start", "../../tanstack-start/src/server.ts"],
@@ -20,6 +24,8 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
     return (await import(moduleUrl)) as {
       createDocsServer(config: Record<string, unknown>): {
         GET(context: { request: Request; url?: URL }): Promise<Response>;
+        HEAD(context: { request: Request; url?: URL }): Promise<Response>;
+        POST(context: { request: Request; url?: URL }): Promise<Response>;
         MCP: { POST(context: { request: Request }): Promise<Response> };
       };
     };
@@ -44,6 +50,12 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       adapter,
       async handle(request, surface) {
         if (surface === "mcp") return server.MCP.POST({ request });
+        if (request.method === "HEAD") {
+          return server.HEAD({ request, url: new URL(request.url) });
+        }
+        if (request.method === "POST") {
+          return server.POST({ request, url: new URL(request.url) });
+        }
         return server.GET({ request, url: new URL(request.url) });
       },
     });
@@ -86,6 +98,136 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       name: "docs",
       digest: `sha256:${createHash("sha256").update(artifact, "utf8").digest("hex")}`,
     });
+  });
+
+  it("matches the shared discovery method contract", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
+    const server = createDocsServer({
+      entry: "docs",
+      nav: { title: "Method Contract Docs" },
+      _preloadedContent: {
+        "/docs/page.md": "# Home\n",
+      },
+    });
+
+    for (const method of ["POST", "PUT", "PATCH"]) {
+      for (const path of [
+        DEFAULT_API_CATALOG_ROUTE,
+        DEFAULT_AGENT_SKILLS_INDEX_ROUTE,
+        "/.well-known/agent-skills/docs/SKILL.md",
+        "/api/docs?format=api-catalog",
+        "/api/docs?format=agent-skills",
+        "/api/docs?format=agent-skill&name=docs",
+      ]) {
+        const url = new URL(path, "https://docs.example.com");
+        const request = new Request(url, { method });
+        const response =
+          method === "POST"
+            ? await server.POST({ request, url })
+            : await server.GET({ request, url });
+        expect(response.status, `${method} ${path}`).toBe(405);
+        expect(response.headers.get("allow"), `${method} ${path}`).toBe("GET, HEAD");
+        expect(response.headers.get("access-control-allow-origin"), `${method} ${path}`).toBe("*");
+        expect(response.headers.get("link"), `${method} ${path}`).toContain('rel="api-catalog"');
+        expect(await response.text(), `${method} ${path}`).toBe("Method Not Allowed");
+      }
+    }
+
+    const customRouteServer = createDocsServer({
+      entry: "docs",
+      cloud: { apiRoute: "/api/internal/docs" },
+      _preloadedContent: {
+        "/docs/page.md": "# Home\n",
+      },
+    });
+    for (const method of ["PUT", "PATCH"]) {
+      const url = new URL("/api/internal/docs?format=agent-skills", "https://docs.example.com");
+      const response = await customRouteServer.GET({
+        request: new Request(url, { method }),
+        url,
+      });
+      expect(response.status, `${method} custom API route`).toBe(405);
+      expect(response.headers.get("allow"), `${method} custom API route`).toBe("GET, HEAD");
+      expect(response.headers.get("link"), `${method} custom API route`).toContain(
+        'rel="api-catalog"',
+      );
+    }
+
+    for (const path of [
+      DEFAULT_API_CATALOG_ROUTE,
+      DEFAULT_AGENT_SKILLS_INDEX_ROUTE,
+      "/.well-known/agent.json",
+      "/AGENTS.md",
+      "/skill.md",
+    ]) {
+      const url = new URL(path, "https://docs.example.com");
+      const getResponse = await server.GET({ request: new Request(url), url });
+      const headResponse = await server.HEAD({
+        request: new Request(url, { method: "HEAD" }),
+        url,
+      });
+
+      expect(getResponse.status, path).toBe(200);
+      expect(await getResponse.text(), path).not.toBe("");
+      expect(headResponse.status, path).toBe(getResponse.status);
+      expect(Object.fromEntries(headResponse.headers), path).toEqual(
+        Object.fromEntries(getResponse.headers),
+      );
+      expect(await headResponse.text(), path).toBe("");
+    }
+  });
+
+  it("keeps discovery HEAD requests metadata-only", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
+    const config: Record<string, unknown> = {
+      entry: "docs",
+      agent: { skills: "must-not-resolve-for-agent-manifest-head" },
+      _preloadedContent: {
+        "/docs/page.md": "# Home\n",
+      },
+    };
+    Object.defineProperty(config, "_preloadedAgentSkills", {
+      get() {
+        throw new Error("HEAD must not resolve configured skills");
+      },
+    });
+
+    const server = createDocsServer(config);
+    const agentManifestUrl = new URL("/.well-known/agent.json", "https://docs.example.com");
+    const agentManifestResponse = await server.HEAD({
+      request: new Request(agentManifestUrl, { method: "HEAD" }),
+      url: agentManifestUrl,
+    });
+    expect(agentManifestResponse.status).toBe(200);
+    expect(await agentManifestResponse.text()).toBe("");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("HEAD must not fetch the OpenAPI document"));
+    try {
+      const openapiServer = createDocsServer({
+        entry: "docs",
+        apiReference: {
+          enabled: true,
+          specUrl: "https://must-not-fetch.example/openapi.json",
+        },
+        _preloadedContent: {
+          "/docs/page.md": "# Home\n",
+        },
+      });
+      const openapiUrl = new URL("/api/docs?format=openapi", "https://docs.example.com");
+      const openapiResponse = await openapiServer.HEAD({
+        request: new Request(openapiUrl, { method: "HEAD" }),
+        url: openapiUrl,
+      });
+
+      expect(openapiResponse.status).toBe(200);
+      expect(openapiResponse.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      expect(await openapiResponse.text()).toBe("");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("applies the same audience policy to search and agent outputs", async () => {

--- a/packages/docs/src/cli/templates.test.ts
+++ b/packages/docs/src/cli/templates.test.ts
@@ -9,7 +9,9 @@ import {
   rootLayoutTemplate,
   injectRootProviderIntoLayout,
   tanstackDocsConfigTemplate,
+  tanstackDocsCatchAllRouteTemplate,
   tanstackInstallationPageTemplate,
+  tanstackApiDocsRouteTemplate,
   tanstackApiReferenceRouteTemplate,
   tanstackDocsPublicRouteTemplate,
   tanstackRootRouteTemplate,
@@ -33,6 +35,7 @@ import {
   svelteViteConfigTemplate,
   injectDocsAgentSkillsVitePlugin,
   svelteDocsLayoutServerTemplate,
+  svelteDocsApiRouteTemplate,
   svelteDocsPublicHookTemplate,
   injectSvelteDocsPublicHook,
   svelteApiReferenceRouteTemplate,
@@ -42,6 +45,7 @@ import {
   injectAstroAgentSkillsPlugin,
   astroDocsMiddlewareTemplate,
   injectAstroDocsMiddleware,
+  astroApiRouteTemplate,
   astroApiReferenceRouteTemplate,
   nuxtServerApiReferenceRouteTemplate,
   nuxtServerDocsPublicMiddlewareTemplate,
@@ -416,6 +420,13 @@ describe("Agent Skills production bundle templates", () => {
     expect(output).toContain("_preloadedAgentSkills: bundledAgentSkills");
   });
 
+  it.each([
+    ["SvelteKit", svelteDocsServerTemplate({ ...baseConfig, framework: "sveltekit" })],
+    ["Astro", astroDocsServerTemplate({ ...baseConfig, framework: "astro" })],
+  ])("exposes the dedicated HEAD handler from the %s server", (_framework, output) => {
+    expect(output).toContain("{ load, GET, HEAD, POST, MCP }");
+  });
+
   it("wires the plugin into generated Vite, Astro, and Nitro configs", () => {
     expect(tanstackViteConfigTemplate(true)).toContain("docsAgentSkills(docsConfig)");
     expect(svelteViteConfigTemplate()).toContain("docsAgentSkills(docsConfig)");
@@ -447,6 +458,32 @@ describe("Agent Skills production bundle templates", () => {
 });
 
 describe("api reference route templates", () => {
+  it("creates a bodyless HEAD path on the specific TanStack docs route", () => {
+    const out = tanstackDocsCatchAllRouteTemplate({
+      entry: "docs",
+      filePath: "src/routes/docs.$.tsx",
+      useAlias: true,
+      projectName: "my-docs",
+    });
+
+    expect(out).toContain("HEAD: async ({ request }) =>");
+    expect(out).toContain("return docsServer.HEAD({ request })");
+    expect(out.match(/isDocsPublicGetRequest/g)).toHaveLength(3);
+  });
+
+  it("creates a method-aware TanStack docs API route", () => {
+    const out = tanstackApiDocsRouteTemplate(true, "src/routes/api.docs.ts");
+
+    expect(out).toContain("GET: async ({ request }) => docsServer.GET({ request })");
+    expect(out).toContain("HEAD: async ({ request }) => docsServer.HEAD({ request })");
+    expect(out).toContain("POST: async ({ request }) => docsServer.POST({ request })");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
+    expect(out).toContain("ANY: async ({ request }) => handleUnsupportedDocsMethod(request)");
+    expect(out).toContain('headers: { Allow: "GET, HEAD, POST" }');
+  });
+
   it("creates a TanStack API reference route handler", () => {
     const out = tanstackApiReferenceRouteTemplate({
       filePath: "src/routes/api-reference.index.ts",
@@ -467,15 +504,27 @@ describe("api reference route templates", () => {
     const out = tanstackDocsPublicRouteTemplate(useAlias, "src/routes/$.ts", "docs");
     expect(out).toContain('createFileRoute("/$")');
     expect(out).toContain("isDocsPublicGetRequest");
+    expect(out).toContain("isDocsStandardsDiscoveryRequest");
     expect(out).toContain("isDocsMcpRequest");
     expect(out).toContain("isDocsMcpRequest(url, docsConfig.mcp)");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
+    expect(out).toContain(
+      "isDocsPublicGetRequest(docsEntry, url, request, { apiRoute: docsConfig.cloud?.apiRoute",
+    );
     expect(out).toContain(serverImport);
     expect(out).toContain('import docsConfig from "../../docs.config";');
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).toContain("llms: docsConfig.llmsTxt");
     expect(out).toContain("robots: docsConfig.robots");
     expect(out).toContain("docsServer.MCP.OPTIONS");
+    expect(out).toContain('if (method === "HEAD") return docsServer.HEAD({ request })');
+    expect(out).toContain('if (method === "POST") return docsServer.POST({ request })');
+    expect(out).toContain('(method === "GET" || method === "HEAD") && isDocsPublicGetRequest');
+    expect(out).toContain("HEAD: async ({ request }) => handlePublicDocsRequest(request)");
     expect(out).toContain("OPTIONS: async");
+    expect(out).toContain("ANY: async ({ request }) => handlePublicDocsRequest(request)");
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE, OPTIONS"');
   });
 
@@ -485,15 +534,32 @@ describe("api reference route templates", () => {
     expect(out).toContain('import config from "$lib/docs.config"');
   });
 
+  it("creates a method-aware SvelteKit docs API route", () => {
+    const out = svelteDocsApiRouteTemplate("src/routes/api/docs/+server.ts", true);
+
+    expect(out).toContain("export { GET, HEAD, POST }");
+  });
+
   it("creates a SvelteKit public docs hook", () => {
     const out = svelteDocsPublicHookTemplate("src/hooks.server.ts", false);
     expect(out).toContain("export const handle");
     expect(out).toContain("isDocsLlmsTxtPublicRequest");
     expect(out).toContain("const nativeResponse = await resolve(event)");
     expect(out).toContain("isDocsPublicGetRequest");
+    expect(out).toContain("isDocsStandardsDiscoveryRequest");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(event.url, { apiRoute: config.cloud?.apiRoute })",
+    );
+    expect(out).toContain(
+      "isDocsPublicGetRequest(docsEntry, event.url, event.request, { apiRoute: config.cloud?.apiRoute",
+    );
     expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
     expect(out).toContain("MCP.OPTIONS");
+    expect(out).toContain("import { GET, HEAD, POST, MCP }");
+    expect(out).toContain('if (method === "HEAD") return HEAD(');
+    expect(out).toContain('if (method === "POST") return POST(');
+    expect(out).toContain('(method === "GET" || method === "HEAD") && isDocsPublicGetRequest');
     expect(out).toContain("isDocsMcpRequest(event.url, config.mcp)");
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE, OPTIONS"');
   });
@@ -515,8 +581,22 @@ export const handle: Handle = async ({ event, resolve }) => {
     expect(out).toContain("const existingHandle: Handle =");
     expect(out).toContain("const docsPublicHandle: Handle =");
     expect(out).toContain("docsMCP.OPTIONS");
+    expect(out).toContain("isDocsStandardsDiscoveryRequest");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(event.url, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
+    expect(out).toContain(
+      "isDocsPublicGetRequest(docsEntry, event.url, event.request, { apiRoute: docsConfig.cloud?.apiRoute",
+    );
+    expect(out).toContain("HEAD as docsHEAD");
+    expect(out).toContain("POST as docsPOST");
+    expect(out).toContain('if (method === "HEAD") return docsHEAD(');
+    expect(out).toContain('if (method === "POST") return docsPOST(');
+    expect(out).toContain('(method === "GET" || method === "HEAD") && isDocsPublicGetRequest');
     expect(out).toContain("isDocsMcpRequest(event.url, docsConfig.mcp)");
-    expect(out).toContain("isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry)");
+    expect(out).toContain(
+      "isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain("export const handle = sequence(docsPublicHandle, existingHandle);");
@@ -528,15 +608,34 @@ export const handle: Handle = async ({ event, resolve }) => {
     expect(out).toContain('import config from "../../lib/docs.config"');
   });
 
+  it("creates a method-aware Astro docs API route", () => {
+    const out = astroApiRouteTemplate({ ...baseConfig, framework: "astro" });
+
+    expect(out).toContain("HEAD as docsHEAD");
+    expect(out).toContain("export const HEAD: APIRoute");
+    expect(out).toContain("return docsHEAD({ request })");
+  });
+
   it("creates an Astro public docs middleware", () => {
     const out = astroDocsMiddlewareTemplate("src/middleware.ts", false);
     expect(out).toContain("export const onRequest");
     expect(out).toContain("isDocsLlmsTxtPublicRequest");
     expect(out).toContain("const nativeResponse = await next()");
     expect(out).toContain("isDocsPublicGetRequest");
+    expect(out).toContain("isDocsStandardsDiscoveryRequest");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(context.url, { apiRoute: config.cloud?.apiRoute })",
+    );
+    expect(out).toContain(
+      "isDocsPublicGetRequest(docsEntry, context.url, context.request, { apiRoute: config.cloud?.apiRoute",
+    );
     expect(out).toContain("sitemap: config.sitemap");
     expect(out).toContain('from "./lib/docs.server"');
     expect(out).toContain("MCP.OPTIONS");
+    expect(out).toContain("import { GET, HEAD, POST, MCP }");
+    expect(out).toContain('if (method === "HEAD") return HEAD(');
+    expect(out).toContain('if (method === "POST") return POST(');
+    expect(out).toContain('(method === "GET" || method === "HEAD") && isDocsPublicGetRequest');
     expect(out).toContain("isDocsMcpRequest(context.url, config.mcp)");
     expect(out).toContain('Allow: "GET, HEAD, POST, DELETE, OPTIONS"');
   });
@@ -558,8 +657,22 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     expect(out).toContain("const existingOnRequest: MiddlewareHandler =");
     expect(out).toContain("const docsPublicMiddleware: MiddlewareHandler =");
     expect(out).toContain("docsMCP.OPTIONS");
+    expect(out).toContain("isDocsStandardsDiscoveryRequest");
+    expect(out).toContain(
+      "isDocsStandardsDiscoveryRequest(context.url, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
+    expect(out).toContain(
+      "isDocsPublicGetRequest(docsEntry, context.url, context.request, { apiRoute: docsConfig.cloud?.apiRoute",
+    );
+    expect(out).toContain("HEAD as docsHEAD");
+    expect(out).toContain("POST as docsPOST");
+    expect(out).toContain('if (method === "HEAD") return docsHEAD(');
+    expect(out).toContain('if (method === "POST") return docsPOST(');
+    expect(out).toContain('(method === "GET" || method === "HEAD") && isDocsPublicGetRequest');
     expect(out).toContain("isDocsMcpRequest(context.url, docsConfig.mcp)");
-    expect(out).toContain("isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry)");
+    expect(out).toContain(
+      "isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry, { apiRoute: docsConfig.cloud?.apiRoute })",
+    );
     expect(out).toContain("sitemap: docsConfig.sitemap");
     expect(out).not.toContain("sitemap: config.sitemap");
     expect(out).toContain(

--- a/packages/docs/src/cli/templates.ts
+++ b/packages/docs/src/cli/templates.ts
@@ -1106,6 +1106,13 @@ export const Route = createFileRoute("${entryUrl}/$")({
         }
         return undefined;
       },
+      HEAD: async ({ request }) => {
+        const url = new URL(request.url);
+        if (isDocsPublicGetRequest(${JSON.stringify(opts.entry)}, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
+          return docsServer.HEAD({ request });
+        }
+        return undefined;
+      },
     },
   },
   loader: async ({ location }) => {
@@ -1148,16 +1155,32 @@ export function tanstackApiDocsRouteTemplate(useAlias: boolean, filePath: string
   const serverImport = useAlias
     ? "@/lib/docs.server"
     : relativeImport(filePath, "src/lib/docs.server.ts");
+  const configImport = tanstackDocsConfigImport(filePath);
 
   return `\
 import { createFileRoute } from "@tanstack/react-router";
+import { isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import { docsServer } from "${serverImport}";
+import docsConfig from "${configImport}";
+
+async function handleUnsupportedDocsMethod(request: Request) {
+  const url = new URL(request.url);
+  if (isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    return docsServer.GET({ request });
+  }
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "GET, HEAD, POST" },
+  });
+}
 
 export const Route = createFileRoute("/api/docs")({
   server: {
     handlers: {
       GET: async ({ request }) => docsServer.GET({ request }),
+      HEAD: async ({ request }) => docsServer.HEAD({ request }),
       POST: async ({ request }) => docsServer.POST({ request }),
+      ANY: async ({ request }) => handleUnsupportedDocsMethod(request),
     },
   },
 });
@@ -1175,7 +1198,7 @@ export function tanstackDocsPublicRouteTemplate(
 
   return `\
 import { createFileRoute } from "@tanstack/react-router";
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsMcpRequest, isDocsPublicGetRequest, isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import { docsServer } from "${serverImport}";
 import docsConfig from "${tanstackDocsConfigImport(filePath)}";
 
@@ -1196,8 +1219,14 @@ async function handlePublicDocsRequest(request: Request) {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
+  if (isDocsStandardsDiscoveryRequest(url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    if (method === "HEAD") return docsServer.HEAD({ request });
+    if (method === "POST") return docsServer.POST({ request });
     return docsServer.GET({ request });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, url, request, { apiRoute: docsConfig.cloud?.apiRoute, sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
+    return method === "HEAD" ? docsServer.HEAD({ request }) : docsServer.GET({ request });
   }
 
   return new Response("Not Found", { status: 404 });
@@ -1207,9 +1236,11 @@ export const Route = createFileRoute("/$")({
   server: {
     handlers: {
       GET: async ({ request }) => handlePublicDocsRequest(request),
+      HEAD: async ({ request }) => handlePublicDocsRequest(request),
       POST: async ({ request }) => handlePublicDocsRequest(request),
       DELETE: async ({ request }) => handlePublicDocsRequest(request),
       OPTIONS: async ({ request }) => handlePublicDocsRequest(request),
+      ANY: async ({ request }) => handlePublicDocsRequest(request),
     },
   },
 });
@@ -1629,7 +1660,7 @@ const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx,svx}", "
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
   _preloadedAgentSkills: bundledAgentSkills,
@@ -1691,7 +1722,7 @@ export function svelteDocsApiRouteTemplate(filePath: string, useAlias: boolean):
   const serverImport = svelteRouteServerImport(filePath, useAlias);
 
   return `\
-export { GET, POST } from "${serverImport}";
+export { GET, HEAD, POST } from "${serverImport}";
 `;
 }
 
@@ -1700,10 +1731,10 @@ export function svelteDocsPublicHookTemplate(filePath: string, useAlias: boolean
   const configImport = svelteRouteConfigImport(filePath, useAlias);
 
   return `\
-import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest, isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import type { Handle } from "@sveltejs/kit";
 import config from "${configImport}";
-import { GET, MCP } from "${serverImport}";
+import { GET, HEAD, POST, MCP } from "${serverImport}";
 
 const docsEntry = config.entry ?? "docs";
 
@@ -1721,13 +1752,21 @@ export const handle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry)) {
+  if (isDocsStandardsDiscoveryRequest(event.url, { apiRoute: config.cloud?.apiRoute })) {
+    if (method === "HEAD") return HEAD({ url: event.url, request: event.request });
+    if (method === "POST") return POST({ url: event.url, request: event.request });
+    return GET({ url: event.url, request: event.request });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry, { apiRoute: config.cloud?.apiRoute })) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
-    return GET({ url: event.url, request: event.request });
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { apiRoute: config.cloud?.apiRoute, sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
+    return method === "HEAD"
+      ? HEAD({ url: event.url, request: event.request })
+      : GET({ url: event.url, request: event.request });
   }
 
   return resolve(event);
@@ -1766,13 +1805,13 @@ export function injectSvelteDocsPublicHook(
   }
 
   const imports = [
-    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
+    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest, isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";',
     ...(next.includes("Handle") ? [] : ['import type { Handle } from "@sveltejs/kit";']),
     ...(hasExistingHandle && !next.includes("sequence")
       ? ['import { sequence } from "@sveltejs/kit/hooks";']
       : []),
     `import docsConfig from "${configImport}";`,
-    `import { GET as docsGET, MCP as docsMCP } from "${serverImport}";`,
+    `import { GET as docsGET, HEAD as docsHEAD, POST as docsPOST, MCP as docsMCP } from "${serverImport}";`,
   ];
 
   const docsHandle = `\
@@ -1792,13 +1831,21 @@ const docsPublicHandle: Handle = async ({ event, resolve }) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry)) {
+  if (isDocsStandardsDiscoveryRequest(event.url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    if (method === "HEAD") return docsHEAD({ url: event.url, request: event.request });
+    if (method === "POST") return docsPOST({ url: event.url, request: event.request });
+    return docsGET({ url: event.url, request: event.request });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(event.url, docsConfig.llmsTxt, docsEntry, { apiRoute: docsConfig.cloud?.apiRoute })) {
     const nativeResponse = await resolve(event);
     if (nativeResponse.status !== 404) return nativeResponse;
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
-    return docsGET({ url: event.url, request: event.request });
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, event.url, event.request, { apiRoute: docsConfig.cloud?.apiRoute, sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
+    return method === "HEAD"
+      ? docsHEAD({ url: event.url, request: event.request })
+      : docsGET({ url: event.url, request: event.request });
   }
 
   return resolve(event);
@@ -2131,7 +2178,7 @@ const contentFiles = import.meta.glob(["/${contentDirName}/**/*.{md,mdx}", "/AGE
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
   _preloadedAgentSkills: bundledAgentSkills,
@@ -2267,10 +2314,14 @@ export function astroApiRouteTemplate(cfg: TemplateConfig): string {
   const serverImport = astroPageServerImport(cfg.useAlias, 2);
   return `\
 import type { APIRoute } from "astro";
-import { GET as docsGET, POST as docsPOST } from "${serverImport}";
+import { GET as docsGET, HEAD as docsHEAD, POST as docsPOST } from "${serverImport}";
 
 export const GET: APIRoute = async ({ request }) => {
   return docsGET({ request });
+};
+
+export const HEAD: APIRoute = async ({ request }) => {
+  return docsHEAD({ request });
 };
 
 export const POST: APIRoute = async ({ request }) => {
@@ -2284,10 +2335,10 @@ export function astroDocsMiddlewareTemplate(filePath: string, useAlias: boolean)
   const configImport = astroRouteConfigImport(filePath, useAlias);
 
   return `\
-import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest, isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import type { MiddlewareHandler } from "astro";
 import config from "${configImport}";
-import { GET, MCP } from "${serverImport}";
+import { GET, HEAD, POST, MCP } from "${serverImport}";
 
 const docsEntry = config.entry ?? "docs";
 
@@ -2305,13 +2356,21 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry)) {
+  if (isDocsStandardsDiscoveryRequest(context.url, { apiRoute: config.cloud?.apiRoute })) {
+    if (method === "HEAD") return HEAD({ request: context.request });
+    if (method === "POST") return POST({ request: context.request });
+    return GET({ request: context.request });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry, { apiRoute: config.cloud?.apiRoute })) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
-    return GET({ request: context.request });
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { apiRoute: config.cloud?.apiRoute, sitemap: config.sitemap, llms: config.llmsTxt, robots: config.robots })) {
+    return method === "HEAD"
+      ? HEAD({ request: context.request })
+      : GET({ request: context.request });
   }
 
   return next();
@@ -2350,7 +2409,7 @@ export function injectAstroDocsMiddleware(
   }
 
   const imports = [
-    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";',
+    'import { isDocsLlmsTxtPublicRequest, isDocsMcpRequest, isDocsPublicGetRequest, isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";',
     ...(next.includes("MiddlewareHandler")
       ? []
       : ['import type { MiddlewareHandler } from "astro";']),
@@ -2358,7 +2417,7 @@ export function injectAstroDocsMiddleware(
       ? ['import { sequence } from "astro:middleware";']
       : []),
     `import docsConfig from "${configImport}";`,
-    `import { GET as docsGET, MCP as docsMCP } from "${serverImport}";`,
+    `import { GET as docsGET, HEAD as docsHEAD, POST as docsPOST, MCP as docsMCP } from "${serverImport}";`,
   ];
 
   const docsMiddleware = `\
@@ -2378,13 +2437,21 @@ const docsPublicMiddleware: MiddlewareHandler = async (context, next) => {
     });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry)) {
+  if (isDocsStandardsDiscoveryRequest(context.url, { apiRoute: docsConfig.cloud?.apiRoute })) {
+    if (method === "HEAD") return docsHEAD({ request: context.request });
+    if (method === "POST") return docsPOST({ request: context.request });
+    return docsGET({ request: context.request });
+  }
+
+  if ((method === "GET" || method === "HEAD") && isDocsLlmsTxtPublicRequest(context.url, docsConfig.llmsTxt, docsEntry, { apiRoute: docsConfig.cloud?.apiRoute })) {
     const nativeResponse = await next();
     if (nativeResponse.status !== 404) return nativeResponse;
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
-    return docsGET({ request: context.request });
+  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest(docsEntry, context.url, context.request, { apiRoute: docsConfig.cloud?.apiRoute, sitemap: docsConfig.sitemap, llms: docsConfig.llmsTxt, robots: docsConfig.robots })) {
+    return method === "HEAD"
+      ? docsHEAD({ request: context.request })
+      : docsGET({ request: context.request });
   }
 
   return next();

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -46,7 +46,6 @@ import {
   isDocsAgentsRequest,
   isDocsDiagnosticsRequest,
   isDocsSkillRequest,
-  isDocsStandardsDiscoveryRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
   parseDocsAgentFeedbackData,
@@ -71,6 +70,7 @@ import {
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
   resolveDocsPublishedAgentSkill,
+  resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
@@ -209,6 +209,7 @@ export interface DocsServer {
     structuredData: string;
   }>;
   GET: (context: { request: Request }) => Promise<Response>;
+  HEAD: (context: { request: Request }) => Promise<Response>;
   POST: (context: { request: Request }) => Promise<Response>;
   MCP: DocsMcpHttpHandlers;
 }
@@ -591,9 +592,13 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const rootDir = path.resolve(
     ((config as Record<string, unknown>).rootDir as string | undefined) ?? process.cwd(),
   );
-  const publishedAgentSkills = Array.isArray(config._preloadedAgentSkills)
-    ? Promise.resolve(config._preloadedAgentSkills)
-    : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+  let publishedAgentSkills: ReturnType<typeof resolveConfiguredAgentSkills> | undefined;
+  function getPublishedAgentSkills() {
+    publishedAgentSkills ??= Array.isArray(config._preloadedAgentSkills)
+      ? Promise.resolve(config._preloadedAgentSkills)
+      : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+    return publishedAgentSkills;
+  }
   const i18n = resolveDocsI18n((config as Record<string, unknown>).i18n as any);
 
   const githubRaw = config.github;
@@ -978,11 +983,63 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       : null;
   }
 
+  function createDiscoveryOptions(origin: string, apiRoute: string) {
+    return {
+      origin,
+      entry,
+      apiRoute,
+      docsPath: config.docsPath,
+      apiCatalog: apiCatalogEnabled,
+      i18n,
+      search: config.search,
+      mcp: mcpConfig,
+      feedback: agentFeedbackDiscovery,
+      llms: {
+        enabled: llmsEnabled,
+        apiCatalog: apiCatalogEnabled,
+        baseUrl: llmsBaseUrl || undefined,
+        siteTitle: llmsTitle,
+        siteDescription: llmsDesc,
+        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
+        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
+      },
+      sitemap: config.sitemap,
+      robots: config.robots,
+      openapi: openapiDiscovery,
+      markdown: {
+        acceptHeader: true,
+      },
+    } as any;
+  }
+
+  async function resolveStandardsResponse(
+    request: Request,
+    url: URL,
+    discoveryOptions: ReturnType<typeof createDiscoveryOptions>,
+  ): Promise<Response | null> {
+    const resolved = resolveDocsStandardsDiscoveryRequest(url, {
+      apiRoute: discoveryOptions.apiRoute,
+    });
+    if (!resolved) return null;
+    const method = request.method.toUpperCase();
+    const needsSkill = (method === "GET" || method === "HEAD") && resolved.kind !== "api-catalog";
+
+    return createDocsStandardsDiscoveryResponse({
+      request,
+      ...discoveryOptions,
+      preferredSkillDocument: needsSkill ? readRootSkillDocument(preloaded, rootDir) : null,
+      fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
+      publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
+      agentCard: config.agent?.a2a,
+    });
+  }
+
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(context: { request: Request }): Promise<Response> {
     trackTelemetryRequest(context.request);
     const ctx = resolveContextFromRequest(context.request);
     const url = new URL(context.request.url);
+    const isHeadRequest = context.request.method.toUpperCase() === "HEAD";
     const requestApiRoute = resolveDocsRequestApiRoute(url, configuredApiRoute);
 
     if (isDocsConfigRequest(url)) {
@@ -1021,61 +1078,33 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const discoveryApiRoute = requestApiRoute;
-    const discoveryOptions = {
-      origin: url.origin,
-      entry,
-      apiRoute: discoveryApiRoute,
-      docsPath: config.docsPath,
-      apiCatalog: apiCatalogEnabled,
-      i18n,
-      search: config.search,
-      mcp: mcpConfig,
-      feedback: agentFeedbackDiscovery,
-      llms: {
-        enabled: llmsEnabled,
-        apiCatalog: apiCatalogEnabled,
-        baseUrl: llmsBaseUrl || undefined,
-        siteTitle: llmsTitle,
-        siteDescription: llmsDesc,
-        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
-        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-      },
-      sitemap: config.sitemap,
-      robots: config.robots,
-      openapi: openapiDiscovery,
-      markdown: {
-        acceptHeader: true,
-      },
-    } as any;
-    if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const standardsDiscoveryResponse = await createDocsStandardsDiscoveryResponse({
-        request: context.request,
-        ...discoveryOptions,
-        preferredSkillDocument: readRootSkillDocument(preloaded, rootDir),
-        fallbackSkillDocument: renderDocsSkillDocument(discoveryOptions),
-        publishedSkills: await publishedAgentSkills,
-        agentCard: config.agent?.a2a,
-      });
-      if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
-    }
+    const discoveryOptions = createDiscoveryOptions(url.origin, discoveryApiRoute);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      context.request,
+      url,
+      discoveryOptions,
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
       return new Response(
-        JSON.stringify(
-          buildDocsAgentDiscoverySpec({
-            ...discoveryOptions,
-            publishedSkills: [
-              await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : JSON.stringify(
+              buildDocsAgentDiscoverySpec({
+                ...discoveryOptions,
+                publishedSkills: [
+                  await resolveDocsPublishedAgentSkill({
+                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
+                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+                  }),
+                  ...(await getPublishedAgentSkills()),
+                ],
+                agentCard: config.agent?.a2a,
               }),
-              ...(await publishedAgentSkills),
-            ],
-            agentCard: config.agent?.a2a,
-          }),
-          null,
-          2,
-        ),
+              null,
+              2,
+            ),
         {
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -1093,6 +1122,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           status: 404,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      if (isHeadRequest) {
+        return new Response(null, {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
             "X-Robots-Tag": "noindex",
           },
         });
@@ -1125,13 +1164,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         });
       }
 
-      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
-        headers: {
-          "Content-Type": "application/schema+json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
-          "X-Robots-Tag": "noindex",
+      return new Response(
+        isHeadRequest ? null : JSON.stringify(agentFeedbackConfig.schema, null, 2),
+        {
+          headers: {
+            "Content-Type": "application/schema+json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
         },
-      });
+      );
     }
 
     if (
@@ -1139,7 +1181,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsAgentsFormat(url) === "agents"
     ) {
       return new Response(
-        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootAgentsDocument(preloaded, rootDir) ??
+              renderDocsAgentsDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1156,7 +1201,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsSkillFormat(url) === "skill"
     ) {
       return new Response(
-        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootSkillDocument(preloaded, rootDir) ??
+              renderDocsSkillDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1349,6 +1397,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   async function POST(context: { request: Request }): Promise<Response> {
     trackTelemetryRequest(context.request);
     const requestUrl = new URL(context.request.url);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      context.request,
+      requestUrl,
+      createDiscoveryOptions(
+        requestUrl.origin,
+        resolveDocsRequestApiRoute(requestUrl, configuredApiRoute),
+      ),
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
+
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
       if (agentFeedbackRequest.kind === "schema") {
@@ -1936,7 +1994,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           preferredDocument: readRootSkillDocument(preloaded, rootDir),
           fallbackDocument: renderDocsSkillDocument(skillOptions),
         });
-        return [rootSkill, ...(await publishedAgentSkills)];
+        return [rootSkill, ...(await getPublishedAgentSkills())];
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
@@ -1947,7 +2005,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     defaultName: mcpSiteTitle,
   });
 
-  return { load, GET, POST, MCP };
+  async function HEAD(context: { request: Request }): Promise<Response> {
+    const response = await GET(context);
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  return { load, GET, HEAD, POST, MCP };
 }
 
 // ─── Nuxt event handler helper ───────────────────────────────
@@ -1984,9 +2051,9 @@ export function defineDocsHandler(config: Record<string, any>, storage: DocsStor
 
     const method = (event.method ?? event.node?.req?.method ?? "GET").toUpperCase();
     const headers = event.headers ?? event.node?.req?.headers ?? {};
+    const reqUrl = new URL(event.node?.req?.url ?? "/", "http://localhost");
 
     if (method === "POST") {
-      const url = new URL(event.node.req.url ?? "/", "http://localhost");
       let body: string | undefined;
       try {
         body = await new Promise<string>((resolve, reject) => {
@@ -1999,26 +2066,27 @@ export function defineDocsHandler(config: Record<string, any>, storage: DocsStor
         /* empty */
       }
       return server.POST({
-        request: new Request(url.href, { method: "POST", headers, body }),
+        request: new Request(reqUrl.href, { method, headers, body }),
       });
     }
 
-    const reqUrl = new URL(event.node.req.url ?? "/", "http://localhost");
     const pathname = reqUrl.searchParams.get("pathname");
-    if (pathname) {
+    if (method === "GET" && pathname) {
       return server.load(pathname);
     }
 
-    const response = await server.GET({
-      request: new Request(reqUrl.href, { method: method === "HEAD" ? "HEAD" : "GET", headers }),
-    });
-    if (method !== "HEAD") return response;
+    if (method === "GET" || method === "HEAD") {
+      const request = new Request(reqUrl.href, { method, headers });
+      return method === "HEAD" ? server.HEAD({ request }) : server.GET({ request });
+    }
 
-    return new Response(null, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
+    const discoveryApiRoute = resolveDocsRequestApiRoute(reqUrl, config.cloud?.apiRoute);
+    if (resolveDocsStandardsDiscoveryRequest(reqUrl, { apiRoute: discoveryApiRoute })) {
+      const request = createUnsupportedMethodRequest(reqUrl, method, headers);
+      return server.GET({ request });
+    }
+
+    return methodNotAllowedResponse("GET, HEAD, POST");
   });
 }
 
@@ -2099,10 +2167,21 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
       return methodNotAllowedResponse();
     }
 
+    const discoveryApiRoute = resolveDocsRequestApiRoute(url, config.cloud?.apiRoute);
+    if (resolveDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
+      const server = await getServer();
+      const request = createUnsupportedMethodRequest(url, method, headers);
+      if (method === "POST") return server.POST({ request });
+      if (method === "HEAD") return server.HEAD({ request });
+      return server.GET({ request });
+    }
+
     if (method === "GET" || method === "HEAD") {
       const request = new Request(url.href, { method, headers });
       if (
-        isDocsLlmsTxtPublicRequest(url, config.llmsTxt, entry) &&
+        isDocsLlmsTxtPublicRequest(url, config.llmsTxt, entry, {
+          apiRoute: discoveryApiRoute,
+        }) &&
         hasNativeNuxtPublicFile(url.pathname)
       ) {
         return undefined;
@@ -2110,6 +2189,7 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
 
       if (
         !isDocsPublicGetRequest(entry, url, request, {
+          apiRoute: discoveryApiRoute,
           sitemap: config.sitemap,
           llms: config.llmsTxt,
           robots: config.robots,
@@ -2119,11 +2199,14 @@ export function defineDocsPublicHandler(config: Record<string, any>, storage: Do
       }
 
       const server = await getServer();
-      return server.GET({
-        request,
-      });
+      return method === "HEAD" ? server.HEAD({ request }) : server.GET({ request });
     }
   });
+}
+
+function createUnsupportedMethodRequest(url: URL, method: string, headers: any): Request {
+  const requestMethod = /^(?:CONNECT|TRACE|TRACK)$/i.test(method) ? "PUT" : method;
+  return new Request(url.href, { method: requestMethod, headers });
 }
 
 function hasNativeNuxtPublicFile(pathname: string): boolean {
@@ -2147,11 +2230,11 @@ function hasNativeNuxtPublicFile(pathname: string): boolean {
   });
 }
 
-function methodNotAllowedResponse() {
+function methodNotAllowedResponse(allow = "GET, HEAD, POST, DELETE, OPTIONS") {
   return new Response("Method Not Allowed", {
     status: 405,
     headers: {
-      Allow: "GET, HEAD, POST, DELETE, OPTIONS",
+      Allow: allow,
       "Content-Type": "text/plain; charset=utf-8",
     },
   });

--- a/packages/nuxt/test/server.test.ts
+++ b/packages/nuxt/test/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defineDocsHandler } from "../src/server.js";
+import { defineDocsHandler, defineDocsPublicHandler } from "../src/server.js";
 
 const storage = () => ({
   getKeys: async () => [],
@@ -82,5 +82,78 @@ describe("defineDocsHandler discovery requests", () => {
     expect(response.status).toBe(200);
     expect(llms).toContain("/api/internal/docs?format=openapi");
     expect(llms).not.toContain("/api/docs?format=openapi");
+  });
+
+  it("rejects unsupported discovery methods without coercing them to GET", async () => {
+    const handler = defineDocsHandler({ entry: "docs", title: "Example Docs" }, storage);
+
+    for (const method of ["POST", "PUT", "TRACE", "CONNECT"]) {
+      const response = await handler(createEvent(method, "/api/docs?format=agent-skills"));
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(405);
+      expect(response.headers.get("allow")).toBe("GET, HEAD");
+      expect(await response.text()).toBe("Method Not Allowed");
+    }
+
+    const unrelated = await handler(createEvent("PUT", "/api/docs?query=docs"));
+    expect(unrelated.status).toBe(405);
+    expect(unrelated.headers.get("allow")).toBe("GET, HEAD, POST");
+
+    const forbiddenMethod = await handler(createEvent("TRACE", "/api/docs?query=docs"));
+    expect(forbiddenMethod.status).toBe(405);
+    expect(forbiddenMethod.headers.get("allow")).toBe("GET, HEAD, POST");
+  });
+});
+
+describe("defineDocsPublicHandler discovery requests", () => {
+  it("uses bodyless HEAD and shared method rejection for public discovery", async () => {
+    const handler = defineDocsPublicHandler({ entry: "docs", title: "Example Docs" }, storage);
+
+    for (const url of [
+      "/.well-known/api-catalog",
+      "/.well-known/agent-skills/index.json",
+      "/.well-known/agent.json",
+      "/AGENTS.md",
+      "/skill.md",
+    ]) {
+      const response = await handler(createEvent("HEAD", url));
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status, `${url} should resolve`).toBe(200);
+      expect(await response.text(), `${url} should not return a HEAD body`).toBe("");
+    }
+
+    for (const method of ["POST", "PUT", "TRACE", "CONNECT"]) {
+      const response = await handler(createEvent(method, "/.well-known/api-catalog"));
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(405);
+      expect(response.headers.get("allow")).toBe("GET, HEAD");
+      expect(await response.text()).toBe("Method Not Allowed");
+    }
+
+    expect(await handler(createEvent("TRACE", "/unrelated"))).toBeUndefined();
+  });
+
+  it("screens query discovery against the configured API route", async () => {
+    const handler = defineDocsPublicHandler(
+      {
+        entry: "docs",
+        title: "Example Docs",
+        cloud: { apiRoute: "/api/internal/docs" },
+      },
+      storage,
+    );
+
+    const defaultRoute = await handler(createEvent("PUT", "/api/docs?format=agent-skills"));
+    expect(defaultRoute).toBeUndefined();
+
+    const configuredRoute = await handler(
+      createEvent("PUT", "/api/internal/docs?format=agent-skills"),
+    );
+    expect(configuredRoute).toBeInstanceOf(Response);
+    expect(configuredRoute.status).toBe(405);
+    expect(configuredRoute.headers.get("allow")).toBe("GET, HEAD");
   });
 });

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -42,13 +42,13 @@ const contentFiles = import.meta.glob("/docs/**/*.{md,mdx,svx}", {
   eager: true,
 }) as Record<string, string>;
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });
 ```
 
-Re-export `load` from the docs `+layout.server.ts` and `GET`/`POST` from the docs API route. Use
+Re-export `load` from the docs `+layout.server.ts` and `GET`/`HEAD`/`POST` from the docs API route. Use
 `DocsLayout` and `DocsContent` from `@farming-labs/svelte-theme` for presentation. The CLI
 generates all of these files, including public agent and MCP forwarding.
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -16,7 +16,7 @@
  *   query: "?raw", import: "default", eager: true,
  * }) as Record<string, string>;
  *
- * export const { load, GET, HEAD, POST } = createDocsServer({
+ * export const { load, GET, HEAD, POST, MCP } = createDocsServer({
  *   ...config,
  *   _preloadedContent: contentFiles,
  * });

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -16,7 +16,7 @@
  *   query: "?raw", import: "default", eager: true,
  * }) as Record<string, string>;
  *
- * export const { load, GET, POST } = createDocsServer({
+ * export const { load, GET, HEAD, POST } = createDocsServer({
  *   ...config,
  *   _preloadedContent: contentFiles,
  * });
@@ -56,7 +56,6 @@ import {
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
   isDocsSkillRequest,
-  isDocsStandardsDiscoveryRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
   parseDocsAgentFeedbackData,
@@ -81,6 +80,7 @@ import {
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
   resolveDocsPublishedAgentSkill,
+  resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
@@ -233,6 +233,7 @@ export interface DocsServer {
     structuredData: string;
   }>;
   GET: (event: RequestEvent) => Promise<Response>;
+  HEAD: (event: RequestEvent) => Promise<Response>;
   POST: (event: RequestEvent) => Promise<Response>;
   MCP: DocsMcpHttpHandlers;
 }
@@ -616,9 +617,13 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   const rootDir = path.resolve(
     ((config as Record<string, unknown>).rootDir as string | undefined) ?? process.cwd(),
   );
-  const publishedAgentSkills = Array.isArray(config._preloadedAgentSkills)
-    ? Promise.resolve(config._preloadedAgentSkills)
-    : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+  let publishedAgentSkills: ReturnType<typeof resolveConfiguredAgentSkills> | undefined;
+  function getPublishedAgentSkills() {
+    publishedAgentSkills ??= Array.isArray(config._preloadedAgentSkills)
+      ? Promise.resolve(config._preloadedAgentSkills)
+      : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+    return publishedAgentSkills;
+  }
   const i18n = resolveDocsI18n((config as Record<string, unknown>).i18n as any);
 
   const githubRaw = config.github;
@@ -1001,10 +1006,62 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       : null;
   }
 
+  function createDiscoveryOptions(origin: string, apiRoute: string) {
+    return {
+      origin,
+      entry,
+      apiRoute,
+      docsPath: config.docsPath,
+      apiCatalog: apiCatalogEnabled,
+      i18n,
+      search: config.search,
+      mcp: mcpConfig,
+      feedback: agentFeedbackDiscovery,
+      llms: {
+        enabled: llmsEnabled,
+        apiCatalog: apiCatalogEnabled,
+        baseUrl: llmsBaseUrl || undefined,
+        siteTitle: llmsTitle,
+        siteDescription: llmsDesc,
+        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
+        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
+      },
+      sitemap: config.sitemap,
+      robots: config.robots,
+      openapi: openapiDiscovery,
+      markdown: {
+        acceptHeader: true,
+      },
+    } as any;
+  }
+
+  async function resolveStandardsResponse(
+    request: Request,
+    url: URL,
+    discoveryOptions: ReturnType<typeof createDiscoveryOptions>,
+  ): Promise<Response | null> {
+    const resolved = resolveDocsStandardsDiscoveryRequest(url, {
+      apiRoute: discoveryOptions.apiRoute,
+    });
+    if (!resolved) return null;
+    const method = request.method.toUpperCase();
+    const needsSkill = (method === "GET" || method === "HEAD") && resolved.kind !== "api-catalog";
+
+    return createDocsStandardsDiscoveryResponse({
+      request,
+      ...discoveryOptions,
+      preferredSkillDocument: needsSkill ? readRootSkillDocument(preloaded, rootDir) : null,
+      fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
+      publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
+      agentCard: config.agent?.a2a,
+    });
+  }
+
   // ─── GET /api/docs?query=… | ?format=llms | ?format=llms-full ──
   async function GET(event: RequestEvent): Promise<Response> {
     trackTelemetryRequest(event.request);
     const ctx = resolveContextFromRequest(event.request);
+    const isHeadRequest = event.request.method.toUpperCase() === "HEAD";
     const requestApiRoute = resolveDocsRequestApiRoute(event.url, configuredApiRoute);
 
     if (isDocsConfigRequest(event.url)) {
@@ -1043,61 +1100,33 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     }
 
     const discoveryApiRoute = requestApiRoute;
-    const discoveryOptions = {
-      origin: event.url.origin,
-      entry,
-      apiRoute: discoveryApiRoute,
-      docsPath: config.docsPath,
-      apiCatalog: apiCatalogEnabled,
-      i18n,
-      search: config.search,
-      mcp: mcpConfig,
-      feedback: agentFeedbackDiscovery,
-      llms: {
-        enabled: llmsEnabled,
-        apiCatalog: apiCatalogEnabled,
-        baseUrl: llmsBaseUrl || undefined,
-        siteTitle: llmsTitle,
-        siteDescription: llmsDesc,
-        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
-        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-      },
-      sitemap: config.sitemap,
-      robots: config.robots,
-      openapi: openapiDiscovery,
-      markdown: {
-        acceptHeader: true,
-      },
-    } as any;
-    if (isDocsStandardsDiscoveryRequest(event.url, { apiRoute: discoveryApiRoute })) {
-      const standardsDiscoveryResponse = await createDocsStandardsDiscoveryResponse({
-        request: event.request,
-        ...discoveryOptions,
-        preferredSkillDocument: readRootSkillDocument(preloaded, rootDir),
-        fallbackSkillDocument: renderDocsSkillDocument(discoveryOptions),
-        publishedSkills: await publishedAgentSkills,
-        agentCard: config.agent?.a2a,
-      });
-      if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
-    }
+    const discoveryOptions = createDiscoveryOptions(event.url.origin, discoveryApiRoute);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      event.request,
+      event.url,
+      discoveryOptions,
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(event.url, { apiRoute: discoveryApiRoute })) {
       return new Response(
-        JSON.stringify(
-          buildDocsAgentDiscoverySpec({
-            ...discoveryOptions,
-            publishedSkills: [
-              await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : JSON.stringify(
+              buildDocsAgentDiscoverySpec({
+                ...discoveryOptions,
+                publishedSkills: [
+                  await resolveDocsPublishedAgentSkill({
+                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
+                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+                  }),
+                  ...(await getPublishedAgentSkills()),
+                ],
+                agentCard: config.agent?.a2a,
               }),
-              ...(await publishedAgentSkills),
-            ],
-            agentCard: config.agent?.a2a,
-          }),
-          null,
-          2,
-        ),
+              null,
+              2,
+            ),
         {
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -1115,6 +1144,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           status: 404,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      if (isHeadRequest) {
+        return new Response(null, {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
             "X-Robots-Tag": "noindex",
           },
         });
@@ -1147,13 +1186,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         });
       }
 
-      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
-        headers: {
-          "Content-Type": "application/schema+json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
-          "X-Robots-Tag": "noindex",
+      return new Response(
+        isHeadRequest ? null : JSON.stringify(agentFeedbackConfig.schema, null, 2),
+        {
+          headers: {
+            "Content-Type": "application/schema+json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
         },
-      });
+      );
     }
 
     if (
@@ -1161,7 +1203,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsAgentsFormat(event.url) === "agents"
     ) {
       return new Response(
-        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootAgentsDocument(preloaded, rootDir) ??
+              renderDocsAgentsDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1178,7 +1223,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       resolveDocsSkillFormat(event.url) === "skill"
     ) {
       return new Response(
-        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootSkillDocument(preloaded, rootDir) ??
+              renderDocsSkillDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1371,6 +1419,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
   async function POST(event: RequestEvent): Promise<Response> {
     trackTelemetryRequest(event.request);
     const requestUrl = new URL(event.request.url);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      event.request,
+      requestUrl,
+      createDiscoveryOptions(
+        requestUrl.origin,
+        resolveDocsRequestApiRoute(requestUrl, configuredApiRoute),
+      ),
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
+
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
       if (agentFeedbackRequest.kind === "schema") {
@@ -1974,7 +2032,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           preferredDocument: readRootSkillDocument(preloaded, rootDir),
           fallbackDocument: renderDocsSkillDocument(skillOptions),
         });
-        return [rootSkill, ...(await publishedAgentSkills)];
+        return [rootSkill, ...(await getPublishedAgentSkills())];
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
@@ -1985,5 +2043,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     defaultName: mcpSiteTitle,
   });
 
-  return { load, GET, POST, MCP };
+  async function HEAD(event: RequestEvent): Promise<Response> {
+    const response = await GET(event);
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  return { load, GET, HEAD, POST, MCP };
 }

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -26,7 +26,6 @@ import {
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
   isDocsSkillRequest,
-  isDocsStandardsDiscoveryRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
   parseDocsAgentFeedbackData,
@@ -51,6 +50,7 @@ import {
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
   resolveDocsPublishedAgentSkill,
+  resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
   resolvePageReadingTime,
   resolveReadingTimeOptions,
@@ -187,6 +187,7 @@ export interface DocsServerLoadResult {
 export interface DocsServer {
   load: (input: { pathname: string; locale?: string }) => Promise<DocsServerLoadResult>;
   GET: (context: { request: Request }) => Promise<Response>;
+  HEAD: (context: { request: Request }) => Promise<Response>;
   POST: (context: { request: Request }) => Promise<Response>;
   MCP: DocsMcpHttpHandlers;
 }
@@ -589,9 +590,13 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   const ordering = config.ordering;
   const contentDirBase = config.contentDir ?? entry;
   const rootDir = path.resolve((config.rootDir as string | undefined) ?? process.cwd());
-  const publishedAgentSkills = Array.isArray(config._preloadedAgentSkills)
-    ? Promise.resolve(config._preloadedAgentSkills)
-    : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+  let publishedAgentSkills: ReturnType<typeof resolveConfiguredAgentSkills> | undefined;
+  function getPublishedAgentSkills() {
+    publishedAgentSkills ??= Array.isArray(config._preloadedAgentSkills)
+      ? Promise.resolve(config._preloadedAgentSkills)
+      : resolveConfiguredAgentSkills(config.agent?.skills, { rootDir });
+    return publishedAgentSkills;
+  }
   const preloaded = resolvePreloadedContent(config._preloadedContent);
   const preloadedSitemapManifest = readDocsSitemapManifestFromContentMap(preloaded);
   const i18n = resolveDocsI18n(config.i18n);
@@ -949,10 +954,62 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       : null;
   }
 
+  function createDiscoveryOptions(origin: string, apiRoute: string) {
+    return {
+      origin,
+      entry,
+      apiRoute,
+      docsPath: config.docsPath,
+      apiCatalog: apiCatalogEnabled,
+      i18n,
+      search: config.search,
+      mcp: mcpConfig,
+      feedback: agentFeedbackDiscovery,
+      llms: {
+        enabled: llmsEnabled,
+        apiCatalog: apiCatalogEnabled,
+        baseUrl: llmsBaseUrl || undefined,
+        siteTitle: llmsTitle,
+        siteDescription: llmsDesc,
+        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
+        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
+      },
+      sitemap: config.sitemap,
+      robots: config.robots,
+      openapi: openapiDiscovery,
+      markdown: {
+        acceptHeader: true,
+      },
+    } as any;
+  }
+
+  async function resolveStandardsResponse(
+    request: Request,
+    url: URL,
+    discoveryOptions: ReturnType<typeof createDiscoveryOptions>,
+  ): Promise<Response | null> {
+    const resolved = resolveDocsStandardsDiscoveryRequest(url, {
+      apiRoute: discoveryOptions.apiRoute,
+    });
+    if (!resolved) return null;
+    const method = request.method.toUpperCase();
+    const needsSkill = (method === "GET" || method === "HEAD") && resolved.kind !== "api-catalog";
+
+    return createDocsStandardsDiscoveryResponse({
+      request,
+      ...discoveryOptions,
+      preferredSkillDocument: needsSkill ? readRootSkillDocument(preloaded, rootDir) : null,
+      fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
+      publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
+      agentCard: config.agent?.a2a,
+    });
+  }
+
   async function GET(event: { request: Request }): Promise<Response> {
     trackTelemetryRequest(event.request);
     const ctx = resolveContextFromRequest(event.request);
     const url = new URL(event.request.url);
+    const isHeadRequest = event.request.method.toUpperCase() === "HEAD";
     const requestApiRoute = resolveDocsRequestApiRoute(url, configuredApiRoute);
 
     if (isDocsConfigRequest(url)) {
@@ -991,61 +1048,33 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     }
 
     const discoveryApiRoute = requestApiRoute;
-    const discoveryOptions = {
-      origin: url.origin,
-      entry,
-      apiRoute: discoveryApiRoute,
-      docsPath: config.docsPath,
-      apiCatalog: apiCatalogEnabled,
-      i18n,
-      search: config.search,
-      mcp: mcpConfig,
-      feedback: agentFeedbackDiscovery,
-      llms: {
-        enabled: llmsEnabled,
-        apiCatalog: apiCatalogEnabled,
-        baseUrl: llmsBaseUrl || undefined,
-        siteTitle: llmsTitle,
-        siteDescription: llmsDesc,
-        maxChars: typeof llmsTxtConfig === "object" ? llmsTxtConfig.maxChars : undefined,
-        sections: typeof llmsTxtConfig === "object" ? llmsTxtConfig.sections : undefined,
-      },
-      sitemap: config.sitemap,
-      robots: config.robots,
-      openapi: openapiDiscovery,
-      markdown: {
-        acceptHeader: true,
-      },
-    } as any;
-    if (isDocsStandardsDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const standardsDiscoveryResponse = await createDocsStandardsDiscoveryResponse({
-        request: event.request,
-        ...discoveryOptions,
-        preferredSkillDocument: readRootSkillDocument(preloaded, rootDir),
-        fallbackSkillDocument: renderDocsSkillDocument(discoveryOptions),
-        publishedSkills: await publishedAgentSkills,
-        agentCard: config.agent?.a2a,
-      });
-      if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
-    }
+    const discoveryOptions = createDiscoveryOptions(url.origin, discoveryApiRoute);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      event.request,
+      url,
+      discoveryOptions,
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
       return new Response(
-        JSON.stringify(
-          buildDocsAgentDiscoverySpec({
-            ...discoveryOptions,
-            publishedSkills: [
-              await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : JSON.stringify(
+              buildDocsAgentDiscoverySpec({
+                ...discoveryOptions,
+                publishedSkills: [
+                  await resolveDocsPublishedAgentSkill({
+                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
+                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+                  }),
+                  ...(await getPublishedAgentSkills()),
+                ],
+                agentCard: config.agent?.a2a,
               }),
-              ...(await publishedAgentSkills),
-            ],
-            agentCard: config.agent?.a2a,
-          }),
-          null,
-          2,
-        ),
+              null,
+              2,
+            ),
         {
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -1063,6 +1092,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
           status: 404,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      if (isHeadRequest) {
+        return new Response(null, {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
             "X-Robots-Tag": "noindex",
           },
         });
@@ -1095,13 +1134,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         });
       }
 
-      return new Response(JSON.stringify(agentFeedbackConfig.schema, null, 2), {
-        headers: {
-          "Content-Type": "application/schema+json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
-          "X-Robots-Tag": "noindex",
+      return new Response(
+        isHeadRequest ? null : JSON.stringify(agentFeedbackConfig.schema, null, 2),
+        {
+          headers: {
+            "Content-Type": "application/schema+json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
         },
-      });
+      );
     }
 
     if (
@@ -1109,7 +1151,10 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       resolveDocsAgentsFormat(url) === "agents"
     ) {
       return new Response(
-        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootAgentsDocument(preloaded, rootDir) ??
+              renderDocsAgentsDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1126,7 +1171,10 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       resolveDocsSkillFormat(url) === "skill"
     ) {
       return new Response(
-        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions),
+        isHeadRequest
+          ? null
+          : (readRootSkillDocument(preloaded, rootDir) ??
+              renderDocsSkillDocument(discoveryOptions)),
         {
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
@@ -1314,6 +1362,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   async function POST(event: { request: Request }): Promise<Response> {
     trackTelemetryRequest(event.request);
     const requestUrl = new URL(event.request.url);
+    const standardsDiscoveryResponse = await resolveStandardsResponse(
+      event.request,
+      requestUrl,
+      createDiscoveryOptions(
+        requestUrl.origin,
+        resolveDocsRequestApiRoute(requestUrl, configuredApiRoute),
+      ),
+    );
+    if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
+
     const agentFeedbackRequest = resolveDocsAgentFeedbackRequest(requestUrl, agentFeedbackConfig);
     if (agentFeedbackRequest) {
       if (agentFeedbackRequest.kind === "schema") {
@@ -1898,7 +1956,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
           preferredDocument: readRootSkillDocument(preloaded, rootDir),
           fallbackDocument: renderDocsSkillDocument(skillOptions),
         });
-        return [rootSkill, ...(await publishedAgentSkills)];
+        return [rootSkill, ...(await getPublishedAgentSkills())];
       },
     },
     mcp: config.mcp,
@@ -1909,5 +1967,14 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     defaultName: mcpSiteTitle,
   });
 
-  return { load, GET, POST, MCP };
+  async function HEAD(event: { request: Request }): Promise<Response> {
+    const response = await GET(event);
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
+  return { load, GET, HEAD, POST, MCP };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ overrides:
   rollup: ^4.59.0
   tar: ^7.5.19
   undici: 7.28.0
-  postcss: 8.5.15
+  postcss@<=8.5.11: 8.5.15
   ws: ^8.21.0
   readdir-glob>minimatch: ^5.1.8
   glob@10>minimatch: ^9.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   rollup: ^4.59.0
   tar: ^7.5.19
   undici: 7.28.0
+  postcss: 8.5.15
   ws: ^8.21.0
   readdir-glob>minimatch: ^5.1.8
   glob@10>minimatch: ^9.0.7
@@ -144,8 +145,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: 8.5.15
+        version: 8.5.15
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.1
@@ -199,8 +200,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: 8.5.15
+        version: 8.5.15
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.1
@@ -759,8 +760,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: 8.5.15
+        version: 8.5.15
       prisma:
         specifier: ^6.19.2
         version: 6.19.2(magicast@0.5.2)(typescript@5.9.3)
@@ -5989,11 +5990,6 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6539,16 +6535,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -10595,7 +10583,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.6
+      postcss: 8.5.15
       tailwindcss: 4.1.18
 
   '@tailwindcss/vite@4.2.1(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
@@ -11117,7 +11105,7 @@ snapshots:
       '@vue/shared': 3.5.28
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.15
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.38':
@@ -13794,8 +13782,6 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   nanoid@5.1.6: {}
@@ -13819,7 +13805,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001769
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -14616,21 +14602,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -16054,7 +16028,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -16071,7 +16045,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -2046,7 +2046,7 @@ Here is every file the CLI generates, ready to copy-paste if you prefer manual s
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       _preloadedContent: contentFiles,
     });
@@ -2089,7 +2089,7 @@ Here is every file the CLI generates, ready to copy-paste if you prefer manual s
     **`src/routes/api/docs/+server.js`** (search & AI)
 
     ```js title="src/routes/api/docs/+server.js"
-    export { GET, POST } from "../../../lib/docs.server";
+    export { GET, HEAD, POST } from "../../../lib/docs.server";
     ```
 
     **`src/app.css`** — add your theme's CSS here so docs styling applies.
@@ -2155,7 +2155,7 @@ Here is every file the CLI generates, ready to copy-paste if you prefer manual s
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       _preloadedContent: contentFiles,
     });
@@ -2188,9 +2188,14 @@ Here is every file the CLI generates, ready to copy-paste if you prefer manual s
 
     ```ts title="src/pages/api/docs.ts"
     import type { APIRoute } from "astro";
-    import { GET as docsGET, POST as docsPOST } from "../../lib/docs.server";
+    import {
+      GET as docsGET,
+      HEAD as docsHEAD,
+      POST as docsPOST,
+    } from "../../lib/docs.server";
 
     export const GET: APIRoute = async ({ request }) => docsGET({ request });
+    export const HEAD: APIRoute = async ({ request }) => docsHEAD({ request });
     export const POST: APIRoute = async ({ request }) => docsPOST({ request });
     ```
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -2207,7 +2207,7 @@ Add a RAG-powered AI chat that lets users ask questions about your docs:
     ```ts title="src/lib/docs.server.ts"
     import { env } from "$env/dynamic/private";
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       ai: { apiKey: env.OPENAI_API_KEY, ...config.ai },
       _preloadedContent: contentFiles,
@@ -2229,7 +2229,7 @@ Add a RAG-powered AI chat that lets users ask questions about your docs:
     Pass the API key through `docs.server.ts` (Astro requires server-only env access):
 
     ```ts title="src/lib/docs.server.ts"
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       ai: { apiKey: import.meta.env.OPENAI_API_KEY, ...config.ai },
       _preloadedContent: contentFiles,

--- a/website/app/docs/customization/ai-chat/page.mdx
+++ b/website/app/docs/customization/ai-chat/page.mdx
@@ -121,7 +121,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       ai: { apiKey: env.OPENAI_API_KEY, ...config.ai },
       _preloadedContent: contentFiles,
@@ -151,7 +151,7 @@ That's it. The AI reads your `OPENAI_API_KEY` environment variable and uses `gpt
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       ai: { apiKey: import.meta.env.OPENAI_API_KEY, ...config.ai },
       _preloadedContent: contentFiles,

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -387,31 +387,65 @@ export default withDocs();
 
 ```ts title="src/routes/$.ts"
 import { createFileRoute } from "@tanstack/react-router";
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
+} from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
 import docsConfig from "../../docs.config";
+
+const docsEntry = docsConfig.entry ?? "docs";
+
+async function handlePublicDocsRequest(request: Request) {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+
+  if (isDocsMcpRequest(url, docsConfig.mcp)) {
+    if (method === "OPTIONS") return docsServer.MCP.OPTIONS({ request });
+    if (method === "POST") return docsServer.MCP.POST({ request });
+    if (method === "DELETE") return docsServer.MCP.DELETE({ request });
+    if (method === "GET" || method === "HEAD") return docsServer.MCP.GET({ request });
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD, POST, DELETE, OPTIONS" },
+    });
+  }
+
+  if (
+    isDocsStandardsDiscoveryRequest(url, {
+      apiRoute: docsConfig.cloud?.apiRoute,
+    })
+  ) {
+    if (method === "HEAD") return docsServer.HEAD({ request });
+    if (method === "POST") return docsServer.POST({ request });
+    return docsServer.GET({ request });
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsPublicGetRequest(docsEntry, url, request, {
+      apiRoute: docsConfig.cloud?.apiRoute,
+      sitemap: docsConfig.sitemap,
+      llms: docsConfig.llmsTxt,
+      robots: docsConfig.robots,
+    })
+  ) {
+    return method === "HEAD" ? docsServer.HEAD({ request }) : docsServer.GET({ request });
+  }
+
+  return new Response("Not Found", { status: 404 });
+}
 
 export const Route = createFileRoute("/$")({
   server: {
     handlers: {
-      OPTIONS: async ({ request }) =>
-        isDocsMcpRequest(new URL(request.url), docsConfig.mcp)
-          ? docsServer.MCP.OPTIONS({ request })
-          : new Response("Not Found", { status: 404 }),
-      GET: async ({ request }) => {
-        const url = new URL(request.url);
-        if (isDocsMcpRequest(url, docsConfig.mcp)) return docsServer.MCP.GET({ request });
-        if (isDocsPublicGetRequest("docs", url, request)) return docsServer.GET({ request });
-        return new Response("Not Found", { status: 404 });
-      },
-      POST: async ({ request }) =>
-        isDocsMcpRequest(new URL(request.url), docsConfig.mcp)
-          ? docsServer.MCP.POST({ request })
-          : new Response("Not Found", { status: 404 }),
-      DELETE: async ({ request }) =>
-        isDocsMcpRequest(new URL(request.url), docsConfig.mcp)
-          ? docsServer.MCP.DELETE({ request })
-          : new Response("Not Found", { status: 404 }),
+      GET: async ({ request }) => handlePublicDocsRequest(request),
+      HEAD: async ({ request }) => handlePublicDocsRequest(request),
+      POST: async ({ request }) => handlePublicDocsRequest(request),
+      DELETE: async ({ request }) => handlePublicDocsRequest(request),
+      OPTIONS: async ({ request }) => handlePublicDocsRequest(request),
+      ANY: async ({ request }) => handlePublicDocsRequest(request),
     },
   },
 });
@@ -420,9 +454,16 @@ export const Route = createFileRoute("/$")({
 ### SvelteKit
 
 ```ts title="src/hooks.server.ts"
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsLlmsTxtPublicRequest,
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
+} from "@farming-labs/docs";
 import config from "$lib/docs.config";
-import { GET, MCP } from "$lib/docs.server";
+import { GET, HEAD, POST, MCP } from "$lib/docs.server";
+
+const docsEntry = config.entry ?? "docs";
 
 export async function handle({ event, resolve }) {
   const method = event.request.method.toUpperCase();
@@ -431,11 +472,45 @@ export async function handle({ event, resolve }) {
     if (method === "OPTIONS") return MCP.OPTIONS({ request: event.request });
     if (method === "POST") return MCP.POST({ request: event.request });
     if (method === "DELETE") return MCP.DELETE({ request: event.request });
-    return MCP.GET({ request: event.request });
+    if (method === "GET" || method === "HEAD") return MCP.GET({ request: event.request });
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD, POST, DELETE, OPTIONS" },
+    });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest("docs", event.url, event.request)) {
+  if (
+    isDocsStandardsDiscoveryRequest(event.url, {
+      apiRoute: config.cloud?.apiRoute,
+    })
+  ) {
+    if (method === "HEAD") return HEAD({ url: event.url, request: event.request });
+    if (method === "POST") return POST({ url: event.url, request: event.request });
     return GET({ url: event.url, request: event.request });
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsLlmsTxtPublicRequest(event.url, config.llmsTxt, docsEntry, {
+      apiRoute: config.cloud?.apiRoute,
+    })
+  ) {
+    const nativeResponse = await resolve(event);
+    if (nativeResponse.status !== 404) return nativeResponse;
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsPublicGetRequest(docsEntry, event.url, event.request, {
+      apiRoute: config.cloud?.apiRoute,
+      sitemap: config.sitemap,
+      llms: config.llmsTxt,
+      robots: config.robots,
+    })
+  ) {
+    return method === "HEAD"
+      ? HEAD({ url: event.url, request: event.request })
+      : GET({ url: event.url, request: event.request });
   }
 
   return resolve(event);
@@ -448,7 +523,7 @@ Your `src/lib/docs.server.ts` can keep using the normal helper:
 import { createDocsServer } from "@farming-labs/svelte/server";
 import config from "./docs.config";
 
-export const { load, GET, POST, MCP } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
 });
 ```
@@ -456,9 +531,16 @@ export const { load, GET, POST, MCP } = createDocsServer({
 ### Astro
 
 ```ts title="src/middleware.ts"
-import { isDocsMcpRequest, isDocsPublicGetRequest } from "@farming-labs/docs";
+import {
+  isDocsLlmsTxtPublicRequest,
+  isDocsMcpRequest,
+  isDocsPublicGetRequest,
+  isDocsStandardsDiscoveryRequest,
+} from "@farming-labs/docs";
 import config from "./lib/docs.config";
-import { GET, MCP } from "./lib/docs.server";
+import { GET, HEAD, POST, MCP } from "./lib/docs.server";
+
+const docsEntry = config.entry ?? "docs";
 
 export async function onRequest(context, next) {
   const method = context.request.method.toUpperCase();
@@ -467,11 +549,45 @@ export async function onRequest(context, next) {
     if (method === "OPTIONS") return MCP.OPTIONS({ request: context.request });
     if (method === "POST") return MCP.POST({ request: context.request });
     if (method === "DELETE") return MCP.DELETE({ request: context.request });
-    return MCP.GET({ request: context.request });
+    if (method === "GET" || method === "HEAD") return MCP.GET({ request: context.request });
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD, POST, DELETE, OPTIONS" },
+    });
   }
 
-  if ((method === "GET" || method === "HEAD") && isDocsPublicGetRequest("docs", context.url, context.request)) {
+  if (
+    isDocsStandardsDiscoveryRequest(context.url, {
+      apiRoute: config.cloud?.apiRoute,
+    })
+  ) {
+    if (method === "HEAD") return HEAD({ request: context.request });
+    if (method === "POST") return POST({ request: context.request });
     return GET({ request: context.request });
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsLlmsTxtPublicRequest(context.url, config.llmsTxt, docsEntry, {
+      apiRoute: config.cloud?.apiRoute,
+    })
+  ) {
+    const nativeResponse = await next();
+    if (nativeResponse.status !== 404) return nativeResponse;
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    isDocsPublicGetRequest(docsEntry, context.url, context.request, {
+      apiRoute: config.cloud?.apiRoute,
+      sitemap: config.sitemap,
+      llms: config.llmsTxt,
+      robots: config.robots,
+    })
+  ) {
+    return method === "HEAD"
+      ? HEAD({ request: context.request })
+      : GET({ request: context.request });
   }
 
   return next();

--- a/website/app/docs/installation/page.mdx
+++ b/website/app/docs/installation/page.mdx
@@ -458,13 +458,31 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
 
     ```ts title="src/routes/api.docs.ts"
     import { createFileRoute } from "@tanstack/react-router";
+    import { isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
     import { docsServer } from "@/lib/docs.server";
+    import docsConfig from "../../docs.config";
+
+    async function handleUnsupportedDocsMethod(request: Request) {
+      if (
+        isDocsStandardsDiscoveryRequest(new URL(request.url), {
+          apiRoute: docsConfig.cloud?.apiRoute,
+        })
+      ) {
+        return docsServer.GET({ request });
+      }
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { Allow: "GET, HEAD, POST" },
+      });
+    }
 
     export const Route = createFileRoute("/api/docs")({
       server: {
         handlers: {
           GET: async ({ request }) => docsServer.GET({ request }),
+          HEAD: async ({ request }) => docsServer.HEAD({ request }),
           POST: async ({ request }) => docsServer.POST({ request }),
+          ANY: async ({ request }) => handleUnsupportedDocsMethod(request),
         },
       },
     });
@@ -534,7 +552,7 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       _preloadedContent: contentFiles,
     });
@@ -579,7 +597,7 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
     **`src/routes/api/docs/+server.js`** (for search and AI):
 
     ```js title="src/routes/api/docs/+server.js"
-    export { GET, POST } from "../../../lib/docs.server";
+    export { GET, HEAD, POST } from "../../../lib/docs.server";
     ```
 
     > **Production note**: The `docs.server.ts` file uses `import.meta.glob` to bundle your markdown files at build time. This is required for serverless deployments (Vercel, Netlify, etc.) where the filesystem is not available at runtime.
@@ -674,7 +692,7 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
       },
     ) as Record<string, string>;
 
-    export const { load, GET, POST } = createDocsServer({
+    export const { load, GET, HEAD, POST } = createDocsServer({
       ...config,
       _preloadedContent: contentFiles,
     });
@@ -713,9 +731,14 @@ Replace `my-docs` with your project name. Then run `cd my-docs` and start the de
 
     ```ts title="src/pages/api/docs.ts"
     import type { APIRoute } from "astro";
-    import { GET as docsGET, POST as docsPOST } from "../../lib/docs.server";
+    import {
+      GET as docsGET,
+      HEAD as docsHEAD,
+      POST as docsPOST,
+    } from "../../lib/docs.server";
 
     export const GET: APIRoute = async ({ request }) => docsGET({ request });
+    export const HEAD: APIRoute = async ({ request }) => docsHEAD({ request });
     export const POST: APIRoute = async ({ request }) => docsPOST({ request });
     ```
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -2236,6 +2236,7 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | `GET`    | `({ request }) => Response`                                | Search, Markdown, discovery standards, `llms.txt`, OpenAPI, sitemap, `AGENTS.md`, and `skill.md` handler |
 | `HEAD`   | `({ request }) => Promise<Response>`                       | Bodyless public-read handler that preserves `GET` status and headers |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
+| `MCP`    | `DocsMcpHttpHandlers`                                      | MCP HTTP transport handlers |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/tanstack-start/server";
@@ -2332,6 +2333,7 @@ import { createDocsServer } from "@farming-labs/svelte/server";
 | `GET`    | `(event) => Response`          | Search endpoint handler                           |
 | `HEAD`   | `(event) => Promise<Response>` | Bodyless public-read handler                      |
 | `POST`   | `(event) => Promise<Response>` | AI chat endpoint handler                          |
+| `MCP`    | `DocsMcpHttpHandlers`          | MCP HTTP transport handlers                       |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/svelte/server";
@@ -2346,7 +2348,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, HEAD, POST } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });
@@ -2368,7 +2370,7 @@ Imported from `@farming-labs/svelte-theme`:
 
 ### `createDocsServer(config)`
 
-Same as SvelteKit — returns `{ load, GET, HEAD, POST }`.
+Same as SvelteKit — returns `{ load, GET, HEAD, POST, MCP }`.
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -2389,6 +2391,7 @@ import { createDocsServer } from "@farming-labs/astro/server";
 | `GET`    | `({ request }) => Response`               | Search endpoint handler for `GET /api/docs?query=...` |
 | `HEAD`   | `({ request }) => Promise<Response>`      | Bodyless public-read handler                          |
 | `POST`   | `({ request }) => Promise<Response>`      | AI chat endpoint handler with SSE streaming           |
+| `MCP`    | `DocsMcpHttpHandlers`                     | MCP HTTP transport handlers                           |
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -2403,7 +2406,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, HEAD, POST } = createDocsServer({
+export const { load, GET, HEAD, POST, MCP } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -2233,7 +2233,8 @@ import { createDocsServer } from "@farming-labs/tanstack-start/server";
 | Property | Type                                                       | Description |
 | -------- | ---------------------------------------------------------- | ----------- |
 | `load`   | `({ pathname, locale? }) => Promise<DocsServerLoadResult>` | Loads docs page data and the sidebar tree for a pathname |
-| `GET`    | `({ request }) => Response`                                | Search, Markdown, discovery standards (including routed `HEAD` requests), `llms.txt`, OpenAPI, sitemap, `AGENTS.md`, and `skill.md` handler |
+| `GET`    | `({ request }) => Response`                                | Search, Markdown, discovery standards, `llms.txt`, OpenAPI, sitemap, `AGENTS.md`, and `skill.md` handler |
+| `HEAD`   | `({ request }) => Promise<Response>`                       | Bodyless public-read handler that preserves `GET` status and headers |
 | `POST`   | `({ request }) => Promise<Response>`                       | AI chat endpoint handler |
 
 ```ts title="src/lib/docs.server.ts"
@@ -2272,13 +2273,31 @@ function DocsIndexPage() {
 
 ```ts title="src/routes/api.docs.ts"
 import { createFileRoute } from "@tanstack/react-router";
+import { isDocsStandardsDiscoveryRequest } from "@farming-labs/docs";
 import { docsServer } from "@/lib/docs.server";
+import docsConfig from "../../docs.config";
+
+async function handleUnsupportedDocsMethod(request: Request) {
+  if (
+    isDocsStandardsDiscoveryRequest(new URL(request.url), {
+      apiRoute: docsConfig.cloud?.apiRoute,
+    })
+  ) {
+    return docsServer.GET({ request });
+  }
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "GET, HEAD, POST" },
+  });
+}
 
 export const Route = createFileRoute("/api/docs")({
   server: {
     handlers: {
       GET: async ({ request }) => docsServer.GET({ request }),
+      HEAD: async ({ request }) => docsServer.HEAD({ request }),
       POST: async ({ request }) => docsServer.POST({ request }),
+      ANY: async ({ request }) => handleUnsupportedDocsMethod(request),
     },
   },
 });
@@ -2311,6 +2330,7 @@ import { createDocsServer } from "@farming-labs/svelte/server";
 | -------- | ------------------------------ | ------------------------------------------------- |
 | `load`   | `(event) => Promise<PageData>` | Layout load function (use in `+layout.server.js`) |
 | `GET`    | `(event) => Response`          | Search endpoint handler                           |
+| `HEAD`   | `(event) => Promise<Response>` | Bodyless public-read handler                      |
 | `POST`   | `(event) => Promise<Response>` | AI chat endpoint handler                          |
 
 ```ts title="src/lib/docs.server.ts"
@@ -2326,7 +2346,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, POST } = createDocsServer({
+export const { load, GET, HEAD, POST } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });
@@ -2348,7 +2368,7 @@ Imported from `@farming-labs/svelte-theme`:
 
 ### `createDocsServer(config)`
 
-Same as SvelteKit — returns `{ load, GET, POST }`.
+Same as SvelteKit — returns `{ load, GET, HEAD, POST }`.
 
 ```ts title="src/lib/docs.server.ts"
 import { createDocsServer } from "@farming-labs/astro/server";
@@ -2367,6 +2387,7 @@ import { createDocsServer } from "@farming-labs/astro/server";
 | -------- | ----------------------------------------- | ----------------------------------------------------- |
 | `load`   | `(pathname: string) => Promise<PageData>` | Takes a URL pathname string, returns page data        |
 | `GET`    | `({ request }) => Response`               | Search endpoint handler for `GET /api/docs?query=...` |
+| `HEAD`   | `({ request }) => Promise<Response>`      | Bodyless public-read handler                          |
 | `POST`   | `({ request }) => Promise<Response>`      | AI chat endpoint handler with SSE streaming           |
 
 ```ts title="src/lib/docs.server.ts"
@@ -2382,7 +2403,7 @@ const contentFiles = import.meta.glob(
   },
 ) as Record<string, string>;
 
-export const { load, GET, POST } = createDocsServer({
+export const { load, GET, HEAD, POST } = createDocsServer({
   ...config,
   _preloadedContent: contentFiles,
 });

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -425,7 +425,7 @@ export default defineDocs({
           code={`import { createDocsServer } from "@farming-labs/svelte/server";
 import config from "./docs.config";
 
-export const { load, GET, POST } = createDocsServer(config);`}
+export const { load, GET, HEAD, POST } = createDocsServer(config);`}
         />
       </div>
 
@@ -547,7 +547,7 @@ export default defineDocs({
           code={`import { createDocsServer } from "@farming-labs/astro/server";
 import config from "./docs.config";
 
-export const { load, GET, POST } = createDocsServer(config);`}
+export const { load, GET, HEAD, POST } = createDocsServer(config);`}
         />
       </div>
 

--- a/website/components/ui/astro-route-tabs.tsx
+++ b/website/components/ui/astro-route-tabs.tsx
@@ -52,10 +52,18 @@ const data = await load(Astro.url.pathname);
     label: "api/docs.ts",
     filename: "src/pages/api/docs.ts",
     code: `import type { APIRoute } from "astro";
-import { GET as docsGET, POST as docsPOST } from "../../lib/docs.server";
+import {
+  GET as docsGET,
+  HEAD as docsHEAD,
+  POST as docsPOST,
+} from "../../lib/docs.server";
 
 export const GET: APIRoute = async ({ request }) => {
   return docsGET({ request });
+};
+
+export const HEAD: APIRoute = async ({ request }) => {
+  return docsHEAD({ request });
 };
 
 export const POST: APIRoute = async ({ request }) => {


### PR DESCRIPTION
## Summary

- expose dedicated bodyless HEAD handlers across Astro, TanStack Start, SvelteKit, and Nuxt while avoiding discarded skill and OpenAPI work
- route POST and unsupported discovery methods through the shared standards resolver so 405, Allow, Link, and CORS semantics match Next.js
- register TanStack ANY forwarding, preserve Nuxt methods safely, and honor custom cloud.apiRoute values in every public forwarder
- update fresh scaffolds, examples, package docs, and website snippets with the method-aware integrations

## Compatibility

Public discovery remains GET/HEAD. Existing generated integration files are not overwritten because the CLI cannot safely distinguish generated files from user-owned custom routes; manually maintained integrations can adopt the updated forwarder snippets.

## Validation

- 57 docs test files / 942 tests
- 109 focused adapter and template tests
- 6 Nuxt handler tests
- docs, Astro, TanStack Start, SvelteKit, Nuxt, website, and TanStack example typechecks
- format check and lint with 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns discovery-method handling across Astro, SvelteKit, Nuxt, and TanStack Start to match Next.js. Adds bodyless `HEAD` and method-aware discovery routing for consistent 405/Allow/Link/CORS; public discovery stays `GET`/`HEAD` with no breaking changes.

- **New Features**
  - Export `HEAD` from `createDocsServer` in `@farming-labs/astro`, `@farming-labs/svelte`, `@farming-labs/nuxt`, and `@farming-labs/tanstack-start`; `GET`/`HEAD` share headers and status.
  - Route discovery `POST` and unsupported methods through shared standards logic; return correct 405/Allow without coercing to `GET`.
  - Public forwarders now detect standards via `isDocsStandardsDiscoveryRequest`; Astro/SvelteKit middleware and TanStack catch-all routes branch on `GET`/`HEAD`/`POST` (TanStack adds `ANY` to serve discovery or 405); all honor `cloud.apiRoute`.
  - Update scaffolds, examples, READMEs, website snippets, and CLI templates to include `HEAD`, discovery detection, and method-aware routing; broaden adapter/template tests and add Nuxt tests for 405/Allow parity.

- **Dependencies**
  - Pin `postcss@8.5.15` and add a scoped override `postcss@<=8.5.11` → `8.5.15` to address a security issue.

<sup>Written for commit abd68cfdbdb16908e0c6e12935164c7e3a628ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

