### PR TITLE
fix: validate full Agent Skills frontmatter

### DIFF
--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -29,12 +29,22 @@ jobs:
     env:
       DOCS_SMOKE_BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.environment_url || inputs.base_url || 'https://docs.farming-labs.dev' }}
       DOCS_SMOKE_EXPECT_SKILLS: ask-ai,cli,configuration,creating-themes,getting-started,page-actions
+      DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER: "1"
     steps:
       - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: pnpm
+
+      - name: Install validator dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the Agent Skills validator
+        run: pnpm --filter @farming-labs/docs build
 
       - name: Test the smoke validator
         run: node --test scripts/smoke-agent-surfaces.test.mjs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/agent-skills-bundle.mjs",
       "default": "./dist/agent-skills-bundle.mjs"
     },
+    "./agent-skills": {
+      "types": "./dist/agent-skills-spec.d.mts",
+      "import": "./dist/agent-skills-spec.mjs",
+      "default": "./dist/agent-skills-spec.mjs"
+    },
     "./vite": {
       "types": "./dist/agent-skills-vite.d.mts",
       "import": "./dist/agent-skills-vite.mjs",
@@ -72,6 +77,7 @@
     "gray-matter": "^4.0.3",
     "jiti": "^2.7.0",
     "picocolors": "^1.1.1",
+    "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/packages/docs/src/agent-conformance.test.ts
+++ b/packages/docs/src/agent-conformance.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import {
   createDocsAgentContractCases,
@@ -22,6 +23,34 @@ description: Use the documentation through its agent-readable resources.
 # Documentation
 `;
 const AGENT_SKILL_DIGEST = createHash("sha256").update(AGENT_SKILL_CONTENT, "utf8").digest("hex");
+
+function createAgentSkillArchive(document: string): Uint8Array<ArrayBuffer> {
+  const content = new TextEncoder().encode(document);
+  const header = new Uint8Array(512);
+  const write = (offset: number, length: number, value: string) => {
+    header.set(new TextEncoder().encode(value).subarray(0, length), offset);
+  };
+  write(0, 100, "SKILL.md");
+  write(100, 8, "0000644");
+  write(108, 8, "0000000");
+  write(116, 8, "0000000");
+  write(124, 12, content.byteLength.toString(8).padStart(11, "0"));
+  write(136, 12, "00000000000");
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  write(257, 6, "ustar");
+  write(263, 2, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  write(148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+
+  const tar = new Uint8Array(512 + Math.ceil(content.byteLength / 512) * 512 + 1024);
+  tar.set(header);
+  tar.set(content, 512);
+  const compressed = gzipSync(tar);
+  const archive = new Uint8Array(new ArrayBuffer(compressed.byteLength));
+  archive.set(compressed);
+  return archive;
+}
 
 function createPassingResponse(surface: DocsAgentContractSurface, contentType?: string): Response {
   const contractCase = createDocsAgentContractCases().find(
@@ -177,8 +206,58 @@ describe("agent conformance contract", () => {
     });
   });
 
-  it("validates archive artifacts as exact binary bytes", async () => {
-    const archive = Uint8Array.from([31, 139, 8, 0, 255, 0, 128, 1]);
+  it("validates every published SKILL.md against the complete frontmatter contract", async () => {
+    const invalidSkill = `---
+name: docs
+description: Use the documentation through its agent-readable resources.
+version: "1.0"
+---
+
+# Documentation
+`;
+    const invalidDigest = createHash("sha256").update(invalidSkill, "utf8").digest("hex");
+    const report = await runDocsAgentConformance({
+      adapter: "next",
+      async handle(request, surface) {
+        const response = createPassingResponse(surface);
+        if (surface === "agent-skills-index") {
+          const index = (await response.json()) as { skills: Array<{ digest: string }> };
+          index.skills[0]!.digest = `sha256:${invalidDigest}`;
+          return new Response(JSON.stringify(index), {
+            status: response.status,
+            headers: response.headers,
+          });
+        }
+        if (
+          surface === "agent-skill" &&
+          request.url.endsWith("/.well-known/agent-skills/docs/SKILL.md")
+        ) {
+          return new Response(invalidSkill, {
+            headers: { "Content-Type": "text/markdown; charset=utf-8" },
+          });
+        }
+        return response;
+      },
+    });
+
+    expect(report.cases.find((result) => result.surface === "agent-skills-index")).toMatchObject({
+      passed: false,
+      issues: [
+        expect.stringContaining(
+          "invalid SKILL.md frontmatter: Unexpected fields in frontmatter: version",
+        ),
+      ],
+    });
+  });
+
+  it("validates archive artifacts and their embedded SKILL.md as exact binary bytes", async () => {
+    const archive = createAgentSkillArchive(`---
+name: bundle
+description: Use the bundled binary workflow.
+---
+
+# Bundle
+`);
     const digest = createHash("sha256").update(archive).digest("hex");
     const report = await runDocsAgentConformance({
       adapter: "next",
@@ -209,6 +288,53 @@ describe("agent conformance contract", () => {
 
     expect(report.cases.filter((result) => !result.passed)).toEqual([]);
     expect(report.passed).toBe(true);
+  });
+
+  it("rejects invalid frontmatter from the SKILL.md embedded in an archive", async () => {
+    const archive = createAgentSkillArchive(`---
+name: bundle
+description: Use the bundled binary workflow.
+version: "1.0"
+---
+
+# Bundle
+`);
+    const digest = createHash("sha256").update(archive).digest("hex");
+    const report = await runDocsAgentConformance({
+      adapter: "next",
+      async handle(request, surface) {
+        if (surface === "agent-skills-index") {
+          const response = createPassingResponse(surface);
+          const index = (await response.json()) as {
+            skills: Array<Record<string, unknown>>;
+          };
+          index.skills.push({
+            name: "bundle",
+            description: "Use the bundled binary workflow.",
+            type: "archive",
+            url: "/.well-known/agent-skills/bundle.tar.gz",
+            digest: `sha256:${digest}`,
+          });
+          return new Response(JSON.stringify(index), {
+            status: response.status,
+            headers: response.headers,
+          });
+        }
+        if (surface === "agent-skill" && request.url.endsWith("/bundle.tar.gz")) {
+          return new Response(archive, { headers: { "Content-Type": "application/gzip" } });
+        }
+        return createPassingResponse(surface);
+      },
+    });
+
+    expect(report.cases.find((result) => result.surface === "agent-skills-index")).toMatchObject({
+      passed: false,
+      issues: [
+        expect.stringContaining(
+          "invalid SKILL.md frontmatter: Unexpected fields in frontmatter: version",
+        ),
+      ],
+    });
   });
 
   it("correlates each Link target and relation while allowing quoted commas", async () => {

--- a/packages/docs/src/agent-conformance.ts
+++ b/packages/docs/src/agent-conformance.ts
@@ -17,7 +17,13 @@ import {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  isDocsAgentSkillName,
+  validateDocsAgentSkillFrontmatter,
 } from "./agent.js";
+import {
+  AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+  readAgentSkillDocumentFromTar,
+} from "./agent-skills-archive.js";
 import {
   httpLinkMatchesExpectation,
   parseHttpLinkHeader,
@@ -27,7 +33,7 @@ import {
 import { DEFAULT_SITEMAP_MD_ROUTE, DEFAULT_SITEMAP_XML_ROUTE } from "./sitemap.js";
 import { DEFAULT_ROBOTS_TXT_ROUTE } from "./robots.js";
 
-export const DOCS_AGENT_CONTRACT_VERSION = "1.2";
+export const DOCS_AGENT_CONTRACT_VERSION = "1.3";
 
 export type DocsAgentAdapter = "next" | "tanstack-start" | "sveltekit" | "astro" | "nuxt";
 
@@ -468,6 +474,35 @@ async function sha256Content(content: Uint8Array<ArrayBuffer>): Promise<string> 
   return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
 }
 
+async function decompressAgentSkillArchive(
+  content: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
+  if (typeof DecompressionStream !== "function") {
+    throw new Error("gzip decompression is unavailable in this runtime");
+  }
+
+  const stream = new Blob([content]).stream().pipeThrough(new DecompressionStream("gzip"));
+  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  let totalBytes = 0;
+  for await (const chunk of stream) {
+    totalBytes += chunk.byteLength;
+    if (totalBytes > AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES) {
+      throw new Error(
+        `archive exceeds ${AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES} uncompressed bytes`,
+      );
+    }
+    chunks.push(chunk);
+  }
+
+  const archive = new Uint8Array(new ArrayBuffer(totalBytes));
+  let offset = 0;
+  for (const chunk of chunks) {
+    archive.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return archive;
+}
+
 async function validateAgentSkillsIndex(
   content: string,
   indexUrl: string,
@@ -499,11 +534,10 @@ async function validateAgentSkillsIndex(
     const digest = skill?.digest;
     if (
       !isNonEmptyString(name) ||
-      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(name) ||
-      name.length > 64 ||
+      !isDocsAgentSkillName(name) ||
       (skill?.type !== "skill-md" && skill?.type !== "archive") ||
       !isNonEmptyString(description) ||
-      description.length > 1024 ||
+      Array.from(description).length > 1024 ||
       !isNonEmptyString(artifactRoute) ||
       typeof digest !== "string" ||
       !/^sha256:[0-9a-f]{64}$/u.test(digest)
@@ -526,8 +560,8 @@ async function validateAgentSkillsIndex(
     }
     const expectedPath =
       skill.type === "archive"
-        ? `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${name}.tar.gz`
-        : `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${name}/SKILL.md`;
+        ? `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(name)}.tar.gz`
+        : `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(name)}/SKILL.md`;
     if (artifactUrl.origin !== origin || !artifactUrl.pathname.endsWith(expectedPath)) {
       issues.push(
         `Agent Skills artifact URL for ${JSON.stringify(name)} did not resolve to same-origin ${expectedPath}`,
@@ -535,6 +569,7 @@ async function validateAgentSkillsIndex(
       continue;
     }
 
+    let skillDocument: string | null = null;
     try {
       const response = await handle(new Request(artifactUrl), "agent-skill");
       const artifact = new Uint8Array(await response.arrayBuffer());
@@ -556,10 +591,35 @@ async function validateAgentSkillsIndex(
           `Agent Skills artifact ${JSON.stringify(artifactRoute)} digest ${actualDigest} did not match ${digest}`,
         );
       }
+      if (skill.type === "skill-md") {
+        skillDocument = new TextDecoder("utf-8", { fatal: true }).decode(artifact);
+      } else {
+        const archive = await decompressAgentSkillArchive(artifact);
+        skillDocument = readAgentSkillDocumentFromTar(archive);
+      }
     } catch (error) {
       issues.push(
         `Agent Skills artifact ${JSON.stringify(artifactRoute)} failed: ${error instanceof Error ? error.message : String(error)}`,
       );
+    }
+
+    if (skillDocument !== null) {
+      const validation = validateDocsAgentSkillFrontmatter(skillDocument, {
+        directoryName: name,
+      });
+      if (!validation.valid) {
+        issues.push(
+          `Agent Skill ${JSON.stringify(name)} has invalid SKILL.md frontmatter: ${validation.issues
+            .map((issue) => issue.message)
+            .join("; ")}`,
+        );
+      } else {
+        if (validation.data.description !== description) {
+          issues.push(
+            `Agent Skill ${JSON.stringify(name)} SKILL.md description does not match the discovery index`,
+          );
+        }
+      }
     }
   }
 

--- a/packages/docs/src/agent-skills-archive.test.ts
+++ b/packages/docs/src/agent-skills-archive.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { readAgentSkillDocumentFromTar } from "./agent-skills-archive.js";
+
+function writeTarText(header: Uint8Array, offset: number, length: number, value: string): void {
+  header.set(new TextEncoder().encode(value).subarray(0, length), offset);
+}
+
+function tarEntry(name: string, content: Uint8Array, type = "0"): Uint8Array {
+  const header = new Uint8Array(512);
+  writeTarText(header, 0, 100, name);
+  writeTarText(header, 100, 8, "0000644");
+  writeTarText(header, 108, 8, "0000000");
+  writeTarText(header, 116, 8, "0000000");
+  writeTarText(header, 124, 12, content.byteLength.toString(8).padStart(11, "0"));
+  writeTarText(header, 136, 12, "00000000000");
+  header.fill(0x20, 148, 156);
+  header[156] = type.charCodeAt(0);
+  writeTarText(header, 257, 6, "ustar");
+  writeTarText(header, 263, 2, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeTarText(header, 148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+
+  const entry = new Uint8Array(512 + Math.ceil(content.byteLength / 512) * 512);
+  entry.set(header);
+  entry.set(content, 512);
+  return entry;
+}
+
+function tarArchive(entries: readonly Uint8Array[]): Uint8Array {
+  const size = entries.reduce((sum, entry) => sum + entry.byteLength, 1024);
+  const archive = new Uint8Array(size);
+  let offset = 0;
+  for (const entry of entries) {
+    archive.set(entry, offset);
+    offset += entry.byteLength;
+  }
+  return archive;
+}
+
+describe("Agent Skill archive parsing", () => {
+  it("returns the exact root SKILL.md bytes while ignoring companion files", () => {
+    const document = `---
+name: archived
+description: Use the archived workflow.
+---
+
+# Archived
+`;
+    const archive = tarArchive([
+      tarEntry("SKILL.md", new TextEncoder().encode(document)),
+      tarEntry("references/notes.md", new TextEncoder().encode("# Notes\n")),
+    ]);
+
+    expect(readAgentSkillDocumentFromTar(archive)).toBe(document);
+  });
+
+  it.each([
+    {
+      label: "a missing root document",
+      archive: tarArchive([tarEntry("nested/SKILL.md", new TextEncoder().encode("# Nested\n"))]),
+      message: "does not contain a root SKILL.md",
+    },
+    {
+      label: "a duplicate root document",
+      archive: tarArchive([
+        tarEntry("SKILL.md", new TextEncoder().encode("# One\n")),
+        tarEntry("SKILL.md", new TextEncoder().encode("# Two\n")),
+      ]),
+      message: "more than one root SKILL.md",
+    },
+    {
+      label: "a non-regular root document",
+      archive: tarArchive([tarEntry("SKILL.md", new Uint8Array(), "2")]),
+      message: "must be a regular file",
+    },
+  ])("rejects $label", ({ archive, message }) => {
+    expect(() => readAgentSkillDocumentFromTar(archive)).toThrow(message);
+  });
+
+  it("rejects corrupt headers before trusting their size or path", () => {
+    const archive = tarArchive([tarEntry("SKILL.md", new TextEncoder().encode("# Corrupt\n"))]);
+    archive[20] ^= 0xff;
+
+    expect(() => readAgentSkillDocumentFromTar(archive)).toThrow("invalid tar header checksum");
+  });
+
+  it("rejects archives without the required second end block", () => {
+    const entry = tarEntry("SKILL.md", new TextEncoder().encode("# One block\n"));
+    const archive = new Uint8Array(entry.byteLength + 512);
+    archive.set(entry);
+
+    expect(() => readAgentSkillDocumentFromTar(archive)).toThrow("truncated end-of-archive marker");
+  });
+
+  it("rejects non-zero trailing bytes after the end marker", () => {
+    const validArchive = tarArchive([
+      tarEntry("SKILL.md", new TextEncoder().encode("# Trailing\n")),
+    ]);
+    const archive = new Uint8Array(validArchive.byteLength + 512);
+    archive.set(validArchive);
+    archive[archive.byteLength - 1] = 1;
+
+    expect(() => readAgentSkillDocumentFromTar(archive)).toThrow(
+      "non-zero bytes after its end marker",
+    );
+  });
+});

--- a/packages/docs/src/agent-skills-archive.ts
+++ b/packages/docs/src/agent-skills-archive.ts
@@ -1,0 +1,131 @@
+const TAR_BLOCK_BYTES = 512;
+const TAR_NAME_BYTES = 100;
+const TAR_PREFIX_OFFSET = 345;
+const TAR_PREFIX_BYTES = 155;
+
+export const AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES = 10 * 1024 * 1024;
+export const AGENT_SKILL_DOCUMENT_MAX_BYTES = 1024 * 1024;
+
+function isZeroBlock(block: Uint8Array): boolean {
+  return block.every((byte) => byte === 0);
+}
+
+function readTarText(header: Uint8Array, offset: number, length: number, field: string): string {
+  const bytes = header.subarray(offset, offset + length);
+  const terminator = bytes.indexOf(0);
+  const value = terminator < 0 ? bytes : bytes.subarray(0, terminator);
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(value);
+  } catch {
+    throw new Error(`Agent Skill archive has invalid UTF-8 in its ${field}.`);
+  }
+}
+
+function readTarOctal(header: Uint8Array, offset: number, length: number, field: string): number {
+  const value = readTarText(header, offset, length, field).trim();
+  if (!/^[0-7]+$/u.test(value)) {
+    throw new Error(`Agent Skill archive has an invalid ${field}.`);
+  }
+  const parsed = Number.parseInt(value, 8);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Agent Skill archive has an unsafe ${field}.`);
+  }
+  return parsed;
+}
+
+function validateTarChecksum(header: Uint8Array): void {
+  const expected = readTarOctal(header, 148, 8, "header checksum");
+  const actual = header.reduce((sum, byte, index) => {
+    return sum + (index >= 148 && index < 156 ? 0x20 : byte);
+  }, 0);
+  if (actual !== expected) {
+    throw new Error("Agent Skill archive has an invalid tar header checksum.");
+  }
+}
+
+/**
+ * Extract the root SKILL.md from an uncompressed Agent Skill tar archive.
+ *
+ * Only the regular-file payload is returned; duplicate, oversized, malformed,
+ * or non-UTF-8 documents are rejected before frontmatter validation.
+ */
+export function readAgentSkillDocumentFromTar(archive: Uint8Array): string {
+  if (archive.byteLength > AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES) {
+    throw new Error(
+      `Agent Skill archive exceeds ${AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES} uncompressed bytes.`,
+    );
+  }
+
+  let skillDocument: Uint8Array | undefined;
+  let offset = 0;
+  let foundEndOfArchive = false;
+  while (offset < archive.byteLength) {
+    if (offset + TAR_BLOCK_BYTES > archive.byteLength) {
+      throw new Error("Agent Skill archive contains a truncated tar header.");
+    }
+    const header = archive.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (isZeroBlock(header)) {
+      const secondZeroBlockStart = offset + TAR_BLOCK_BYTES;
+      const secondZeroBlockEnd = secondZeroBlockStart + TAR_BLOCK_BYTES;
+      if (secondZeroBlockEnd > archive.byteLength) {
+        throw new Error("Agent Skill archive contains a truncated end-of-archive marker.");
+      }
+      const secondZeroBlock = archive.subarray(secondZeroBlockStart, secondZeroBlockEnd);
+      if (!isZeroBlock(secondZeroBlock)) {
+        throw new Error("Agent Skill archive is missing the second end-of-archive block.");
+      }
+      const trailingBytes = archive.subarray(secondZeroBlockEnd);
+      if (!trailingBytes.every((byte) => byte === 0)) {
+        throw new Error("Agent Skill archive contains non-zero bytes after its end marker.");
+      }
+      foundEndOfArchive = true;
+      break;
+    }
+
+    validateTarChecksum(header);
+    const name = readTarText(header, 0, TAR_NAME_BYTES, "file name");
+    const prefix = readTarText(header, TAR_PREFIX_OFFSET, TAR_PREFIX_BYTES, "file prefix");
+    const path = prefix ? `${prefix}/${name}` : name;
+    const size = readTarOctal(header, 124, 12, "file size");
+    const contentStart = offset + TAR_BLOCK_BYTES;
+    const contentEnd = contentStart + size;
+    if (contentEnd > archive.byteLength) {
+      throw new Error(`Agent Skill archive entry ${JSON.stringify(path)} is truncated.`);
+    }
+
+    const typeFlag = header[156];
+    if (path === "SKILL.md") {
+      if (typeFlag !== 0 && typeFlag !== "0".charCodeAt(0)) {
+        throw new Error("Agent Skill archive root SKILL.md must be a regular file.");
+      }
+      if (skillDocument) {
+        throw new Error("Agent Skill archive contains more than one root SKILL.md.");
+      }
+      if (size > AGENT_SKILL_DOCUMENT_MAX_BYTES) {
+        throw new Error(
+          `Agent Skill archive SKILL.md exceeds ${AGENT_SKILL_DOCUMENT_MAX_BYTES} bytes.`,
+        );
+      }
+      skillDocument = archive.subarray(contentStart, contentEnd);
+    }
+
+    const paddedSize = Math.ceil(size / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+    const nextOffset = contentStart + paddedSize;
+    if (nextOffset > archive.byteLength) {
+      throw new Error(`Agent Skill archive entry ${JSON.stringify(path)} has truncated padding.`);
+    }
+    offset = nextOffset;
+  }
+
+  if (!foundEndOfArchive) {
+    throw new Error("Agent Skill archive is missing its end-of-archive marker.");
+  }
+  if (!skillDocument) {
+    throw new Error("Agent Skill archive does not contain a root SKILL.md.");
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(skillDocument);
+  } catch {
+    throw new Error("Agent Skill archive SKILL.md is not valid UTF-8.");
+  }
+}

--- a/packages/docs/src/agent-skills-server.test.ts
+++ b/packages/docs/src/agent-skills-server.test.ts
@@ -1,6 +1,15 @@
-import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -167,6 +176,29 @@ describe("configured Agent Skills", () => {
     );
   });
 
+  it("reports full-spec frontmatter errors through both filesystem resolvers", async () => {
+    const root = createWorkspace();
+    const directory = writeSkill(root, "invalid-fields");
+    writeFileSync(
+      path.join(directory, "SKILL.md"),
+      `---
+name: invalid-fields
+description: Exercise configured skill validation.
+version: "1.0"
+metadata:
+  numeric-version: 1
+---
+`,
+    );
+
+    expect(() => resolveConfiguredAgentSkillsSync(directory, { rootDir: root })).toThrow(
+      "Unexpected fields in frontmatter: version",
+    );
+    await expect(resolveConfiguredAgentSkills(directory, { rootDir: root })).rejects.toThrow(
+      "Unexpected fields in frontmatter: version",
+    );
+  });
+
   it("accepts spec-valid folded YAML descriptions and inline comments", async () => {
     const root = createWorkspace();
     const directory = writeSkill(root, "yaml-skill");
@@ -184,6 +216,28 @@ description: >
     );
 
     const [skill] = await resolveConfiguredAgentSkills(directory, { rootDir: root });
-    expect(skill.description).toBe("Use the folded workflow without losing YAML semantics.");
+    expect(skill.description).toBe("Use the folded workflow without losing YAML semantics.\n");
+  });
+
+  it("keeps every Agent Skill shipped by this repository spec-valid", () => {
+    const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+    const skills = resolveConfiguredAgentSkillsSync("skills/farming-labs", {
+      rootDir: repositoryRoot,
+      workspaceRoot: repositoryRoot,
+    });
+    const expectedNames = readdirSync(path.join(repositoryRoot, "skills", "farming-labs"), {
+      withFileTypes: true,
+    })
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          readdirSync(path.join(repositoryRoot, "skills", "farming-labs", entry.name)).includes(
+            "SKILL.md",
+          ),
+      )
+      .map((entry) => entry.name)
+      .sort();
+
+    expect(skills.map((skill) => skill.name)).toEqual(expectedNames);
   });
 });

--- a/packages/docs/src/agent-skills-server.ts
+++ b/packages/docs/src/agent-skills-server.ts
@@ -513,12 +513,10 @@ function publishSkillDocumentSync(skillPath: string): DocsPublishedAgentSkill {
   if (skillDocumentBytes > MAX_FILE_BYTES) {
     throw new Error(`Agent Skill SKILL.md exceeds ${MAX_FILE_BYTES} bytes: ${skillPath}`);
   }
-  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument));
-  if (base.name !== path.basename(skillDir)) {
-    throw new Error(
-      `Agent Skill frontmatter name "${base.name}" must match its directory "${path.basename(skillDir)}".`,
-    );
-  }
+  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument), {
+    directoryName: path.basename(skillDir),
+    source: skillPath,
+  });
   const companions = readCompanionFiles(skillDir, base.name, skillDocumentBytes);
   const files = [...base.files, ...companions].sort(compareSkillFilePath);
   if (companions.length === 0) return { ...base, files };
@@ -545,12 +543,10 @@ async function publishSkillDocumentAsync(skillPath: string): Promise<DocsPublish
   if (skillDocumentBytes > MAX_FILE_BYTES) {
     throw new Error(`Agent Skill SKILL.md exceeds ${MAX_FILE_BYTES} bytes: ${skillPath}`);
   }
-  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument));
-  if (base.name !== path.basename(skillDir)) {
-    throw new Error(
-      `Agent Skill frontmatter name "${base.name}" must match its directory "${path.basename(skillDir)}".`,
-    );
-  }
+  const base = buildDocsPublishedAgentSkill(skillDocument, hashBytes(skillDocument), {
+    directoryName: path.basename(skillDir),
+    source: skillPath,
+  });
   const companions = await readCompanionFilesAsync(skillDir, base.name, skillDocumentBytes);
   const files = [...base.files, ...companions].sort(compareSkillFilePath);
   if (companions.length === 0) return { ...base, files };

--- a/packages/docs/src/agent-skills-spec.test.ts
+++ b/packages/docs/src/agent-skills-spec.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_SKILL_FRONTMATTER_FIELDS,
+  DocsAgentSkillFrontmatterError,
+  isDocsAgentSkillName,
+  parseDocsAgentSkillFrontmatter,
+  validateDocsAgentSkillFrontmatter,
+} from "./agent-skills-spec.js";
+
+function skillDocument(frontmatter: string, body = "# Test skill\n"): string {
+  return `---\n${frontmatter}\n---\n\n${body}`;
+}
+
+function issueMessages(document: string, directoryName?: string): string[] {
+  const validation = validateDocsAgentSkillFrontmatter(document, { directoryName });
+  return validation.valid ? [] : validation.issues.map((issue) => issue.message);
+}
+
+describe("Agent Skills frontmatter validation", () => {
+  it("parses every standard field without changing its values", () => {
+    const document = skillDocument(`name: release-helper
+description: Prepare and verify a release. Use when publishing packages.
+license: Apache-2.0
+compatibility: Requires Node.js 22+ and pnpm.
+metadata:
+  author: farming-labs
+  version: "1.0"
+allowed-tools: Bash(git:*) Bash(pnpm:*) Read
+`);
+
+    expect(
+      parseDocsAgentSkillFrontmatter(document, {
+        directoryName: "release-helper",
+      }),
+    ).toEqual({
+      name: "release-helper",
+      description: "Prepare and verify a release. Use when publishing packages.",
+      license: "Apache-2.0",
+      compatibility: "Requires Node.js 22+ and pnpm.",
+      metadata: {
+        author: "farming-labs",
+        version: "1.0",
+      },
+      "allowed-tools": "Bash(git:*) Bash(pnpm:*) Read",
+    });
+  });
+
+  it("normalizes and accepts Unicode lowercase alphanumeric names", () => {
+    const decomposedName = "cafe\u0301-tools";
+    const validation = validateDocsAgentSkillFrontmatter(
+      skillDocument(`name: ${decomposedName}
+description: Handle localized documentation tools.
+`),
+      { directoryName: "café-tools" },
+    );
+
+    expect(validation).toMatchObject({
+      valid: true,
+      data: { name: "café-tools" },
+    });
+    expect(isDocsAgentSkillName("文档-工具2")).toBe(true);
+    expect(isDocsAgentSkillName("PDF-tools")).toBe(false);
+  });
+
+  it("preserves accepted description whitespace exactly as YAML parsed it", () => {
+    const parsed = parseDocsAgentSkillFrontmatter(
+      skillDocument(`name: spaced-description
+description: " Keep deliberate spacing. "
+`),
+    );
+
+    expect(parsed.description).toBe(" Keep deliberate spacing. ");
+  });
+
+  it("rejects unknown top-level fields and points extensions to the standard field set", () => {
+    const messages = issueMessages(
+      skillDocument(`name: extra-fields
+description: Exercise strict top-level field validation.
+version: "1.0"
+author: farming-labs
+`),
+    );
+
+    expect(messages).toContain(
+      `Unexpected fields in frontmatter: author, version. Only ${JSON.stringify([
+        ...AGENT_SKILL_FRONTMATTER_FIELDS,
+      ])} are allowed.`,
+    );
+  });
+
+  it.each([
+    {
+      label: "a mapping-valued license",
+      fields: "license:\n  name: MIT\n",
+      message: "Field 'license' must be a string",
+    },
+    {
+      label: "an empty compatibility value",
+      fields: 'compatibility: "   "\n',
+      message: "Field 'compatibility' must contain at least 1 character",
+    },
+    {
+      label: "an oversized compatibility value",
+      fields: `compatibility: ${"x".repeat(501)}\n`,
+      message: "Compatibility exceeds 500 character limit (501 chars)",
+    },
+    {
+      label: "a list-valued metadata field",
+      fields: "metadata:\n  - author\n",
+      message: "Field 'metadata' must be a mapping from string keys to string values",
+    },
+    {
+      label: "a timestamp-valued metadata field",
+      fields: "metadata: 2020-01-01\n",
+      message: "Field 'metadata' must be a mapping from string keys to string values",
+    },
+    {
+      label: "a non-string metadata key",
+      fields: "metadata:\n  1: release\n",
+      message: "Field 'metadata' keys must be strings",
+    },
+    {
+      label: "a non-string metadata value",
+      fields: "metadata:\n  version: 1\n",
+      message: "Field 'metadata.version' must be a string",
+    },
+    {
+      label: "a list-valued allowed-tools field",
+      fields: "allowed-tools:\n  - Read\n",
+      message: "Field 'allowed-tools' must be a space-separated string",
+    },
+  ])("rejects $label", ({ fields, message }) => {
+    expect(
+      issueMessages(
+        skillDocument(`name: optional-fields
+description: Exercise optional field validation.
+${fields}`),
+      ),
+    ).toContain(message);
+  });
+
+  it.each([
+    ["uppercase characters", "Release-helper", "must be lowercase"],
+    ["a leading hyphen", "-release-helper", "cannot start or end with a hyphen"],
+    ["a trailing hyphen", "release-helper-", "cannot start or end with a hyphen"],
+    ["consecutive hyphens", "release--helper", "cannot contain consecutive hyphens"],
+    ["unsupported punctuation", "release_helper", "contains invalid characters"],
+    ["surrounding whitespace", '" release-helper "', "contains invalid characters"],
+    ["more than 64 characters", "a".repeat(65), "exceeds 64 character limit"],
+  ])("rejects names with %s", (_label, name, expectedMessage) => {
+    expect(
+      issueMessages(
+        skillDocument(`name: ${name}
+description: Exercise name validation.
+`),
+      ).some((message) => message.includes(expectedMessage)),
+    ).toBe(true);
+  });
+
+  it("requires the normalized name to match the parent directory", () => {
+    expect(
+      issueMessages(
+        skillDocument(`name: release-helper
+description: Exercise directory matching.
+`),
+        "other-directory",
+      ),
+    ).toContain(
+      'Agent Skill frontmatter name "release-helper" must match its directory "other-directory".',
+    );
+  });
+
+  it("enforces required string fields and their character limits", () => {
+    const missing = issueMessages(skillDocument("license: MIT\n"));
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        "Missing required field in frontmatter: name",
+        "Missing required field in frontmatter: description",
+      ]),
+    );
+
+    const typed = issueMessages(
+      skillDocument(`name: 123
+description: false
+`),
+    );
+    expect(typed).toEqual(
+      expect.arrayContaining([
+        "Field 'name' must be a non-empty string",
+        "Field 'description' must be a non-empty string",
+      ]),
+    );
+
+    expect(
+      issueMessages(
+        skillDocument(`name: long-description
+description: ${"x".repeat(1025)}
+`),
+      ),
+    ).toContain("Description exceeds 1024 character limit (1025 chars)");
+  });
+
+  it.each([
+    ["missing opening delimiter", "# No frontmatter\n", "must start with YAML frontmatter"],
+    [
+      "a byte-order mark",
+      `\uFEFF${skillDocument("name: bom\ndescription: A BOM-prefixed document.\n")}`,
+      "must start with YAML frontmatter",
+    ],
+    [
+      "missing closing delimiter",
+      "---\nname: unclosed\ndescription: Missing the closing delimiter.\n",
+      "not properly closed",
+    ],
+    [
+      "a non-mapping document",
+      "---\n- name: list\n- description: Not a mapping.\n---\n",
+      "must be a YAML mapping",
+    ],
+    [
+      "duplicate YAML keys",
+      "---\nname: first\nname: second\ndescription: Duplicate name.\n---\n",
+      "Invalid YAML in frontmatter",
+    ],
+  ])("rejects %s", (_label, document, expectedMessage) => {
+    expect(issueMessages(document).some((message) => message.includes(expectedMessage))).toBe(true);
+  });
+
+  it("throws a structured error with the source and every issue", () => {
+    const document = skillDocument(`name: BROKEN--name
+description: Valid description.
+owner: farming-labs
+`);
+
+    try {
+      parseDocsAgentSkillFrontmatter(document, { source: "/workspace/skills/broken/SKILL.md" });
+      throw new Error("Expected frontmatter parsing to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DocsAgentSkillFrontmatterError);
+      expect(error).toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ code: "unexpected-field" }),
+          expect.objectContaining({ code: "invalid-name" }),
+        ]),
+      });
+      expect(String(error)).toContain(
+        "Invalid Agent Skill frontmatter in /workspace/skills/broken/SKILL.md",
+      );
+      expect(String(error)).toContain("Unexpected fields in frontmatter: owner");
+      expect(String(error)).toContain("must be lowercase");
+      expect(String(error)).toContain("cannot contain consecutive hyphens");
+    }
+  });
+});

--- a/packages/docs/src/agent-skills-spec.ts
+++ b/packages/docs/src/agent-skills-spec.ts
@@ -1,0 +1,466 @@
+import { isMap, isScalar, parseDocument, type YAMLMap } from "yaml";
+
+export const AGENT_SKILL_FRONTMATTER_FIELDS = [
+  "name",
+  "description",
+  "license",
+  "compatibility",
+  "metadata",
+  "allowed-tools",
+] as const;
+
+export const AGENT_SKILL_NAME_MAX_LENGTH = 64;
+export const AGENT_SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+export const AGENT_SKILL_COMPATIBILITY_MAX_LENGTH = 500;
+
+export type DocsAgentSkillFrontmatterField =
+  | (typeof AGENT_SKILL_FRONTMATTER_FIELDS)[number]
+  | "frontmatter";
+
+export interface DocsAgentSkillFrontmatter {
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  metadata?: Record<string, string>;
+  "allowed-tools"?: string;
+}
+
+export interface DocsAgentSkillFrontmatterIssue {
+  code:
+    | "missing-frontmatter"
+    | "unclosed-frontmatter"
+    | "invalid-yaml"
+    | "invalid-mapping"
+    | "unexpected-field"
+    | "missing-field"
+    | "invalid-type"
+    | "invalid-length"
+    | "invalid-name"
+    | "directory-mismatch";
+  field: DocsAgentSkillFrontmatterField;
+  message: string;
+}
+
+export interface DocsAgentSkillFrontmatterValidationOptions {
+  /** Parent directory name, when the document came from a skill directory. */
+  directoryName?: string;
+  /** Human-readable file or generated-document label used in thrown diagnostics. */
+  source?: string;
+}
+
+export type DocsAgentSkillFrontmatterValidation =
+  | {
+      valid: true;
+      data: DocsAgentSkillFrontmatter;
+      issues: readonly [];
+    }
+  | {
+      valid: false;
+      data: null;
+      issues: readonly DocsAgentSkillFrontmatterIssue[];
+    };
+
+const AGENT_SKILL_FRONTMATTER_FIELD_SET = new Set<string>(AGENT_SKILL_FRONTMATTER_FIELDS);
+const FRONTMATTER_OPEN_PATTERN = /^---[ \t]*(?:\r?\n)/u;
+const FRONTMATTER_CLOSE_PATTERN = /^---[ \t]*(?:\r?\n|$)/mu;
+const UNICODE_ALPHANUMERIC_PATTERN = /^[\p{L}\p{N}]$/u;
+
+function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function hasOwn(value: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, field);
+}
+
+function yamlErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.trim() || "unknown YAML parser error";
+}
+
+function findYamlMappingValue(mapping: YAMLMap, field: string): unknown {
+  return mapping.items.find((pair) => isScalar(pair.key) && pair.key.value === field)?.value;
+}
+
+/**
+ * Check the Agent Skills name grammar after NFKC normalization.
+ *
+ * The official reference validator accepts Unicode lowercase letters and numbers
+ * in addition to the ASCII examples documented by the specification.
+ */
+export function isDocsAgentSkillName(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const normalized = value.normalize("NFKC");
+  const characters = Array.from(normalized);
+  return (
+    characters.length > 0 &&
+    characters.length <= AGENT_SKILL_NAME_MAX_LENGTH &&
+    normalized === normalized.toLowerCase() &&
+    !normalized.startsWith("-") &&
+    !normalized.endsWith("-") &&
+    !normalized.includes("--") &&
+    characters.every(
+      (character) => character === "-" || UNICODE_ALPHANUMERIC_PATTERN.test(character),
+    )
+  );
+}
+
+function validateName(
+  data: Record<string, unknown>,
+  options: DocsAgentSkillFrontmatterValidationOptions,
+  issues: DocsAgentSkillFrontmatterIssue[],
+): string | null {
+  if (!hasOwn(data, "name")) {
+    issues.push({
+      code: "missing-field",
+      field: "name",
+      message: "Missing required field in frontmatter: name",
+    });
+    return null;
+  }
+
+  if (typeof data.name !== "string" || data.name.trim().length === 0) {
+    issues.push({
+      code: "invalid-type",
+      field: "name",
+      message: "Field 'name' must be a non-empty string",
+    });
+    return null;
+  }
+
+  const name = data.name.normalize("NFKC");
+  const length = characterCount(name);
+  if (length > AGENT_SKILL_NAME_MAX_LENGTH) {
+    issues.push({
+      code: "invalid-length",
+      field: "name",
+      message: `Skill name '${name}' exceeds ${AGENT_SKILL_NAME_MAX_LENGTH} character limit (${length} chars)`,
+    });
+  }
+  if (name !== name.toLowerCase()) {
+    issues.push({
+      code: "invalid-name",
+      field: "name",
+      message: `Skill name '${name}' must be lowercase`,
+    });
+  }
+  if (name.startsWith("-") || name.endsWith("-")) {
+    issues.push({
+      code: "invalid-name",
+      field: "name",
+      message: "Skill name cannot start or end with a hyphen",
+    });
+  }
+  if (name.includes("--")) {
+    issues.push({
+      code: "invalid-name",
+      field: "name",
+      message: "Skill name cannot contain consecutive hyphens",
+    });
+  }
+  if (
+    !Array.from(name).every(
+      (character) => character === "-" || UNICODE_ALPHANUMERIC_PATTERN.test(character),
+    )
+  ) {
+    issues.push({
+      code: "invalid-name",
+      field: "name",
+      message: `Skill name '${name}' contains invalid characters. Only letters, digits, and hyphens are allowed.`,
+    });
+  }
+
+  if (options.directoryName !== undefined && options.directoryName.normalize("NFKC") !== name) {
+    issues.push({
+      code: "directory-mismatch",
+      field: "name",
+      message: `Agent Skill frontmatter name "${name}" must match its directory "${options.directoryName}".`,
+    });
+  }
+
+  return name;
+}
+
+function validateDescription(
+  data: Record<string, unknown>,
+  issues: DocsAgentSkillFrontmatterIssue[],
+): string | null {
+  if (!hasOwn(data, "description")) {
+    issues.push({
+      code: "missing-field",
+      field: "description",
+      message: "Missing required field in frontmatter: description",
+    });
+    return null;
+  }
+
+  if (typeof data.description !== "string" || data.description.trim().length === 0) {
+    issues.push({
+      code: "invalid-type",
+      field: "description",
+      message: "Field 'description' must be a non-empty string",
+    });
+    return null;
+  }
+
+  const length = characterCount(data.description);
+  if (length > AGENT_SKILL_DESCRIPTION_MAX_LENGTH) {
+    issues.push({
+      code: "invalid-length",
+      field: "description",
+      message: `Description exceeds ${AGENT_SKILL_DESCRIPTION_MAX_LENGTH} character limit (${length} chars)`,
+    });
+  }
+  return data.description;
+}
+
+function validateOptionalFields(
+  data: Record<string, unknown>,
+  frontmatter: YAMLMap,
+  issues: DocsAgentSkillFrontmatterIssue[],
+): Pick<DocsAgentSkillFrontmatter, "license" | "compatibility" | "metadata" | "allowed-tools"> {
+  const result: Pick<
+    DocsAgentSkillFrontmatter,
+    "license" | "compatibility" | "metadata" | "allowed-tools"
+  > = {};
+
+  if (hasOwn(data, "license")) {
+    if (typeof data.license !== "string") {
+      issues.push({
+        code: "invalid-type",
+        field: "license",
+        message: "Field 'license' must be a string",
+      });
+    } else {
+      result.license = data.license;
+    }
+  }
+
+  if (hasOwn(data, "compatibility")) {
+    if (typeof data.compatibility !== "string") {
+      issues.push({
+        code: "invalid-type",
+        field: "compatibility",
+        message: "Field 'compatibility' must be a string",
+      });
+    } else {
+      const length = characterCount(data.compatibility);
+      if (data.compatibility.trim().length === 0) {
+        issues.push({
+          code: "invalid-length",
+          field: "compatibility",
+          message: "Field 'compatibility' must contain at least 1 character",
+        });
+      } else if (length > AGENT_SKILL_COMPATIBILITY_MAX_LENGTH) {
+        issues.push({
+          code: "invalid-length",
+          field: "compatibility",
+          message: `Compatibility exceeds ${AGENT_SKILL_COMPATIBILITY_MAX_LENGTH} character limit (${length} chars)`,
+        });
+      }
+      result.compatibility = data.compatibility;
+    }
+  }
+
+  if (hasOwn(data, "metadata")) {
+    const metadataNode = findYamlMappingValue(frontmatter, "metadata");
+    const metadata = asRecord(data.metadata);
+    if (!isMap(metadataNode) || !metadata) {
+      issues.push({
+        code: "invalid-type",
+        field: "metadata",
+        message: "Field 'metadata' must be a mapping from string keys to string values",
+      });
+    } else {
+      if (
+        metadataNode.items.some((pair) => !isScalar(pair.key) || typeof pair.key.value !== "string")
+      ) {
+        issues.push({
+          code: "invalid-type",
+          field: "metadata",
+          message: "Field 'metadata' keys must be strings",
+        });
+      }
+      const invalidKeys = Object.keys(metadata)
+        .filter((key) => typeof metadata[key] !== "string")
+        .sort();
+      for (const key of invalidKeys) {
+        issues.push({
+          code: "invalid-type",
+          field: "metadata",
+          message: `Field 'metadata.${key}' must be a string`,
+        });
+      }
+      result.metadata = Object.fromEntries(
+        Object.entries(metadata).filter((entry): entry is [string, string] => {
+          return typeof entry[1] === "string";
+        }),
+      );
+    }
+  }
+
+  if (hasOwn(data, "allowed-tools")) {
+    if (typeof data["allowed-tools"] !== "string") {
+      issues.push({
+        code: "invalid-type",
+        field: "allowed-tools",
+        message: "Field 'allowed-tools' must be a space-separated string",
+      });
+    } else {
+      result["allowed-tools"] = data["allowed-tools"];
+    }
+  }
+
+  return result;
+}
+
+/** Validate one SKILL.md document against the complete Agent Skills frontmatter contract. */
+export function validateDocsAgentSkillFrontmatter(
+  document: string,
+  options: DocsAgentSkillFrontmatterValidationOptions = {},
+): DocsAgentSkillFrontmatterValidation {
+  const issues: DocsAgentSkillFrontmatterIssue[] = [];
+  const opening = document.match(FRONTMATTER_OPEN_PATTERN);
+  if (!opening) {
+    return {
+      valid: false,
+      data: null,
+      issues: [
+        {
+          code: "missing-frontmatter",
+          field: "frontmatter",
+          message: "SKILL.md must start with YAML frontmatter (---)",
+        },
+      ],
+    };
+  }
+
+  const remainder = document.slice(opening[0].length);
+  const closing = FRONTMATTER_CLOSE_PATTERN.exec(remainder);
+  if (!closing) {
+    return {
+      valid: false,
+      data: null,
+      issues: [
+        {
+          code: "unclosed-frontmatter",
+          field: "frontmatter",
+          message: "SKILL.md frontmatter not properly closed with ---",
+        },
+      ],
+    };
+  }
+
+  let data: Record<string, unknown> | null;
+  let frontmatter: YAMLMap;
+  try {
+    const parsed = parseDocument(remainder.slice(0, closing.index), {
+      uniqueKeys: true,
+    });
+    if (parsed.errors.length > 0) {
+      throw parsed.errors[0];
+    }
+    if (!isMap(parsed.contents)) {
+      return {
+        valid: false,
+        data: null,
+        issues: [
+          {
+            code: "invalid-mapping",
+            field: "frontmatter",
+            message: "SKILL.md frontmatter must be a YAML mapping",
+          },
+        ],
+      };
+    }
+    frontmatter = parsed.contents;
+    data = asRecord(parsed.toJS());
+  } catch (error) {
+    return {
+      valid: false,
+      data: null,
+      issues: [
+        {
+          code: "invalid-yaml",
+          field: "frontmatter",
+          message: `Invalid YAML in frontmatter: ${yamlErrorMessage(error)}`,
+        },
+      ],
+    };
+  }
+  if (!data) {
+    return {
+      valid: false,
+      data: null,
+      issues: [
+        {
+          code: "invalid-mapping",
+          field: "frontmatter",
+          message: "SKILL.md frontmatter must be a YAML mapping",
+        },
+      ],
+    };
+  }
+
+  const unexpectedFields = Object.keys(data)
+    .filter((field) => !AGENT_SKILL_FRONTMATTER_FIELD_SET.has(field))
+    .sort();
+  if (unexpectedFields.length > 0) {
+    issues.push({
+      code: "unexpected-field",
+      field: "frontmatter",
+      message: `Unexpected fields in frontmatter: ${unexpectedFields.join(", ")}. Only ${JSON.stringify(
+        [...AGENT_SKILL_FRONTMATTER_FIELDS],
+      )} are allowed.`,
+    });
+  }
+
+  const name = validateName(data, options, issues);
+  const description = validateDescription(data, issues);
+  const optionalFields = validateOptionalFields(data, frontmatter, issues);
+  if (issues.length > 0 || name === null || description === null) {
+    return { valid: false, data: null, issues };
+  }
+
+  return {
+    valid: true,
+    data: { name, description, ...optionalFields },
+    issues: [],
+  };
+}
+
+export class DocsAgentSkillFrontmatterError extends Error {
+  readonly issues: readonly DocsAgentSkillFrontmatterIssue[];
+
+  constructor(
+    issues: readonly DocsAgentSkillFrontmatterIssue[],
+    options: DocsAgentSkillFrontmatterValidationOptions = {},
+  ) {
+    const source = options.source ? ` in ${options.source}` : "";
+    super(
+      `Invalid Agent Skill frontmatter${source}:\n${issues
+        .map((issue) => `- ${issue.message}`)
+        .join("\n")}`,
+    );
+    this.name = "DocsAgentSkillFrontmatterError";
+    this.issues = issues;
+  }
+}
+
+/** Parse valid frontmatter or throw a structured, field-specific validation error. */
+export function parseDocsAgentSkillFrontmatter(
+  document: string,
+  options: DocsAgentSkillFrontmatterValidationOptions = {},
+): DocsAgentSkillFrontmatter {
+  const validation = validateDocsAgentSkillFrontmatter(document, options);
+  if (!validation.valid) {
+    throw new DocsAgentSkillFrontmatterError(validation.issues, options);
+  }
+  return validation.data;
+}

--- a/packages/docs/src/agent-skills-vite.test.ts
+++ b/packages/docs/src/agent-skills-vite.test.ts
@@ -70,4 +70,29 @@ describe("docsAgentSkills", () => {
     const source = await plugin.load(resolvedId);
     expect(source).toContain("const snapshot = [];");
   });
+
+  it("fails the build with full-spec frontmatter diagnostics", async () => {
+    const { app, root } = createWorkspace();
+    const skillDir = path.join(root, "shared", "skills", "invalid");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      `---
+name: invalid
+description: Exercise Vite snapshot validation.
+allowed-tools:
+  - Read
+---
+`,
+    );
+    const plugin = docsAgentSkills(
+      { agent: { skills: "../../shared/skills" } },
+      { rootDir: app, workspaceRoot: root },
+    );
+    const resolvedId = plugin.resolveId(DOCS_AGENT_SKILLS_BUNDLE_MODULE)!;
+
+    await expect(plugin.load(resolvedId)).rejects.toThrow(
+      "Field 'allowed-tools' must be a space-separated string",
+    );
+  });
 });

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -131,6 +131,23 @@ export type {
   DocsStandardsDiscoveryRouteOptions,
   DocsStandardsDiscoveryRequest,
 } from "./standards-discovery.js";
+export {
+  AGENT_SKILL_COMPATIBILITY_MAX_LENGTH,
+  AGENT_SKILL_DESCRIPTION_MAX_LENGTH,
+  AGENT_SKILL_FRONTMATTER_FIELDS,
+  AGENT_SKILL_NAME_MAX_LENGTH,
+  DocsAgentSkillFrontmatterError,
+  isDocsAgentSkillName,
+  parseDocsAgentSkillFrontmatter,
+  validateDocsAgentSkillFrontmatter,
+} from "./agent-skills-spec.js";
+export type {
+  DocsAgentSkillFrontmatter,
+  DocsAgentSkillFrontmatterField,
+  DocsAgentSkillFrontmatterIssue,
+  DocsAgentSkillFrontmatterValidation,
+  DocsAgentSkillFrontmatterValidationOptions,
+} from "./agent-skills-spec.js";
 
 export {
   findDocsAudienceMdxIssues,

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -13,6 +13,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import type { AddressInfo } from "node:net";
+import { gzipSync } from "node:zlib";
 import { compactAgentDocs } from "./agent.js";
 import { renderDocsRobotsTxt } from "../robots.js";
 import {
@@ -54,6 +55,31 @@ description: "Docs home"
 `,
     "utf-8",
   );
+}
+
+function createAgentSkillArchive(document: string): Uint8Array {
+  const content = new TextEncoder().encode(document);
+  const header = new Uint8Array(512);
+  const write = (offset: number, length: number, value: string) => {
+    header.set(new TextEncoder().encode(value).subarray(0, length), offset);
+  };
+  write(0, 100, "SKILL.md");
+  write(100, 8, "0000644");
+  write(108, 8, "0000000");
+  write(116, 8, "0000000");
+  write(124, 12, content.byteLength.toString(8).padStart(11, "0"));
+  write(136, 12, "00000000000");
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  write(257, 6, "ustar");
+  write(263, 2, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  write(148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+
+  const tar = new Uint8Array(512 + Math.ceil(content.byteLength / 512) * 512 + 1024);
+  tar.set(header);
+  tar.set(content, 512);
+  return new Uint8Array(gzipSync(tar));
 }
 
 describe("parseDoctorArgs", () => {
@@ -612,7 +638,12 @@ Use this docs site through markdown routes and MCP.
     expect(report.checks.find((check) => check.id === "public-routes")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "agent-discovery")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "sitemap")?.status).toBe("pass");
-    expect(report.checks.find((check) => check.id === "skill")?.status).toBe("pass");
+    expect(report.checks.find((check) => check.id === "skill")).toMatchObject({
+      status: "warn",
+      score: 4,
+      maxScore: 5,
+      detail: expect.stringContaining("Agent Skills discovery will publish the generated fallback"),
+    });
     expect(report.checks.find((check) => check.id === "feedback")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "metadata")?.status).toBe("pass");
     expect(report.checks.find((check) => check.id === "compact")?.status).toBe("pass");
@@ -622,6 +653,42 @@ Use this docs site through markdown routes and MCP.
     );
     expect(report.checks.find((check) => check.id === "golden-tasks")?.status).toBe("pass");
     expect(report.evaluations).toMatchObject({ status: "passed", passedTaskCount: 1 });
+  });
+
+  it("reports full-spec errors in every configured Agent Skill", async () => {
+    writePackageJson(tmpDir, "doctor-invalid-agent-skill", { next: "16.0.0" });
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  agent: { skills: "skills/broken" },
+};
+`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "skills", "broken"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "skills", "broken", "SKILL.md"),
+      `---
+name: broken
+description: Exercise doctor validation for configured skills.
+version: "1.0"
+metadata:
+  revision: 1
+---
+`,
+      "utf-8",
+    );
+    writeDocsPage(tmpDir);
+    process.chdir(tmpDir);
+
+    const report = await inspectAgentReadiness();
+    const check = report.checks.find((candidate) => candidate.id === "agent-skills-frontmatter");
+
+    expect(check?.status).toBe("fail");
+    expect(check?.detail).toContain("Unexpected fields in frontmatter: version");
+    expect(check?.detail).toContain("Field 'metadata.revision' must be a string");
+    expect(report.grade).not.toBe("Agent-optimized");
   });
 
   it("evaluates the configured Ask AI surface, answer callback, base URL, and runtime examples", async () => {
@@ -1247,8 +1314,16 @@ description: Use the hosted documentation through its agent-readable resources.
 
 Use MCP and markdown routes.
 `;
-    const hostedSkillDigest = createHash("sha256").update(hostedSkill).digest("hex");
+    const invalidHostedSkill = hostedSkill.replace(
+      "description: Use the hosted documentation through its agent-readable resources.",
+      'description: Use the hosted documentation through its agent-readable resources.\nversion: "1.0"',
+    );
+    const invalidHostedSkillUtf8 = Buffer.from([0xff, 0xfe, 0xfd]);
+    const invalidHostedSkillArchive = createAgentSkillArchive(invalidHostedSkill);
     let serveStaleRobots = false;
+    let serveInvalidSkillFrontmatter = false;
+    let serveInvalidSkillUtf8 = false;
+    let serveArchiveSkill = false;
 
     const server = createServer(async (req, res) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -1290,6 +1365,12 @@ Use MCP and markdown routes.
 
       if (req.method === "HEAD" && url.pathname === "/.well-known/agent-skills/docs/SKILL.md") {
         res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8" });
+        res.end();
+        return;
+      }
+
+      if (req.method === "HEAD" && url.pathname === "/.well-known/agent-skills/docs.tar.gz") {
+        res.writeHead(200, { "Content-Type": "application/gzip" });
         res.end();
         return;
       }
@@ -1386,10 +1467,22 @@ Use MCP and markdown routes.
               skills: [
                 {
                   name: "docs",
-                  type: "skill-md",
+                  type: serveArchiveSkill ? "archive" : "skill-md",
                   description: "Use the hosted documentation through its agent-readable resources.",
-                  url: "/.well-known/agent-skills/docs/SKILL.md",
-                  digest: `sha256:${hostedSkillDigest}`,
+                  url: serveArchiveSkill
+                    ? "/.well-known/agent-skills/docs.tar.gz"
+                    : "/.well-known/agent-skills/docs/SKILL.md",
+                  digest: `sha256:${createHash("sha256")
+                    .update(
+                      serveArchiveSkill
+                        ? invalidHostedSkillArchive
+                        : serveInvalidSkillUtf8
+                          ? invalidHostedSkillUtf8
+                          : serveInvalidSkillFrontmatter
+                            ? invalidHostedSkill
+                            : hostedSkill,
+                    )
+                    .digest("hex")}`,
                 },
               ],
             }),
@@ -1399,7 +1492,19 @@ Use MCP and markdown routes.
 
         if (url.pathname === "/.well-known/agent-skills/docs/SKILL.md") {
           res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8" });
-          res.end(hostedSkill);
+          res.end(
+            serveInvalidSkillUtf8
+              ? invalidHostedSkillUtf8
+              : serveInvalidSkillFrontmatter
+                ? invalidHostedSkill
+                : hostedSkill,
+          );
+          return;
+        }
+
+        if (url.pathname === "/.well-known/agent-skills/docs.tar.gz") {
+          res.writeHead(200, { "Content-Type": "application/gzip" });
+          res.end(invalidHostedSkillArchive);
           return;
         }
 
@@ -1606,6 +1711,43 @@ Use MCP and markdown routes.
       expect(staleRobots).toMatchObject({ status: "warn", score: 3, maxScore: 5 });
       expect(staleRobots?.detail).toContain(
         "agent routes (/.well-known/agent-skills/*, /.well-known/skills/index.json",
+      );
+
+      serveStaleRobots = false;
+      serveInvalidSkillFrontmatter = true;
+      const invalidSkillReport = await inspectAgentReadiness({
+        url: `http://127.0.0.1:${port}`,
+      });
+      const invalidSkillCheck = invalidSkillReport.checks.find(
+        (check) => check.id === "hosted-agent-skills",
+      );
+      expect(invalidSkillCheck?.status).toBe("fail");
+      expect(invalidSkillCheck?.detail).toContain(
+        "invalid SKILL.md frontmatter: Unexpected fields in frontmatter: version",
+      );
+
+      serveInvalidSkillFrontmatter = false;
+      serveInvalidSkillUtf8 = true;
+      const invalidUtf8Report = await inspectAgentReadiness({
+        url: `http://127.0.0.1:${port}`,
+      });
+      const invalidUtf8Check = invalidUtf8Report.checks.find(
+        (check) => check.id === "hosted-agent-skills",
+      );
+      expect(invalidUtf8Check?.status).toBe("fail");
+      expect(invalidUtf8Check?.detail).toContain("artifact failed:");
+
+      serveInvalidSkillUtf8 = false;
+      serveArchiveSkill = true;
+      const invalidArchiveReport = await inspectAgentReadiness({
+        url: `http://127.0.0.1:${port}`,
+      });
+      const invalidArchiveCheck = invalidArchiveReport.checks.find(
+        (check) => check.id === "hosted-agent-skills",
+      );
+      expect(invalidArchiveCheck?.status).toBe("fail");
+      expect(invalidArchiveCheck?.detail).toContain(
+        "invalid SKILL.md frontmatter: Unexpected fields in frontmatter: version",
       );
     } finally {
       await new Promise<void>((resolve, reject) =>

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1,6 +1,7 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
 import pc from "picocolors";
 import {
@@ -27,7 +28,9 @@ import {
   buildDocsConfigMap,
   buildDocsMcpEndpointCandidates,
   getDocsMcpProtectedResourceMetadataRoutes,
+  isDocsAgentSkillName,
   resolveDocsDiscoveryApiRoute,
+  validateDocsAgentSkillFrontmatter,
 } from "../agent.js";
 import {
   AGENT_SKILLS_DISCOVERY_SCHEMA_URI,
@@ -42,6 +45,11 @@ import {
 } from "../agent-usefulness.js";
 import { runDocsGoldenTasks, type DocsGoldenTasksReport } from "../agent-evals.js";
 import { analyzeAgentSurfaceDrift } from "../agent-surface-drift.js";
+import { resolveConfiguredAgentSkills } from "../agent-skills-server.js";
+import {
+  AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+  readAgentSkillDocumentFromTar,
+} from "../agent-skills-archive.js";
 import { httpLinkHeaderHasTargetRelation } from "../http-link.js";
 import { resolveDocsMetadataBaseUrl } from "../metadata.js";
 import { isDocsMcpOAuthScopeToken, normalizeDocsMcpAuthorizationServerUrls } from "../mcp-auth.js";
@@ -958,6 +966,7 @@ function navigationScore(navigationCoverage: number): { status: DoctorStatus; sc
 
 const AGENT_OPTIMIZATION_BLOCKING_CHECKS = new Set([
   "surface-drift",
+  "agent-skills-frontmatter",
   "agent-context-quality",
   "agent-task-completeness",
   "agent-applicability",
@@ -2086,11 +2095,10 @@ function isValidAgentSkillEntry(value: unknown): value is {
   return Boolean(
     entry &&
     typeof entry.name === "string" &&
-    /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(entry.name) &&
-    entry.name.length <= 64 &&
+    isDocsAgentSkillName(entry.name) &&
     (entry.type === "skill-md" || entry.type === "archive") &&
     isNonEmptyString(entry.description) &&
-    entry.description.length <= 1024 &&
+    Array.from(entry.description).length <= 1024 &&
     isNonEmptyString(entry.url) &&
     typeof entry.digest === "string" &&
     /^sha256:[0-9a-f]{64}$/u.test(entry.digest),
@@ -2163,8 +2171,8 @@ async function probeAgentSkillsDiscovery(baseUrl: string): Promise<HostedStandar
 
         const expectedPath =
           skill.type === "archive"
-            ? `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${skill.name}.tar.gz`
-            : DEFAULT_AGENT_SKILLS_ROUTE_PATTERN.replace("{name}", skill.name);
+            ? `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(skill.name)}.tar.gz`
+            : DEFAULT_AGENT_SKILLS_ROUTE_PATTERN.replace("{name}", encodeURIComponent(skill.name));
         const expectedMediaType = skill.type === "archive" ? "application/gzip" : "text/markdown";
         if (artifactUrl.origin !== baseOrigin) {
           failures.push(`${skill.name} artifact is not same-origin`);
@@ -2209,6 +2217,28 @@ async function probeAgentSkillsDiscovery(baseUrl: string): Promise<HostedStandar
             failures.push(`${skill.name} artifact digest does not match the index`);
           } else {
             artifactDetails.push(`${skill.name} digest verified`);
+          }
+
+          const skillDocument =
+            skill.type === "skill-md"
+              ? new TextDecoder("utf-8", { fatal: true }).decode(content)
+              : readAgentSkillDocumentFromTar(
+                  gunzipSync(content, {
+                    maxOutputLength: AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+                  }),
+                );
+
+          const validation = validateDocsAgentSkillFrontmatter(skillDocument, {
+            directoryName: skill.name,
+          });
+          if (!validation.valid) {
+            failures.push(
+              `${skill.name} has invalid SKILL.md frontmatter: ${validation.issues
+                .map((issue) => issue.message)
+                .join("; ")}`,
+            );
+          } else if (validation.data.description !== skill.description) {
+            failures.push(`${skill.name} SKILL.md description does not match the index`);
           }
         } catch (error) {
           failures.push(
@@ -2882,6 +2912,18 @@ export async function inspectAgentReadiness(
   const configContent = readFileSync(configPath, "utf-8");
   const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, options.configPath);
   const config = configLoad.status === "evaluated" ? configLoad.config : undefined;
+  let configuredAgentSkillNames: string[] | undefined;
+  let configuredAgentSkillsError: string | undefined;
+  const configuredAgentSkills = config?.agent?.skills;
+  if (configuredAgentSkills) {
+    try {
+      configuredAgentSkillNames = (
+        await resolveConfiguredAgentSkills(configuredAgentSkills, { rootDir })
+      ).map((skill) => skill.name);
+    } catch (error) {
+      configuredAgentSkillsError = error instanceof Error ? error.message : String(error);
+    }
+  }
   const entry = config?.entry ?? readTopLevelStringProperty(configContent, "entry") ?? "docs";
   const contentDir = config?.contentDir ?? resolveDocsContentDir(rootDir, configContent, entry);
   const ordering =
@@ -2902,7 +2944,11 @@ export async function inspectAgentReadiness(
   const mcpEnabled = resolveFeatureEnabled(config, configContent, "mcp");
   const agentFeedbackEnabled = resolveAgentFeedbackEnabled(config, configContent);
   const compactConfigured = hasAgentCompactDefaults(config, configContent);
-  const skillFileExists = existsSync(path.join(rootDir, "skill.md"));
+  const skillFilePath = path.join(rootDir, "skill.md");
+  const skillFileExists = existsSync(skillFilePath);
+  const rootSkillValidation = skillFileExists
+    ? validateDocsAgentSkillFrontmatter(readFileSync(skillFilePath, "utf8"))
+    : undefined;
   const agentsFileExists =
     existsSync(path.join(rootDir, "AGENTS.md")) || existsSync(path.join(rootDir, "AGENT.md"));
 
@@ -3097,6 +3143,26 @@ export async function inspectAgentReadiness(
       configLoad.status === "evaluated"
         ? undefined
         : "Fix docs.config module evaluation before relying on resolved diagnostic scores.",
+    ),
+  );
+
+  checks.push(
+    makeCheck(
+      "agent-skills-frontmatter",
+      "Configured Agent Skills frontmatter",
+      configLoad.status !== "evaluated" ? "warn" : configuredAgentSkillsError ? "fail" : "pass",
+      configLoad.status === "evaluated" && !configuredAgentSkillsError ? 1 : 0,
+      1,
+      configLoad.status !== "evaluated"
+        ? "Not verified because docs.config could not be evaluated."
+        : configuredAgentSkillsError
+          ? configuredAgentSkillsError
+          : configuredAgentSkillNames
+            ? `${configuredAgentSkillNames.length} configured Agent Skill${configuredAgentSkillNames.length === 1 ? "" : "s"} passed full frontmatter validation: ${configuredAgentSkillNames.join(", ")}.`
+            : "No configured Agent Skills require validation.",
+      configuredAgentSkillsError
+        ? "Fix every configured SKILL.md field reported here before building or publishing the docs site."
+        : undefined,
     ),
   );
 
@@ -3341,14 +3407,26 @@ export async function inspectAgentReadiness(
 
   checks.push(
     skillFileExists
-      ? makeCheck(
-          "skill",
-          "Skill document",
-          "pass",
-          5,
-          5,
-          `Found root skill.md for ${DEFAULT_SKILL_MD_ROUTE} and ${DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE}.`,
-        )
+      ? rootSkillValidation?.valid
+        ? makeCheck(
+            "skill",
+            "Skill document",
+            "pass",
+            5,
+            5,
+            `Found a standards-compliant root skill.md for ${DEFAULT_SKILL_MD_ROUTE}, ${DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE}, and Agent Skills discovery.`,
+          )
+        : makeCheck(
+            "skill",
+            "Skill document",
+            "warn",
+            4,
+            5,
+            `Root skill.md remains available on the legacy routes, but Agent Skills discovery will publish the generated fallback because its frontmatter is invalid: ${rootSkillValidation?.issues
+              .map((issue) => issue.message)
+              .join("; ")}`,
+            "Add complete Agent Skills frontmatter to root skill.md if it should be published through standards discovery.",
+          )
       : makeCheck(
           "skill",
           "Skill document",

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -154,6 +154,11 @@ export {
   API_CATALOG_MEDIA_TYPE,
   API_CATALOG_PROFILE_URI,
   AGENT_SKILLS_DISCOVERY_SCHEMA_URI,
+  AGENT_SKILL_COMPATIBILITY_MAX_LENGTH,
+  AGENT_SKILL_DESCRIPTION_MAX_LENGTH,
+  AGENT_SKILL_FRONTMATTER_FIELDS,
+  AGENT_SKILL_NAME_MAX_LENGTH,
+  DocsAgentSkillFrontmatterError,
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
@@ -186,6 +191,7 @@ export {
   getDocsMarkdownVaryHeader,
   hasDocsMarkdownSignatureAgent,
   isDocsAgentDiscoveryRequest,
+  isDocsAgentSkillName,
   isDocsAgentsRequest,
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
@@ -209,6 +215,7 @@ export {
   renderDocsAgentsDocument,
   renderDocsSkillDocument,
   parseDocsAgentFeedbackData,
+  parseDocsAgentSkillFrontmatter,
   findDocsAudienceMdxIssues,
   resolveDocsAgentFeedbackConfig,
   resolveDocsAgentFeedbackRequest,
@@ -231,6 +238,7 @@ export {
   resolveDocsMarkdownRequest,
   toDocsMarkdownUrl,
   validateDocsAgentFeedbackPayload,
+  validateDocsAgentSkillFrontmatter,
 } from "./agent.js";
 export type { DocsAudienceMdxIssue, DocsContentAudience } from "./audience.js";
 export type {
@@ -253,6 +261,11 @@ export type {
   DocsOpenApiDiscoveryConfig,
   DocsOpenApiResolvedDiscoveryConfig,
   DocsStandardsDiscoveryResponseOptions,
+  DocsAgentSkillFrontmatter,
+  DocsAgentSkillFrontmatterField,
+  DocsAgentSkillFrontmatterIssue,
+  DocsAgentSkillFrontmatterValidation,
+  DocsAgentSkillFrontmatterValidationOptions,
 } from "./agent.js";
 export type {
   PromptAction,

--- a/packages/docs/src/standards-discovery.test.ts
+++ b/packages/docs/src/standards-discovery.test.ts
@@ -234,6 +234,21 @@ description: 'Use the café documentation.'
     });
   });
 
+  it("publishes spec-valid Unicode names on encoded discovery routes", async () => {
+    const document = `---
+name: 文档-工具
+description: Use the localized documentation tools.
+---
+`;
+    const skill = await resolveDocsPublishedAgentSkill({
+      preferredDocument: document,
+      fallbackDocument: generatedSkill,
+    });
+
+    expect(skill.name).toBe("文档-工具");
+    expect(skill.url).toBe(`/.well-known/agent-skills/${encodeURIComponent("文档-工具")}/SKILL.md`);
+  });
+
   it("keeps an invalid custom legacy skill private from the standards index", async () => {
     const selected = await resolveDocsPublishedAgentSkill({
       preferredDocument: "# Custom legacy instructions without frontmatter\n",
@@ -241,6 +256,44 @@ description: 'Use the café documentation.'
     });
     expect(selected.name).toBe("docs");
     expect(selected.content).toBe(generatedSkill);
+  });
+
+  it("keeps a legacy skill with non-standard frontmatter fields private", async () => {
+    const selected = await resolveDocsPublishedAgentSkill({
+      preferredDocument: `---
+name: custom
+description: Use the custom legacy instructions.
+version: "1.0"
+---
+`,
+      fallbackDocument: generatedSkill,
+    });
+
+    expect(selected.name).toBe("docs");
+    expect(selected.content).toBe(generatedSkill);
+  });
+
+  it("reports every full-spec error in an invalid generated fallback", async () => {
+    await expect(
+      resolveDocsPublishedAgentSkill({
+        fallbackDocument: `---
+name: BROKEN--fallback
+description: Use the generated fallback.
+version: "1.0"
+---
+`,
+      }),
+    ).rejects.toThrow("Unexpected fields in frontmatter: version");
+    await expect(
+      resolveDocsPublishedAgentSkill({
+        fallbackDocument: `---
+name: BROKEN--fallback
+description: Use the generated fallback.
+version: "1.0"
+---
+`,
+      }),
+    ).rejects.toThrow("cannot contain consecutive hyphens");
   });
 
   it("serves an index whose digest matches the exact individual response", async () => {

--- a/packages/docs/src/standards-discovery.ts
+++ b/packages/docs/src/standards-discovery.ts
@@ -1,4 +1,3 @@
-import matter from "gray-matter";
 import type {
   DocsAgentA2AApiKeySecurityScheme,
   DocsAgentA2ACapabilities,
@@ -16,6 +15,12 @@ import type {
   DocsAgentA2ASecurityScopeList,
   DocsAgentA2ASkill,
 } from "./types.js";
+import {
+  parseDocsAgentSkillFrontmatter,
+  validateDocsAgentSkillFrontmatter,
+  type DocsAgentSkillFrontmatter,
+  type DocsAgentSkillFrontmatterValidationOptions,
+} from "./agent-skills-spec.js";
 
 export const DEFAULT_API_CATALOG_ROUTE = "/.well-known/api-catalog";
 export const DEFAULT_API_CATALOG_FORMAT = "api-catalog";
@@ -47,9 +52,6 @@ export const DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE = "application/schema+json";
 
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";
 const DEFAULT_AGENT_MANIFEST_ROUTE = "/.well-known/agent.json";
-const AGENT_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const AGENT_SKILL_NAME_MAX_LENGTH = 64;
-const AGENT_SKILL_DESCRIPTION_MAX_LENGTH = 1024;
 const DISCOVERY_CACHE_CONTROL = "public, max-age=0, s-maxage=3600";
 const LEGACY_A2A_PROTOCOL_VERSION = "0.3";
 
@@ -124,6 +126,8 @@ export interface DocsPublishedAgentSkillOptions {
   preferredDocument?: string | null;
   fallbackDocument: string;
 }
+
+export type DocsPublishedAgentSkillBuildOptions = DocsAgentSkillFrontmatterValidationOptions;
 
 export interface DocsApiCatalogLinkTarget {
   href: string;
@@ -368,29 +372,6 @@ export function buildDocsApiCatalog(options: DocsApiCatalogOptions): DocsApiCata
   return { linkset };
 }
 
-function readAgentSkillFrontmatter(document: string): { name: string; description: string } | null {
-  const normalized = document.startsWith("\uFEFF") ? document.slice(1) : document;
-  let data: Record<string, unknown>;
-  try {
-    data = matter(normalized).data;
-  } catch {
-    return null;
-  }
-  const name = typeof data.name === "string" ? data.name.trim() : "";
-  const description = typeof data.description === "string" ? data.description.trim() : "";
-  if (
-    !name ||
-    name.length > AGENT_SKILL_NAME_MAX_LENGTH ||
-    !AGENT_SKILL_NAME_PATTERN.test(name) ||
-    !description ||
-    description.length > AGENT_SKILL_DESCRIPTION_MAX_LENGTH
-  ) {
-    return null;
-  }
-
-  return { name, description };
-}
-
 function toDiscoveryBytes(content: string | Uint8Array): Uint8Array<ArrayBuffer> {
   if (typeof content === "string") return new TextEncoder().encode(content);
   const bytes = new Uint8Array(new ArrayBuffer(content.byteLength));
@@ -417,14 +398,14 @@ export async function sha256DocsDiscoveryContent(content: string | Uint8Array): 
 
 function createDocsPublishedAgentSkill(
   content: string,
-  metadata: { name: string; description: string },
+  metadata: Pick<DocsAgentSkillFrontmatter, "name" | "description">,
   sha256: string,
 ): DocsPublishedAgentSkill {
   return {
     name: metadata.name,
     type: "skill-md",
     description: metadata.description,
-    url: `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${metadata.name}/SKILL.md`,
+    url: `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(metadata.name)}/SKILL.md`,
     digest: `sha256:${sha256}`,
     content,
     sha256,
@@ -432,7 +413,7 @@ function createDocsPublishedAgentSkill(
     files: [
       {
         path: "SKILL.md",
-        url: `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${metadata.name}/SKILL.md`,
+        url: `${DEFAULT_AGENT_SKILLS_ROUTE_PREFIX}/${encodeURIComponent(metadata.name)}/SKILL.md`,
         mediaType: "text/markdown",
         content,
         sha256,
@@ -446,13 +427,9 @@ function createDocsPublishedAgentSkill(
 export function buildDocsPublishedAgentSkill(
   document: string,
   sha256: string,
+  options: DocsPublishedAgentSkillBuildOptions = {},
 ): DocsPublishedAgentSkill {
-  const metadata = readAgentSkillFrontmatter(document);
-  if (!metadata) {
-    throw new Error(
-      "The generated Agent Skills fallback must contain valid name and description frontmatter.",
-    );
-  }
+  const metadata = parseDocsAgentSkillFrontmatter(document, options);
   if (!/^[a-f0-9]{64}$/.test(sha256)) {
     throw new Error("Agent Skill SHA-256 must be a lowercase 64-character hexadecimal digest.");
   }
@@ -464,16 +441,15 @@ export async function resolveDocsPublishedAgentSkill({
   preferredDocument,
   fallbackDocument,
 }: DocsPublishedAgentSkillOptions): Promise<DocsPublishedAgentSkill> {
-  const preferredMetadata = preferredDocument ? readAgentSkillFrontmatter(preferredDocument) : null;
-  const fallbackMetadata = readAgentSkillFrontmatter(fallbackDocument);
-  const content = preferredMetadata ? preferredDocument! : fallbackDocument;
-  const metadata = preferredMetadata ?? fallbackMetadata;
-
-  if (!metadata) {
-    throw new Error(
-      "The generated Agent Skills fallback must contain valid name and description frontmatter.",
-    );
-  }
+  const preferredValidation = preferredDocument
+    ? validateDocsAgentSkillFrontmatter(preferredDocument)
+    : null;
+  const content = preferredValidation?.valid ? preferredDocument! : fallbackDocument;
+  const metadata = preferredValidation?.valid
+    ? preferredValidation.data
+    : parseDocsAgentSkillFrontmatter(fallbackDocument, {
+        source: "generated Agent Skills fallback",
+      });
 
   const sha256 = await sha256DocsDiscoveryContent(content);
   return createDocsPublishedAgentSkill(content, metadata, sha256);

--- a/packages/docs/tsdown.config.ts
+++ b/packages/docs/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/server.ts",
+    "src/agent-skills-spec.ts",
     "src/agent-skills-bundle.ts",
     "src/agent-skills-vite.ts",
     "src/docs-cloud-server.ts",

--- a/packages/next/src/config.test.ts
+++ b/packages/next/src/config.test.ts
@@ -1197,14 +1197,14 @@ describe("withDocs (app dir: src/app vs app)", () => {
     const resources = ["/api/internal/docs/mcp", "/mcp", "/.well-known/mcp"];
 
     expect(rewrites).toEqual(
-      expect.arrayContaining([
-        ...resources.map((resourcePath) =>
+      expect.arrayContaining(
+        resources.map((resourcePath) =>
           expect.objectContaining({
             source: buildMcpProtectedResourceMetadataRoute(resourcePath),
             destination: "/api/internal/docs/mcp",
           }),
         ),
-      ]),
+      ),
     );
   });
 
@@ -1934,10 +1934,19 @@ export default { entry: "docs", agent };
     );
     mkdirSync(join(tmpDir, "app"), { recursive: true });
     mkdirSync(join(tmpDir, "skills", "broken"), { recursive: true });
-    writeFileSync(join(tmpDir, "skills", "broken", "SKILL.md"), "# Missing frontmatter\n", "utf8");
+    writeFileSync(
+      join(tmpDir, "skills", "broken", "SKILL.md"),
+      `---
+name: broken
+description: Exercise full Agent Skills frontmatter validation.
+version: "1.0"
+---
+`,
+      "utf8",
+    );
     process.chdir(tmpDir);
 
-    expect(() => withDocs({})).toThrow("valid name and description frontmatter");
+    expect(() => withDocs({})).toThrow("Unexpected fields in frontmatter: version");
   });
 
   it("reads a top-level contentDir even when nested config uses deeper indentation", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,16 +87,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.4.8(@types/node@22.19.11)(@vercel/functions@3.7.1(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.1)(jiti@2.7.0)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.2.11(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))(ws@8.21.0)
       '@farming-labs/astro':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -108,13 +108,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -157,13 +157,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -212,16 +212,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -240,16 +240,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -277,13 +277,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.68
+        specifier: 0.2.69
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0
@@ -392,6 +392,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
 
 const DEFAULT_BASE_URL = "https://docs.farming-labs.dev";
 const AGENT_SKILLS_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
@@ -20,6 +21,17 @@ const MCP_PROTOCOL_VERSION = "2025-06-18";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_ATTEMPTS = 3;
 const MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+const TAR_BLOCK_BYTES = 512;
+const TAR_NAME_BYTES = 100;
+const TAR_PREFIX_OFFSET = 345;
+const TAR_PREFIX_BYTES = 155;
+const AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES = 10 * 1024 * 1024;
+const AGENT_SKILL_DOCUMENT_MAX_BYTES = 1024 * 1024;
+const fullSkillFrontmatterValidator =
+  process.env.DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER === "1"
+    ? (await import("../packages/docs/dist/agent-skills-spec.mjs"))
+        .validateDocsAgentSkillFrontmatter
+    : null;
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -31,6 +43,145 @@ function asRecord(value) {
 
 function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isAgentSkillName(value) {
+  if (typeof value !== "string") return false;
+  const normalized = value.normalize("NFKC");
+  const characters = Array.from(normalized);
+  return (
+    characters.length > 0 &&
+    characters.length <= 64 &&
+    normalized === normalized.toLowerCase() &&
+    !normalized.startsWith("-") &&
+    !normalized.endsWith("-") &&
+    !normalized.includes("--") &&
+    characters.every((character) => character === "-" || /^[\p{L}\p{N}]$/u.test(character))
+  );
+}
+
+function validateAgentSkillDocument(bytes, name, label) {
+  if (!fullSkillFrontmatterValidator) return null;
+
+  let document;
+  try {
+    document = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`${label} was not valid UTF-8`);
+  }
+  const validation = fullSkillFrontmatterValidator(document, { directoryName: name });
+  assert(
+    validation.valid,
+    `${label} had invalid Agent Skills frontmatter: ${validation.issues
+      .map((issue) => issue.message)
+      .join("; ")}`,
+  );
+  return validation.data;
+}
+
+function isZeroTarBlock(block) {
+  return block.every((byte) => byte === 0);
+}
+
+function readTarText(header, offset, length, field) {
+  const bytes = header.subarray(offset, offset + length);
+  const terminator = bytes.indexOf(0);
+  const value = terminator < 0 ? bytes : bytes.subarray(0, terminator);
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(value);
+  } catch {
+    throw new Error(`Agent Skill archive had invalid UTF-8 in its ${field}`);
+  }
+}
+
+function readTarOctal(header, offset, length, field) {
+  const value = readTarText(header, offset, length, field).trim();
+  assert(/^[0-7]+$/u.test(value), `Agent Skill archive had an invalid ${field}`);
+  const parsed = Number.parseInt(value, 8);
+  assert(Number.isSafeInteger(parsed) && parsed >= 0, `Agent Skill archive had an unsafe ${field}`);
+  return parsed;
+}
+
+function validateTarChecksum(header) {
+  const expected = readTarOctal(header, 148, 8, "header checksum");
+  const actual = header.reduce((sum, byte, index) => {
+    return sum + (index >= 148 && index < 156 ? 0x20 : byte);
+  }, 0);
+  assert(actual === expected, "Agent Skill archive had an invalid tar header checksum");
+}
+
+function readAgentSkillDocumentFromTar(archive) {
+  assert(
+    archive.byteLength <= AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+    "Agent Skill archive exceeded the uncompressed size limit",
+  );
+
+  let skillDocument = null;
+  let foundEndOfArchive = false;
+  let offset = 0;
+  while (offset < archive.byteLength) {
+    assert(
+      offset + TAR_BLOCK_BYTES <= archive.byteLength,
+      "Agent Skill archive contained a truncated tar header",
+    );
+    const header = archive.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (isZeroTarBlock(header)) {
+      const secondZeroBlockStart = offset + TAR_BLOCK_BYTES;
+      const secondZeroBlockEnd = secondZeroBlockStart + TAR_BLOCK_BYTES;
+      assert(
+        secondZeroBlockEnd <= archive.byteLength,
+        "Agent Skill archive contained a truncated end-of-archive marker",
+      );
+      assert(
+        isZeroTarBlock(archive.subarray(secondZeroBlockStart, secondZeroBlockEnd)),
+        "Agent Skill archive was missing the second end-of-archive block",
+      );
+      assert(
+        archive.subarray(secondZeroBlockEnd).every((byte) => byte === 0),
+        "Agent Skill archive had non-zero bytes after its end marker",
+      );
+      foundEndOfArchive = true;
+      break;
+    }
+
+    validateTarChecksum(header);
+    const name = readTarText(header, 0, TAR_NAME_BYTES, "file name");
+    const prefix = readTarText(header, TAR_PREFIX_OFFSET, TAR_PREFIX_BYTES, "file prefix");
+    const path = prefix ? `${prefix}/${name}` : name;
+    const size = readTarOctal(header, 124, 12, "file size");
+    const contentStart = offset + TAR_BLOCK_BYTES;
+    const contentEnd = contentStart + size;
+    assert(
+      contentEnd <= archive.byteLength,
+      `Agent Skill archive entry ${JSON.stringify(path)} was truncated`,
+    );
+
+    const typeFlag = header[156];
+    if (path === "SKILL.md") {
+      assert(
+        typeFlag === 0 || typeFlag === "0".charCodeAt(0),
+        "Agent Skill archive root SKILL.md was not a regular file",
+      );
+      assert(!skillDocument, "Agent Skill archive contained more than one root SKILL.md");
+      assert(
+        size <= AGENT_SKILL_DOCUMENT_MAX_BYTES,
+        "Agent Skill archive SKILL.md exceeded the document size limit",
+      );
+      skillDocument = archive.subarray(contentStart, contentEnd);
+    }
+
+    const paddedSize = Math.ceil(size / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+    const nextOffset = contentStart + paddedSize;
+    assert(
+      nextOffset <= archive.byteLength,
+      `Agent Skill archive entry ${JSON.stringify(path)} had truncated padding`,
+    );
+    offset = nextOffset;
+  }
+
+  assert(foundEndOfArchive, "Agent Skill archive was missing its end-of-archive marker");
+  assert(skillDocument, "Agent Skill archive did not contain a root SKILL.md");
+  return skillDocument;
 }
 
 function parsePositiveInteger(value, fallback) {
@@ -1041,13 +1192,13 @@ function validateModernSkillIndex(json, expectedSkillNames, response) {
   const skills = root.skills.map((value) => {
     const skill = asRecord(value);
     assert(skill, "Agent Skills index contained a non-object entry");
-    assert(
-      isNonEmptyString(skill.name) && /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(skill.name),
-      "Agent Skills index contained an invalid name",
-    );
+    assert(isAgentSkillName(skill.name), "Agent Skills index contained an invalid name");
     assert(!seen.has(skill.name), `Agent Skills index duplicated ${JSON.stringify(skill.name)}`);
     seen.add(skill.name);
-    assert(isNonEmptyString(skill.description), `Agent Skill ${skill.name} had no description`);
+    assert(
+      isNonEmptyString(skill.description) && Array.from(skill.description).length <= 1024,
+      `Agent Skill ${skill.name} had an invalid description`,
+    );
     assert(
       skill.type === "skill-md" || skill.type === "archive",
       `Agent Skill ${skill.name} had an invalid type`,
@@ -1112,6 +1263,25 @@ async function validateModernSkillArtifact(request, baseUrl, skill) {
     ].includes(artifact.response.headers.get("etag")),
     `${skill.url} did not expose the indexed digest as its ETag`,
   );
+  if (skill.type === "skill-md" || skill.type === "archive") {
+    const documentBytes =
+      skill.type === "skill-md"
+        ? artifact.bytes
+        : readAgentSkillDocumentFromTar(
+            gunzipSync(artifact.bytes, {
+              maxOutputLength: AGENT_SKILL_ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+            }),
+          );
+    const frontmatter = validateAgentSkillDocument(
+      documentBytes,
+      skill.name,
+      `Agent Skill ${skill.name}`,
+    );
+    assert(
+      !frontmatter || frontmatter.description === skill.description,
+      `Agent Skill ${skill.name} frontmatter description did not match its index entry`,
+    );
+  }
 }
 
 function validateManifestPublishedSkills(manifest, modernNames, expectedSkillNames) {
@@ -1175,6 +1345,13 @@ async function validateManifestSkillFile(request, baseUrl, file) {
     `sha256:${sha256(result.bytes)}` === file.digest,
     `Agent Skill file ${file.name}/${file.path} did not match its published digest`,
   );
+  if (file.path === "SKILL.md") {
+    validateAgentSkillDocument(
+      result.bytes,
+      file.name,
+      `Agent Skill file ${file.name}/${file.path}`,
+    );
+  }
 }
 
 function validateLegacySkillIndex(json, modernNames) {
@@ -1218,6 +1395,7 @@ async function validateLegacySkillFile(request, file, expectedDigests) {
       mediaType(result.response) === "text/markdown",
       `${route} returned the wrong content-type`,
     );
+    validateAgentSkillDocument(result.bytes, file.name, `Legacy Agent Skill ${file.name}`);
   }
   const expectedDigest = expectedDigests.get(`${file.name}/${file.path}`);
   if (expectedDigest) {

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 
 import { runAgentSurfaceSmoke } from "./smoke-agent-surfaces.mjs";
 
@@ -30,7 +31,48 @@ description: Use the portable workflow.
 
 # Portable workflow
 `;
-const portableArchive = new Uint8Array([31, 139, 8, 0, 1, 2, 3, 4]);
+const invalidPortableDocument = `---
+name: portable
+description: Wrong archive description.
+---
+
+# Portable workflow
+`;
+
+function writeTarText(header, offset, length, value) {
+  header.set(new TextEncoder().encode(value).subarray(0, length), offset);
+}
+
+function tarEntry(name, content) {
+  const header = new Uint8Array(512);
+  writeTarText(header, 0, 100, name);
+  writeTarText(header, 100, 8, "0000644");
+  writeTarText(header, 108, 8, "0000000");
+  writeTarText(header, 116, 8, "0000000");
+  writeTarText(header, 124, 12, content.byteLength.toString(8).padStart(11, "0"));
+  writeTarText(header, 136, 12, "00000000000");
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  writeTarText(header, 257, 6, "ustar");
+  writeTarText(header, 263, 2, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeTarText(header, 148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+
+  const entry = new Uint8Array(512 + Math.ceil(content.byteLength / 512) * 512);
+  entry.set(header);
+  entry.set(content, 512);
+  return entry;
+}
+
+function createSkillArchive(document) {
+  const entry = tarEntry("SKILL.md", new TextEncoder().encode(document));
+  const archive = new Uint8Array(entry.byteLength + 1024);
+  archive.set(entry);
+  return gzipSync(archive);
+}
+
+const portableArchive = createSkillArchive(portableDocument);
+const invalidPortableArchive = createSkillArchive(invalidPortableDocument);
 
 function digest(content) {
   return createHash("sha256").update(content).digest("hex");
@@ -38,7 +80,6 @@ function digest(content) {
 
 const docsDigest = digest(docsDocument);
 const portableDocumentDigest = digest(portableDocument);
-const portableArchiveDigest = digest(portableArchive);
 
 function jsonResponse(method, value, options = {}) {
   return response(method, `${JSON.stringify(value)}\n`, {
@@ -82,6 +123,8 @@ function createFixtureFetch(options = {}) {
   const calls = [];
   const streamState = { aborted: false, cancelled: false, pulls: 0 };
   const canonicalBaseUrl = options.canonicalBaseUrl ?? BASE_URL;
+  const archiveBytes = options.invalidArchiveFrontmatter ? invalidPortableArchive : portableArchive;
+  const archiveDigest = digest(archiveBytes);
   const manifest = {
     $schema: AGENT_MANIFEST_SCHEMA,
     format: AGENT_MANIFEST_FORMAT,
@@ -149,7 +192,7 @@ function createFixtureFetch(options = {}) {
           type: "archive",
           description: "Use the portable workflow.",
           url: "/.well-known/agent-skills/portable.tar.gz",
-          digest: `sha256:${portableArchiveDigest}`,
+          digest: `sha256:${archiveDigest}`,
           files: [
             {
               path: "SKILL.md",
@@ -247,7 +290,7 @@ function createFixtureFetch(options = {}) {
         type: "archive",
         description: "Use the portable workflow.",
         url: "/.well-known/agent-skills/portable.tar.gz",
-        digest: `sha256:${portableArchiveDigest}`,
+        digest: `sha256:${archiveDigest}`,
       },
     ],
   };
@@ -363,11 +406,11 @@ function createFixtureFetch(options = {}) {
     if (url.pathname === "/.well-known/agent-skills/portable.tar.gz") {
       return cachedResponse(
         method,
-        options.corruptArchive ? new Uint8Array([0]) : portableArchive,
+        options.corruptArchive ? new Uint8Array([0]) : archiveBytes,
         requestHeaders,
         {
           contentType: "application/gzip",
-          etag: `"${portableArchiveDigest}"`,
+          etag: `"${archiveDigest}"`,
           headers: {
             link: `<${AGENT_SKILLS_INDEX_ROUTE}>; rel="collection"; type="application/json"`,
           },
@@ -797,6 +840,28 @@ test("fails when an indexed Agent Skill artifact does not match its digest", asy
     /1 agent surface smoke check failed/u,
   );
 });
+
+test(
+  "fails when an archived Agent Skill has invalid frontmatter",
+  { skip: process.env.DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER !== "1" },
+  async () => {
+    const fixture = createFixtureFetch({ invalidArchiveFrontmatter: true });
+    const logs = [];
+    await assert.rejects(
+      runAgentSurfaceSmoke({
+        attempts: 1,
+        baseUrl: BASE_URL,
+        expectedSkillNames: ["portable"],
+        fetchImpl: fixture.fetch,
+        log(message) {
+          logs.push(message);
+        },
+      }),
+      /1 agent surface smoke check failed/u,
+    );
+    assert.match(logs.join("\n"), /frontmatter description did not match its index entry/u);
+  },
+);
 
 test("validates an advertised strict A2A v1 Agent Card and its cache contract", async () => {
   const fixture = createFixtureFetch({ agentCard: true });


### PR DESCRIPTION
## Summary
- add a shared Agent Skills frontmatter validator based on the official Agent Skills specification
- validate configured and published SKILL.md files across server, Vite, doctor, conformance, archive, and deployed smoke paths
- reject drift such as unknown frontmatter fields, mismatched directory/name values, invalid descriptions, invalid metadata maps, and invalid bundled archives

## References
- https://agentskills.io/specification
- https://github.com/agentskills/agentskills/blob/38a2ff82958afee88dadf4831509e6f7e9d8ef4e/docs/specification.mdx

## Tests
- pnpm --filter @farming-labs/docs run test
- pnpm --filter @farming-labs/docs run typecheck
- pnpm --filter @farming-labs/next run test
- pnpm --filter @farming-labs/next run typecheck
- pnpm run test:smoke-agent-surfaces
- DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER=1 pnpm run test:smoke-agent-surfaces
- pnpm format:check
- pnpm lint (passes with existing warnings)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a spec‑accurate Agent Skills SKILL.md frontmatter validator, exports it for reuse, and enforces full validation across server, Vite, doctor, conformance, standards discovery, smoke tests, and CI. Also validates `.tar.gz` skills (including embedded SKILL.md) and bumps the agent contract to 1.3.

- **New Features**
  - Validator exported via `@farming-labs/docs` as `./agent-skills` (with parse/validate APIs, `isDocsAgentSkillName`, and limits) and re‑exported in `agent.ts`/`index.ts`; adds `yaml` dependency.
  - Enforcement:
    - Conformance 1.3: validates discovery entries, fetches artifacts, verifies digests/ETags, decompresses archives with limits, extracts SKILL.md, validates frontmatter, and checks index vs SKILL.md descriptions.
    - `doctor`: validates hosted index and artifacts (skill-md and archives), adds “Configured Agent Skills frontmatter” check, and warns on invalid root `skill.md`.
    - Vite snapshot plugin: fails the build on invalid SKILL.md.
    - Standards discovery: publishes only spec‑valid skills; validates/generates fallback with full checks; allows normalized Unicode lowercase names; routes are `encodeURIComponent(name)` encoded.
    - Smoke tests: optional full frontmatter validation via `DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER=1`; validates archives; CI builds the validator before smoke.
  - Archive support: strict tar+gzip handling, UTF‑8 validation, single root SKILL.md regular file; SKILL.md ≤ 1 MB and total uncompressed ≤ 10 MB.

- **Migration**
  - SKILL.md frontmatter must use only: name, description, license, compatibility (≤ 500 chars), metadata (string map), allowed-tools (space‑separated string). Description ≤ 1024 chars. Name must be lowercase, NFKC‑normalized, Unicode letters/digits/hyphens, and match its directory.
  - Archives: include exactly one root `SKILL.md` regular file (UTF‑8, ≤ 1 MB) in the tar; total uncompressed ≤ 10 MB.
  - Enable stricter smoke checks with `DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER=1`. Add full frontmatter to root `skill.md` or discovery will publish the generated fallback (doctor will warn/fail).

<sup>Written for commit ad195d7613ed3e8b0ea2189d2e12dd03d4a69693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

