### PR TITLE
fix: harden deployed agent conformance

### DIFF
--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -17,13 +17,13 @@ permissions:
 
 jobs:
   smoke:
-    # The docs-website preview project is intentionally protected by Vercel SSO.
-    # The public docs-cloud preview exercises the same site, while scheduled and
+    # Every docs-website deployment is protected by Vercel SSO. Deployment events
+    # therefore exercise only the public docs-cloud project, while scheduled and
     # manual runs continue to verify the production origin.
     if: >-
       github.event_name != 'deployment_status' ||
       (github.event.deployment_status.state == 'success' &&
-      github.event.deployment.environment != 'Preview – docs-website')
+      endsWith(github.event.deployment.environment, ' – farming-labs-docs-docs-cloud'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -275,6 +275,7 @@ function createRequester({ baseUrl, fetchImpl, timeoutMs, attempts, maxResponseB
     const url = new URL(target, `${baseUrl}/`);
     const headers = new Headers(init.headers);
     if (!headers.has("accept")) headers.set("accept", "*/*");
+    if (!headers.has("accept-encoding")) headers.set("accept-encoding", "identity");
     headers.set("cache-control", "no-cache");
     headers.set("user-agent", "farming-labs-agent-surface-smoke/1.0");
 

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -152,8 +152,8 @@ function includesHeaderToken(response, header, token) {
     .some((value) => value.trim().toLowerCase() === token.toLowerCase());
 }
 
-function normalizeOpaqueEtag(value) {
-  return isNonEmptyString(value) ? value.trim().replace(/^W\//iu, "") : null;
+function normalizeEtag(value) {
+  return isNonEmptyString(value) ? value.trim() : null;
 }
 
 function resolveSameOriginTarget(baseUrl, value, label) {
@@ -542,17 +542,17 @@ async function validateHeadParity(request, target, initial, label) {
 
 async function validateHashedCacheContract(request, target, initial, label) {
   const etag = initial.response.headers.get("etag");
-  assert(normalizeOpaqueEtag(etag), `${label} did not return an ETag`);
+  assert(normalizeEtag(etag), `${label} did not return an ETag`);
   const head = await validateHeadParity(request, target, initial, label);
   assert(
-    normalizeOpaqueEtag(head.response.headers.get("etag")) === normalizeOpaqueEtag(etag),
+    normalizeEtag(head.response.headers.get("etag")) === normalizeEtag(etag),
     `${label} HEAD returned a different ETag`,
   );
 
   const notModified = await request(target, { headers: { "If-None-Match": etag } }, [304]);
   assert(notModified.bytes.byteLength === 0, `${label} 304 returned a body`);
   assert(
-    normalizeOpaqueEtag(notModified.response.headers.get("etag")) === normalizeOpaqueEtag(etag),
+    normalizeEtag(notModified.response.headers.get("etag")) === normalizeEtag(etag),
     `${label} 304 returned a different ETag`,
   );
   assert(
@@ -1638,8 +1638,11 @@ export async function runAgentSurfaceSmoke(options = {}) {
   );
   if (manifest) {
     const canonicalMcp = readAdvertisedValue(manifest, ["mcp", "canonicalEndpoint"]);
-    if (isNonEmptyString(canonicalMcp) && !MCP_ROUTES.includes(canonicalMcp)) {
-      await recorder.check(`MCP initialize ${canonicalMcp}`, () =>
+    if (!MCP_ROUTES.includes(canonicalMcp)) {
+      const label = isNonEmptyString(canonicalMcp)
+        ? `MCP initialize ${canonicalMcp}`
+        : "advertised canonical MCP endpoint";
+      await recorder.check(label, () =>
         validateMcp(
           request,
           resolveSameOriginTarget(baseUrl, canonicalMcp, "canonical MCP endpoint"),

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -69,14 +69,6 @@ function formatStatusExpectation(statuses) {
   return statuses.length === 1 ? String(statuses[0]) : statuses.join(" or ");
 }
 
-function includesLinkRelation(response, relation) {
-  const link = response.headers.get("link") ?? "";
-  return new RegExp(
-    `(?:^|[,;]\\s*)rel=(?:"[^"]*\\b${relation}\\b[^"]*"|${relation})(?:[,;]|$)`,
-    "i",
-  ).test(link);
-}
-
 function splitLinkValues(header) {
   const values = [];
   let start = 0;
@@ -124,16 +116,66 @@ function parseLinkParameters(linkValue) {
   return parameters;
 }
 
+function linkTargetMatches(response, actual, expected) {
+  try {
+    return new URL(actual, response.url).href === new URL(expected, response.url).href;
+  } catch {
+    return actual === expected;
+  }
+}
+
 function includesTypedLinkRelation(response, href, relation, type) {
   const link = response.headers.get("link") ?? "";
   return splitLinkValues(link).some((linkValue) => {
     const target = /^\s*<([^>]*)>/u.exec(linkValue)?.[1];
-    if (target !== href) return false;
+    if (!target || !linkTargetMatches(response, target, href)) return false;
     const parameters = parseLinkParameters(linkValue);
     const relations = (parameters.get("rel") ?? "").toLowerCase().split(/\s+/u);
     const linkedType = (parameters.get("type") ?? "").split(";", 1)[0].trim().toLowerCase();
     return relations.includes(relation.toLowerCase()) && linkedType === type.toLowerCase();
   });
+}
+
+function includesExactLinkRelation(response, href, relation) {
+  const link = response.headers.get("link") ?? "";
+  return splitLinkValues(link).some((linkValue) => {
+    const target = /^\s*<([^>]*)>/u.exec(linkValue)?.[1];
+    if (!target || !linkTargetMatches(response, target, href)) return false;
+    const relations = (parseLinkParameters(linkValue).get("rel") ?? "").toLowerCase().split(/\s+/u);
+    return relations.includes(relation.toLowerCase());
+  });
+}
+
+function includesHeaderToken(response, header, token) {
+  return (response.headers.get(header) ?? "")
+    .split(",")
+    .some((value) => value.trim().toLowerCase() === token.toLowerCase());
+}
+
+function normalizeOpaqueEtag(value) {
+  return isNonEmptyString(value) ? value.trim().replace(/^W\//iu, "") : null;
+}
+
+function resolveSameOriginTarget(baseUrl, value, label) {
+  assert(isNonEmptyString(value), `${label} was not advertised`);
+  let url;
+  try {
+    url = new URL(value, `${baseUrl}/`);
+  } catch {
+    throw new Error(`${label} was not a valid URL`);
+  }
+  assert(!url.username && !url.password, `${label} contained credentials`);
+  assert(url.origin === baseUrl, `${label} was not same-origin`);
+  assert(!url.hash, `${label} contained a fragment`);
+  return url;
+}
+
+function readAdvertisedValue(root, path) {
+  let value = root;
+  for (const key of path) {
+    value = asRecord(value)?.[key];
+  }
+  return value;
 }
 
 function encodePath(path) {
@@ -365,6 +407,13 @@ function validateManifest(json, route, response) {
   return manifest;
 }
 
+async function validateManifestEndpoint(request, route) {
+  const result = await readJson(request, route);
+  const manifest = validateManifest(result.json, route, result.response);
+  await validateHeadParity(request, route, result, route);
+  return manifest;
+}
+
 async function validateAgentManifestSchema(request) {
   const result = await readJson(
     request,
@@ -447,6 +496,69 @@ function validatePublicCacheControl(value, label) {
   assert(
     /^\d+$/u.test(directives.get("s-maxage") ?? ""),
     `${label} omitted a numeric shared-cache max-age`,
+  );
+}
+
+function validateRevalidationCacheControl(value, label) {
+  const directives = new Map(
+    value
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const separator = part.indexOf("=");
+        return separator === -1
+          ? [part.toLowerCase(), ""]
+          : [part.slice(0, separator).trim().toLowerCase(), part.slice(separator + 1).trim()];
+      }),
+  );
+  assert(directives.has("public"), `${label} did not declare public caching`);
+  assert(
+    !directives.has("private") && !directives.has("no-store"),
+    `${label} disabled public caching`,
+  );
+  assert(/^\d+$/u.test(directives.get("max-age") ?? ""), `${label} omitted a numeric max-age`);
+}
+
+async function validateHeadParity(request, target, initial, label) {
+  const cacheControl = initial.response.headers.get("cache-control") ?? "";
+  validateRevalidationCacheControl(cacheControl, label);
+  const head = await request(target, { method: "HEAD" });
+  assert(head.bytes.byteLength === 0, `${label} HEAD returned a body`);
+  assert(
+    head.response.headers.get("content-type") === initial.response.headers.get("content-type"),
+    `${label} HEAD returned different content metadata`,
+  );
+  assert(
+    head.response.headers.get("cache-control") === cacheControl,
+    `${label} HEAD returned different cache metadata`,
+  );
+  assert(
+    head.response.headers.get("link") === initial.response.headers.get("link"),
+    `${label} HEAD returned different Link metadata`,
+  );
+  return head;
+}
+
+async function validateHashedCacheContract(request, target, initial, label) {
+  const etag = initial.response.headers.get("etag");
+  assert(normalizeOpaqueEtag(etag), `${label} did not return an ETag`);
+  const head = await validateHeadParity(request, target, initial, label);
+  assert(
+    normalizeOpaqueEtag(head.response.headers.get("etag")) === normalizeOpaqueEtag(etag),
+    `${label} HEAD returned a different ETag`,
+  );
+
+  const notModified = await request(target, { headers: { "If-None-Match": etag } }, [304]);
+  assert(notModified.bytes.byteLength === 0, `${label} 304 returned a body`);
+  assert(
+    normalizeOpaqueEtag(notModified.response.headers.get("etag")) === normalizeOpaqueEtag(etag),
+    `${label} 304 returned a different ETag`,
+  );
+  assert(
+    notModified.response.headers.get("cache-control") ===
+      initial.response.headers.get("cache-control"),
+    `${label} 304 returned different cache metadata`,
   );
 }
 
@@ -895,8 +1007,13 @@ async function validateApiCatalog(request) {
     `${API_CATALOG_ROUTE} did not declare the RFC 9727 profile`,
   );
   assert(
-    includesLinkRelation(catalog.response, "api-catalog"),
-    `${API_CATALOG_ROUTE} omitted its Link relation`,
+    includesTypedLinkRelation(
+      catalog.response,
+      API_CATALOG_ROUTE,
+      "api-catalog",
+      "application/linkset+json",
+    ),
+    `${API_CATALOG_ROUTE} omitted its typed api-catalog Link relation`,
   );
   const root = asRecord(catalog.json);
   assert(
@@ -908,19 +1025,10 @@ async function validateApiCatalog(request) {
     assert(serialized.includes(route), `${API_CATALOG_ROUTE} did not advertise ${route}`);
   }
 
-  const head = await request(API_CATALOG_ROUTE, { method: "HEAD" });
-  assert(head.bytes.byteLength === 0, `${API_CATALOG_ROUTE} HEAD returned a body`);
-  assert(
-    mediaType(head.response) === "application/linkset+json",
-    `${API_CATALOG_ROUTE} HEAD returned the wrong content-type`,
-  );
-  assert(
-    (head.response.headers.get("content-type") ?? "").includes(`profile="${API_CATALOG_PROFILE}"`),
-    `${API_CATALOG_ROUTE} HEAD did not declare the RFC 9727 profile`,
-  );
+  await validateHashedCacheContract(request, API_CATALOG_ROUTE, catalog, API_CATALOG_ROUTE);
 }
 
-function validateModernSkillIndex(json, expectedSkillNames) {
+function validateModernSkillIndex(json, expectedSkillNames, response) {
   const root = asRecord(json);
   assert(root?.$schema === AGENT_SKILLS_SCHEMA, "Agent Skills index declared the wrong schema");
   assert(
@@ -947,6 +1055,11 @@ function validateModernSkillIndex(json, expectedSkillNames) {
     assert(
       /^sha256:[0-9a-f]{64}$/u.test(skill.digest),
       `Agent Skill ${skill.name} had an invalid digest`,
+    );
+    const expectedType = skill.type === "archive" ? "application/gzip" : "text/markdown";
+    assert(
+      includesTypedLinkRelation(response, skill.url, "item", expectedType),
+      `Agent Skills index omitted the typed item Link for ${skill.name}`,
     );
     return skill;
   });
@@ -981,22 +1094,22 @@ async function validateModernSkillArtifact(request, baseUrl, skill) {
     `${skill.url} did not match its published digest`,
   );
   assert(
-    includesLinkRelation(artifact.response, "collection"),
-    `${skill.url} omitted its collection Link`,
+    includesTypedLinkRelation(
+      artifact.response,
+      AGENT_SKILLS_INDEX_ROUTE,
+      "collection",
+      "application/json",
+    ),
+    `${skill.url} omitted its typed collection Link`,
   );
 
-  const head = await request(artifactUrl, { method: "HEAD" });
-  assert(head.bytes.byteLength === 0, `${skill.url} HEAD returned a body`);
-  assert(
-    mediaType(head.response) === expectedType,
-    `${skill.url} HEAD returned the wrong content-type`,
-  );
+  await validateHashedCacheContract(request, artifactUrl, artifact, skill.url);
   assert(
     [
       `"${skill.digest.slice("sha256:".length)}"`,
       `W/"${skill.digest.slice("sha256:".length)}"`,
-    ].includes(head.response.headers.get("etag")),
-    `${skill.url} HEAD did not expose the indexed digest as its ETag`,
+    ].includes(artifact.response.headers.get("etag")),
+    `${skill.url} did not expose the indexed digest as its ETag`,
   );
 }
 
@@ -1187,6 +1300,202 @@ async function validateWellKnownText(request, route, expectedType, requiredText)
     assert(text.includes(requiredText), `${route} did not include ${JSON.stringify(requiredText)}`);
 }
 
+async function validateAdvertisedJsonFormat(
+  request,
+  baseUrl,
+  manifest,
+  path,
+  expectedFormat,
+  label,
+) {
+  assert(isNonEmptyString(expectedFormat), `${label} did not advertise its response format`);
+  const target = resolveSameOriginTarget(baseUrl, readAdvertisedValue(manifest, path), label);
+  const result = await readJson(request, target);
+  const root = asRecord(result.json);
+  assert(root, `${label} did not return a JSON object`);
+  assert(root.format === expectedFormat, `${label} returned the wrong format`);
+}
+
+async function validateAdvertisedFeedbackSchema(request, baseUrl, manifest) {
+  const target = resolveSameOriginTarget(
+    baseUrl,
+    readAdvertisedValue(manifest, ["feedback", "schema"]),
+    "feedback schema",
+  );
+  const result = await readJson(request, target, [200], "application/schema+json");
+  assert(
+    mediaType(result.response) === "application/schema+json",
+    "feedback schema returned the wrong content-type",
+  );
+  assert(asRecord(result.json), "feedback schema did not return a JSON object");
+}
+
+async function validateAdvertisedSearch(request, baseUrl, manifest, path, label) {
+  const template = readAdvertisedValue(manifest, path);
+  assert(isNonEmptyString(template) && template.includes("{query}"), `${label} was not templated`);
+  const target = resolveSameOriginTarget(
+    baseUrl,
+    template.replaceAll("{query}", encodeURIComponent("installation")),
+    label,
+  );
+  const result = await readJson(request, target);
+  assert(Array.isArray(result.json) && result.json.length > 0, `${label} returned no results`);
+  for (const [index, value] of result.json.slice(0, 5).entries()) {
+    const item = asRecord(value);
+    assert(item, `${label} result ${index} was not an object`);
+    assert(
+      isNonEmptyString(item.url) && isNonEmptyString(item.content),
+      `${label} result ${index} omitted its URL or content`,
+    );
+  }
+}
+
+async function validateMarkdownNegotiation(request, baseUrl, manifest) {
+  const entry = readAdvertisedValue(manifest, ["site", "entry"]);
+  assert(isNonEmptyString(entry), "agent manifest did not advertise a docs entry");
+  const pagePath = `/${entry.replace(/^\/+|\/+$/gu, "")}`;
+  const pageTarget = new URL(pagePath, `${baseUrl}/`);
+  const advertisedSiteBaseUrl = readAdvertisedValue(manifest, ["site", "baseUrl"]);
+  let canonicalBaseUrl;
+  try {
+    canonicalBaseUrl = new URL(
+      isNonEmptyString(advertisedSiteBaseUrl) ? advertisedSiteBaseUrl : baseUrl,
+    );
+  } catch {
+    throw new Error("agent manifest advertised an invalid site base URL");
+  }
+  assert(
+    ["http:", "https:"].includes(canonicalBaseUrl.protocol) &&
+      !canonicalBaseUrl.username &&
+      !canonicalBaseUrl.password,
+    "agent manifest advertised an unsafe site base URL",
+  );
+  const canonical = new URL(pagePath, canonicalBaseUrl);
+  const explicitTarget = resolveSameOriginTarget(
+    baseUrl,
+    readAdvertisedValue(manifest, ["markdown", "rootPage"]),
+    "explicit root Markdown route",
+  );
+
+  const negotiated = await request(pageTarget, { headers: { accept: "text/markdown" } });
+  assert(
+    mediaType(negotiated.response) === "text/markdown",
+    `${pageTarget.pathname} did not negotiate Markdown`,
+  );
+  assert(negotiated.bytes.byteLength > 0, `${pageTarget.pathname} returned empty Markdown`);
+  assert(
+    includesHeaderToken(negotiated.response, "vary", "accept"),
+    `${pageTarget.pathname} Markdown response did not vary on Accept`,
+  );
+  assert(
+    includesExactLinkRelation(negotiated.response, canonical.href, "canonical"),
+    `${pageTarget.pathname} Markdown response omitted its canonical Link`,
+  );
+
+  const explicit = await request(explicitTarget);
+  assert(
+    mediaType(explicit.response) === "text/markdown",
+    `${explicitTarget.pathname} returned the wrong content-type`,
+  );
+  assert(
+    sha256(explicit.bytes) === sha256(negotiated.bytes),
+    `${explicitTarget.pathname} differed from the negotiated Markdown representation`,
+  );
+  assert(
+    includesExactLinkRelation(explicit.response, canonical.href, "canonical"),
+    `${explicitTarget.pathname} omitted its canonical Link`,
+  );
+
+  const html = await request(pageTarget, { headers: { accept: "text/html" } });
+  assert(
+    mediaType(html.response) === "text/html" && html.bytes.byteLength > 0,
+    `${pageTarget.pathname} did not preserve its HTML representation`,
+  );
+}
+
+function advertisedTextSurfaceSpecs(manifest) {
+  const specs = [];
+  const seen = new Set();
+  const add = (label, value, type) => {
+    if (!isNonEmptyString(value) || seen.has(value)) return;
+    seen.add(value);
+    specs.push({ label, type, value });
+  };
+
+  add("public llms.txt", readAdvertisedValue(manifest, ["llms", "defaultTxt"]), "text/plain");
+  add("public llms-full.txt", readAdvertisedValue(manifest, ["llms", "defaultFull"]), "text/plain");
+  add("public AGENTS.md", readAdvertisedValue(manifest, ["agents", "route"]), "text/markdown");
+  for (const [index, alias] of (Array.isArray(readAdvertisedValue(manifest, ["agents", "aliases"]))
+    ? readAdvertisedValue(manifest, ["agents", "aliases"])
+    : []
+  ).entries()) {
+    add(`public agent instructions alias ${index + 1}`, alias, "text/markdown");
+  }
+  add("public skill.md", readAdvertisedValue(manifest, ["skills", "route"]), "text/markdown");
+  add(
+    "public Markdown sitemap",
+    readAdvertisedValue(manifest, ["sitemap", "markdown", "route"]),
+    "text/markdown",
+  );
+  add(
+    "docs Markdown sitemap",
+    readAdvertisedValue(manifest, ["sitemap", "markdown", "docsRoute"]),
+    "text/markdown",
+  );
+  return specs;
+}
+
+async function validateAdvertisedTextSurface(request, baseUrl, spec) {
+  const target = resolveSameOriginTarget(baseUrl, spec.value, spec.label);
+  const result = await request(target);
+  assert(mediaType(result.response) === spec.type, `${spec.value} returned the wrong content-type`);
+  assert(result.bytes.byteLength > 0, `${spec.value} returned an empty document`);
+}
+
+async function validateAdvertisedRobots(request, baseUrl, manifest) {
+  const route = readAdvertisedValue(manifest, ["robots", "route"]);
+  const target = resolveSameOriginTarget(baseUrl, route, "robots.txt");
+  const result = await request(target);
+  assert(mediaType(result.response) === "text/plain", `${route} returned the wrong content-type`);
+  const text = new TextDecoder().decode(result.bytes);
+  assert(text.includes("User-agent:"), `${route} did not contain a User-agent directive`);
+  assert(text.includes("Sitemap:"), `${route} did not advertise a sitemap`);
+  const allowedPaths = new Set(
+    text
+      .split(/\r?\n/u)
+      .map((line) => line.replace(/#.*$/u, "").trim())
+      .map((line) => /^allow\s*:\s*(\S+)\s*$/iu.exec(line)?.[1])
+      .filter(isNonEmptyString),
+  );
+
+  const requiredRoutes = [
+    readAdvertisedValue(manifest, ["api", "agentSpecDefault"]),
+    readAdvertisedValue(manifest, ["apiCatalog", "route"]),
+    readAdvertisedValue(manifest, ["skills", "discovery", "index"]),
+    ...(Array.isArray(readAdvertisedValue(manifest, ["mcp", "publicEndpoints"]))
+      ? readAdvertisedValue(manifest, ["mcp", "publicEndpoints"])
+      : []),
+  ].filter(isNonEmptyString);
+  for (const requiredRoute of requiredRoutes) {
+    const requiredPath = new URL(requiredRoute, `${baseUrl}/`).pathname;
+    assert(allowedPaths.has(requiredPath), `${route} did not cover ${requiredPath}`);
+  }
+}
+
+async function validateAdvertisedXmlSitemap(request, baseUrl, manifest) {
+  const route = readAdvertisedValue(manifest, ["sitemap", "xml", "route"]);
+  const target = resolveSameOriginTarget(baseUrl, route, "XML sitemap");
+  const result = await request(target);
+  assert(
+    ["application/xml", "text/xml"].includes(mediaType(result.response)),
+    `${route} returned the wrong content-type`,
+  );
+  assert(
+    new TextDecoder().decode(result.bytes).includes("<urlset"),
+    `${route} did not contain a URL set`,
+  );
+}
+
 function createRecorder(log) {
   const failures = [];
   let passed = 0;
@@ -1233,19 +1542,16 @@ export async function runAgentSurfaceSmoke(options = {}) {
 
   log(`Agent surface smoke test: ${baseUrl}`);
 
-  const manifest = await recorder.check("agent manifest /.well-known/agent.json", async () => {
-    const result = await readJson(request, "/.well-known/agent.json");
-    return validateManifest(result.json, "/.well-known/agent.json", result.response);
-  });
+  const manifest = await recorder.check("agent manifest /.well-known/agent.json", () =>
+    validateManifestEndpoint(request, "/.well-known/agent.json"),
+  );
   await Promise.all([
-    recorder.check("agent manifest /.well-known/agent", async () => {
-      const result = await readJson(request, "/.well-known/agent");
-      validateManifest(result.json, "/.well-known/agent", result.response);
-    }),
-    recorder.check("agent manifest /api/docs/agent/spec", async () => {
-      const result = await readJson(request, "/api/docs/agent/spec");
-      validateManifest(result.json, "/api/docs/agent/spec", result.response);
-    }),
+    recorder.check("agent manifest /.well-known/agent", () =>
+      validateManifestEndpoint(request, "/.well-known/agent"),
+    ),
+    recorder.check("agent manifest /api/docs/agent/spec", () =>
+      validateManifestEndpoint(request, "/api/docs/agent/spec"),
+    ),
     recorder.check("Farming Labs agent manifest schema", () =>
       validateAgentManifestSchema(request),
     ),
@@ -1254,9 +1560,14 @@ export async function runAgentSurfaceSmoke(options = {}) {
 
   const modernIndex = await recorder.check("Agent Skills v0.2 index", async () => {
     const result = await readJson(request, AGENT_SKILLS_INDEX_ROUTE);
-    const head = await request(AGENT_SKILLS_INDEX_ROUTE, { method: "HEAD" });
-    assert(head.bytes.byteLength === 0, `${AGENT_SKILLS_INDEX_ROUTE} HEAD returned a body`);
-    return validateModernSkillIndex(result.json, expectedSkillNames);
+    const skills = validateModernSkillIndex(result.json, expectedSkillNames, result.response);
+    await validateHashedCacheContract(
+      request,
+      AGENT_SKILLS_INDEX_ROUTE,
+      result,
+      AGENT_SKILLS_INDEX_ROUTE,
+    );
+    return skills;
   });
   const modernNames = new Set((modernIndex ?? []).map((skill) => skill.name));
   const expectedFileDigests = new Map(
@@ -1295,9 +1606,14 @@ export async function runAgentSurfaceSmoke(options = {}) {
 
   const legacyFiles = await recorder.check("legacy Agent Skills index", async () => {
     const result = await readJson(request, LEGACY_SKILLS_INDEX_ROUTE);
-    const head = await request(LEGACY_SKILLS_INDEX_ROUTE, { method: "HEAD" });
-    assert(head.bytes.byteLength === 0, `${LEGACY_SKILLS_INDEX_ROUTE} HEAD returned a body`);
-    return validateLegacySkillIndex(result.json, modernNames);
+    const files = validateLegacySkillIndex(result.json, modernNames);
+    await validateHashedCacheContract(
+      request,
+      LEGACY_SKILLS_INDEX_ROUTE,
+      result,
+      LEGACY_SKILLS_INDEX_ROUTE,
+    );
+    return files;
   });
   if (legacyFiles) {
     await Promise.all(
@@ -1320,6 +1636,17 @@ export async function runAgentSurfaceSmoke(options = {}) {
       recorder.check(`MCP initialize ${route}`, () => validateMcp(request, route)),
     ),
   );
+  if (manifest) {
+    const canonicalMcp = readAdvertisedValue(manifest, ["mcp", "canonicalEndpoint"]);
+    if (isNonEmptyString(canonicalMcp) && !MCP_ROUTES.includes(canonicalMcp)) {
+      await recorder.check(`MCP initialize ${canonicalMcp}`, () =>
+        validateMcp(
+          request,
+          resolveSameOriginTarget(baseUrl, canonicalMcp, "canonical MCP endpoint"),
+        ),
+      );
+    }
+  }
 
   await Promise.all([
     recorder.check("well-known site skill", () =>
@@ -1341,6 +1668,76 @@ export async function runAgentSurfaceSmoke(options = {}) {
       validateWellKnownText(request, "/.well-known/sitemap.md", "text/markdown"),
     ),
   ]);
+
+  if (manifest) {
+    const advertisedChecks = [
+      recorder.check("advertised config endpoint", () =>
+        validateAdvertisedJsonFormat(
+          request,
+          baseUrl,
+          manifest,
+          ["config", "endpoint"],
+          readAdvertisedValue(manifest, ["config", "format"]),
+          "config endpoint",
+        ),
+      ),
+      recorder.check("advertised diagnostics endpoint", () =>
+        validateAdvertisedJsonFormat(
+          request,
+          baseUrl,
+          manifest,
+          ["api", "diagnostics"],
+          "docs-diagnostics.v1",
+          "diagnostics endpoint",
+        ),
+      ),
+      recorder.check("advertised Markdown negotiation", () =>
+        validateMarkdownNegotiation(request, baseUrl, manifest),
+      ),
+      recorder.check("advertised robots.txt", () =>
+        validateAdvertisedRobots(request, baseUrl, manifest),
+      ),
+      recorder.check("advertised XML sitemap", () =>
+        validateAdvertisedXmlSitemap(request, baseUrl, manifest),
+      ),
+    ];
+
+    if (asRecord(manifest.feedback)?.enabled === true) {
+      advertisedChecks.push(
+        recorder.check("advertised feedback schema", () =>
+          validateAdvertisedFeedbackSchema(request, baseUrl, manifest),
+        ),
+      );
+    }
+    if (asRecord(manifest.search)?.enabled === true) {
+      advertisedChecks.push(
+        recorder.check("advertised human search", () =>
+          validateAdvertisedSearch(
+            request,
+            baseUrl,
+            manifest,
+            ["search", "endpoint"],
+            "human search endpoint",
+          ),
+        ),
+        recorder.check("advertised agent search", () =>
+          validateAdvertisedSearch(
+            request,
+            baseUrl,
+            manifest,
+            ["search", "agentEndpoint"],
+            "agent search endpoint",
+          ),
+        ),
+      );
+    }
+    for (const spec of advertisedTextSurfaceSpecs(manifest)) {
+      advertisedChecks.push(
+        recorder.check(spec.label, () => validateAdvertisedTextSurface(request, baseUrl, spec)),
+      );
+    }
+    await Promise.all(advertisedChecks);
+  }
 
   if (recorder.failures.length > 0) {
     const error = new Error(

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -264,6 +264,7 @@ function createFixtureFetch(options = {}) {
     const requestHeaders = new Headers(init.headers);
     calls.push({
       accept: requestHeaders.get("accept"),
+      acceptEncoding: requestHeaders.get("accept-encoding"),
       ifNoneMatch: requestHeaders.get("if-none-match"),
       method,
       pathname: url.pathname,
@@ -598,6 +599,7 @@ test("smoke-checks deployed discovery, skills, MCP, and well-known aliases", asy
   assert(fixture.calls.some((call) => call.pathname === "/robots.txt"));
   assert(fixture.calls.some((call) => call.pathname === "/sitemap.xml"));
   assert(fixture.calls.some((call) => call.ifNoneMatch));
+  assert(fixture.calls.every((call) => call.acceptEncoding === "identity"));
 });
 
 test("rejects stale typed API catalog Link metadata", async () => {

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -56,20 +56,84 @@ function response(method, body, options = {}) {
   });
 }
 
+function cachedResponse(method, body, requestHeaders, options = {}) {
+  const etag = options.etag ?? `"${digest(body)}"`;
+  const cacheControl = options.cacheControl ?? "public, max-age=0";
+  const headers = new Headers(options.headers);
+  headers.set("cache-control", cacheControl);
+  headers.set("etag", etag);
+  const requestedEtag = requestHeaders.get("if-none-match")?.replace(/^W\//u, "");
+  if (requestedEtag === etag.replace(/^W\//u, "")) {
+    return response("HEAD", "", {
+      status: 304,
+      headers: { "cache-control": cacheControl, etag: etag.replace(/^W\//u, "") },
+    });
+  }
+  return response(method, body, {
+    contentType: options.contentType,
+    headers,
+  });
+}
+
 function createFixtureFetch(options = {}) {
   const calls = [];
   const streamState = { aborted: false, cancelled: false, pulls: 0 };
+  const canonicalBaseUrl = options.canonicalBaseUrl ?? BASE_URL;
   const manifest = {
     $schema: AGENT_MANIFEST_SCHEMA,
     format: AGENT_MANIFEST_FORMAT,
     version: "1",
     name: "@farming-labs/docs",
-    capabilities: { agentSkillsDiscovery: true, mcp: true },
+    site: { baseUrl: canonicalBaseUrl, entry: "docs" },
+    capabilities: {
+      agentFeedback: true,
+      agentSkillsDiscovery: true,
+      markdownRoutes: true,
+      mcp: true,
+      robots: true,
+      search: true,
+      sitemap: true,
+    },
     api: {
       agentSkillsIndex: AGENT_SKILLS_INDEX_ROUTE,
+      agentSpecDefault: "/.well-known/agent.json",
+      diagnostics: "/api/docs?format=diagnostics",
       legacySkillsIndex: LEGACY_SKILLS_INDEX_ROUTE,
     },
     apiCatalog: { enabled: true, route: API_CATALOG_ROUTE },
+    config: {
+      endpoint: "/api/docs?format=config",
+      format: "docs-config-map.v1",
+    },
+    markdown: {
+      enabled: true,
+      rootPage: "/docs.md",
+    },
+    llms: {
+      enabled: true,
+      defaultTxt: "/llms.txt",
+      defaultFull: "/llms-full.txt",
+    },
+    sitemap: {
+      enabled: true,
+      xml: { enabled: true, route: "/sitemap.xml" },
+      markdown: {
+        enabled: true,
+        route: "/sitemap.md",
+        docsRoute: "/docs/sitemap.md",
+      },
+    },
+    robots: { enabled: true, route: "/robots.txt" },
+    search: {
+      enabled: true,
+      endpoint: "/api/docs?query={query}",
+      agentEndpoint: "/api/docs?query={query}&audience=agent",
+    },
+    agents: {
+      enabled: true,
+      route: "/AGENTS.md",
+      aliases: ["/AGENT.md"],
+    },
     skills: {
       discovery: {
         schema: AGENT_SKILLS_SCHEMA,
@@ -92,9 +156,15 @@ function createFixtureFetch(options = {}) {
           ],
         },
       ],
+      route: "/skill.md",
     },
     mcp: {
+      canonicalEndpoint: "/api/docs/mcp",
       publicEndpoints: ["/mcp", "/.well-known/mcp"],
+    },
+    feedback: {
+      enabled: true,
+      schema: "/api/docs/agent/feedback/schema",
     },
   };
   if (options.agentCard) manifest.api.agentCard = AGENT_CARD_ROUTE;
@@ -188,7 +258,13 @@ function createFixtureFetch(options = {}) {
     const url = new URL(input);
     const method = init.method ?? "GET";
     const requestHeaders = new Headers(init.headers);
-    calls.push({ accept: requestHeaders.get("accept"), method, pathname: url.pathname });
+    calls.push({
+      accept: requestHeaders.get("accept"),
+      ifNoneMatch: requestHeaders.get("if-none-match"),
+      method,
+      pathname: url.pathname,
+      search: url.search,
+    });
 
     if (
       url.pathname === "/.well-known/agent.json" ||
@@ -197,6 +273,7 @@ function createFixtureFetch(options = {}) {
     ) {
       return jsonResponse(method, manifest, {
         headers: {
+          "cache-control": "public, max-age=0",
           link:
             options.manifestLink ??
             `<${AGENT_MANIFEST_SCHEMA}>; rel="describedby"; type="${AGENT_MANIFEST_SCHEMA_MEDIA_TYPE}"`,
@@ -226,49 +303,70 @@ function createFixtureFetch(options = {}) {
       );
     }
     if (url.pathname === API_CATALOG_ROUTE) {
-      return jsonResponse(
-        method,
-        {
-          linkset: [
-            {
-              anchor: `${BASE_URL}${API_CATALOG_ROUTE}`,
-              item: [{ href: `${BASE_URL}/api/docs` }],
-              "service-meta": [
-                { href: `${BASE_URL}/.well-known/agent.json` },
-                { href: `${BASE_URL}${AGENT_SKILLS_INDEX_ROUTE}` },
-              ],
-            },
-          ],
+      const value = {
+        linkset: [
+          {
+            anchor: `${BASE_URL}${API_CATALOG_ROUTE}`,
+            item: [{ href: `${BASE_URL}/api/docs` }],
+            "service-meta": [
+              { href: `${BASE_URL}/.well-known/agent.json` },
+              { href: `${BASE_URL}${AGENT_SKILLS_INDEX_ROUTE}` },
+            ],
+          },
+        ],
+      };
+      return cachedResponse(method, `${JSON.stringify(value)}\n`, requestHeaders, {
+        contentType: `application/linkset+json; profile="${API_CATALOG_PROFILE}"; charset=utf-8`,
+        headers: {
+          link:
+            options.apiCatalogLink ??
+            `<${API_CATALOG_ROUTE}>; rel="api-catalog"; type="application/linkset+json"`,
         },
-        {
-          contentType: `application/linkset+json; profile="${API_CATALOG_PROFILE}"; charset=utf-8`,
-          headers: { link: `<${API_CATALOG_ROUTE}>; rel="api-catalog"` },
-        },
-      );
+      });
     }
     if (url.pathname === AGENT_SKILLS_INDEX_ROUTE) {
-      return jsonResponse(method, modernIndex);
+      const links = modernIndex.skills
+        .map(
+          (skill) =>
+            `<${skill.url}>; rel="item"; type="${skill.type === "archive" ? "application/gzip" : "text/markdown"}"`,
+        )
+        .join(", ");
+      return cachedResponse(method, `${JSON.stringify(modernIndex)}\n`, requestHeaders, {
+        contentType: "application/json; charset=utf-8",
+        headers: { link: links },
+      });
     }
     if (url.pathname === LEGACY_SKILLS_INDEX_ROUTE) {
-      return jsonResponse(method, legacyIndex);
+      return cachedResponse(method, `${JSON.stringify(legacyIndex)}\n`, requestHeaders, {
+        contentType: "application/json; charset=utf-8",
+      });
     }
     if (url.pathname === "/.well-known/agent-skills/docs/SKILL.md") {
-      return response(method, docsDocument, {
+      return cachedResponse(method, docsDocument, requestHeaders, {
+        cacheControl:
+          options.docsArtifactHeadCacheMismatch && method === "HEAD"
+            ? "public, max-age=60"
+            : undefined,
         contentType: "text/markdown; charset=utf-8",
+        etag: `W/"${docsDigest}"`,
         headers: {
-          etag: `W/"${docsDigest}"`,
-          link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"`,
+          link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"; type="application/json"`,
         },
       });
     }
     if (url.pathname === "/.well-known/agent-skills/portable.tar.gz") {
-      return response(method, options.corruptArchive ? new Uint8Array([0]) : portableArchive, {
-        contentType: "application/gzip",
-        headers: {
+      return cachedResponse(
+        method,
+        options.corruptArchive ? new Uint8Array([0]) : portableArchive,
+        requestHeaders,
+        {
+          contentType: "application/gzip",
           etag: `"${portableArchiveDigest}"`,
-          link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"`,
+          headers: {
+            link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"; type="application/json"`,
+          },
         },
-      });
+      );
     }
     if (url.pathname === "/.well-known/agent-skills/portable/SKILL.md") {
       return response(method, portableDocument, { contentType: "text/markdown; charset=utf-8" });
@@ -302,7 +400,11 @@ function createFixtureFetch(options = {}) {
     if (url.pathname === AGENT_CARD_ROUTE) {
       return response(method, "Not Found", { status: 404, contentType: "text/plain" });
     }
-    if (url.pathname === "/mcp" || url.pathname === "/.well-known/mcp") {
+    if (
+      url.pathname === "/mcp" ||
+      url.pathname === "/.well-known/mcp" ||
+      url.pathname === "/api/docs/mcp"
+    ) {
       return jsonResponse(method, {
         jsonrpc: "2.0",
         id: 1,
@@ -312,6 +414,72 @@ function createFixtureFetch(options = {}) {
           serverInfo: { name: "Fixture docs", version: "1.0.0" },
         },
       });
+    }
+    if (url.pathname === "/api/docs/agent/feedback/schema") {
+      return jsonResponse(
+        method,
+        {
+          type: "object",
+          properties: { helpful: { type: "boolean" } },
+        },
+        { contentType: "application/schema+json; charset=utf-8" },
+      );
+    }
+    if (url.pathname === "/api/docs" && url.searchParams.get("format") === "config") {
+      return jsonResponse(method, { format: "docs-config-map.v1" });
+    }
+    if (url.pathname === "/api/docs" && url.searchParams.get("format") === "diagnostics") {
+      return jsonResponse(method, { format: "docs-diagnostics.v1", ok: true });
+    }
+    if (url.pathname === "/api/docs" && url.searchParams.has("query")) {
+      return jsonResponse(method, [
+        {
+          id: "/docs/installation",
+          url: "/docs/installation",
+          content: "Installation",
+        },
+      ]);
+    }
+    if (url.pathname === "/docs" && requestHeaders.get("accept") === "text/markdown") {
+      return response(method, "# Introduction\n", {
+        contentType: "text/markdown; charset=utf-8",
+        headers: {
+          link: `<${canonicalBaseUrl}/docs>; rel="canonical"`,
+          vary: "Accept",
+        },
+      });
+    }
+    if (url.pathname === "/docs") {
+      return response(method, "<!doctype html><title>Introduction</title>", {
+        contentType: "text/html; charset=utf-8",
+      });
+    }
+    if (url.pathname === "/docs.md") {
+      return response(method, options.explicitMarkdownBody ?? "# Introduction\n", {
+        contentType: "text/markdown; charset=utf-8",
+        headers: { link: `<${canonicalBaseUrl}/docs>; rel="canonical"` },
+      });
+    }
+    if (url.pathname === "/robots.txt") {
+      const rootMcpAllow = options.robotsOmitRootMcp ? "" : "Allow: /mcp\n";
+      return response(
+        method,
+        `User-agent: *
+Allow: /.well-known/agent.json
+Allow: /.well-known/api-catalog
+Allow: /.well-known/agent-skills/index.json
+${rootMcpAllow}Allow: /.well-known/mcp
+Sitemap: ${BASE_URL}/sitemap.xml
+`,
+        { contentType: "text/plain; charset=utf-8" },
+      );
+    }
+    if (url.pathname === "/sitemap.xml") {
+      return response(
+        method,
+        `<?xml version="1.0"?><urlset><url><loc>${BASE_URL}/docs</loc></url></urlset>`,
+        { contentType: "application/xml; charset=utf-8" },
+      );
     }
 
     if (url.pathname === "/.well-known/skill.md" && options.oversizedStream) {
@@ -345,6 +513,13 @@ function createFixtureFetch(options = {}) {
       "/.well-known/llms.txt": ["text/plain", "# Documentation\n"],
       "/.well-known/llms-full.txt": ["text/plain", "# Full documentation\n"],
       "/.well-known/sitemap.md": ["text/markdown", "# Sitemap\n"],
+      "/skill.md": ["text/markdown", docsDocument],
+      "/AGENTS.md": ["text/markdown", "# AGENTS.md\n"],
+      "/AGENT.md": ["text/markdown", "# AGENT.md\n"],
+      "/llms.txt": ["text/plain", "# Documentation\n"],
+      "/llms-full.txt": ["text/plain", "# Full documentation\n"],
+      "/sitemap.md": ["text/markdown", "# Sitemap\n"],
+      "/docs/sitemap.md": ["text/markdown", "# Documentation sitemap\n"],
     };
     const textRoute = textRoutes[url.pathname];
     if (textRoute) return response(method, textRoute[1], { contentType: textRoute[0] });
@@ -403,6 +578,109 @@ test("smoke-checks deployed discovery, skills, MCP, and well-known aliases", asy
     fixture.calls.some((call) => call.pathname === "/.well-known/agent-skills/portable/SKILL.md"),
   );
   assert(fixture.calls.some((call) => call.pathname === AGENT_MANIFEST_SCHEMA_ROUTE));
+  assert(fixture.calls.some((call) => call.method === "POST" && call.pathname === "/api/docs/mcp"));
+  assert(
+    fixture.calls.some(
+      (call) =>
+        call.pathname === "/docs" && call.accept === "text/markdown" && call.method === "GET",
+    ),
+  );
+  assert(
+    fixture.calls.some(
+      (call) => call.pathname === "/api/docs" && call.search.includes("audience=agent"),
+    ),
+  );
+  assert(fixture.calls.some((call) => call.pathname === "/robots.txt"));
+  assert(fixture.calls.some((call) => call.pathname === "/sitemap.xml"));
+  assert(fixture.calls.some((call) => call.ifNoneMatch));
+});
+
+test("rejects stale typed API catalog Link metadata", async () => {
+  const fixture = createFixtureFetch({
+    apiCatalogLink: `<${API_CATALOG_ROUTE}>; rel="api-catalog"; type="application/json"`,
+  });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(({ label }) => label === "RFC 9727 API catalog");
+      assert.match(failure?.message ?? "", /omitted its typed api-catalog Link relation/u);
+      return true;
+    },
+  );
+});
+
+test("rejects a hashed skill artifact with mismatched HEAD cache metadata", async () => {
+  const fixture = createFixtureFetch({ docsArtifactHeadCacheMismatch: true });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(({ label }) => label === "Agent Skill artifact docs");
+      assert.match(failure?.message ?? "", /HEAD returned different cache metadata/u);
+      return true;
+    },
+  );
+});
+
+test("rejects explicit Markdown that drifts from content negotiation", async () => {
+  const fixture = createFixtureFetch({ explicitMarkdownBody: "# Stale documentation\n" });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(
+        ({ label }) => label === "advertised Markdown negotiation",
+      );
+      assert.match(failure?.message ?? "", /differed from the negotiated Markdown/u);
+      return true;
+    },
+  );
+});
+
+test("accepts a preview whose Markdown links to its advertised production canonical", async () => {
+  const fixture = createFixtureFetch({ canonicalBaseUrl: "https://docs.example.com" });
+  const result = await runAgentSurfaceSmoke({
+    attempts: 1,
+    baseUrl: BASE_URL,
+    expectedSkillNames: ["portable"],
+    fetchImpl: fixture.fetch,
+    log() {},
+  });
+  assert.equal(result.passed, true);
+});
+
+test("requires exact robots.txt coverage for both MCP routes", async () => {
+  const fixture = createFixtureFetch({ robotsOmitRootMcp: true });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(({ label }) => label === "advertised robots.txt");
+      assert.match(failure?.message ?? "", /did not cover \/mcp/u);
+      return true;
+    },
+  );
 });
 
 for (const [name, manifestLink] of [

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -66,7 +66,10 @@ function cachedResponse(method, body, requestHeaders, options = {}) {
   if (requestedEtag === etag.replace(/^W\//u, "")) {
     return response("HEAD", "", {
       status: 304,
-      headers: { "cache-control": cacheControl, etag: etag.replace(/^W\//u, "") },
+      headers: {
+        "cache-control": cacheControl,
+        etag: options.notModifiedEtag ?? etag,
+      },
     });
   }
   return response(method, body, {
@@ -168,6 +171,7 @@ function createFixtureFetch(options = {}) {
     },
   };
   if (options.agentCard) manifest.api.agentCard = AGENT_CARD_ROUTE;
+  if (options.missingCanonicalMcp) delete manifest.mcp.canonicalEndpoint;
   const agentCard = {
     name: "Fixture docs agent",
     description: "Answers questions from the fixture documentation.",
@@ -349,6 +353,7 @@ function createFixtureFetch(options = {}) {
             : undefined,
         contentType: "text/markdown; charset=utf-8",
         etag: `W/"${docsDigest}"`,
+        notModifiedEtag: options.docsArtifactNotModifiedEtag,
         headers: {
           link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"; type="application/json"`,
         },
@@ -628,6 +633,46 @@ test("rejects a hashed skill artifact with mismatched HEAD cache metadata", asyn
     (error) => {
       const failure = error.failures.find(({ label }) => label === "Agent Skill artifact docs");
       assert.match(failure?.message ?? "", /HEAD returned different cache metadata/u);
+      return true;
+    },
+  );
+});
+
+test("rejects a hashed skill artifact whose 304 changes ETag strength", async () => {
+  const fixture = createFixtureFetch({
+    docsArtifactNotModifiedEtag: `"${docsDigest}"`,
+  });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(({ label }) => label === "Agent Skill artifact docs");
+      assert.match(failure?.message ?? "", /304 returned a different ETag/u);
+      return true;
+    },
+  );
+});
+
+test("rejects a missing advertised canonical MCP endpoint", async () => {
+  const fixture = createFixtureFetch({ missingCanonicalMcp: true });
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      expectedSkillNames: ["portable"],
+      fetchImpl: fixture.fetch,
+      log() {},
+    }),
+    (error) => {
+      const failure = error.failures.find(
+        ({ label }) => label === "advertised canonical MCP endpoint",
+      );
+      assert.match(failure?.message ?? "", /canonical MCP endpoint was not advertised/u);
       return true;
     },
   );

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install --frozen-lockfile --force",
   "crons": [
     {
       "path": "/api/enterprise-support/email/process",


### PR DESCRIPTION
## Summary

- force Vercel installs to reconstruct the pnpm modules graph while preserving the frozen lockfile
- run deployment-triggered smoke tests only against the public Docs Cloud project, while scheduled/manual runs continue to test production
- extend the existing deployed validator across advertised config, diagnostics, feedback schema, human and agent search, the canonical MCP route, Markdown/HTML negotiation, robots, sitemaps, aliases, typed Link metadata, and ETag/HEAD/304 contracts
- add regression coverage for stale Link metadata, cache drift, Markdown representation drift, production canonicals on previews, and exact robots route coverage, ETag strength preservation, and required canonical MCP discovery

## Root cause

Both Vercel projects restored a partial cached `node_modules` graph. A normal frozen pnpm install reconciled changed packages but left dangling virtual-store links, so the builds later failed while resolving `recma-jsx` and `acorn-jsx`. The workspace dependency tree is larger than Vercel's build-cache allowance. `pnpm install --frozen-lockfile --force` recreates the modules graph on every Vercel install without changing dependency resolution.

The deployment smoke workflow also admitted SSO-protected `docs-website` production events, producing false 401 failures. It now accepts successful deployment events only from the public `farming-labs-docs-docs-cloud` project.

The smoke client requests the identity representation so Vercel compression cannot change ETag strength between 200 and 304 responses.

## Validation

- `pnpm test:smoke-agent-surfaces` — 24 tests passed
- `pnpm test` — 58 files / 978 tests passed
- `pnpm format:check`
- `pnpm lint` — 0 errors (existing repository warnings remain)
- workflow YAML and Vercel JSON parsing
- live production endpoint probe — 55 checks passed with only the newly merged, not-yet-deployed manifest-schema response shimmed
- live public preview probe — all 55 deployed-surface checks passed
- independent diff review completed; Cubic follow-up findings addressed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened agent deployment and stabilized cache/link contracts in the deployed validator to reduce flaky previews and catch drift. Deployment smoke runs only trigger for the public Docs Cloud project to avoid SSO noise.

- **Bug Fixes**
  - Vercel install: use `pnpm install --frozen-lockfile --force` to rebuild `node_modules` and prevent dangling virtual-store links.
  - Workflow filter: run on successful deployments only from `farming-labs-docs-docs-cloud`; scheduled/manual runs still target production.

- **New Features**
  - Cache and revalidation: require public Cache-Control with numeric max-age; enforce HEAD parity for content, cache, and Link metadata; require ETag and stable 304 ETag/cache; send Accept-Encoding: identity to avoid compression variance.
  - Typed links and skills: require a typed `api-catalog` Link on the catalog; enforce typed `collection`/`item` links for skills; skill artifacts must expose the indexed digest as their ETag and honor hashed-cache contracts.
  - Advertised surfaces: validate config endpoint format, diagnostics format, feedback schema (`application/schema+json`), and human/agent search; require Markdown negotiation with Vary: Accept and canonical links, and parity with the explicit Markdown route; verify canonical MCP endpoint; require exact robots.txt coverage (API spec default, API catalog, skills index, MCP routes) and a valid XML sitemap; check public text surfaces (AGENTS and aliases, skill.md, `llms`, sitemaps).

<sup>Written for commit 8245abf6a5b9e8b203e0cc575d0b47405567bd2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->