### PR TITLE
fix: unify agent section anchors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Run Next adapter tests
         run: pnpm --filter @farming-labs/next test
 
+      - name: Run TanStack Start adapter tests
+        run: pnpm --filter @farming-labs/tanstack-start test
+
       - name: Run Fumadocs theme tests
         run: pnpm --filter @farming-labs/theme test
 
@@ -80,6 +83,12 @@ jobs:
 
       - name: Run Nuxt adapter tests
         run: pnpm --filter @farming-labs/nuxt test
+
+      - name: Run Astro adapter tests
+        run: pnpm --filter @farming-labs/astro test
+
+      - name: Run Svelte adapter tests
+        run: pnpm --filter @farming-labs/svelte test
   security-audit:
     runs-on: ubuntu-latest
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -45,6 +45,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -55,7 +57,8 @@
   "devDependencies": {
     "@farming-labs/docs": "workspace:*",
     "@types/node": "^22.10.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "@farming-labs/docs": ">=0.2.73"

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -58,6 +58,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@farming-labs/docs": "*"
+    "@farming-labs/docs": ">=0.2.73"
   }
 }

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -11,6 +11,7 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  createDocsMarkdownBlockPlaceholderAllocator,
   extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
   extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
   prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
@@ -23,6 +24,7 @@ import {
   type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
 } from "@farming-labs/docs/markdown-rendering";
 import {
+  extractDocsMarkdownPromptBlocks,
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -99,6 +101,11 @@ interface RenderMarkdownOptions {
   theme?: DocsTheme;
   icons?: Record<string, string>;
   openDocsProviders?: SerializedOpenDocsProvider[];
+}
+
+interface RenderedMarkdownBlock {
+  html: string;
+  token: string;
 }
 
 function escapeHtml(value: string): string {
@@ -603,7 +610,15 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAudienceMdxContent(content, "human");
+  // Prompt children are literal copyable text, not renderable Markdown. Protect
+  // them before audience projection, reference collection, and heading
+  // preparation so none of those document-level passes can consume or interpret
+  // Prompt-only syntax.
+  const extractedPrompts = extractDocsMarkdownPromptBlocks(content);
+  const promptBlocks = extractedPrompts.blocks;
+  let result = extractedPrompts.markdown;
+  result = resolveDocsAudienceMdxContent(result, "human");
+  const allocateBlockPlaceholder = createDocsMarkdownBlockPlaceholderAllocator(result);
   const extractedReferences = extractMarkdownReferenceDefinitions(result);
   const referenceDefinitions = extractedReferences.definitions;
   const preparedHeadings = prepareMarkdownHeadings(result);
@@ -618,7 +633,7 @@ export async function renderMarkdown(
   const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
-  const tabsBlocks: string[] = [];
+  const tabsBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
     (_: string, attrSource: string | undefined, body: string) => {
@@ -663,8 +678,8 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
@@ -722,78 +737,60 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
 
-  // Prompt bodies are literal copyable text. Protect them before fenced code
-  // rendering so examples remain escaped text rather than injected figures.
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      const extractedHeadings = extractRenderedHeadingElements(
-        children,
-        referenceDefinitions,
-        true,
-        headingOpeningTags,
-      );
-      promptBlocks.push(
-        extractedHeadings.headingsHtml +
-          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
-      );
-      return placeholder;
-    },
-  );
-
-  const hoverLinkBlocks: string[] = [];
+  const hoverLinkBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
-      const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
+      const placeholder = allocateBlockPlaceholder("HOVERLINK");
       const extractedHeadings = extractRenderedHeadingElements(
         children,
         referenceDefinitions,
         false,
         headingOpeningTags,
       );
-      hoverLinkBlocks.push(
-        extractedHeadings.headingsHtml +
+      hoverLinkBlocks.push({
+        html:
+          extractedHeadings.headingsHtml +
           renderHoverLink(attrSource, extractedHeadings.content, options.theme),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
 
   // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  const codeBlocks: RenderedMarkdownBlock[] = [];
   result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
     const { lang, title } = parseMeta(info);
     const { html, raw } = highlightCode(hl, code, lang);
-    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    const placeholder = allocateBlockPlaceholder("CODEBLOCK");
+    codeBlocks.push({ html: wrapCodeWithCopy(html, raw, title, lang), token: placeholder });
     return placeholder;
   });
 
-  const calloutBlocks: string[] = [];
+  const calloutBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
     (_: string, attrSource: string | undefined, children: string) => {
       const attrs = parseJsxAttributes(attrSource ?? "");
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(
-        renderCallout(
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(
           type,
           restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
           title,
           referenceDefinitions,
         ),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
@@ -810,8 +807,11 @@ export async function renderMarkdown(
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
@@ -819,15 +819,19 @@ export async function renderMarkdown(
     if (boldMatch) {
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
-    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-    calloutBlocks.push(
-      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
-    );
+    const placeholder = allocateBlockPlaceholder("CALLOUT");
+    calloutBlocks.push({
+      html: `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+      token: placeholder,
+    });
     return placeholder;
   });
 
@@ -862,24 +866,47 @@ export async function renderMarkdown(
   );
 
   // Unordered lists
-  result = result.replace(/(?:^- .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => l.startsWith("- "))
-      .map((l: string) => `<li>${l.slice(2)}</li>`)
-      .join("");
-    return `<ul>${items}</ul>`;
-  });
+  result = result.replace(
+    /(?:^[-+*] [^\r\n]+(?:\r?\n(?:(?: {2,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        if (/^[-+*] /.test(line)) {
+          items.push(line.slice(2));
+          continue;
+        }
+        if (items.length > 0) {
+          items[items.length - 1] += `\n${line.replace(/^(?: {2}|\t)/, "")}`;
+        }
+      }
+      return `<ul>${items.map((item) => `<li>${item}</li>`).join("")}</ul>`;
+    },
+  );
 
   // Ordered lists
-  result = result.replace(/(?:^\d+\. .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => /^\d+\. /.test(l))
-      .map((l: string) => `<li>${l.replace(/^\d+\. /, "")}</li>`)
-      .join("");
-    return `<ol>${items}</ol>`;
-  });
+  result = result.replace(
+    /(?:^\d{1,9}[.)] [^\r\n]+(?:\r?\n(?:(?: {3,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      let continuationIndent = 0;
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        const marker = /^(\d{1,9}[.)]) (.*)$/.exec(line);
+        if (marker) {
+          items.push(marker[2]);
+          continuationIndent = marker[1].length + 1;
+          continue;
+        }
+        if (items.length > 0) {
+          const content =
+            line[0] === "\t"
+              ? line.slice(1)
+              : line.slice(Math.min(continuationIndent, /^ */.exec(line)?.[0].length ?? 0));
+          items[items.length - 1] += `\n${content}`;
+        }
+      }
+      return `<ol>${items.map((item) => `<li>${item}</li>`).join("")}</ol>`;
+    },
+  );
 
   // Wrap remaining bare text in <p> tags
   result = result
@@ -897,24 +924,27 @@ export async function renderMarkdown(
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < calloutBlocks.length; i++) {
-    result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
+  for (const block of calloutBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < tabsBlocks.length; i++) {
-    result = result.replace(`%%TABS_${i}%%`, tabsBlocks[i]);
+  for (const block of tabsBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < hoverLinkBlocks.length; i++) {
-    result = result.replace(`%%HOVERLINK_${i}%%`, hoverLinkBlocks[i]);
+  for (const block of hoverLinkBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < promptBlocks.length; i++) {
-    result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
-  }
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  for (const block of codeBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
 
-  return restoreMarkdownHeadingOpeningTags(
+  result = restoreMarkdownHeadingOpeningTags(
     stripPreparedMarkdownHeadingTokens(result),
     headingOpeningTags,
   );
+  for (const block of promptBlocks) {
+    result = result.replace(block.token, () =>
+      renderPrompt(block.attributes, block.children, options),
+    );
+  }
+  return result;
 }

--- a/packages/astro/src/markdown.ts
+++ b/packages/astro/src/markdown.ts
@@ -11,6 +11,18 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
+  extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
+  prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
+  replaceDocsMarkdownFencedCodeBlocks as replaceMarkdownFencedCodeBlocks,
+  renderDocsMarkdownBlockContent as renderMarkdownBlockContent,
+  renderDocsMarkdownHeadings as renderMarkdownHeadings,
+  renderDocsMarkdownInline as renderMarkdownInline,
+  restoreDocsMarkdownHeadingOpeningTags as restoreMarkdownHeadingOpeningTags,
+  stripPreparedDocsMarkdownHeadingTokens as stripPreparedMarkdownHeadingTokens,
+  type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
+} from "@farming-labs/docs/markdown-rendering";
+import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -45,16 +57,6 @@ function getHighlighter(): Promise<Highlighter> {
   return highlighterPromise;
 }
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/<[^>]+>/g, "")
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .trim();
-}
-
 const hoverLinkDefaults = {
   linkLabel: "Open page",
   showIndicator: false,
@@ -72,6 +74,16 @@ const promptDefaults = {
   copiedIcon: "check",
   openIcon: "arrowUpRight",
 } as const;
+
+function slugifyCodeGroupTab(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
 
 const promptActionIcons: Record<string, string> = {
   copy: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>',
@@ -408,23 +420,17 @@ function normalizeCalloutType(type: string): string {
   return calloutIcons[aliased] ? aliased : "note";
 }
 
-function renderInlineCalloutContent(content: string): string {
-  return content
-    .trim()
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
-    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/\n+/g, "<br />");
-}
-
-function renderCallout(type: string, content: string, title?: string | null): string {
+function renderCallout(
+  type: string,
+  content: string,
+  title: string | null | undefined,
+  definitions: MarkdownReferenceDefinitions,
+): string {
   const normalizedType = normalizeCalloutType(type);
   const icon = calloutIcons[normalizedType] || calloutIcons.note;
   const label = title?.trim() || calloutLabels[normalizedType] || "Note";
-  const renderedContent = renderInlineCalloutContent(content);
-  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
+  const renderedContent = renderMarkdownBlockContent(content, definitions);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p>${renderedContent}</div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -515,7 +521,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
 }
 
 function createCodeGroupTabValue(label: string, used: Set<string>): string {
-  const slug = slugify(label) || `code-${used.size + 1}`;
+  const slug = slugifyCodeGroupTab(label) || `code-${used.size + 1}`;
   let value = slug;
   let suffix = 2;
 
@@ -598,6 +604,18 @@ export async function renderMarkdown(
 
   const hl = await getHighlighter();
   let result = resolveDocsAudienceMdxContent(content, "human");
+  const extractedReferences = extractMarkdownReferenceDefinitions(result);
+  const referenceDefinitions = extractedReferences.definitions;
+  const preparedHeadings = prepareMarkdownHeadings(result);
+  const preparedWithoutReferences = extractMarkdownReferenceDefinitions(
+    preparedHeadings.markdown,
+  ).markdown;
+  const renderedHeadings = renderMarkdownHeadings(
+    preparedWithoutReferences,
+    preparedHeadings.headings,
+  );
+  result = renderedHeadings.markdown;
+  const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
@@ -608,25 +626,31 @@ export async function renderMarkdown(
       const dropdown = toBoolean(attrs.dropdown, false);
       const usedValues = new Set<string>();
       const panels: { label: string; value: string; html: string }[] = [];
-      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
-      let codeMatch: RegExpExecArray | null;
-
-      while ((codeMatch = codeRegex.exec(body)) !== null) {
-        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+      replaceMarkdownFencedCodeBlocks(body, ({ code, info }) => {
+        const { lang, title } = parseCodeGroupMeta(info);
         const label = title || lang || `Code ${panels.length + 1}`;
         const value = createCodeGroupTabValue(label, usedValues);
-        const dedented = dedentCode(codeMatch[2]);
+        const dedented = dedentCode(code);
         const { html, raw } = highlightCode(hl, dedented, lang);
         panels.push({
           label,
           value,
           html: wrapCodeWithCopy(html, raw, null, lang),
         });
-      }
+        return "";
+      });
 
       if (panels.length === 0) return body;
+      const extractedHeadings = extractRenderedHeadingElements(
+        body,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
 
-      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      let tabsHtml =
+        extractedHeadings.headingsHtml +
+        `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
       tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
         const state = i === 0 ? "active" : "inactive";
@@ -655,15 +679,33 @@ export async function renderMarkdown(
       let tabMatch: RegExpExecArray | null;
       while ((tabMatch = tabRegex.exec(body)) !== null) {
         const tabValue = tabMatch[1];
-        const tabContent = tabMatch[2].trim();
-        const codeMatch = tabContent.match(/```([^\n]*)\n([\s\S]*?)```/);
-        if (codeMatch) {
-          const { lang, title } = parseMeta(codeMatch[1]);
-          const dedented = dedentCode(codeMatch[2]);
+        const extractedHeadings = extractRenderedHeadingElements(
+          tabMatch[2].trim(),
+          referenceDefinitions,
+          false,
+          headingOpeningTags,
+        );
+        let renderedCode: string | undefined;
+        replaceMarkdownFencedCodeBlocks(extractedHeadings.content, ({ code, info }) => {
+          if (renderedCode !== undefined) return "";
+          const { lang, title } = parseMeta(info);
+          const dedented = dedentCode(code);
           const { html, raw } = highlightCode(hl, dedented, lang);
-          panels.push({ value: tabValue, html: wrapCodeWithCopy(html, raw, title, lang) });
+          renderedCode = wrapCodeWithCopy(html, raw, title, lang);
+          return "";
+        });
+        if (renderedCode !== undefined) {
+          panels.push({
+            value: tabValue,
+            html: extractedHeadings.headingsHtml + renderedCode,
+          });
         } else {
-          panels.push({ value: tabValue, html: `<p>${tabContent}</p>` });
+          panels.push({
+            value: tabValue,
+            html:
+              extractedHeadings.headingsHtml +
+              renderMarkdownBlockContent(extractedHeadings.content, referenceDefinitions),
+          });
         }
       }
 
@@ -686,15 +728,23 @@ export async function renderMarkdown(
     },
   );
 
-  // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  // Prompt bodies are literal copyable text. Protect them before fenced code
+  // rendering so examples remain escaped text rather than injected figures.
+  const promptBlocks: string[] = [];
   result = result.replace(
-    /```([^\n]*)\n([\s\S]*?)```/g,
-    (_: string, meta: string, code: string) => {
-      const { lang, title } = parseMeta(meta);
-      const { html, raw } = highlightCode(hl, code, lang);
-      const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-      codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        true,
+        headingOpeningTags,
+      );
+      promptBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
+      );
       return placeholder;
     },
   );
@@ -704,20 +754,29 @@ export async function renderMarkdown(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
       const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
-      hoverLinkBlocks.push(renderHoverLink(attrSource, children, options.theme));
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
+      hoverLinkBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderHoverLink(attrSource, extractedHeadings.content, options.theme),
+      );
       return placeholder;
     },
   );
 
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      promptBlocks.push(renderPrompt(attrSource ?? "", children, options));
-      return placeholder;
-    },
-  );
+  // ── Fenced code blocks ──
+  const codeBlocks: string[] = [];
+  result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
+    const { lang, title } = parseMeta(info);
+    const { html, raw } = highlightCode(hl, code, lang);
+    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
+    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    return placeholder;
+  });
 
   const calloutBlocks: string[] = [];
   result = result.replace(
@@ -727,37 +786,32 @@ export async function renderMarkdown(
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, children, title));
+      calloutBlocks.push(
+        renderCallout(
+          type,
+          restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
+          title,
+          referenceDefinitions,
+        ),
+      );
       return placeholder;
     },
   );
 
-  // Inline code
-  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
-
-  // Headings (h4 → h1 order to avoid prefix collisions)
-  result = result.replace(/^#### (.+)$/gm, (_: string, text: string) => {
-    return `<h4 id="${slugify(text)}">${text}</h4>`;
-  });
-  result = result.replace(/^### (.+)$/gm, (_: string, text: string) => {
-    return `<h3 id="${slugify(text)}">${text}</h3>`;
-  });
-  result = result.replace(/^## (.+)$/gm, (_: string, text: string) => {
-    return `<h2 id="${slugify(text)}">${text}</h2>`;
-  });
-  result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
-
   // ── Callouts / blockquotes (before inline formatting) ──
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
-    const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");
+    const inner = restoreMarkdownHeadingOpeningTags(
+      lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n"),
+      headingOpeningTags,
+    );
 
     const ghMatch = inner.match(/^\[!(NOTE|WARNING|TIP|IMPORTANT|CAUTION)\]\s*\n?([\s\S]*)/i);
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
@@ -766,26 +820,18 @@ export async function renderMarkdown(
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
-    return `<blockquote><p>${inner}</p></blockquote>`;
+    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+    calloutBlocks.push(
+      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+    );
+    return placeholder;
   });
 
-  // Inline formatting
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
-  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
-
-  // Images — before links so ![alt](url) is not captured as a link
-  result = result.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (_: string, alt: string, src: string) =>
-      `<img src="${src}" alt="${alt.replace(/"/g, "&quot;")}" class="fd-docs-content-img" loading="lazy" decoding="async" />`,
-  );
-  // Links
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  result = renderMarkdownInline(result, referenceDefinitions);
 
   // Horizontal rules
   result = result.replace(/^---$/gm, "<hr />");
@@ -842,15 +888,15 @@ export async function renderMarkdown(
       block = block.trim();
       if (!block) return "";
       if (/^<(h[1-6]|pre|ul|ol|blockquote|hr|table|div)/.test(block)) return block;
-      if (/^%%(CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%$/.test(block)) return block;
+      if (/^%%FARMINGLABS_DOCS_HEADING_OPEN_\d+%%/.test(block)) return block;
+      if (/^%%(?:CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%/.test(block)) {
+        return block;
+      }
       return `<p>${block}</p>`;
     })
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
-  }
   for (let i = 0; i < calloutBlocks.length; i++) {
     result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
   }
@@ -863,6 +909,12 @@ export async function renderMarkdown(
   for (let i = 0; i < promptBlocks.length; i++) {
     result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
   }
+  for (let i = 0; i < codeBlocks.length; i++) {
+    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  }
 
-  return result;
+  return restoreMarkdownHeadingOpeningTags(
+    stripPreparedMarkdownHeadingTokens(result),
+    headingOpeningTags,
+  );
 }

--- a/packages/astro/test/markdown-placeholders.test.ts
+++ b/packages/astro/test/markdown-placeholders.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown block placeholders", () => {
+  it("keeps authored placeholder-like text separate from rendered blocks", async () => {
+    const html = await renderMarkdown(
+      [
+        "%%CALLOUT_0%%",
+        "",
+        "%%CODEBLOCK_0%%",
+        "",
+        "<Callout>Real callout content.</Callout>",
+        "",
+        "```js",
+        'console.log("real code");',
+        "```",
+      ].join("\n"),
+    );
+
+    expect(html).toContain("%%CALLOUT_0%%");
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html.match(/class="fd-callout fd-callout-/gu)).toHaveLength(1);
+    expect(html.match(/console\.log/gu)).toHaveLength(1);
+    expect(html.indexOf("%%CALLOUT_0%%")).toBeLessThan(html.indexOf("Real callout content."));
+    expect(html.indexOf("%%CODEBLOCK_0%%")).toBeLessThan(html.indexOf("console.log"));
+  });
+});

--- a/packages/astro/test/markdown.test.ts
+++ b/packages/astro/test/markdown.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown Prompt reference definitions", () => {
+  it("preserves literal Prompt definitions without exposing them to document links", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+Use [prompt-only].
+[prompt-only]: /from-prompt "Prompt only"
+<Agent>Keep this literal.</Agent>
+</Prompt>
+
+Outside [prompt-only].
+
+[public]: /outside
+
+Outside [public].`);
+
+    expect(html).toContain("Use [prompt-only].");
+    expect(html).toContain("[prompt-only]: /from-prompt &quot;Prompt only&quot;");
+    expect(html).toContain("&lt;Agent&gt;Keep this literal.&lt;/Agent&gt;");
+    expect(html).toContain("Outside [prompt-only].");
+    expect(html).not.toContain('href="/from-prompt"');
+    expect(html).toContain('Outside <a href="/outside">public</a>.');
+    expect(html).not.toContain("[public]: /outside");
+  });
+
+  it("keeps Prompt-looking Markdown literals inert", async () => {
+    const literalSources = [
+      [
+        "FENCED_PROMPT_LITERAL",
+        ["```mdx", "<Prompt>", "FENCED_PROMPT_LITERAL", "</Prompt>", "```"].join("\n"),
+      ],
+      [
+        "QUOTED_PROMPT_LITERAL",
+        ["> ~~~~mdx", "> <Prompt>", "> QUOTED_PROMPT_LITERAL", "> </Prompt>", "> ~~~~"].join("\n"),
+      ],
+      [
+        "LIST_PROMPT_LITERAL",
+        ["- ~~~mdx", "  <Prompt>", "  LIST_PROMPT_LITERAL", "  </Prompt>", "  ~~~"].join("\n"),
+      ],
+      ["INLINE_PROMPT_LITERAL", "`<Prompt>INLINE_PROMPT_LITERAL</Prompt>`"],
+      [
+        "LINK_PROMPT_LITERAL",
+        '[Example](https://example.com "Use <Prompt>LINK_PROMPT_LITERAL</Prompt>")',
+      ],
+      [
+        "LINK_LABEL_PROMPT_LITERAL",
+        "[<Prompt>LINK_LABEL_PROMPT_LITERAL</Prompt>](https://example.com)",
+      ],
+      ["EXPRESSION_PROMPT_LITERAL", "{<Prompt>EXPRESSION_PROMPT_LITERAL</Prompt>}"],
+      [
+        "PROP_PROMPT_LITERAL",
+        "<Card example={<Prompt>PROP_PROMPT_LITERAL</Prompt>}>Card body</Card>",
+      ],
+      ["UNRESOLVED_PROMPT_LITERAL", "[<Prompt>UNRESOLVED_PROMPT_LITERAL</Prompt>][]"],
+      ["UNRESOLVED_IMAGE_PROMPT_LITERAL", "![<Prompt>UNRESOLVED_IMAGE_PROMPT_LITERAL</Prompt>]"],
+      [
+        "RAW_HTML_PROMPT_LITERAL",
+        ["<pre>", "<Prompt>RAW_HTML_PROMPT_LITERAL</Prompt>", "</pre>"].join("\n"),
+      ],
+      [
+        "UPPERCASE_RAW_HTML_PROMPT_LITERAL",
+        ["<SCRIPT>", "<Prompt>UPPERCASE_RAW_HTML_PROMPT_LITERAL</Prompt>", "</SCRIPT>"].join("\n"),
+      ],
+      ["SVG_PROMPT_LITERAL", "<svg><Prompt>SVG_PROMPT_LITERAL</Prompt></svg>"],
+      ["UPPERCASE_SVG_PROMPT_LITERAL", "<SVG><Prompt>UPPERCASE_SVG_PROMPT_LITERAL</Prompt></SVG>"],
+      ["MATH_PROMPT_LITERAL", "<math><Prompt>MATH_PROMPT_LITERAL</Prompt></math>"],
+      [
+        "UPPERCASE_MATH_PROMPT_LITERAL",
+        "<MATH><Prompt>UPPERCASE_MATH_PROMPT_LITERAL</Prompt></MATH>",
+      ],
+      ["CDATA_PROMPT_LITERAL", "<![CDATA[<Prompt>CDATA_PROMPT_LITERAL</Prompt>]]>"],
+    ] as const;
+
+    for (const [marker, source] of literalSources) {
+      const html = await renderMarkdown(source);
+      expect(html).toContain(marker);
+      expect(html).not.toContain("data-prompt-card");
+    }
+
+    const liveHtml = await renderMarkdown("<Prompt showPrompt>LIVE_PROMPT</Prompt>");
+    expect(liveHtml).toContain("LIVE_PROMPT");
+    expect(liveHtml.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("preserves flow boundaries and complete nested Prompt copy", async () => {
+    const html = await renderMarkdown(`Before.
+<Prompt showPrompt>
+Run the check.
+</Prompt>
+After.
+
+---
+
+Done.`);
+
+    expect(html).toContain("<p>Before.</p>");
+    expect(html).toContain("<p>After.</p>");
+    expect(html).toContain("<hr />");
+    expect(html).toContain("<p>Done.</p>");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(html).not.toMatch(/<(?:p|h[1-6])[^>]*>\s*<div class="fd-prompt"/);
+
+    const nested = await renderMarkdown(
+      "<Prompt showPrompt>outer <Prompt>inner</Prompt> tail</Prompt>",
+    );
+    expect(nested.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(nested).toContain("outer &lt;Prompt&gt;inner&lt;/Prompt&gt; tail");
+  });
+
+  it("restores Prompt after downstream code and heading transport tokens", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+%%CODEBLOCK_0%%
+%%FARMINGLABS_DOCS_HEADING_OPEN_0%%
+</Prompt>
+
+## Real heading
+
+\`\`\`ts
+const real = true;
+\`\`\``);
+
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html).toContain("%%FARMINGLABS_DOCS_HEADING_OPEN_0%%");
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).toContain("real");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("keeps live Prompt cards and copied text inside blockquote and list containers", async () => {
+    const html = await renderMarkdown(`> Before
+> <Prompt showPrompt>
+> Quote task
+> </Prompt>
+> After
+
+- Before
+  <Prompt showPrompt>
+  List task
+  </Prompt>
+  After`);
+
+    expect(html).toMatch(
+      /<blockquote>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/blockquote>/,
+    );
+    expect(html).toMatch(/<li>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/li>/);
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">Quote task</div>');
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">List task</div>');
+    expect(html).not.toContain("&gt; Quote task");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(2);
+  });
+
+  it("keeps Prompt cards inside every unordered and ordered list marker", async () => {
+    const html = await renderMarkdown(`+ <Prompt showPrompt>
+  Plus task
+  </Prompt>
+
+* <Prompt showPrompt>
+  Star task
+  </Prompt>
+
+1. Before
+   <Prompt showPrompt>
+   Ordered task
+   </Prompt>
+   After
+
+2) <Prompt showPrompt>
+   Parenthesized task
+   </Prompt>`);
+
+    expect(html.match(/data-prompt-card/g)).toHaveLength(4);
+    expect(html.match(/<ul><li><div class="fd-prompt"/g)).toHaveLength(2);
+    expect(html).toMatch(/<ol><li>Before[\s\S]*data-prompt-card[\s\S]*After<\/li><\/ol>/);
+    expect(html).toContain('<ol><li><div class="fd-prompt"');
+    for (const task of ["Plus task", "Star task", "Ordered task", "Parenthesized task"]) {
+      expect(html).toContain(`<div data-prompt-text hidden aria-hidden="true">${task}</div>`);
+    }
+
+    const simple = await renderMarkdown(
+      ["- One", "+ Two", "* Three", "", "1. First", "2. Second"].join("\n"),
+    );
+    expect(simple).toContain("<ul><li>One</li><li>Two</li><li>Three</li></ul>");
+    expect(simple).toContain("<ol><li>First</li><li>Second</li></ol>");
+  });
+
+  it("keeps standalone Prompt cards separate from Setext markers for LF and CRLF", async () => {
+    for (const newline of ["\n", "\r\n"]) {
+      for (const marker of ["---", "==="]) {
+        const html = await renderMarkdown(
+          `<Prompt showPrompt>x</Prompt>${newline}${marker}${newline}After`,
+        );
+        expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+        expect(html).not.toMatch(/<h[12][^>]*>\s*<div class="fd-prompt"/);
+      }
+    }
+
+    const inline = await renderMarkdown("Before <Prompt showPrompt>x</Prompt> after");
+    expect(inline).toContain('<p>Before <div class="fd-prompt"');
+  });
+});

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -30,6 +30,11 @@
       "import": "./dist/server.mjs",
       "default": "./dist/server.mjs"
     },
+    "./markdown-rendering": {
+      "types": "./dist/markdown-rendering.d.mts",
+      "import": "./dist/markdown-rendering.mjs",
+      "default": "./dist/markdown-rendering.mjs"
+    },
     "./agent-skills-bundle": {
       "types": "./dist/agent-skills-bundle.d.mts",
       "import": "./dist/agent-skills-bundle.mjs",
@@ -74,9 +79,12 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@scalar/core": "^0.4.3",
     "@vercel/sandbox": "^2.0.0",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "jiti": "^2.7.0",
+    "parse-entities": "^4.0.2",
     "picocolors": "^1.1.1",
+    "remark-gfm": "^4.0.1",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -285,14 +285,10 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
 
     expect(getResponse.status).toBe(200);
     expect(getResponse.headers.get("content-type")).toBe("application/json; charset=utf-8");
-    expect(getResponse.headers.get("x-docs-markdown-section-count")).toBe("3");
-    expect(payload.format).toBe("docs-markdown-sections.v1");
-    expect(payload.sectionCount).toBe(3);
-    expect(payload.sections.map((section) => section.id)).toEqual([
-      adapter === "tanstack-start" ? "documentation" : "page",
-      "home",
-      "install",
-    ]);
+    expect(getResponse.headers.get("x-docs-markdown-section-count")).toBe("2");
+    expect(payload.format).toBe("docs-markdown-sections.v2");
+    expect(payload.sectionCount).toBe(2);
+    expect(payload.sections.map((section) => section.id)).toEqual(["home", "install"]);
 
     const headResponse = await server.HEAD({
       request: new Request(url, { method: "HEAD" }),

--- a/packages/docs/src/agent-conformance.test.ts
+++ b/packages/docs/src/agent-conformance.test.ts
@@ -13,6 +13,7 @@ import {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
 } from "./agent.js";
 
 const AGENT_SKILL_CONTENT = `---
@@ -83,6 +84,7 @@ function createPassingResponse(surface: DocsAgentContractSurface, contentType?: 
     body = JSON.stringify({
       $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
       format: DOCS_AGENT_MANIFEST_FORMAT,
+      version: DOCS_AGENT_MANIFEST_VERSION,
     });
   } else if (surface === "agent-skills-index") {
     body = JSON.stringify({
@@ -370,6 +372,7 @@ version: "1.0"
             nested: {
               $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
               format: DOCS_AGENT_MANIFEST_FORMAT,
+              version: DOCS_AGENT_MANIFEST_VERSION,
             },
           }),
           {
@@ -385,7 +388,35 @@ version: "1.0"
       issues: [
         expect.stringContaining("top-level $schema"),
         expect.stringContaining("top-level format"),
+        expect.stringContaining("top-level version"),
       ],
+    });
+  });
+
+  it("rejects a manifest version that does not match its schema identity", async () => {
+    const report = await runDocsAgentConformance({
+      adapter: "next",
+      async handle(_request, surface) {
+        const response = createPassingResponse(surface);
+        if (surface !== "discovery") return response;
+
+        return new Response(
+          JSON.stringify({
+            $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
+            format: DOCS_AGENT_MANIFEST_FORMAT,
+            version: "1",
+          }),
+          {
+            status: response.status,
+            headers: response.headers,
+          },
+        );
+      },
+    });
+
+    expect(report.cases.find((result) => result.surface === "discovery")).toMatchObject({
+      passed: false,
+      issues: [expect.stringContaining(`top-level version ${DOCS_AGENT_MANIFEST_VERSION}`)],
     });
   });
 

--- a/packages/docs/src/agent-conformance.ts
+++ b/packages/docs/src/agent-conformance.ts
@@ -17,6 +17,7 @@ import {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   isDocsAgentSkillName,
   validateDocsAgentSkillFrontmatter,
 } from "./agent.js";
@@ -412,6 +413,9 @@ function validateAgentManifest(content: string): string[] {
   }
   if (root?.format !== DOCS_AGENT_MANIFEST_FORMAT) {
     issues.push(`Agent manifest did not declare top-level format ${DOCS_AGENT_MANIFEST_FORMAT}`);
+  }
+  if (root?.version !== DOCS_AGENT_MANIFEST_VERSION) {
+    issues.push(`Agent manifest did not declare top-level version ${DOCS_AGENT_MANIFEST_VERSION}`);
   }
   return issues;
 }

--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -464,6 +464,63 @@ ${"Useful café guidance 🚜. ".repeat(60)}
     });
   });
 
+  it("preserves authored fenced contract-marker examples during hydration", () => {
+    const markerExamplePage = page({
+      slug: "contract-marker-example",
+      url: "/docs/contract-marker-example",
+      title: "Contract marker example",
+      rawContent: [
+        "## Marker example",
+        "",
+        "Keep both literal markers.",
+        "",
+        "```md",
+        "<!-- farming-labs:agent-contract:start -->",
+        "<!-- farming-labs:agent-contract:end -->",
+        "```",
+      ].join("\n"),
+    });
+    const source = hydrateDocsEvaluationSearchSource(
+      {
+        id: "marker-example",
+        url: "/docs/contract-marker-example#marker-example",
+        content: "Provider snippet.",
+        type: "heading",
+      },
+      0,
+      new Map([[markerExamplePage.url, markerExamplePage]]),
+      "page-section",
+    );
+
+    expect(source?.content).toContain("<!-- farming-labs:agent-contract:start -->");
+    expect(source?.content).toContain("<!-- farming-labs:agent-contract:end -->");
+
+    const generatedContractPage = page({
+      slug: "generated-contract-marker",
+      url: "/docs/generated-contract-marker",
+      title: "Generated contract marker",
+      rawContent: "## Authored section\n\nAuthored guidance.",
+      agent: {
+        task: "Inspect generated contract cleanup.",
+        outcome: "Only generated boundary markers are removed.",
+      },
+    });
+    const generatedSource = hydrateDocsEvaluationSearchSource(
+      {
+        id: "generated-contract",
+        url: "/docs/generated-contract-marker#agent-contract",
+        content: "Provider snippet.",
+        type: "heading",
+      },
+      0,
+      new Map([[generatedContractPage.url, generatedContractPage]]),
+      "page-section",
+    );
+
+    expect(generatedSource?.content).toContain("## Agent Contract");
+    expect(generatedSource?.content).not.toContain("farming-labs:agent-contract");
+  });
+
   it("does not count a source when the budget can render only its header", async () => {
     const headerOnlyPage = page({
       slug: "header-only",

--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DocsMcpPage } from "./mcp.js";
-import { runDocsGoldenTasks, type DocsGoldenTask } from "./agent-evals.js";
+import {
+  hydrateDocsEvaluationSearchSource,
+  runDocsGoldenTasks,
+  type DocsGoldenTask,
+} from "./agent-evals.js";
 
 function page(
   input: Partial<DocsMcpPage> & Pick<DocsMcpPage, "slug" | "url" | "title">,
@@ -268,7 +272,7 @@ ${"Useful café guidance 🚜. ".repeat(60)}
       query: "configure café",
       tokenBudget: 220,
       topK: 1,
-      expect: { relevantSources: ["/docs/unicode#configure-caf"] },
+      expect: { relevantSources: ["/docs/unicode#configure-café"] },
     };
 
     const forward = await runDocsGoldenTasks([...pages, unicodePage], [task]);
@@ -280,6 +284,184 @@ ${"Useful café guidance 🚜. ".repeat(60)}
     expect(result.usage.usedUtf8Bytes).toBe(Buffer.byteLength(result.context, "utf8"));
     expect(result.usage.usedUtf8Bytes).toBeLessThanOrEqual(220);
     expect(result.context).not.toContain("�");
+  });
+
+  it("keeps case-sensitive custom anchors distinct in retrieval and citations", async () => {
+    const caseSensitivePage = page({
+      slug: "case-sensitive",
+      url: "/docs/case-sensitive",
+      title: "Case-sensitive anchors",
+      rawContent: [
+        "## Upper [#Foo]",
+        "",
+        "Uppercase section marker.",
+        "",
+        "## Lower [#foo]",
+        "",
+        "Lowercase unique retrieval marker.",
+      ].join("\n"),
+    });
+    const report = await runDocsGoldenTasks(
+      [caseSensitivePage],
+      [
+        {
+          id: "case-sensitive-anchor",
+          query: "lowercase unique retrieval marker",
+          surface: "configured-search",
+          topK: 1,
+          expect: {
+            relevantSources: ["/docs/case-sensitive#Foo"],
+            forbiddenSources: ["/docs/case-sensitive#foo"],
+          },
+        },
+      ],
+    );
+    const result = report.tasks[0];
+
+    expect(report.status).toBe("failed");
+    expect(result.retrieval).toMatchObject({
+      expectedRelevant: 1,
+      retrievedRelevant: 0,
+      forbiddenSources: ["/docs/case-sensitive#foo"],
+      passed: false,
+    });
+    expect(result.citations).toMatchObject({
+      expected: ["/docs/case-sensitive#Foo"],
+      actual: ["/docs/case-sensitive#foo"],
+      passed: false,
+    });
+    expect(result.issues.join(" ")).not.toContain("Invalid golden task configuration");
+  });
+
+  it("keeps literal percent escapes distinct from their decoded reserved characters", async () => {
+    const reservedPage = page({
+      slug: "reserved-evaluation",
+      url: "/docs/reserved-evaluation",
+      title: "Reserved evaluation anchors",
+      rawContent: [
+        "## Hash [#foo#bar]",
+        "",
+        "Hash character retrieval marker.",
+        "",
+        "## Percent [#foo%23bar]",
+        "",
+        "Literal percent escape retrieval marker.",
+      ].join("\n"),
+    });
+    const tasks: DocsGoldenTask[] = ["configured-search", "ask-ai-context"].map((surface) => ({
+      id: `reserved-anchor-${surface}`,
+      query: "literal percent escape retrieval marker",
+      surface: surface as DocsGoldenTask["surface"],
+      topK: 1,
+      tokenBudget: 2_000,
+      expect: {
+        relevantSources: ["/docs/reserved-evaluation#foo%2523bar"],
+        forbiddenSources: ["/docs/reserved-evaluation#foo%23bar"],
+      },
+    }));
+    const report = await runDocsGoldenTasks([reservedPage], tasks);
+
+    expect(report.status).toBe("passed");
+    for (const result of report.tasks) {
+      expect(result.retrieval).toMatchObject({
+        retrievedRelevant: 1,
+        forbiddenSources: [],
+        passed: true,
+      });
+      expect(result.citations).toMatchObject({
+        actual: ["/docs/reserved-evaluation#foo%2523bar"],
+        missing: [],
+        unexpected: [],
+        integrity: true,
+        passed: true,
+      });
+    }
+  });
+
+  it("hydrates authored DOM anchors ahead of generated contracts on the Ask AI surface", async () => {
+    const collisionPage = page({
+      slug: "contract-collision-evaluation",
+      url: "/docs/contract-collision-evaluation",
+      title: "Contract collision evaluation",
+      rawContent: "## Authored [#agent-contract]\n\nAuthored golden collision marker.",
+      agent: {
+        task: "Run the generated contract task.",
+        outcome: "The generated contract outcome is available.",
+      },
+    });
+    const report = await runDocsGoldenTasks(
+      [collisionPage],
+      [
+        {
+          id: "contract-reserved-anchor",
+          query: "authored golden collision marker",
+          surface: "ask-ai-context",
+          topK: 1,
+          tokenBudget: 2_000,
+          expect: {
+            relevantSources: ["/docs/contract-collision-evaluation#agent-contract"],
+            forbiddenSources: ["/docs/contract-collision-evaluation#agent-contract-1"],
+          },
+        },
+      ],
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.tasks[0].citations).toMatchObject({
+      actual: ["/docs/contract-collision-evaluation#agent-contract"],
+      integrity: true,
+      passed: true,
+    });
+    expect(report.tasks[0].context).toContain("Authored golden collision marker.");
+    expect(report.tasks[0].context).not.toContain("generated contract outcome");
+  });
+
+  it("rejects unresolved section hydration instead of substituting a whole page", () => {
+    const caseSensitivePage = page({
+      slug: "case-sensitive-hydration",
+      url: "/docs/case-sensitive-hydration",
+      title: "Case-sensitive hydration",
+      rawContent: [
+        "## Upper [#Foo]",
+        "",
+        "Uppercase section.",
+        "",
+        "## Lower [#foo]",
+        "",
+        "Lowercase section.",
+      ].join("\n"),
+    });
+    const pagesByUrl = new Map([[caseSensitivePage.url, caseSensitivePage]]);
+
+    expect(
+      hydrateDocsEvaluationSearchSource(
+        {
+          id: "stale-anchor",
+          url: "/docs/case-sensitive-hydration#FOO",
+          content: "Provider snippet.",
+          type: "heading",
+        },
+        0,
+        pagesByUrl,
+        "page-section",
+      ),
+    ).toBeUndefined();
+    expect(
+      hydrateDocsEvaluationSearchSource(
+        {
+          id: "exact-anchor",
+          url: "/docs/case-sensitive-hydration#foo",
+          content: "Provider snippet.",
+          type: "heading",
+        },
+        0,
+        pagesByUrl,
+        "page-section",
+      ),
+    ).toMatchObject({
+      anchor: "foo",
+      content: expect.stringContaining("Lowercase section."),
+    });
   });
 
   it("does not count a source when the budget can render only its header", async () => {

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -22,6 +22,11 @@ import {
   type DocsMcpContextSource,
   type DocsMcpPage,
 } from "./mcp.js";
+import {
+  PAGE_AGENT_CONTRACT_END_MARKER,
+  PAGE_AGENT_CONTRACT_START_MARKER,
+  upsertPageAgentContractMarkdown,
+} from "./agent-contract.js";
 import { findDocsMarkdownSection } from "./markdown-sections.js";
 import {
   buildDocsAskAIContext,
@@ -683,7 +688,9 @@ function canonicalizeSource(value: string, baseUrl?: string): string {
       origin = `${parsed.protocol}//${parsed.host}`;
     }
   } catch {
-    const [pathAndQuery = "/", fragment = ""] = rawValue.split("#", 2);
+    const hashIndex = rawValue.indexOf("#");
+    const pathAndQuery = hashIndex >= 0 ? rawValue.slice(0, hashIndex) : rawValue || "/";
+    const fragment = hashIndex >= 0 ? rawValue.slice(hashIndex + 1) : "";
     pathname = pathAndQuery.split("?", 1)[0] || "/";
     hash = fragment ? `#${fragment}` : "";
   }
@@ -692,9 +699,11 @@ function canonicalizeSource(value: string, baseUrl?: string): string {
   if (pathname !== "/") pathname = pathname.replace(/\/+$/gu, "");
   if (!pathname.startsWith("/")) pathname = `/${pathname}`;
 
-  const normalizedHash = hash
-    ? `#${safeDecode(hash.slice(1)).trim().replace(/^#+/u, "").toLowerCase()}`
-    : "";
+  // Canonical section anchors are case-sensitive. Keep the fragment URL-encoded so this
+  // operation is idempotent: returning a decoded literal such as `foo%23bar` would cause a
+  // later canonicalization pass to reinterpret it as the distinct `foo#bar` identifier.
+  const decodedHash = hash ? safeDecode(hash.slice(1)).trim() : "";
+  const normalizedHash = decodedHash ? `#${encodeURIComponent(decodedHash)}` : "";
   return `${origin}${pathname || "/"}${normalizedHash === "#" ? "" : normalizedHash}`;
 }
 
@@ -835,15 +844,26 @@ function extractRenderedCitations(
   return { actual, layoutIntegrity, blockUtf8Bytes };
 }
 
-function getPageAgentMarkdown(page: DocsMcpPage): string {
-  return (
+function getPageAgentSectionMarkdown(page: DocsMcpPage): string {
+  const source =
     page.agentRawContent ??
     page.agentFallbackRawContent ??
     page.agentContent ??
     page.agentFallbackContent ??
     page.rawContent ??
-    page.content
-  );
+    page.content;
+  return upsertPageAgentContractMarkdown(source, page.agent);
+}
+
+function cleanPageAgentContractMarkers(markdown: string): string {
+  return markdown
+    .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
+    .replace(PAGE_AGENT_CONTRACT_END_MARKER, "")
+    .replace(/^\r?\n+/, "");
+}
+
+function getPageAgentMarkdown(page: DocsMcpPage): string {
+  return cleanPageAgentContractMarkers(getPageAgentSectionMarkdown(page));
 }
 
 function findPageForSource(
@@ -855,26 +875,30 @@ function findPageForSource(
 
 function getResultAnchor(value: string): string | undefined {
   const canonical = canonicalizeSource(value);
-  const anchor = canonical.split("#", 2)[1];
+  const hashIndex = canonical.indexOf("#");
+  const anchor = hashIndex >= 0 ? canonical.slice(hashIndex + 1) : "";
   return anchor || undefined;
 }
 
-function hydrateSearchSource(
+/** @internal */
+export function hydrateDocsEvaluationSearchSource(
   result: DocsSearchResult,
   index: number,
   pagesByUrl: ReadonlyMap<string, DocsMcpPage>,
   contentMode: "result" | "page-section",
   baseUrl?: string,
-): DocsMcpContextSource {
+): DocsMcpContextSource | undefined {
   const normalizedResultUrl = canonicalizeSource(result.url, baseUrl);
   const page = findPageForSource(pagesByUrl, normalizedResultUrl);
   const anchor = getResultAnchor(result.url);
   const section = anchor ?? result.section;
+  const sectionMarkdown = page ? getPageAgentSectionMarkdown(page) : undefined;
   const pageSection =
-    page && section ? findDocsMarkdownSection(getPageAgentMarkdown(page), section) : undefined;
+    sectionMarkdown && section ? findDocsMarkdownSection(sectionMarkdown, section) : undefined;
+  if (contentMode === "page-section" && page && section && !pageSection) return undefined;
   const content =
     contentMode === "page-section" && page
-      ? (pageSection?.content ?? getPageAgentMarkdown(page)).trim()
+      ? cleanPageAgentContractMarkers(pageSection?.content ?? getPageAgentMarkdown(page)).trim()
       : [result.content, result.description].filter(Boolean).join("\n\n").trim();
   const scope = page ? getPageScope(page) : undefined;
   const url = normalizedResultUrl;
@@ -1149,7 +1173,7 @@ function createContextShell(options: {
 function parseAskAIContextSources(options: {
   context: string;
   blocks: readonly string[];
-  results: readonly ReturnType<typeof hydrateSearchSource>[];
+  results: readonly ReturnType<typeof hydrateDocsEvaluationSearchSource>[];
   baseUrl?: string;
 }): { sources: DocsMcpContextSource[]; citations: string[]; integrity: boolean } {
   if (!options.context) {
@@ -1302,8 +1326,15 @@ async function buildGoldenSurface(options: {
     const rankedSources = results
       .slice(0, options.topK)
       .map((result, index) =>
-        hydrateSearchSource(result, index, pagesByUrl, "result", options.runOptions.baseUrl),
-      );
+        hydrateDocsEvaluationSearchSource(
+          result,
+          index,
+          pagesByUrl,
+          "result",
+          options.runOptions.baseUrl,
+        ),
+      )
+      .filter((source): source is DocsMcpContextSource => Boolean(source));
     const rankedContext = buildContextFromSources({
       query: options.task.query,
       filters: options.task.filters,
@@ -1360,10 +1391,23 @@ async function buildGoldenSurface(options: {
   const rankedSources = askAI.searchResults
     .slice(0, options.topK)
     .map((result, index) =>
-      hydrateSearchSource(result, index, pagesByUrl, "result", options.runOptions.baseUrl),
-    );
+      hydrateDocsEvaluationSearchSource(
+        result,
+        index,
+        pagesByUrl,
+        "result",
+        options.runOptions.baseUrl,
+      ),
+    )
+    .filter((source): source is DocsMcpContextSource => Boolean(source));
   const resultSources = askAI.results.map((result, index) =>
-    hydrateSearchSource(result, index, pagesByUrl, "page-section", options.runOptions.baseUrl),
+    hydrateDocsEvaluationSearchSource(
+      result,
+      index,
+      pagesByUrl,
+      "page-section",
+      options.runOptions.baseUrl,
+    ),
   );
   const parsed = parseAskAIContextSources({
     context: askAI.context,

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -22,12 +22,11 @@ import {
   type DocsMcpContextSource,
   type DocsMcpPage,
 } from "./mcp.js";
+import { upsertPageAgentContractMarkdown } from "./agent-contract.js";
 import {
-  PAGE_AGENT_CONTRACT_END_MARKER,
-  PAGE_AGENT_CONTRACT_START_MARKER,
-  upsertPageAgentContractMarkdown,
-} from "./agent-contract.js";
-import { findDocsMarkdownSection } from "./markdown-sections.js";
+  findDocsMarkdownSection,
+  stripDocsGeneratedAgentContractMarkers,
+} from "./markdown-sections.js";
 import {
   buildDocsAskAIContext,
   normalizeDocsSearchFilters,
@@ -855,11 +854,14 @@ function getPageAgentSectionMarkdown(page: DocsMcpPage): string {
   return upsertPageAgentContractMarkdown(source, page.agent);
 }
 
-function cleanPageAgentContractMarkers(markdown: string): string {
-  return markdown
-    .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
-    .replace(PAGE_AGENT_CONTRACT_END_MARKER, "")
-    .replace(/^\r?\n+/, "");
+function cleanPageAgentContractMarkers(
+  markdown: string,
+  sourceMarkdown?: string,
+  startLine?: number,
+): string {
+  return sourceMarkdown && startLine
+    ? stripDocsGeneratedAgentContractMarkers(markdown, { sourceMarkdown, startLine })
+    : stripDocsGeneratedAgentContractMarkers(markdown);
 }
 
 function getPageAgentMarkdown(page: DocsMcpPage): string {
@@ -898,7 +900,11 @@ export function hydrateDocsEvaluationSearchSource(
   if (contentMode === "page-section" && page && section && !pageSection) return undefined;
   const content =
     contentMode === "page-section" && page
-      ? cleanPageAgentContractMarkers(pageSection?.content ?? getPageAgentMarkdown(page)).trim()
+      ? cleanPageAgentContractMarkers(
+          pageSection?.content ?? getPageAgentMarkdown(page),
+          pageSection ? sectionMarkdown : undefined,
+          pageSection?.startLine,
+        ).trim()
       : [result.content, result.description].filter(Boolean).join("\n\n").trim();
   const scope = page ? getPageScope(page) : undefined;
   const url = normalizedResultUrl;

--- a/packages/docs/src/agent-manifest-schema.test.ts
+++ b/packages/docs/src/agent-manifest-schema.test.ts
@@ -8,13 +8,19 @@ import { buildDocsAgentDiscoverySpec } from "./agent.js";
 import { exportAgentBundle } from "./cli/agent-export.js";
 import { resolveDocsMcpConfig } from "./mcp.js";
 
-const schemaPath = new URL(
+const legacySchemaPath = new URL(
   "../../../website/public/schema/agent-manifest.v1.json",
   import.meta.url,
 );
+const schemaPath = new URL(
+  "../../../website/public/schema/agent-manifest.v2.json",
+  import.meta.url,
+);
+const legacySchema = JSON.parse(readFileSync(legacySchemaPath, "utf8")) as Record<string, unknown>;
 const schema = JSON.parse(readFileSync(schemaPath, "utf8")) as Record<string, unknown>;
 const ajv = new Ajv2020({ allErrors: true, strict: true });
 addFormats(ajv);
+const validateLegacy = ajv.compile(legacySchema);
 const validate = ajv.compile(schema);
 
 function buildManifest(overrides: Partial<Parameters<typeof buildDocsAgentDiscoverySpec>[0]> = {}) {
@@ -74,21 +80,60 @@ description: "Start here"
 }
 
 describe("Farming Labs agent manifest schema", () => {
-  it("publishes an immutable Draft 2020-12 identity", () => {
+  it("publishes a versioned Draft 2020-12 identity", () => {
     expect(schema).toMatchObject({
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json",
+      $id: "https://docs.farming-labs.dev/schema/agent-manifest.v2.json",
     });
 
     const manifest = buildManifest();
     expect(manifest).toMatchObject({
-      $schema: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json",
-      format: "farming-labs-agent-manifest.v1",
-      version: "1",
+      $schema: "https://docs.farming-labs.dev/schema/agent-manifest.v2.json",
+      format: "farming-labs-agent-manifest.v2",
+      version: "2",
       name: "@farming-labs/docs",
     });
     expect(manifest.api).not.toHaveProperty("agentCard");
     expectValid(manifest);
+  });
+
+  it("keeps the published v1 schema immutable and valid for v1 manifests", () => {
+    expect(legacySchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      $id: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json",
+      properties: {
+        $schema: { const: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json" },
+        format: { const: "farming-labs-agent-manifest.v1" },
+        version: { const: "1" },
+        markdown: {
+          properties: {
+            sectionDiscovery: {
+              properties: {
+                format: { const: "docs-markdown-sections.v1" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const current = buildManifest();
+    const legacy = {
+      ...current,
+      $schema: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json",
+      format: "farming-labs-agent-manifest.v1",
+      version: "1",
+      markdown: {
+        ...current.markdown,
+        sectionDiscovery: {
+          ...current.markdown.sectionDiscovery,
+          format: "docs-markdown-sections.v1",
+        },
+      },
+    };
+
+    expect(validateLegacy(legacy), JSON.stringify(validateLegacy.errors, null, 2)).toBe(true);
+    expect(validateLegacy(current)).toBe(false);
   });
 
   it("validates feature-rich, disabled-feature, and exported static manifests", async () => {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { findDocsAudienceMdxTags } from "./audience.js";
+import { extractDocsMarkdownPromptBlocks, findDocsAudienceMdxTags } from "./audience.js";
 import {
   acceptsDocsMarkdown,
   AGENT_SKILLS_DISCOVERY_SCHEMA_URI,
@@ -2233,6 +2233,211 @@ describe("agent route helpers", () => {
     expect(document).toContain("Related: /docs/configuration");
     expect(document).toContain("Hidden");
     expect(document).toContain("## Sitemap");
+  });
+
+  describe("Prompt literal extraction", () => {
+    it("preserves flow-component block grammar around paragraphs and thematic breaks", () => {
+      const extracted = extractDocsMarkdownPromptBlocks(
+        ["Before", "<Prompt>", "Run the check.", "</Prompt>", "---", "After"].join("\n"),
+      );
+
+      expect(extracted.blocks).toEqual([
+        {
+          attributes: "",
+          children: "\nRun the check.\n",
+          token: "%%PROMPT_0%%",
+        },
+      ]);
+      expect(extracted.markdown).toBe(
+        ["Before", "", "%%PROMPT_0%%", "", "---", "After"].join("\n"),
+      );
+    });
+
+    it("preserves standalone flow grammar when malformed MDX requires fallback parsing", () => {
+      const standalone = extractDocsMarkdownPromptBlocks("<Prompt>x</Prompt>\n---\n{invalid");
+      expect(standalone.markdown).toBe("%%PROMPT_0%%\n\n---\n{invalid");
+
+      const inline = extractDocsMarkdownPromptBlocks("Before <Prompt>x</Prompt> after\n{invalid");
+      expect(inline.markdown).toBe("Before %%PROMPT_0%% after\n{invalid");
+    });
+
+    it("preserves standalone flow grammar after successful parsing without changing inline Prompt", () => {
+      const lf = extractDocsMarkdownPromptBlocks("<Prompt>x</Prompt>\n---\nAfter");
+      expect(lf.markdown).toBe("%%PROMPT_0%%\n\n---\nAfter");
+
+      const crlf = extractDocsMarkdownPromptBlocks("<Prompt>x</Prompt>\r\n===\r\nAfter");
+      expect(crlf.markdown).toBe("%%PROMPT_0%%\r\n\r\n===\r\nAfter");
+
+      const inline = extractDocsMarkdownPromptBlocks("Before <Prompt>x</Prompt> after");
+      expect(inline.markdown).toBe("Before %%PROMPT_0%% after");
+    });
+
+    it("keeps flow Prompt placeholders and copied text inside Markdown containers", () => {
+      const blockquote = extractDocsMarkdownPromptBlocks(
+        ["> <Prompt>", "> Quote task", "> </Prompt>"].join("\n"),
+      );
+      expect(blockquote.markdown).toBe("> %%PROMPT_0%%");
+      expect(blockquote.blocks[0]?.children.trim()).toBe("Quote task");
+
+      const list = extractDocsMarkdownPromptBlocks(
+        ["- <Prompt>", "  List task", "  </Prompt>"].join("\n"),
+      );
+      expect(list.markdown).toBe("- %%PROMPT_0%%");
+      expect(list.blocks[0]?.children.trim()).toBe("List task");
+
+      const continuedList = extractDocsMarkdownPromptBlocks(
+        ["- Before", "  <Prompt>", "  Continued task", "  </Prompt>", "  After"].join("\n"),
+      );
+      expect(continuedList.markdown).toBe("- Before\n  %%PROMPT_0%%\n  After");
+      expect(continuedList.blocks[0]?.children.trim()).toBe("Continued task");
+
+      const continuedQuote = extractDocsMarkdownPromptBlocks(
+        ["> Before", "> <Prompt>", "> Continued quote", "> </Prompt>", "> After"].join("\n"),
+      );
+      expect(continuedQuote.markdown).toBe(["> Before", "> %%PROMPT_0%%", "> After"].join("\n"));
+      expect(continuedQuote.blocks[0]?.children.trim()).toBe("Continued quote");
+    });
+
+    it("pairs nested and sibling Prompts without truncating their literal children", () => {
+      const nested = extractDocsMarkdownPromptBlocks(
+        "<Prompt>outer <Prompt>inner</Prompt> tail</Prompt>",
+      );
+      expect(nested.blocks).toEqual([
+        {
+          attributes: "",
+          children: "outer <Prompt>inner</Prompt> tail",
+          token: "%%PROMPT_0%%",
+        },
+      ]);
+      expect(nested.markdown).toBe("%%PROMPT_0%%");
+
+      const siblings = extractDocsMarkdownPromptBlocks(
+        "<Prompt>first</Prompt>\n<Prompt>second</Prompt>",
+      );
+      expect(siblings.blocks.map((block) => block.children)).toEqual(["first", "second"]);
+      expect(siblings.markdown).toBe("%%PROMPT_0%%\n%%PROMPT_1%%");
+    });
+
+    it("recovers balanced children after an unmatched opener without consuming trailing content", () => {
+      const source = "<Prompt>unclosed\n<Prompt>valid</Prompt>\nAfter";
+      const extracted = extractDocsMarkdownPromptBlocks(source);
+
+      expect(extracted.blocks.map((block) => block.children)).toEqual(["valid"]);
+      expect(extracted.markdown).toBe("<Prompt>unclosed\n\n%%PROMPT_0%%\n\nAfter");
+      expect(extractDocsMarkdownPromptBlocks("</Prompt>\nShared.")).toEqual({
+        blocks: [],
+        markdown: "</Prompt>\nShared.",
+      });
+    });
+
+    it.each([
+      ["raw HTML blocks", "<div>\n<Prompt>raw div</Prompt>\n</div>"],
+      ["inline raw HTML", "<span><Prompt>raw span</Prompt></span>"],
+      ["raw pre blocks", "<pre>\n<Prompt>raw pre</Prompt>\n</pre>"],
+      ["raw textarea blocks", "<textarea>\n<Prompt>raw textarea</Prompt>\n</textarea>"],
+      ["raw script elements", "<script><Prompt>raw script</Prompt></script>"],
+      ["uppercase raw script elements", "<SCRIPT><Prompt>raw script</Prompt></SCRIPT>"],
+      ["uppercase raw HTML blocks", "<DIV>\n<Prompt>raw div</Prompt>\n</DIV>"],
+      ["SVG namespace roots", "<svg><Prompt>raw svg</Prompt></svg>"],
+      ["uppercase SVG namespace roots", "<SVG><Prompt>raw svg</Prompt></SVG>"],
+      ["MathML namespace roots", "<math><Prompt>raw math</Prompt></math>"],
+      ["uppercase MathML namespace roots", "<MATH><Prompt>raw math</Prompt></MATH>"],
+      ["processing instructions", "<?sample <Prompt>raw instruction</Prompt> ?>"],
+      ["CDATA", "<![CDATA[<Prompt>raw cdata</Prompt>]]>"],
+      ["declarations", "<!DOCTYPE sample <Prompt>raw declaration</Prompt>>"],
+    ])("keeps Prompt-looking text inert inside %s", (_name, source) => {
+      expect(extractDocsMarkdownPromptBlocks(source)).toEqual({
+        blocks: [],
+        markdown: source,
+      });
+    });
+
+    it("keeps Prompt live inside capitalized MDX and custom elements", () => {
+      for (const source of [
+        "<Script><Prompt>capitalized</Prompt></Script>",
+        "<Div><Prompt>capitalized div</Prompt></Div>",
+        "<script-loader><Prompt>custom</Prompt></script-loader>",
+      ]) {
+        expect(extractDocsMarkdownPromptBlocks(source).blocks).toHaveLength(1);
+      }
+    });
+
+    it("keeps Prompt JSX used as expression values out of document block extraction", () => {
+      for (const source of [
+        "{<Prompt>expression value</Prompt>}",
+        "<Card example={<Prompt>prop value</Prompt>}>Card body</Card>",
+        "<Card>{ready ? <Prompt>conditional value</Prompt> : null}</Card>",
+        "<Card render={() => <Prompt>render value</Prompt>} />",
+      ]) {
+        expect(extractDocsMarkdownPromptBlocks(source)).toEqual({
+          blocks: [],
+          markdown: source,
+        });
+      }
+
+      const directChild = extractDocsMarkdownPromptBlocks(
+        "<Card><Prompt>direct child</Prompt></Card>",
+      );
+      expect(directChild.blocks.map((block) => block.children)).toEqual(["direct child"]);
+
+      const literalOuter = extractDocsMarkdownPromptBlocks(
+        "<Prompt>outer {<Prompt>expression child</Prompt>} tail</Prompt>",
+      );
+      expect(literalOuter.blocks.map((block) => block.children)).toEqual([
+        "outer {<Prompt>expression child</Prompt>} tail",
+      ]);
+    });
+
+    it("keeps expression-contained Prompt JSX inert when malformed MDX uses fallback scanning", () => {
+      const source = [
+        "<Card example={<Prompt>prop value</Prompt>}>Card body</Card>",
+        "",
+        "<Prompt>document block</Prompt>",
+        "",
+        "{invalid",
+      ].join("\n");
+      const extracted = extractDocsMarkdownPromptBlocks(source);
+
+      expect(extracted.blocks.map((block) => block.children)).toEqual(["document block"]);
+      expect(extracted.markdown).toContain(
+        "<Card example={<Prompt>prop value</Prompt>}>Card body</Card>",
+      );
+      expect(extracted.markdown).toContain("%%PROMPT_0%%");
+    });
+
+    it("still extracts a standalone multiline Prompt HTML block", () => {
+      const extracted = extractDocsMarkdownPromptBlocks("<Prompt>\nlive\n</Prompt>");
+      expect(extracted.blocks.map((block) => block.children)).toEqual(["\nlive\n"]);
+      expect(extracted.markdown).toBe("%%PROMPT_0%%");
+
+      const bomPrefixed = extractDocsMarkdownPromptBlocks("\uFEFF<Prompt>live</Prompt>");
+      expect(bomPrefixed.blocks.map((block) => block.children)).toEqual(["live"]);
+      expect(bomPrefixed.markdown).toBe("\uFEFF%%PROMPT_0%%");
+    });
+
+    it.each([
+      "[<Prompt>shortcut</Prompt>]",
+      "![<Prompt>image shortcut</Prompt>]",
+      "[<Prompt>collapsed</Prompt>][]",
+      "![<Prompt>collapsed image</Prompt>][]",
+      "[<Prompt>full</Prompt>][missing]",
+      "![<Prompt>full image</Prompt>][missing]",
+    ])("keeps unresolved Markdown reference syntax inert: %s", (source) => {
+      expect(extractDocsMarkdownPromptBlocks(source)).toEqual({
+        blocks: [],
+        markdown: source,
+      });
+    });
+
+    it("allocates placeholders that cannot collide with authored content", () => {
+      const extracted = extractDocsMarkdownPromptBlocks(
+        "%%PROMPT_0%%\n<Prompt>first</Prompt>\n<Prompt>second</Prompt>",
+      );
+      expect(extracted.blocks.map((block) => block.token)).toEqual([
+        "%%PROMPT_1%%",
+        "%%PROMPT_2%%",
+      ]);
+    });
   });
 
   it("resolves Agent, Human, and Audience blocks without changing literal examples", () => {

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -16,6 +16,7 @@ import {
   detectDocsMarkdownAgentRequest,
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
   findDocsAudienceMdxIssues,
   findDocsMarkdownPage,
@@ -1259,7 +1260,7 @@ describe("agent route helpers", () => {
       "prerequisites",
       "expected-results",
       "logs",
-      "expected-results-2",
+      "expected-results-1",
     ]);
 
     const selected = selectDocsMarkdownSection(document, {
@@ -1301,7 +1302,7 @@ describe("agent route helpers", () => {
     expect(selected.document).toContain("## Expected Results");
   });
 
-  it("reuses search and MCP heading parsing while preserving public duplicate ids", () => {
+  it("reuses canonical search and MCP anchors for public section ids", () => {
     const document = [
       "# [Install the CLI](https://example.com/install)",
       "",
@@ -1313,6 +1314,10 @@ describe("agent route helpers", () => {
       "```bash",
       "# not-a-section",
       "```",
+      "",
+      "## Overview [#release-overview]",
+      "",
+      "Custom anchor.",
       "",
       "## Repeat",
       "",
@@ -1331,13 +1336,15 @@ describe("agent route helpers", () => {
     expect(sections.map((section) => section.id)).toEqual([
       "install-the-cli",
       "verify-setup",
+      "release-overview",
       "repeat",
+      "repeat-1",
       "repeat-2",
-      "repeat-3",
     ]);
     expect(sections.map((section) => section.heading)).toEqual([
       "Install the CLI",
       "Verify setup",
+      "Overview",
       "Repeat",
       "Repeat",
       "Repeat",
@@ -1354,20 +1361,55 @@ describe("agent route helpers", () => {
         canonicalUrl: "https://example.com/docs/repeated",
         markdownUrl: "https://example.com/docs/repeated.md",
       }).sections.map((section) => section.id),
-    ).toEqual(["install-the-cli", "verify-setup", "repeat", "repeat-2", "repeat-3"]);
+    ).toEqual([
+      "install-the-cli",
+      "verify-setup",
+      "release-overview",
+      "repeat",
+      "repeat-1",
+      "repeat-2",
+    ]);
     expect(selectDocsMarkdownSection(document, { section: "repeat-1" })).toMatchObject({
       found: true,
-      section: { id: "repeat-2" },
+      section: { id: "repeat-1" },
       document: expect.stringContaining("Second."),
     });
     expect(selectDocsMarkdownSection(document, { section: "repeat-2" })).toMatchObject({
       found: true,
       section: { id: "repeat-2" },
-      document: expect.stringContaining("Second."),
+      document: expect.stringContaining("Third."),
     });
-    expect(selectDocsMarkdownSection(document, { section: "repeat-2" }).document).not.toContain(
+    expect(selectDocsMarkdownSection(document, { section: "repeat-1" }).document).not.toContain(
       "Third.",
     );
+  });
+
+  it("round-trips case-sensitive custom section ids without ambiguous aliases", () => {
+    const document = [
+      "## Upper [#Foo]",
+      "",
+      "Uppercase content.",
+      "",
+      "## Lower [#foo]",
+      "",
+      "Lowercase content.",
+    ].join("\n");
+    const sections = collectDocsMarkdownSections(document);
+
+    expect(sections.map((section) => section.id)).toEqual(["Foo", "foo"]);
+    expect(selectDocsMarkdownSection(document, { section: "Foo" })).toMatchObject({
+      found: true,
+      section: { id: "Foo" },
+      document: expect.stringContaining("Uppercase content."),
+    });
+    expect(selectDocsMarkdownSection(document, { section: "foo" })).toMatchObject({
+      found: true,
+      section: { id: "foo" },
+      document: expect.stringContaining("Lowercase content."),
+    });
+    expect(selectDocsMarkdownSection(document, { section: "FOO" })).toMatchObject({
+      found: false,
+    });
   });
 
   it("applies budget-only Markdown requests to the full document", () => {
@@ -1401,47 +1443,38 @@ describe("agent route helpers", () => {
     expect(selected.document).toContain("## Expected Results");
   });
 
-  it("keeps generated page titles addressable without generated metadata or Sitemap content", async () => {
+  it("excludes generated page titles so source heading anchors stay canonical", async () => {
     const document = renderDocsMarkdownDocument(
       {
         url: "/docs/install",
         title: "Install",
         description: "Install the framework.",
         related: [{ href: "/docs/configuration" }],
-        content: ["Install overview.", "", "## Prerequisites", "", "Use Node.js 22."].join("\n"),
+        content: [
+          "Install overview.",
+          "",
+          "## Install",
+          "",
+          "Run the installer.",
+          "",
+          "## Prerequisites",
+          "",
+          "Use Node.js 22.",
+        ].join("\n"),
       },
       { origin: "https://example.com" },
     );
     const sections = collectDocsMarkdownSections(document);
 
-    expect(
-      sections.map(({ id, heading, level, startLine, endLine }) => ({
-        id,
-        heading,
-        level,
-        startLine,
-        endLine,
-      })),
-    ).toEqual([
-      {
-        id: "install",
-        heading: "Install",
-        level: 1,
-        startLine: 2,
-        endLine: 12,
-      },
-      {
-        id: "prerequisites",
-        heading: "Prerequisites",
-        level: 2,
-        startLine: 10,
-        endLine: 12,
-      },
+    expect(document).toContain("x_farming_labs_generated_preamble: true");
+    expect(sections.map(({ id, heading, level }) => ({ id, heading, level }))).toEqual([
+      { id: "install", heading: "Install", level: 2 },
+      { id: "prerequisites", heading: "Prerequisites", level: 2 },
     ]);
-    expect(sections[0]?.content).toContain("# Install");
-    expect(sections[0]?.content).toContain("Install overview.");
-    expect(sections[0]?.content).toContain("## Prerequisites");
-    expect(sections[0]?.content).not.toMatch(
+    expect(sections[0]?.content).toContain("## Install");
+    expect(sections[0]?.content).toContain("Run the installer.");
+    expect(sections[0]?.content).not.toContain("## Prerequisites");
+    expect(sections.map((section) => section.content).join("\n")).not.toMatch(
       /^(?:URL|LLM index|Description|Related):|^## Sitemap$/mu,
     );
 
@@ -1454,9 +1487,10 @@ describe("agent route helpers", () => {
     });
     const index = (await indexResponse.json()) as ReturnType<typeof buildDocsMarkdownSectionIndex>;
     expect(index.sections).toMatchObject([
-      { id: "install", level: 1 },
-      { id: "prerequisites", level: 2, parentId: "install" },
+      { id: "install", level: 2 },
+      { id: "prerequisites", level: 2 },
     ]);
+    expect(index.sections.every((section) => section.parentId === undefined)).toBe(true);
 
     const sectionResponse = createDocsMarkdownResponse({
       request: new Request("https://example.com/docs/install.md?section=install"),
@@ -1468,10 +1502,37 @@ describe("agent route helpers", () => {
     const sectionBody = await sectionResponse.text();
     expect(sectionResponse.status).toBe(200);
     expect(sectionResponse.headers.get("x-docs-markdown-section")).toBe("install");
-    expect(sectionBody).toContain("# Install");
-    expect(sectionBody).toContain("Install overview.");
-    expect(sectionBody).toContain("## Prerequisites");
+    expect(sectionBody).toContain("## Install");
+    expect(sectionBody).toContain("Run the installer.");
+    expect(sectionBody).not.toContain("Install overview.");
+    expect(sectionBody).not.toContain("## Prerequisites");
     expect(sectionBody).not.toMatch(/^(?:URL|LLM index|Description|Related):|^## Sitemap$/mu);
+  });
+
+  it("does not infer a generated preamble from authored heading and URL text", () => {
+    const document = renderDocsMarkdownDocument({
+      url: "/docs/authored",
+      title: "Authored",
+      content: "Human fallback.",
+      agentRawContent: [
+        "# Authored heading",
+        "URL: https://example.com/source",
+        "",
+        "Authored introduction.",
+        "",
+        "## Next step",
+        "",
+        "Continue here.",
+      ].join("\n"),
+    });
+
+    expect(document).not.toContain("x_farming_labs_generated_preamble: true");
+    expect(
+      collectDocsMarkdownSections(document).map(({ id, heading }) => ({ id, heading })),
+    ).toEqual([
+      { id: "authored-heading", heading: "Authored heading" },
+      { id: "next-step", heading: "Next step" },
+    ]);
   });
 
   it("builds compact section discovery metadata without section bodies", async () => {
@@ -1527,7 +1588,7 @@ describe("agent route helpers", () => {
     expect(response.headers.get("etag")).toMatch(/^W\/"/u);
     expect(response.headers.get("last-modified")).toBe("Sat, 25 Jul 2026 10:00:00 GMT");
     expect(index).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       format: DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
       canonicalUrl: "https://example.com/docs/install?lang=en",
       markdownUrl: "https://example.com/docs/install.md?lang=en",
@@ -1607,7 +1668,7 @@ describe("agent route helpers", () => {
     expect(await head.text()).toBe("");
   });
 
-  it("preserves Unicode public section ids and encodes them in fetch URLs", () => {
+  it("preserves Unicode public section ids and encodes them in fetch URLs and headers", async () => {
     const document = [
       "# 安装",
       "",
@@ -1625,7 +1686,7 @@ describe("agent route helpers", () => {
 
     expect(sections.map(({ id, heading }) => ({ id, heading }))).toEqual([
       { id: "安装", heading: "安装" },
-      { id: "cafe-配置", heading: "Café 配置" },
+      { id: "café-配置", heading: "Café 配置" },
       { id: "привет-мир", heading: "Привет мир" },
     ]);
     for (const section of sections) {
@@ -1641,18 +1702,95 @@ describe("agent route helpers", () => {
     });
     expect(index.sections.map((section) => section.id)).toEqual([
       "安装",
-      "cafe-配置",
+      "café-配置",
       "привет-мир",
     ]);
     expect(index.sections[0]?.markdownUrl).toBe(
       "https://example.com/docs/international.md?section=%E5%AE%89%E8%A3%85",
     );
     expect(index.sections[1]?.markdownUrl).toBe(
-      "https://example.com/docs/international.md?section=cafe-%E9%85%8D%E7%BD%AE",
+      "https://example.com/docs/international.md?section=caf%C3%A9-%E9%85%8D%E7%BD%AE",
     );
     expect(index.sections[2]?.markdownUrl).toBe(
       "https://example.com/docs/international.md?section=%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82-%D0%BC%D0%B8%D1%80",
     );
+
+    const response = createDocsMarkdownResponse({
+      request: new Request(index.sections[0]?.markdownUrl ?? ""),
+      document,
+      entry: "docs",
+      requestedPath: "international",
+      origin: "https://example.com",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-docs-markdown-section")).toBe("%E5%AE%89%E8%A3%85");
+    expect(response.headers.get("link")).toBe(
+      '<https://example.com/docs/international#%E5%AE%89%E8%A3%85>; rel="canonical"',
+    );
+    expect(await response.text()).toContain("中文。");
+  });
+
+  it("round-trips reserved characters in explicit section ids", async () => {
+    const document = [
+      "## Hash [#foo#bar]",
+      "",
+      "Hash content.",
+      "",
+      "## Percent [#foo%23bar]",
+      "",
+      "Percent content.",
+      "",
+      "## Entity [#foo&amp;bar]",
+      "",
+      "Entity content.",
+      "",
+      "## Leading hash [##foo]",
+      "",
+      "Leading content.",
+    ].join("\n");
+    const index = buildDocsMarkdownSectionIndex(document, {
+      canonicalUrl: "https://example.com/docs/punctuation",
+      markdownUrl: "https://example.com/docs/punctuation.md",
+    });
+
+    expect(index.sections.map((section) => section.id)).toEqual([
+      "foo#bar",
+      "foo%23bar",
+      "foo&bar",
+      "#foo",
+    ]);
+    expect(index.sections.map((section) => section.markdownUrl)).toEqual([
+      "https://example.com/docs/punctuation.md?section=foo%23bar",
+      "https://example.com/docs/punctuation.md?section=foo%2523bar",
+      "https://example.com/docs/punctuation.md?section=foo%26bar",
+      "https://example.com/docs/punctuation.md?section=%23foo",
+    ]);
+    expect(index.sections.map((section) => section.canonicalUrl)).toEqual([
+      "https://example.com/docs/punctuation#foo%23bar",
+      "https://example.com/docs/punctuation#foo%2523bar",
+      "https://example.com/docs/punctuation#foo%26bar",
+      "https://example.com/docs/punctuation#%23foo",
+    ]);
+
+    for (const section of index.sections) {
+      expect(selectDocsMarkdownSection(document, { section: section.canonicalUrl })).toMatchObject({
+        found: true,
+        section: { id: section.id },
+      });
+
+      const response = createDocsMarkdownResponse({
+        request: new Request(section.markdownUrl),
+        document,
+        entry: "docs",
+        requestedPath: "punctuation",
+        origin: "https://example.com",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-docs-markdown-section")).toBe(encodeURIComponent(section.id));
+      expect(response.headers.get("link")).toBe(`<${section.canonicalUrl}>; rel="canonical"`);
+      expect(await response.text()).toContain(`${section.heading} [#`);
+    }
   });
 
   it("returns an empty section index for heading-less Markdown", async () => {
@@ -1864,7 +2002,7 @@ describe("agent route helpers", () => {
     expect(response.headers.get("x-docs-markdown-section-found")).toBe("false");
     expect(body).toContain("# Markdown Section Not Found");
     expect(body).toContain("- Prerequisites (#prerequisites)");
-    expect(body).toContain("- Install (#install)");
+    expect(body).not.toContain("- Install (#install)");
   });
 
   it("resolves section-addressable Markdown query parameters", () => {
@@ -1888,6 +2026,7 @@ describe("agent route helpers", () => {
     expect(toDocsMarkdownUrl("/docs/install?lang=es", { locale: "fr" })).toBe(
       "/docs/install.md?lang=es",
     );
+    expect(toDocsMarkdownUrl("/docs/install#foo#bar")).toBe("/docs/install.md#foo#bar");
   });
 
   it("builds canonical Link headers for markdown mirrors", () => {
@@ -2634,7 +2773,7 @@ After`;
 
     expect(spec.$schema).toBe(DOCS_AGENT_MANIFEST_SCHEMA_URI);
     expect(spec.format).toBe(DOCS_AGENT_MANIFEST_FORMAT);
-    expect(spec.version).toBe("1");
+    expect(spec.version).toBe(DOCS_AGENT_MANIFEST_VERSION);
     expect(spec.api.agentSpecDefault).toBe("/.well-known/agent.json");
     expect(spec.api).not.toHaveProperty("agentCard");
     expect(spec.api.config).toBe("/api/docs?format=config");

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -44,6 +44,7 @@ import {
   API_CATALOG_PROFILE_URI,
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   DEFAULT_AGENT_SKILLS_INDEX_FORMAT,
   DEFAULT_AGENT_SKILLS_INDEX_ROUTE,
   DEFAULT_AGENT_SKILLS_ARCHIVE_ROUTE_PATTERN,
@@ -69,6 +70,7 @@ export {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   DEFAULT_AGENT_SKILL_FORMAT,
   DEFAULT_AGENT_SKILL_ARCHIVE_FORMAT,
   DEFAULT_AGENT_SKILL_FILE_FORMAT,
@@ -235,7 +237,7 @@ const DEFAULT_DOCS_DIAGNOSTICS_MCP_TOOLS = {
   getContext: true,
 } satisfies DocsMcpResolvedConfig["tools"];
 export const DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER = "Signature-Agent";
-export const DOCS_MARKDOWN_SECTION_INDEX_FORMAT = "docs-markdown-sections.v1";
+export const DOCS_MARKDOWN_SECTION_INDEX_FORMAT = "docs-markdown-sections.v2";
 const DOCS_AI_AGENT_USER_AGENT_PATTERNS = [
   "claudebot",
   "claude-searchbot",
@@ -303,6 +305,7 @@ export const DOCS_BOT_LIKE_USER_AGENT_HEADER_PATTERN = buildDocsUserAgentHeaderP
   DOCS_BOT_LIKE_USER_AGENT_TERMS,
 );
 const DOCS_LLMS_TXT_DIRECTIVE_LINE = "LLM index: /llms.txt";
+const DOCS_MARKDOWN_GENERATED_PREAMBLE_FIELD = "x_farming_labs_generated_preamble";
 
 const DOCS_MCP_SERVICE_SUBDOMAIN_LABELS = new Set([
   "api",
@@ -729,7 +732,7 @@ export interface DocsMarkdownSectionMetadata {
 }
 
 export interface DocsMarkdownSectionIndex {
-  schemaVersion: 1;
+  schemaVersion: 2;
   format: typeof DOCS_MARKDOWN_SECTION_INDEX_FORMAT;
   canonicalUrl: string;
   markdownUrl: string;
@@ -1825,7 +1828,9 @@ export function validateDocsAgentFeedbackPayload(
 }
 
 export function toDocsMarkdownUrl(url: string, options: { locale?: string } = {}): string {
-  const [withoutHash, hash = ""] = url.split("#", 2);
+  const hashIndex = url.indexOf("#");
+  const withoutHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const hash = hashIndex >= 0 ? url.slice(hashIndex + 1) : "";
   const [pathname, query = ""] = withoutHash.split("?", 2);
   const normalizedPath = normalizeDocsUrlPath(pathname || "/");
   const markdownPath = normalizedPath.endsWith(".md") ? normalizedPath : `${normalizedPath}.md`;
@@ -2861,6 +2866,7 @@ function renderDocsMarkdownFrontmatter({
   markdownUrl,
   lastUpdated,
   agent,
+  generatedPreamble,
 }: {
   title: string;
   description?: string;
@@ -2868,6 +2874,7 @@ function renderDocsMarkdownFrontmatter({
   markdownUrl: string;
   lastUpdated?: string;
   agent?: PageAgentFrontmatter;
+  generatedPreamble?: boolean;
 }): string {
   const lines = [
     "---",
@@ -2876,6 +2883,7 @@ function renderDocsMarkdownFrontmatter({
     `canonical_url: ${toYamlString(canonicalUrl)}`,
     `markdown_url: ${toYamlString(markdownUrl)}`,
     ...(lastUpdated ? [`last_updated: ${toYamlString(lastUpdated)}`] : []),
+    ...(generatedPreamble ? [`${DOCS_MARKDOWN_GENERATED_PREAMBLE_FIELD}: true`] : []),
     ...renderPageAgentFrontmatterYamlLines(agent),
     "---",
   ];
@@ -2901,23 +2909,12 @@ function stripDocsMarkdownFrontmatter(markdown: string): { frontmatter: string; 
   return { frontmatter: match[1] ?? "", body: match[2] ?? "" };
 }
 
-function slugifyPublicDocsMarkdownSectionId(value: string): string {
-  return value
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/<[^>]*>/g, "")
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
 function resolveDocsMarkdownSectionBody(document: string): { body: string; lineOffset: number } {
-  const stripped = stripDocsMarkdownFrontmatter(document).body;
-  const lines = stripped.split(/\r?\n/u);
+  const stripped = stripDocsMarkdownFrontmatter(document);
+  const hasGeneratedPreamble = stripped.frontmatter
+    .split(/\r?\n/u)
+    .some((line) => line.trim() === `${DOCS_MARKDOWN_GENERATED_PREAMBLE_FIELD}: true`);
+  const lines = stripped.body.split(/\r?\n/u);
   let generatedPreambleStart = 0;
   while (
     generatedPreambleStart < lines.length &&
@@ -2927,9 +2924,14 @@ function resolveDocsMarkdownSectionBody(document: string): { body: string; lineO
   }
 
   if (
+    hasGeneratedPreamble &&
     /^#(?:\s+|$)/u.test(lines[generatedPreambleStart] ?? "") &&
     /^URL:\s+\S/u.test(lines[generatedPreambleStart + 1] ?? "")
   ) {
+    // The page-title heading is generated for the Markdown representation. It is not part
+    // of the rendered MDX heading tree, search index, Ask AI, or MCP source, so it must not
+    // consume an anchor or advertise a fragment that those surfaces cannot resolve.
+    lines[generatedPreambleStart] = "";
     let metadataEnd = generatedPreambleStart + 2;
     while (/^(?:LLM index|Description|Related):\s*/u.test(lines[metadataEnd] ?? "")) {
       metadataEnd += 1;
@@ -3031,23 +3033,14 @@ export function isDocsMarkdownSectionIndexRequest(url: URL): boolean {
 
 export function collectDocsMarkdownSections(document: string): DocsMarkdownSection[] {
   const { body, lineOffset } = resolveDocsMarkdownSectionBody(document);
-  const seen = new Map<string, number>();
-  return parseDocsMarkdownSections(body).flatMap((section) => {
-    const baseId = slugifyPublicDocsMarkdownSectionId(section.title);
-    if (!baseId) return [];
-    const count = seen.get(baseId) ?? 0;
-    seen.set(baseId, count + 1);
-    return [
-      {
-        id: count === 0 ? baseId : `${baseId}-${count + 1}`,
-        heading: section.title,
-        level: section.level,
-        content: section.content,
-        startLine: section.startLine + lineOffset,
-        endLine: section.endLine + lineOffset,
-      },
-    ];
-  });
+  return parseDocsMarkdownSections(body).map((section) => ({
+    id: section.anchor,
+    heading: section.title,
+    level: section.level,
+    content: section.content,
+    startLine: section.startLine + lineOffset,
+    endLine: section.endLine + lineOffset,
+  }));
 }
 
 function updateDocsMarkdownUrl(value: string, update: (url: URL) => void): string {
@@ -3064,7 +3057,9 @@ function updateDocsMarkdownUrl(value: string, update: (url: URL) => void): strin
 
 function resolveDocsMarkdownSectionCanonicalUrl(canonicalUrl: string, sectionId: string): string {
   return updateDocsMarkdownUrl(canonicalUrl, (url) => {
-    url.hash = sectionId;
+    // URL.hash does not encode "%" or an embedded "#". Encode the complete identifier
+    // first so distinct section IDs always round-trip through standards-compliant URLs.
+    url.hash = encodeURIComponent(sectionId);
   });
 }
 
@@ -3153,7 +3148,7 @@ export function buildDocsMarkdownSectionIndex(
       : undefined;
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     format: DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
     canonicalUrl: options.canonicalUrl,
     markdownUrl: options.markdownUrl,
@@ -3170,14 +3165,14 @@ export function buildDocsMarkdownSectionIndex(
 
 function normalizeRequestedDocsMarkdownSectionId(requestedSection: string): string {
   let selector = requestedSection.trim();
-  const hashIndex = selector.lastIndexOf("#");
+  const hashIndex = selector.indexOf("#");
   if (hashIndex >= 0) selector = selector.slice(hashIndex + 1);
   try {
     selector = decodeURIComponent(selector);
   } catch {
     // Keep malformed fragments usable as literal selectors.
   }
-  return selector.replace(/^#+/u, "").toLowerCase();
+  return selector;
 }
 
 export function selectDocsMarkdownSection(
@@ -3203,8 +3198,18 @@ export function selectDocsMarkdownSection(
     };
   }
 
+  const rawRequestedId = requestedSection.trim();
+  const rawExactSection = availableSections.find((candidate) => candidate.id === rawRequestedId);
   const requestedId = normalizeRequestedDocsMarkdownSectionId(requestedSection);
-  const directSection = availableSections.find((candidate) => candidate.id === requestedId);
+  const exactSection =
+    rawExactSection ?? availableSections.find((candidate) => candidate.id === requestedId);
+  const caseInsensitiveSections = exactSection
+    ? []
+    : availableSections.filter(
+        (candidate) => candidate.id.toLowerCase() === requestedId.toLowerCase(),
+      );
+  const directSection =
+    exactSection ?? (caseInsensitiveSections.length === 1 ? caseInsensitiveSections[0] : undefined);
   const { body, lineOffset } = resolveDocsMarkdownSectionBody(document);
   const selectedSharedSection = directSection
     ? undefined
@@ -3593,14 +3598,16 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
   const responseDocument = sectionResult?.document ?? document;
   const sectionCanonicalUrl =
     sectionResult?.found && sectionResult.section
-      ? `${canonicalUrl}#${sectionResult.section.id}`
+      ? resolveDocsMarkdownSectionCanonicalUrl(canonicalUrl, sectionResult.section.id)
       : canonicalUrl;
   const sectionContentLocation = sectionRequest
     ? appendDocsMarkdownSectionQuery(contentLocation, sectionRequest)
     : contentLocation;
   const sectionHeaders: Record<string, string> = sectionResult
     ? {
-        "X-Docs-Markdown-Section": sectionResult.section?.id ?? "",
+        "X-Docs-Markdown-Section": sectionResult.section
+          ? encodeURIComponent(sectionResult.section.id)
+          : "",
         "X-Docs-Markdown-Section-Found": sectionResult.found ? "true" : "false",
         "X-Docs-Markdown-Section-Truncated": sectionResult.truncated ? "true" : "false",
         "X-Docs-Markdown-Estimated-Tokens": String(sectionResult.estimatedTokens),
@@ -4098,10 +4105,10 @@ export function renderDocsMarkdownDocument(
     ),
   );
   return appendDocsMarkdownSitemapFooter(
-    prependDocsMarkdownFrontmatter(
-      lines.join("\n"),
-      resolveDocsMarkdownPageMetadata(page, options),
-    ),
+    prependDocsMarkdownFrontmatter(lines.join("\n"), {
+      ...resolveDocsMarkdownPageMetadata(page, options),
+      generatedPreamble: true,
+    }),
     options?.sitemap,
   );
 }
@@ -4251,7 +4258,7 @@ export function buildDocsAgentDiscoverySpec({
   return {
     $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
     format: DOCS_AGENT_MANIFEST_FORMAT,
-    version: "1",
+    version: DOCS_AGENT_MANIFEST_VERSION,
     name: "@farming-labs/docs",
     baseUrl: origin,
     site: {

--- a/packages/docs/src/audience.ts
+++ b/packages/docs/src/audience.ts
@@ -37,6 +37,20 @@ interface ProtectedRange {
   end: number;
 }
 
+export interface DocsMarkdownPromptBlock {
+  /** Raw JSX attributes between the Prompt name and opening bracket. */
+  attributes: string;
+  /** Literal source between the Prompt tags, with enclosing Markdown container prefixes removed. */
+  children: string;
+  /** Collision-safe placeholder carried through document-level rendering. */
+  token: string;
+}
+
+export interface ExtractedDocsMarkdownPromptBlocks {
+  blocks: DocsMarkdownPromptBlock[];
+  markdown: string;
+}
+
 export interface DocsAudienceMdxIssue {
   code:
     | "missing-only"
@@ -1396,6 +1410,729 @@ function findProtectedRanges(content: string): ProtectedRange[] {
   const excludedRanges = mergeProtectedRanges([...baseExcludedRanges, ...svelteDirectives]);
   const htmlLiterals = findHtmlLiteralRanges(content, excludedRanges);
   return mergeProtectedRanges([...excludedRanges, ...htmlLiterals]);
+}
+
+function findMarkdownLinkLiteralRanges(content: string): ProtectedRange[] {
+  try {
+    const offsetAdjustment = content.startsWith("\uFEFF") ? 1 : 0;
+    const tree = docsAudienceMarkdownProcessor.parse(
+      offsetAdjustment > 0 ? content.slice(offsetAdjustment) : content,
+    ) as MdxAstNode;
+    const ranges: ProtectedRange[] = [];
+
+    const visit = (node: MdxAstNode): void => {
+      const rawStart = getOffset(node.position, "start");
+      const rawEnd = getOffset(node.position, "end");
+      const start = rawStart === undefined ? undefined : rawStart + offsetAdjustment;
+      const end = rawEnd === undefined ? undefined : rawEnd + offsetAdjustment;
+      if (
+        start !== undefined &&
+        end !== undefined &&
+        (node.type === "link" ||
+          node.type === "image" ||
+          node.type === "linkReference" ||
+          node.type === "imageReference")
+      ) {
+        ranges.push({ start, end });
+        return;
+      }
+      for (const child of node.children ?? []) visit(child);
+    };
+
+    visit(tree);
+    return ranges;
+  } catch {
+    return [];
+  }
+}
+
+function findDocsMarkdownPromptBracketLiteralRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const index = content.indexOf("[", cursor);
+    if (index === -1 || isEscapedAt(content, index) || isInsideRange(index, protectedRanges)) {
+      if (index === -1) break;
+      cursor = index + 1;
+      continue;
+    }
+
+    let depth = 1;
+    let end = index + 1;
+    while (end < content.length && depth > 0) {
+      if (content[end] === "\\") {
+        end += 2;
+        continue;
+      }
+      if (content[end] === "[") depth += 1;
+      if (content[end] === "]") depth -= 1;
+      end += 1;
+    }
+
+    if (depth !== 0) {
+      cursor = index + 1;
+      continue;
+    }
+
+    const label = content.slice(index + 1, end - 1);
+    if (/<Prompt(?=[\s/>])/.test(label) && /<\/Prompt\s*>/.test(label)) {
+      let rangeEnd = end;
+      if (content[rangeEnd] === "[") {
+        let referenceEnd = rangeEnd + 1;
+        while (referenceEnd < content.length) {
+          if (content[referenceEnd] === "\\") {
+            referenceEnd += 2;
+            continue;
+          }
+          if (content[referenceEnd] === "]") {
+            referenceEnd += 1;
+            break;
+          }
+          referenceEnd += 1;
+        }
+        if (content[referenceEnd - 1] === "]") rangeEnd = referenceEnd;
+      }
+      ranges.push({ start: content[index - 1] === "!" ? index - 1 : index, end: rangeEnd });
+    }
+
+    cursor = end;
+  }
+
+  return ranges;
+}
+
+interface DocsMarkdownPromptTag {
+  attributes: string;
+  closing: boolean;
+  end: number;
+  index: number;
+  selfClosing: boolean;
+}
+
+interface DocsMarkdownPromptContainer {
+  blockquoteDepth: number;
+  listIndent: number;
+}
+
+// Keep this finite so lowercase custom elements remain live MDX. The HTML list
+// contains every non-void container element; the SVG and MathML namespace roots
+// protect their complete descendant trees without classifying arbitrary
+// lowercase component names as raw markup.
+const DOCS_MARKDOWN_INTRINSIC_CONTAINER_NAMES = new Set([
+  "a",
+  "abbr",
+  "address",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "body",
+  "button",
+  "canvas",
+  "caption",
+  "cite",
+  "code",
+  "colgroup",
+  "data",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "html",
+  "i",
+  "iframe",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "main",
+  "map",
+  "mark",
+  "math",
+  "menu",
+  "meter",
+  "nav",
+  "noembed",
+  "noframes",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "picture",
+  "pre",
+  "progress",
+  "q",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "script",
+  "search",
+  "section",
+  "select",
+  "slot",
+  "small",
+  "span",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "svg",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "xmp",
+]);
+
+function normalizeDocsMarkdownIntrinsicContainerName(name: string): string | undefined {
+  const normalized = name.toLowerCase();
+  if (!DOCS_MARKDOWN_INTRINSIC_CONTAINER_NAMES.has(normalized)) return undefined;
+  const isLowercase = name === normalized;
+  const isUppercase = name === name.toUpperCase() && /[A-Z]/.test(name);
+  return isLowercase || isUppercase ? normalized : undefined;
+}
+
+function readDocsMarkdownPromptTagAt(
+  content: string,
+  index: number,
+): DocsMarkdownPromptTag | undefined {
+  const closing = content[index + 1] === "/";
+  const nameStart = index + (closing ? 2 : 1);
+  if (
+    !content.startsWith("Prompt", nameStart) ||
+    !/[\s/>]/.test(content[nameStart + "Prompt".length] ?? "")
+  ) {
+    return undefined;
+  }
+
+  const tag = readGenericMdxJsxTag(content, index);
+  if (!tag) return undefined;
+
+  const attributesStart = nameStart + "Prompt".length;
+  let attributesEnd = tag.end - 1;
+  while (attributesEnd > attributesStart && /\s/.test(content[attributesEnd - 1] ?? "")) {
+    attributesEnd -= 1;
+  }
+  if (content[attributesEnd - 1] === "/") attributesEnd -= 1;
+
+  return {
+    attributes: closing ? "" : content.slice(attributesStart, attributesEnd),
+    closing,
+    end: tag.end,
+    index,
+    selfClosing: tag.selfClosing,
+  };
+}
+
+function findDocsMarkdownHtmlContainerLiteralRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  const openings: Array<{ name: string; start: number }> = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const index = content.indexOf("<", cursor);
+    if (index === -1) break;
+    if (isEscapedAt(content, index) || isInsideRange(index, protectedRanges)) {
+      cursor = index + 1;
+      continue;
+    }
+
+    const closing = content[index + 1] === "/";
+    const nameStart = index + (closing ? 2 : 1);
+    let nameEnd = nameStart;
+    while (/[\w:.-]/.test(content[nameEnd] ?? "")) nameEnd += 1;
+    const name = normalizeDocsMarkdownIntrinsicContainerName(content.slice(nameStart, nameEnd));
+    if (!name) {
+      cursor = index + 1;
+      continue;
+    }
+
+    const tag = readGenericMdxJsxTag(content, index);
+    if (!tag) {
+      cursor = index + 1;
+      continue;
+    }
+    cursor = tag.end;
+    if (!closing) {
+      if (!tag.selfClosing) openings.push({ name, start: index });
+      continue;
+    }
+
+    let openingIndex = openings.length - 1;
+    while (openingIndex >= 0 && openings[openingIndex].name !== name) openingIndex -= 1;
+    if (openingIndex < 0) continue;
+    const [opening] = openings.splice(openingIndex);
+    ranges.push({ start: opening.start, end: tag.end });
+  }
+
+  return ranges;
+}
+
+function isStandaloneDocsMarkdownPromptHtmlRange(
+  content: string,
+  start: number,
+  end: number,
+): boolean {
+  while (start < end && /\s/.test(content[start] ?? "")) start += 1;
+  while (end > start && /\s/.test(content[end - 1] ?? "")) end -= 1;
+
+  const first = readDocsMarkdownPromptTagAt(content, start);
+  // CommonMark may split one multiline Prompt component into several `html`
+  // nodes at blank lines. Exempt every fragment whose first tag is Prompt; the
+  // balanced scanner below still decides whether the full component is live.
+  return first !== undefined;
+}
+
+function findDocsMarkdownRawHtmlLiteralRanges(content: string): ProtectedRange[] {
+  try {
+    const offsetAdjustment = content.startsWith("\uFEFF") ? 1 : 0;
+    const tree = docsAudienceMarkdownProcessor.parse(
+      offsetAdjustment > 0 ? content.slice(offsetAdjustment) : content,
+    ) as MdxAstNode;
+    const ranges: ProtectedRange[] = [];
+
+    const visit = (node: MdxAstNode): void => {
+      const rawStart = getOffset(node.position, "start");
+      const rawEnd = getOffset(node.position, "end");
+      const start = rawStart === undefined ? undefined : rawStart + offsetAdjustment;
+      const end = rawEnd === undefined ? undefined : rawEnd + offsetAdjustment;
+      if (node.type === "html" && start !== undefined && end !== undefined) {
+        if (isStandaloneDocsMarkdownPromptHtmlRange(content, start, end)) return;
+        const raw = content.slice(start, end).trimStart();
+        const elementName = raw.match(/^<\/?([A-Za-z][\w:.-]*)(?=[\s/>])/)?.[1];
+        if (elementName && !normalizeDocsMarkdownIntrinsicContainerName(elementName)) return;
+
+        let cursor = start;
+        let promptDepth = 0;
+        let trailingClosingPrompt: number | undefined;
+        while (cursor < end) {
+          const index = content.indexOf("<", cursor);
+          if (index === -1 || index >= end) break;
+          const tag = readDocsMarkdownPromptTagAt(content, index);
+          if (!tag || tag.end > end) {
+            cursor = index + 1;
+            continue;
+          }
+          if (!tag.closing && !tag.selfClosing) {
+            promptDepth += 1;
+          } else if (tag.closing && promptDepth > 0) {
+            promptDepth -= 1;
+          } else if (tag.closing && content.slice(tag.end, end).trim().length === 0) {
+            trailingClosingPrompt = tag.index;
+          }
+          cursor = tag.end;
+        }
+
+        // A CommonMark raw-HTML node inside Prompt can absorb the outer closing
+        // tag. Keep the raw child protected without hiding that delimiter from
+        // the balanced Prompt scanner.
+        const literalEnd = trailingClosingPrompt ?? end;
+        if (literalEnd > start) ranges.push({ start, end: literalEnd });
+        return;
+      }
+      for (const child of node.children ?? []) visit(child);
+    };
+
+    visit(tree);
+    return ranges;
+  } catch {
+    return [];
+  }
+}
+
+interface DocsMarkdownPromptAstInfo {
+  flowStarts: ReadonlySet<number>;
+  starts: ReadonlySet<number>;
+}
+
+function findDocsMarkdownPromptAstInfo(content: string): DocsMarkdownPromptAstInfo | undefined {
+  try {
+    const prepared = prepareMdxParserSource(content);
+    const offsetAdjustment = prepared.startsWith("\uFEFF") ? 1 : 0;
+    const tree = docsAudienceMdxProcessor.parse(
+      offsetAdjustment > 0 ? prepared.slice(offsetAdjustment) : prepared,
+    ) as MdxAstNode;
+    const flowStarts = new Set<number>();
+    const starts = new Set<number>();
+
+    const visit = (node: MdxAstNode): void => {
+      if (
+        node.name === "Prompt" &&
+        (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+        getOffset(node.position, "start") !== undefined
+      ) {
+        const start = getOffset(node.position, "start")! + offsetAdjustment;
+        starts.add(start);
+        if (node.type === "mdxJsxFlowElement") flowStarts.add(start);
+      }
+      for (const child of node.children ?? []) visit(child);
+    };
+
+    visit(tree);
+    return { flowStarts, starts };
+  } catch {
+    return undefined;
+  }
+}
+
+function findDocsMarkdownPromptExpressionRanges(
+  content: string,
+  protectedRanges: readonly ProtectedRange[],
+): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  let protectedIndex = 0;
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const start = content.indexOf("{", cursor);
+    if (start === -1) break;
+    if (isEscapedAt(content, start) || isInsideRange(start, protectedRanges)) {
+      cursor = start + 1;
+      continue;
+    }
+
+    let depth = 1;
+    let end = start + 1;
+    while (end < content.length && depth > 0) {
+      while (
+        protectedIndex < protectedRanges.length &&
+        protectedRanges[protectedIndex].end <= end
+      ) {
+        protectedIndex += 1;
+      }
+      const candidate = protectedRanges[protectedIndex];
+      const protectedRange =
+        candidate && end >= candidate.start && end < candidate.end ? candidate : undefined;
+      if (protectedRange) {
+        end = protectedRange.end;
+        continue;
+      }
+      if (content[end] === "{") depth += 1;
+      if (content[end] === "}") depth -= 1;
+      end += 1;
+    }
+
+    // An unterminated expression makes the remaining source ambiguous. Keeping
+    // it protected is safer than promoting a JSX value to a document block.
+    ranges.push({ start, end: depth === 0 ? end : content.length });
+    if (depth !== 0) break;
+    cursor = end;
+  }
+
+  return ranges;
+}
+
+function createDocsMarkdownPromptToken(
+  content: string,
+  used: ReadonlySet<string>,
+  startAt: number,
+): string {
+  let index = startAt;
+  let token = "";
+  do {
+    token = `%%PROMPT_${index}%%`;
+    index += 1;
+  } while (content.includes(token) || used.has(token));
+  return token;
+}
+
+function isFallbackDocsMarkdownPromptFlow(
+  content: string,
+  opening: DocsMarkdownPromptTag,
+  closing: DocsMarkdownPromptTag,
+): boolean {
+  const lineStart = Math.max(0, content.lastIndexOf("\n", opening.index - 1) + 1);
+  const prefix = content.slice(lineStart, opening.index);
+  if (!/^[\t ]{0,3}$/.test(prefix)) return false;
+
+  const lineEnd = content.indexOf("\n", closing.end);
+  const suffix = content.slice(closing.end, lineEnd === -1 ? content.length : lineEnd);
+  return content.slice(opening.end, closing.index).includes("\n") || /^[\t\r ]*$/.test(suffix);
+}
+
+function resolveDocsMarkdownPromptContainer(
+  content: string,
+  opening: DocsMarkdownPromptTag,
+): DocsMarkdownPromptContainer | undefined {
+  const lineStart = Math.max(0, content.lastIndexOf("\n", opening.index - 1) + 1);
+  let prefix = content.slice(lineStart, opening.index);
+  let blockquoteDepth = 0;
+  let listIndent = 0;
+
+  while (true) {
+    const blockquote = /^ {0,3}>[\t ]?/.exec(prefix);
+    if (!blockquote) break;
+    blockquoteDepth += 1;
+    prefix = prefix.slice(blockquote[0].length);
+  }
+
+  while (true) {
+    const list = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/.exec(prefix);
+    if (!list) break;
+    listIndent += list[0].length;
+    prefix = prefix.slice(list[0].length);
+  }
+
+  // A flow component can begin on a continuation line after a list item's
+  // initial text. Recover the marker's continuation width so the placeholder
+  // remains in that same item and the copied Prompt body loses only the list
+  // indentation.
+  if (listIndent === 0 && /^[\t ]+$/.test(prefix)) {
+    let previousLineEnd = Math.max(0, lineStart - 1);
+    while (previousLineEnd > 0) {
+      const previousLineStart = Math.max(0, content.lastIndexOf("\n", previousLineEnd - 1) + 1);
+      let previousLine = content.slice(previousLineStart, previousLineEnd).replace(/\r$/, "");
+      for (let depth = 0; depth < blockquoteDepth; depth += 1) {
+        const blockquote = /^ {0,3}>[\t ]?/.exec(previousLine);
+        if (!blockquote) {
+          previousLine = "";
+          break;
+        }
+        previousLine = previousLine.slice(blockquote[0].length);
+      }
+      const list = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/.exec(previousLine);
+      if (list && prefix.length >= list[0].length) {
+        listIndent = list[0].length;
+        break;
+      }
+      if (previousLine.trim().length === 0) break;
+      previousLineEnd = Math.max(0, previousLineStart - 1);
+    }
+  }
+
+  if ((blockquoteDepth === 0 && listIndent === 0) || !/^[\t ]*$/.test(prefix)) {
+    return undefined;
+  }
+  return { blockquoteDepth, listIndent };
+}
+
+function stripDocsMarkdownPromptContainer(
+  children: string,
+  container: DocsMarkdownPromptContainer | undefined,
+): string {
+  if (!container) return children;
+
+  return children
+    .split(/(\r?\n)/)
+    .map((segment, index) => {
+      if (index % 2 === 1) return segment;
+      let line = segment;
+      for (let depth = 0; depth < container.blockquoteDepth; depth += 1) {
+        const blockquote = /^ {0,3}>[\t ]?/.exec(line);
+        if (!blockquote) break;
+        line = line.slice(blockquote[0].length);
+      }
+      let remainingIndent = container.listIndent;
+      while (remainingIndent > 0 && /^[\t ]/.test(line)) {
+        line = line.slice(1);
+        remainingIndent -= 1;
+      }
+      return line;
+    })
+    .join("");
+}
+
+function createDocsMarkdownPromptReplacement(
+  content: string,
+  start: number,
+  end: number,
+  token: string,
+  flow: boolean,
+  container?: DocsMarkdownPromptContainer,
+  adjacentFlowBefore = false,
+  adjacentFlowAfter = false,
+): string {
+  if (!flow || container) return token;
+
+  const newline = content.includes("\r\n") ? "\r\n" : "\n";
+  const before = content.slice(0, start);
+  const after = content.slice(end);
+  const leading =
+    adjacentFlowBefore || before.length === 0 || /(?:\r?\n){2}$/.test(before)
+      ? ""
+      : /\r?\n$/.test(before)
+        ? newline
+        : newline + newline;
+  const trailing =
+    adjacentFlowAfter || after.length === 0 || /^(?:\r?\n){2}/.test(after)
+      ? ""
+      : /^\r?\n/.test(after)
+        ? newline
+        : newline + newline;
+  return leading + token + trailing;
+}
+
+/**
+ * Extract live MDX Prompt blocks while leaving Markdown literals untouched.
+ *
+ * Prompt bodies are copyable source, so callers can safely run audience,
+ * reference-definition, and heading passes over `markdown`, then restore each
+ * block from its token. Fences (including container fences), inline code, links,
+ * comments, raw elements, and other literal contexts are never extracted.
+ */
+export function extractDocsMarkdownPromptBlocks(
+  content: string,
+): ExtractedDocsMarkdownPromptBlocks {
+  if (!/<Prompt(?=[\s/>])/.test(content)) return { blocks: [], markdown: content };
+
+  const syntaxProtectedRanges = mergeProtectedRanges([
+    ...findProtectedRanges(content),
+    ...findMarkdownLinkLiteralRanges(content),
+  ]);
+  const expressionRanges = findDocsMarkdownPromptExpressionRanges(content, syntaxProtectedRanges);
+  const baseProtectedRanges = mergeProtectedRanges([
+    ...syntaxProtectedRanges,
+    ...expressionRanges,
+    ...findDocsMarkdownRawHtmlLiteralRanges(content),
+    ...findDocsMarkdownHtmlContainerLiteralRanges(content, syntaxProtectedRanges),
+  ]);
+  const protectedRanges = mergeProtectedRanges([
+    ...baseProtectedRanges,
+    ...findDocsMarkdownPromptBracketLiteralRanges(content, baseProtectedRanges),
+  ]);
+  const promptAst = findDocsMarkdownPromptAstInfo(content);
+  const pairs: Array<{
+    attributes: string;
+    children: string;
+    container?: DocsMarkdownPromptContainer;
+    end: number;
+    flow: boolean;
+    start: number;
+  }> = [];
+  const openings: Array<{
+    completedChildren: typeof pairs;
+    tag: DocsMarkdownPromptTag;
+  }> = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const index = content.indexOf("<", cursor);
+    if (index === -1) break;
+    if (isEscapedAt(content, index) || isInsideRange(index, protectedRanges)) {
+      cursor = index + 1;
+      continue;
+    }
+
+    const tag = readDocsMarkdownPromptTagAt(content, index);
+    if (!tag) {
+      cursor = index + 1;
+      continue;
+    }
+
+    cursor = tag.end;
+    if (!tag.closing) {
+      if (promptAst && !promptAst.starts.has(tag.index)) continue;
+      if (!tag.selfClosing) openings.push({ completedChildren: [], tag });
+      continue;
+    }
+    const frame = openings.pop();
+    if (!frame) continue;
+
+    const container = resolveDocsMarkdownPromptContainer(content, frame.tag);
+    const pair = {
+      attributes: frame.tag.attributes,
+      children: stripDocsMarkdownPromptContainer(
+        content.slice(frame.tag.end, tag.index),
+        container,
+      ),
+      container,
+      end: tag.end,
+      flow:
+        promptAst?.flowStarts.has(frame.tag.index) === true ||
+        isFallbackDocsMarkdownPromptFlow(content, frame.tag, tag),
+      start: frame.tag.index,
+    };
+    const parent = openings.at(-1);
+    if (parent) parent.completedChildren.push(pair);
+    else pairs.push(pair);
+  }
+
+  // When an outer opener is malformed, retain it verbatim but still recover
+  // any fully balanced Prompt children that follow it.
+  for (const frame of openings) pairs.push(...frame.completedChildren);
+  pairs.sort((left, right) => left.start - right.start);
+
+  if (pairs.length === 0) return { blocks: [], markdown: content };
+
+  const usedTokens = new Set<string>();
+  const blocks: DocsMarkdownPromptBlock[] = pairs.map((pair, index) => {
+    const token = createDocsMarkdownPromptToken(content, usedTokens, index);
+    usedTokens.add(token);
+    return {
+      attributes: pair.attributes,
+      children: pair.children,
+      token,
+    };
+  });
+  let markdown = content;
+  for (let index = pairs.length - 1; index >= 0; index -= 1) {
+    const replacement = createDocsMarkdownPromptReplacement(
+      content,
+      pairs[index].start,
+      pairs[index].end,
+      blocks[index].token,
+      pairs[index].flow,
+      pairs[index].container,
+      index > 0 &&
+        pairs[index - 1].flow &&
+        /^[\t \r\n]*$/.test(content.slice(pairs[index - 1].end, pairs[index].start)),
+      index + 1 < pairs.length &&
+        pairs[index + 1].flow &&
+        /^[\t \r\n]*$/.test(content.slice(pairs[index].end, pairs[index + 1].start)),
+    );
+    markdown =
+      markdown.slice(0, pairs[index].start) + replacement + markdown.slice(pairs[index].end);
+  }
+
+  return { blocks, markdown };
 }
 
 function normalizeProjectedWhitespace(content: string): string {

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -19,7 +19,11 @@ import {
   parseAgentExportArgs,
   type AgentBundleManifest,
 } from "./agent-export.js";
-import { DOCS_AGENT_MANIFEST_FORMAT, DOCS_AGENT_MANIFEST_SCHEMA_URI } from "../agent.js";
+import {
+  DOCS_AGENT_MANIFEST_FORMAT,
+  DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
+} from "../agent.js";
 
 describe("agent export cli", () => {
   const originalCwd = process.cwd();
@@ -168,7 +172,7 @@ pnpm add example
     expect(discoveryFallback).toEqual(discovery);
     expect(discovery.$schema).toBe(DOCS_AGENT_MANIFEST_SCHEMA_URI);
     expect(discovery.format).toBe(DOCS_AGENT_MANIFEST_FORMAT);
-    expect(discovery.version).toBe("1");
+    expect(discovery.version).toBe(DOCS_AGENT_MANIFEST_VERSION);
     expect(discovery.api).not.toHaveProperty("agentCard");
     expect(discovery.staticBundle.manifest).toBe("/.well-known/agent-bundle.json");
     expect(discovery.capabilities.mcp).toBe(false);
@@ -467,7 +471,7 @@ pnpm add example
     expect(discovery).toMatchObject({
       $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
       format: DOCS_AGENT_MANIFEST_FORMAT,
-      version: "1",
+      version: DOCS_AGENT_MANIFEST_VERSION,
       api: { agentCard: "/.well-known/agent-card.json" },
     });
     expect(discovery).not.toHaveProperty("supportedInterfaces");

--- a/packages/docs/src/heading-toc.test.ts
+++ b/packages/docs/src/heading-toc.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { encodeDocsHeadingTocUrls } from "./heading-toc.js";
+
+describe("renderer heading TOC URLs", () => {
+  it("encodes nested fragments while preserving URL prefixes", () => {
+    const toc = [
+      {
+        url: "#café-配置",
+        children: [
+          { url: "/docs/guide#foo#bar" },
+          { url: "#foo%23bar" },
+          { url: "/docs/without-fragment" },
+        ],
+      },
+    ];
+
+    encodeDocsHeadingTocUrls(toc);
+
+    expect(toc).toEqual([
+      {
+        url: "#caf%C3%A9-%E9%85%8D%E7%BD%AE",
+        children: [
+          { url: "/docs/guide#foo%23bar" },
+          { url: "#foo%2523bar" },
+          { url: "/docs/without-fragment" },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/docs/src/heading-toc.ts
+++ b/packages/docs/src/heading-toc.ts
@@ -1,0 +1,24 @@
+/**
+ * Encode heading fragments emitted by a renderer's nested table of contents.
+ *
+ * Fumadocs stores fragment URLs as raw DOM ids. Encoding the fragment after its
+ * heading visitor runs keeps links valid without changing path prefixes.
+ */
+export function encodeDocsHeadingTocUrls(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) encodeDocsHeadingTocUrls(item);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  const item = value as { url?: unknown; children?: unknown };
+  if (typeof item.url === "string") {
+    const hashIndex = item.url.indexOf("#");
+    if (hashIndex >= 0) {
+      item.url = `${item.url.slice(0, hashIndex)}#${encodeURIComponent(
+        item.url.slice(hashIndex + 1),
+      )}`;
+    }
+  }
+  encodeDocsHeadingTocUrls(item.children);
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -162,6 +162,7 @@ export {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   DEFAULT_SKILL_MD_ROUTE,
   DEFAULT_SKILL_MD_WELL_KNOWN_ROUTE,
   DOCS_AI_AGENT_USER_AGENT_HEADER_PATTERN,
@@ -246,6 +247,19 @@ export {
   validateDocsAgentFeedbackPayload,
   validateDocsAgentSkillFrontmatter,
 } from "./agent.js";
+export {
+  applyDocsMarkdownHeadingAnchors,
+  cleanDocsRenderedHeadingLabel,
+  createDocsMarkdownHeadingAnchorResolver,
+  createDocsRenderedHeadingAnchorResolver,
+  slugifyDocsMarkdownHeading,
+  withDocsMarkdownRenderableHeadings,
+} from "./markdown-sections.js";
+export type {
+  ApplyDocsMarkdownHeadingAnchorsOptions,
+  DocsMarkdownHeadingAnchor,
+  DocsRenderedHeadingAnchorOptions,
+} from "./markdown-sections.js";
 export type { DocsAudienceMdxIssue, DocsContentAudience } from "./audience.js";
 export type {
   DocsAgentsDocumentOptions,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -255,6 +255,8 @@ export {
   slugifyDocsMarkdownHeading,
   withDocsMarkdownRenderableHeadings,
 } from "./markdown-sections.js";
+export { encodeDocsHeadingTocUrls } from "./heading-toc.js";
+export { isolateDocsMarkdownPromptReferences } from "./prompt-references.js";
 export type {
   ApplyDocsMarkdownHeadingAnchorsOptions,
   DocsMarkdownHeadingAnchor,

--- a/packages/docs/src/markdown-rendering.test.ts
+++ b/packages/docs/src/markdown-rendering.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createDocsMarkdownBlockPlaceholderAllocator,
   extractDocsMarkdownReferenceDefinitions,
   extractDocsRenderedHeadingElements,
   prepareDocsMarkdownHeadings,
@@ -141,6 +142,36 @@ custom second [#custom-setext]
     const html = renderDocsMarkdownBlockContent("Before.\n\n%%CODEBLOCK_0%%\n\nAfter.", new Map());
 
     expect(html).toBe("<p>Before.</p>%%CODEBLOCK_0%%<p>After.</p>");
+  });
+
+  it("keeps every nested component placeholder outside callout paragraphs", () => {
+    const placeholders = [
+      "%%CODEBLOCK_0%%",
+      "%%CALLOUT_1%%",
+      "%%TABS_2%%",
+      "%%PROMPT_3%%",
+      "%%HOVERLINK_4%%",
+    ];
+    const html = renderDocsMarkdownBlockContent(
+      ["Before.", "", ...placeholders.flatMap((placeholder) => [placeholder, ""]), "After."].join(
+        "\n",
+      ),
+      new Map(),
+    );
+
+    expect(html).toBe(`<p>Before.</p>${placeholders.join("")}<p>After.</p>`);
+    expect(html).not.toContain("<p>%%");
+  });
+
+  it("allocates block placeholders around authored token-like text", () => {
+    const allocate = createDocsMarkdownBlockPlaceholderAllocator(
+      ["%%CALLOUT_0%%", "%%CALLOUT_1%%", "%%CODEBLOCK_0%%"].join("\n"),
+    );
+
+    expect(allocate("CALLOUT")).toBe("%%CALLOUT_2%%");
+    expect(allocate("CALLOUT")).toBe("%%CALLOUT_3%%");
+    expect(allocate("CODEBLOCK")).toBe("%%CODEBLOCK_1%%");
+    expect(allocate("TABS")).toBe("%%TABS_0%%");
   });
 
   it("extracts only protected pipeline headings and leaves authored HTML in content", () => {

--- a/packages/docs/src/markdown-rendering.test.ts
+++ b/packages/docs/src/markdown-rendering.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractDocsMarkdownReferenceDefinitions,
+  extractDocsRenderedHeadingElements,
+  prepareDocsMarkdownHeadings,
+  replaceDocsMarkdownFencedCodeBlocks,
+  renderDocsMarkdownBlockContent,
+  renderDocsMarkdownHeadings,
+  renderDocsMarkdownInline,
+  restoreDocsMarkdownHeadingOpeningTags,
+} from "./markdown-rendering.js";
+
+describe("shared Markdown rendering helpers", () => {
+  it("carries canonical anchors through frontmatter, containers, and Setext headings", () => {
+    const prepared = prepareDocsMarkdownHeadings(`---
+title: Anchors
+---
+
+> \`\`\`
+> code
+
+## Outside
+
+> Quoted
+>===
+
+- Listed
+  ===
+`);
+    const rendered = renderDocsMarkdownHeadings(prepared.markdown, prepared.headings);
+    const html = restoreDocsMarkdownHeadingOpeningTags(rendered.markdown, rendered.openingTags);
+
+    expect(html).toContain('<h2 id="outside">Outside</h2>');
+    expect(html).toContain('> <h1 id="quoted">Quoted</h1>');
+    expect(html).toContain('- <h1 id="listed">Listed</h1>');
+    expect(html).not.toContain("FARMINGLABS_DOCS_HEADING_ANCHOR");
+  });
+
+  it("keeps BOM-prefixed frontmatter out of canonical heading preparation", () => {
+    const prepared = prepareDocsMarkdownHeadings(
+      "\uFEFF---\ntitle: Not a heading\n---\n\n## Visible",
+    );
+    const rendered = renderDocsMarkdownHeadings(prepared.markdown, prepared.headings);
+    const html = restoreDocsMarkdownHeadingOpeningTags(rendered.markdown, rendered.openingTags);
+
+    expect(prepared.headings).toHaveLength(1);
+    expect(html).toContain('<h2 id="visible">Visible</h2>');
+    expect(html).not.toContain('id="title-not-a-heading"');
+  });
+
+  it("preserves every line of multiline Setext headings and consumes the underline", () => {
+    const prepared = prepareDocsMarkdownHeadings(`First *line*
+second \`line\`
+---
+
+10. Nested first
+    nested second
+    ---
+
+Custom first
+custom second [#custom-setext]
+---
+`);
+    const rendered = renderDocsMarkdownHeadings(prepared.markdown, prepared.headings);
+    const html = restoreDocsMarkdownHeadingOpeningTags(rendered.markdown, rendered.openingTags);
+
+    expect(html).toContain('<h2 id="first-line-second-line">First *line* second `line`</h2>');
+    expect(html).toContain(
+      '10. <h2 id="nested-first-nested-second">Nested first nested second</h2>',
+    );
+    expect(html).toContain('<h2 id="custom-setext">Custom first custom second</h2>');
+    expect(html).not.toContain("[#custom-setext]");
+    expect(html).not.toContain("---");
+  });
+
+  it("keeps resolved shortcut links visible instead of consuming them as custom ids", () => {
+    const markdown = "## [#foo]\n\n[#foo]: /guide";
+    const references = extractDocsMarkdownReferenceDefinitions(markdown);
+    const prepared = prepareDocsMarkdownHeadings(markdown);
+    const preparedWithoutReferences = extractDocsMarkdownReferenceDefinitions(
+      prepared.markdown,
+    ).markdown;
+    const rendered = renderDocsMarkdownHeadings(preparedWithoutReferences, prepared.headings);
+    const html = renderDocsMarkdownInline(
+      restoreDocsMarkdownHeadingOpeningTags(rendered.markdown, rendered.openingTags),
+      references.definitions,
+    );
+
+    expect(html).toContain('<h2 id="foo"><a href="/guide">#foo</a></h2>');
+  });
+
+  it("renders balanced and reference resources while preserving unresolved literals", () => {
+    const extracted = extractDocsMarkdownReferenceDefinitions(
+      [
+        "![Rocket](assets/a(b).png) ![Rocket] ![Rocket &amp;] ![Missing]",
+        "",
+        '[Rocket]: /rocket.png "Ship"',
+        "[Rocket &]: /entity.png",
+      ].join("\n"),
+    );
+    const html = renderDocsMarkdownInline(extracted.markdown, extracted.definitions);
+
+    expect(html).toContain('src="assets/a(b).png"');
+    expect(html).toContain('src="/rocket.png"');
+    expect(html).toContain('src="/entity.png"');
+    expect(html).toContain('title="Ship"');
+    expect(html).toContain("![Missing]");
+    expect(html).not.toContain("[Rocket]:");
+  });
+
+  it("renders linked images recursively and keeps the first reference definition", () => {
+    const extracted = extractDocsMarkdownReferenceDefinitions(
+      [
+        "[![Rocket][image]][guide]",
+        "",
+        "[image]: /rocket-first.png",
+        "[IMAGE]: /rocket-second.png",
+        "[guide]: /guide-first",
+        "[GUIDE]: /guide-second",
+      ].join("\n"),
+    );
+    const html = renderDocsMarkdownInline(extracted.markdown, extracted.definitions);
+
+    expect(html).toContain(
+      '<a href="/guide-first"><img src="/rocket-first.png" alt="Rocket" class="fd-docs-content-img"',
+    );
+    expect(html).not.toContain("rocket-second.png");
+    expect(html).not.toContain("guide-second");
+  });
+
+  it("keeps heading elements outside generated paragraphs", () => {
+    const html = renderDocsMarkdownBlockContent(
+      '<h2 id="verify">Verify</h2>\n\nRun **tests**.',
+      new Map(),
+    );
+
+    expect(html).toBe('<h2 id="verify">Verify</h2><p>Run <strong>tests</strong>.</p>');
+  });
+
+  it("keeps code-block placeholders outside generated paragraphs", () => {
+    const html = renderDocsMarkdownBlockContent("Before.\n\n%%CODEBLOCK_0%%\n\nAfter.", new Map());
+
+    expect(html).toBe("<p>Before.</p>%%CODEBLOCK_0%%<p>After.</p>");
+  });
+
+  it("extracts only protected pipeline headings and leaves authored HTML in content", () => {
+    const prepared = prepareDocsMarkdownHeadings(
+      [
+        "## Real",
+        "",
+        '<h2 id="authored" onclick="alert(1)">Authored HTML</h2>',
+        "",
+        "```html",
+        "<h2>Example only</h2>",
+        "```",
+        "",
+        "> ~~~html",
+        "> <h2>Quoted example only</h2>",
+        "> ~~~",
+        "",
+        "- ````html",
+        "  <h2>Listed example only</h2>",
+        "  ````",
+      ].join("\n"),
+    );
+    const rendered = renderDocsMarkdownHeadings(prepared.markdown, prepared.headings);
+    const extracted = extractDocsRenderedHeadingElements(
+      rendered.markdown,
+      new Map(),
+      false,
+      rendered.openingTags,
+    );
+
+    expect(extracted.headingsHtml).toBe('<h2 id="real">Real</h2>');
+    expect(extracted.content).toContain('<h2 id="authored" onclick="alert(1)">Authored HTML</h2>');
+    expect(extracted.content).toContain("```html\n<h2>Example only</h2>\n```");
+    expect(extracted.content).toContain("> <h2>Quoted example only</h2>");
+    expect(extracted.content).toContain("  <h2>Listed example only</h2>");
+  });
+
+  it("replaces tilde and length-matched backtick fences without closing early", () => {
+    const source = [
+      "~~~html",
+      "<h2>Tilde example</h2>",
+      "~~~",
+      "",
+      "````markdown",
+      "```html",
+      "<h2>Nested example</h2>",
+      "```",
+      "````",
+    ].join("\n");
+    const blocks: Array<{ code: string; info: string; marker: string }> = [];
+    const rendered = replaceDocsMarkdownFencedCodeBlocks(source, (block, index) => {
+      blocks.push({ code: block.code, info: block.info, marker: block.marker });
+      return `BLOCK_${index}`;
+    });
+
+    expect(blocks).toEqual([
+      {
+        code: "<h2>Tilde example</h2>\n",
+        info: "html",
+        marker: "~",
+      },
+      {
+        code: "```html\n<h2>Nested example</h2>\n```\n",
+        info: "markdown",
+        marker: "`",
+      },
+    ]);
+    expect(rendered).toBe("BLOCK_0\n\nBLOCK_1");
+  });
+
+  it("treats an unclosed fence as code through the end of the document", () => {
+    for (const source of [
+      "~~~html\n<h2>Tilde example</h2>",
+      "````markdown\n```html\n<h2>Nested example</h2>\n```",
+    ]) {
+      const blocks: Array<{ code: string; info: string; marker: string }> = [];
+      const rendered = replaceDocsMarkdownFencedCodeBlocks(source, (block) => {
+        blocks.push({ code: block.code, info: block.info, marker: block.marker });
+        return "BLOCK";
+      });
+
+      expect(rendered).toBe("BLOCK");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]?.code).toContain("<h2>");
+    }
+  });
+
+  it("replaces fenced code inside blockquote and list containers", () => {
+    const source = [
+      "> ~~~html",
+      "> <h2>Quote example</h2>",
+      "> ~~~",
+      "",
+      "- ````markdown",
+      "  ```html",
+      "  <h2>List example</h2>",
+      "  ```",
+      "  ````",
+    ].join("\n");
+    const blocks: string[] = [];
+    const rendered = replaceDocsMarkdownFencedCodeBlocks(source, (block, index) => {
+      blocks.push(block.code);
+      return `BLOCK_${index}`;
+    });
+
+    expect(blocks).toEqual(["<h2>Quote example</h2>\n", "```html\n<h2>List example</h2>\n```\n"]);
+    expect(rendered).toBe("> BLOCK_0\n\n- BLOCK_1");
+  });
+
+  it("preserves the line after an implicitly closed container fence", () => {
+    const rendered = replaceDocsMarkdownFencedCodeBlocks(
+      ["> ~~~html", "> <h2>Quote example</h2>", "## Outside"].join("\n"),
+      () => "BLOCK",
+    );
+
+    expect(rendered).toBe("> BLOCK\n## Outside");
+  });
+
+  it("preserves authored text that resembles internal transport tokens", () => {
+    const authoredTokens = [
+      "%%FARMINGLABS_DOCS_HEADING_ANCHOR_0%%",
+      "%%FARMINGLABS_DOCS_HEADING_OPEN_0%%",
+      "%%FARMINGLABS_DOCS_INLINE_LITERAL_0%%",
+      "\uE100FARMINGLABS_DOCS_ANCHOR_0_0\uE101",
+      "\uE100FARMINGLABS_DOCS_OPEN_0_0\uE101",
+      "\uE100FARMINGLABS_DOCS_INLINE_0_0\uE101",
+    ];
+    const markdown = `## Real\n\n${authoredTokens.join(" ")}`;
+    const prepared = prepareDocsMarkdownHeadings(markdown);
+    const rendered = renderDocsMarkdownHeadings(prepared.markdown, prepared.headings);
+    const html = restoreDocsMarkdownHeadingOpeningTags(rendered.markdown, rendered.openingTags);
+    const inline = renderDocsMarkdownInline(
+      `${authoredTokens.join(" ")} \`code\` \\*literal\\*`,
+      new Map(),
+    );
+
+    for (const token of authoredTokens) {
+      expect(html).toContain(token);
+      expect(inline).toContain(token);
+    }
+    expect(html).toContain('<h2 id="real">Real</h2>');
+    expect(inline).toContain("<code>code</code> *literal*");
+  });
+});

--- a/packages/docs/src/markdown-rendering.ts
+++ b/packages/docs/src/markdown-rendering.ts
@@ -37,7 +37,35 @@ export interface DocsMarkdownHeadingOpeningTag {
 
 export type DocsMarkdownReferenceDefinitions = ReadonlyMap<string, DocsMarkdownReferenceDefinition>;
 
+export type DocsMarkdownBlockPlaceholderKind = "CALLOUT" | "CODEBLOCK" | "HOVERLINK" | "TABS";
+
 const TRAILING_DOCS_MARKDOWN_HEADING_ID = /\s*\\?\[#([^\]\r\n]+)\]\s*$/;
+
+/**
+ * Allocate transport placeholders without colliding with authored Markdown.
+ *
+ * Manual renderers restore these tokens after their inline/block passes, so a
+ * collision would otherwise move rendered component HTML to user-authored text.
+ */
+export function createDocsMarkdownBlockPlaceholderAllocator(
+  source: string,
+): (kind: DocsMarkdownBlockPlaceholderKind) => string {
+  const nextIndexes = new Map<DocsMarkdownBlockPlaceholderKind, number>();
+  const used = new Set<string>();
+
+  return (kind) => {
+    let index = nextIndexes.get(kind) ?? 0;
+    let token = "";
+    do {
+      token = `%%${kind}_${index}%%`;
+      index += 1;
+    } while (source.includes(token) || used.has(token));
+
+    nextIndexes.set(kind, index);
+    used.add(token);
+    return token;
+  };
+}
 
 function createDocsMarkdownTransportToken(
   source: string,
@@ -781,7 +809,7 @@ export function renderDocsMarkdownBlockContent(
       continue;
     }
 
-    if (/^%%CODEBLOCK_\d+%%$/.test(trimmed)) {
+    if (/^%%(?:CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%$/.test(trimmed)) {
       flushParagraph();
       output.push(trimmed);
       continue;

--- a/packages/docs/src/markdown-rendering.ts
+++ b/packages/docs/src/markdown-rendering.ts
@@ -1,0 +1,881 @@
+import { parseDocsMarkdownSections } from "./markdown-sections.js";
+import { parseEntities } from "parse-entities";
+
+interface PreparedDocsMarkdownHeading {
+  anchor: string;
+  explicit: boolean;
+  level: number;
+  token: string;
+}
+
+export interface PreparedDocsMarkdownHeadings {
+  markdown: string;
+  headings: PreparedDocsMarkdownHeading[];
+}
+
+export interface RenderedDocsMarkdownHeadings {
+  markdown: string;
+  openingTags: DocsMarkdownHeadingOpeningTag[];
+}
+
+export interface DocsMarkdownFencedCodeBlock {
+  code: string;
+  fenceLength: number;
+  info: string;
+  marker: "`" | "~";
+}
+
+interface DocsMarkdownReferenceDefinition {
+  destination: string;
+  title?: string;
+}
+
+export interface DocsMarkdownHeadingOpeningTag {
+  html: string;
+  token: string;
+}
+
+export type DocsMarkdownReferenceDefinitions = ReadonlyMap<string, DocsMarkdownReferenceDefinition>;
+
+const TRAILING_DOCS_MARKDOWN_HEADING_ID = /\s*\\?\[#([^\]\r\n]+)\]\s*$/;
+
+function createDocsMarkdownTransportToken(
+  source: string,
+  kind: "anchor" | "inline",
+  index: number,
+  used: ReadonlySet<string>,
+): string {
+  let salt = 0;
+  let token = "";
+  do {
+    token = `\uE100FARMINGLABS_DOCS_${kind.toUpperCase()}_${index}_${salt}\uE101`;
+    salt += 1;
+  } while (source.includes(token) || used.has(token));
+  return token;
+}
+
+function createDocsMarkdownOpeningTagToken(
+  source: string,
+  index: number,
+  used: ReadonlySet<string>,
+): string {
+  let candidate = index;
+  let token = "";
+  do {
+    token = `%%FARMINGLABS_DOCS_HEADING_OPEN_${candidate}%%`;
+    candidate += 1;
+  } while (source.includes(token) || used.has(token));
+  return token;
+}
+
+function escapeDocsMarkdownHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function splitDocsMarkdownHeadingContainerLine(line: string): {
+  prefix: string;
+  content: string;
+} {
+  let prefix = "";
+  let content = line;
+  while (content) {
+    const container = content.match(/^(?: {0,3}>[\t ]?| {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+)/);
+    if (!container) break;
+    prefix += container[0];
+    content = content.slice(container[0].length);
+  }
+  return { prefix, content };
+}
+
+/**
+ * Annotate only headings accepted by the canonical section parser.
+ *
+ * The opaque tokens let the lightweight Astro, Nuxt, and Svelte renderers carry
+ * exact IDs through their component and inline-Markdown passes without parsing
+ * the document a second, divergent way.
+ */
+export function prepareDocsMarkdownHeadings(markdown: string): PreparedDocsMarkdownHeadings {
+  const frontmatter = markdown.match(/^(\uFEFF?---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$))/)?.[1] ?? "";
+  const frontmatterLineOffset = frontmatter.match(/\r?\n/g)?.length ?? 0;
+  const canonicalHeadings = parseDocsMarkdownSections(
+    frontmatter ? markdown.slice(frontmatter.length) : markdown,
+  );
+  const canonicalHeadingsByLine = new Map(
+    canonicalHeadings.map((heading) => [heading.startLine + frontmatterLineOffset, heading]),
+  );
+  const headings: PreparedDocsMarkdownHeading[] = [];
+  const headingTokens = new Set<string>();
+  const output: string[] = [];
+
+  const annotate = (
+    source: string,
+    canonicalHeading: (typeof canonicalHeadings)[number],
+  ): string => {
+    const token = createDocsMarkdownTransportToken(
+      markdown,
+      "anchor",
+      headings.length,
+      headingTokens,
+    );
+    headingTokens.add(token);
+    headings.push({
+      anchor: canonicalHeading.anchor,
+      explicit: canonicalHeading.explicit,
+      level: canonicalHeading.level,
+      token,
+    });
+    return `${source} ${token}`;
+  };
+
+  const lines = markdown.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const canonicalHeading = canonicalHeadingsByLine.get(index + 1);
+    if (!canonicalHeading) {
+      output.push(line);
+      continue;
+    }
+
+    const containerLine = splitDocsMarkdownHeadingContainerLine(line);
+    const atx = containerLine.content.match(/^ {0,3}(#{1,6})(?:[\t ]+|$)(.*)$/);
+    if (atx) {
+      const source = atx[2].replace(/[\t ]+#+[\t ]*$/, "").trim();
+      output.push(`${containerLine.prefix}${atx[1]} ${annotate(source, canonicalHeading)}`);
+      continue;
+    }
+
+    output.push(
+      `${containerLine.prefix}${annotate(containerLine.content.trim(), canonicalHeading)}`,
+    );
+  }
+
+  return { markdown: output.join("\n"), headings };
+}
+
+export function stripPreparedDocsMarkdownHeadingTokens(value: string): string {
+  return value;
+}
+
+export function renderDocsMarkdownHeadings(
+  markdown: string,
+  preparedHeadings: readonly PreparedDocsMarkdownHeading[],
+): RenderedDocsMarkdownHeadings {
+  const lines = markdown.split(/\r?\n/);
+  const output: string[] = [];
+  const openingTags: DocsMarkdownHeadingOpeningTag[] = [];
+  const openingTagTokens = new Set<string>();
+
+  const protectOpeningTag = (level: number, anchor: string): string => {
+    const token = createDocsMarkdownOpeningTagToken(markdown, openingTags.length, openingTagTokens);
+    openingTagTokens.add(token);
+    openingTags.push({
+      html: `<h${level} id="${escapeDocsMarkdownHtml(anchor)}">`,
+      token,
+    });
+    return token;
+  };
+
+  const resolveHeading = (
+    source: string,
+  ): { anchor: string; explicit: boolean; source: string; level: number } | undefined => {
+    const prepared = preparedHeadings.find((heading) => source.includes(heading.token));
+    if (!prepared) return undefined;
+    const withoutToken = source.split(prepared.token).join("");
+    return {
+      anchor: prepared.anchor,
+      explicit: prepared.explicit,
+      level: prepared.level,
+      source: prepared.explicit
+        ? withoutToken.replace(TRAILING_DOCS_MARKDOWN_HEADING_ID, "").trim()
+        : withoutToken.trim(),
+    };
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const containerLine = splitDocsMarkdownHeadingContainerLine(line);
+    const atx = containerLine.content.match(/^ {0,3}(#{1,6})(?:[\t ]+|$)(.*)$/);
+    if (atx) {
+      const source = atx[2].replace(/[\t ]+#+[\t ]*$/, "").trim();
+      const heading = resolveHeading(source);
+      if (!heading) {
+        output.push(line);
+        continue;
+      }
+      const level = atx[1].length;
+      output.push(
+        `${containerLine.prefix}${protectOpeningTag(level, heading.anchor)}${heading.source}</h${level}>`,
+      );
+      continue;
+    }
+
+    const heading = resolveHeading(containerLine.content.trim());
+    if (heading) {
+      const sourceLines = [heading.source];
+      let underlineIndex = index + 1;
+      const expectedUnderline = heading.level === 1 ? /^=+$/ : /^-+$/;
+
+      while (underlineIndex < lines.length) {
+        const continuation = splitDocsMarkdownHeadingContainerLine(
+          lines[underlineIndex] ?? "",
+        ).content;
+        if (expectedUnderline.test(continuation.trim())) break;
+        if (!continuation.trim()) break;
+        sourceLines.push(continuation.trim());
+        underlineIndex += 1;
+      }
+
+      const combinedSource = sourceLines.join(" ");
+      const visibleSource = heading.explicit
+        ? combinedSource.replace(TRAILING_DOCS_MARKDOWN_HEADING_ID, "").trim()
+        : combinedSource;
+      output.push(
+        `${containerLine.prefix}${protectOpeningTag(heading.level, heading.anchor)}${visibleSource}</h${heading.level}>`,
+      );
+      if (underlineIndex < lines.length) index = underlineIndex;
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  let renderedMarkdown = output.join("\n");
+  for (const prepared of preparedHeadings) {
+    renderedMarkdown = renderedMarkdown.split(prepared.token).join("");
+  }
+  return { markdown: renderedMarkdown, openingTags };
+}
+
+export function restoreDocsMarkdownHeadingOpeningTags(
+  value: string,
+  openingTags: readonly DocsMarkdownHeadingOpeningTag[],
+): string {
+  let restored = value;
+  for (const openingTag of openingTags) {
+    restored = restored.split(openingTag.token).join(openingTag.html);
+  }
+  return restored;
+}
+
+interface DocsMarkdownFenceContainer {
+  continuationIndent: number;
+  type: "blockquote" | "list";
+}
+
+function splitDocsMarkdownFenceContainerLine(line: string): {
+  containers: DocsMarkdownFenceContainer[];
+  content: string;
+  prefix: string;
+} {
+  const containers: DocsMarkdownFenceContainer[] = [];
+  let content = line;
+  let prefix = "";
+
+  while (content) {
+    const blockquote = content.match(/^ {0,3}>[\t ]?/);
+    if (blockquote) {
+      prefix += blockquote[0];
+      content = content.slice(blockquote[0].length);
+      containers.push({ continuationIndent: 0, type: "blockquote" });
+      continue;
+    }
+
+    const listItem = content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/);
+    if (listItem) {
+      prefix += listItem[0];
+      content = content.slice(listItem[0].length);
+      containers.push({
+        continuationIndent: listItem[0].length,
+        type: "list",
+      });
+      continue;
+    }
+
+    break;
+  }
+
+  return { containers, content, prefix };
+}
+
+function continueDocsMarkdownFenceContainerLine(
+  line: string,
+  containers: readonly DocsMarkdownFenceContainer[],
+): string | undefined {
+  let content = line;
+
+  for (const container of containers) {
+    if (container.type === "blockquote") {
+      const blockquote = content.match(/^ {0,3}>[\t ]?/);
+      if (!blockquote) return undefined;
+      content = content.slice(blockquote[0].length);
+      continue;
+    }
+
+    if (!content.trim()) {
+      content = "";
+      continue;
+    }
+
+    const indentation = content.match(/^[\t ]*/)?.[0] ?? "";
+    const indentationWidth = indentation.replace(/\t/g, "    ").length;
+    if (indentationWidth < container.continuationIndent) return undefined;
+
+    let consumedLength = 0;
+    let consumedWidth = 0;
+    while (consumedLength < indentation.length) {
+      consumedWidth += indentation[consumedLength] === "\t" ? 4 : 1;
+      consumedLength += 1;
+      if (consumedWidth >= container.continuationIndent) break;
+    }
+    content = content.slice(consumedLength);
+  }
+
+  return content;
+}
+
+/**
+ * Replace complete CommonMark fenced code blocks without confusing shorter
+ * marker runs inside a longer outer fence for its closing delimiter.
+ */
+export function replaceDocsMarkdownFencedCodeBlocks(
+  value: string,
+  render: (block: DocsMarkdownFencedCodeBlock, index: number) => string,
+): string {
+  const lines: Array<{
+    end: number;
+    ending: string;
+    start: number;
+    text: string;
+  }> = [];
+
+  for (const match of value.matchAll(/[^\r\n]*(?:\r\n|\n|\r|$)/g)) {
+    const raw = match[0];
+    if (!raw) continue;
+    const ending = raw.match(/(?:\r\n|\n|\r)$/)?.[0] ?? "";
+    const start = match.index;
+    const end = start + raw.length - ending.length;
+    lines.push({
+      end,
+      ending,
+      start,
+      text: ending ? raw.slice(0, -ending.length) : raw,
+    });
+  }
+
+  let blockIndex = 0;
+  let cursor = 0;
+  let output = "";
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const openingLine = lines[lineIndex];
+    const containerLine = splitDocsMarkdownFenceContainerLine(openingLine.text);
+    const opening = containerLine.content.match(/^( {0,3})(`{3,}|~{3,})([^\r\n]*)$/);
+    if (!opening) continue;
+
+    const marker = opening[2][0] as "`" | "~";
+    const info = opening[3].trim();
+    if (marker === "`" && info.includes("`")) continue;
+
+    const codeLines: string[] = [];
+    let closingIndex = lineIndex + 1;
+    for (; closingIndex < lines.length; closingIndex += 1) {
+      const continuedContent =
+        containerLine.containers.length === 0
+          ? lines[closingIndex].text
+          : continueDocsMarkdownFenceContainerLine(
+              lines[closingIndex].text,
+              containerLine.containers,
+            );
+      if (continuedContent === undefined) break;
+
+      const closing = continuedContent.match(/^ {0,3}(`+|~+)[\t ]*$/);
+      if (closing && closing[1][0] === marker && closing[1].length >= opening[2].length) {
+        break;
+      }
+      codeLines.push(`${continuedContent}${lines[closingIndex].ending}`);
+    }
+
+    const candidateClosingLine = lines[closingIndex];
+    const candidateClosingContent = candidateClosingLine
+      ? containerLine.containers.length === 0
+        ? candidateClosingLine.text
+        : continueDocsMarkdownFenceContainerLine(
+            candidateClosingLine.text,
+            containerLine.containers,
+          )
+      : undefined;
+    const candidateClosing = candidateClosingContent?.match(/^ {0,3}(`+|~+)[\t ]*$/);
+    const closingLine =
+      candidateClosing &&
+      candidateClosing[1][0] === marker &&
+      candidateClosing[1].length >= opening[2].length
+        ? candidateClosingLine
+        : undefined;
+    const implicitClosingLine = candidateClosingLine ? lines[closingIndex - 1] : undefined;
+    const blockEnd = closingLine?.end ?? implicitClosingLine?.end ?? value.length;
+    output += value.slice(cursor, openingLine.start);
+    output += containerLine.prefix + opening[1];
+    output += render(
+      {
+        code: codeLines.join(""),
+        fenceLength: opening[2].length,
+        info,
+        marker,
+      },
+      blockIndex,
+    );
+    blockIndex += 1;
+    cursor = blockEnd;
+    if (closingLine) {
+      lineIndex = closingIndex;
+    } else if (candidateClosingLine) {
+      lineIndex = closingIndex - 1;
+    } else {
+      break;
+    }
+  }
+
+  return blockIndex === 0 ? value : output + value.slice(cursor);
+}
+
+function normalizeDocsMarkdownReferenceLabel(value: string): string {
+  return parseEntities(unescapeDocsMarkdownPunctuation(value), {
+    nonTerminated: false,
+  })
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function unescapeDocsMarkdownPunctuation(value: string): string {
+  return value.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/g, "$1");
+}
+
+function findDocsMarkdownClosingDelimiter(
+  value: string,
+  start: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 0;
+  for (let index = start; index < value.length; index += 1) {
+    if (value[index] === "\\") {
+      index += 1;
+      continue;
+    }
+    if (value[index] === open) depth += 1;
+    if (value[index] !== close) continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+  return -1;
+}
+
+function readDocsMarkdownHtmlTagEnd(value: string, start: number): number {
+  if (value[start] !== "<" || !/[A-Za-z/!?]/.test(value[start + 1] ?? "")) {
+    return -1;
+  }
+
+  let quote: "'" | '"' | undefined;
+  for (let index = start + 1; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote && value[index - 1] !== "\\") quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === ">") return index;
+  }
+  return -1;
+}
+
+function parseDocsMarkdownDestination(source: string): DocsMarkdownReferenceDefinition | undefined {
+  const value = source.trim();
+  if (!value) return { destination: "" };
+
+  let destination = "";
+  let remainder = "";
+  if (value.startsWith("<")) {
+    const end = value.indexOf(">");
+    if (end < 0) return undefined;
+    destination = value.slice(1, end);
+    remainder = value.slice(end + 1).trim();
+  } else {
+    let depth = 0;
+    let end = value.length;
+    for (let index = 0; index < value.length; index += 1) {
+      if (value[index] === "\\") {
+        index += 1;
+        continue;
+      }
+      if (value[index] === "(") depth += 1;
+      if (value[index] === ")") depth = Math.max(0, depth - 1);
+      if (/\s/.test(value[index]) && depth === 0) {
+        end = index;
+        break;
+      }
+    }
+    destination = value.slice(0, end);
+    remainder = value.slice(end).trim();
+  }
+
+  let title: string | undefined;
+  if (remainder) {
+    const titleMatch = remainder.match(/^(?:"([^"]*)"|'([^']*)'|\(([^()]*)\))$/);
+    if (!titleMatch) return undefined;
+    title = titleMatch[1] ?? titleMatch[2] ?? titleMatch[3];
+  }
+
+  return {
+    destination: unescapeDocsMarkdownPunctuation(destination),
+    ...(title === undefined ? {} : { title: unescapeDocsMarkdownPunctuation(title) }),
+  };
+}
+
+export function extractDocsMarkdownReferenceDefinitions(markdown: string): {
+  markdown: string;
+  definitions: DocsMarkdownReferenceDefinitions;
+} {
+  const definitions = new Map<string, DocsMarkdownReferenceDefinition>();
+  const output: string[] = [];
+  let openFence: { marker: "`" | "~"; length: number } | undefined;
+
+  for (const line of markdown.split(/\r?\n/)) {
+    if (openFence) {
+      const marker = openFence.marker === "`" ? "`" : "~";
+      if (new RegExp(`^ {0,3}${marker}{${openFence.length},}[\\t ]*$`).test(line)) {
+        openFence = undefined;
+      }
+      output.push(line);
+      continue;
+    }
+
+    const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (openingFence) {
+      openFence = {
+        marker: openingFence[1][0] as "`" | "~",
+        length: openingFence[1].length,
+      };
+      output.push(line);
+      continue;
+    }
+
+    const definitionMatch = line.match(/^ {0,3}\[([^\]]+)\]:[ \t]*(.*)$/);
+    const definition = definitionMatch
+      ? parseDocsMarkdownDestination(definitionMatch[2])
+      : undefined;
+    if (!definitionMatch || !definition) {
+      output.push(line);
+      continue;
+    }
+
+    const normalizedLabel = normalizeDocsMarkdownReferenceLabel(definitionMatch[1]);
+    if (!definitions.has(normalizedLabel)) {
+      definitions.set(normalizedLabel, definition);
+    }
+    output.push("");
+  }
+
+  return { markdown: output.join("\n"), definitions };
+}
+
+function renderDocsMarkdownResources(
+  value: string,
+  definitions: DocsMarkdownReferenceDefinitions,
+): string {
+  let output = "";
+  let index = 0;
+
+  while (index < value.length) {
+    const htmlTagEnd = readDocsMarkdownHtmlTagEnd(value, index);
+    if (htmlTagEnd >= 0) {
+      output += value.slice(index, htmlTagEnd + 1);
+      index = htmlTagEnd + 1;
+      continue;
+    }
+
+    const image = value[index] === "!" && value[index + 1] === "[";
+    const link = value[index] === "[";
+    if (!image && !link) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+
+    const labelStart = index + (image ? 2 : 1);
+    const labelEnd = findDocsMarkdownClosingDelimiter(value, labelStart - 1, "[", "]");
+    if (labelEnd < 0) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+
+    const label = value.slice(labelStart, labelEnd);
+    let end = labelEnd + 1;
+    let target: DocsMarkdownReferenceDefinition | undefined;
+    if (value[end] === "(") {
+      const destinationEnd = findDocsMarkdownClosingDelimiter(value, end, "(", ")");
+      if (destinationEnd < 0) {
+        output += value[index];
+        index += 1;
+        continue;
+      }
+      target = parseDocsMarkdownDestination(value.slice(end + 1, destinationEnd));
+      end = destinationEnd + 1;
+    } else if (value[end] === "[") {
+      const referenceEnd = findDocsMarkdownClosingDelimiter(value, end, "[", "]");
+      if (referenceEnd < 0) {
+        output += value[index];
+        index += 1;
+        continue;
+      }
+      const referenceLabel = value.slice(end + 1, referenceEnd) || label;
+      target = definitions.get(normalizeDocsMarkdownReferenceLabel(referenceLabel));
+      end = referenceEnd + 1;
+    } else {
+      target = definitions.get(normalizeDocsMarkdownReferenceLabel(label));
+    }
+
+    if (!target) {
+      output += value.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    const titleAttribute =
+      target.title === undefined ? "" : ` title="${escapeDocsMarkdownHtml(target.title)}"`;
+    if (image) {
+      const alt = unescapeDocsMarkdownPunctuation(label)
+        .replace(/<[^>]+>/g, "")
+        .replace(/[*_~`]/g, "");
+      output += `<img src="${escapeDocsMarkdownHtml(target.destination)}" alt="${escapeDocsMarkdownHtml(alt)}" class="fd-docs-content-img" loading="lazy" decoding="async"${titleAttribute} />`;
+    } else {
+      output += `<a href="${escapeDocsMarkdownHtml(target.destination)}"${titleAttribute}>${renderDocsMarkdownResources(
+        label,
+        definitions,
+      )}</a>`;
+    }
+    index = end;
+  }
+
+  return output;
+}
+
+function renderDocsMarkdownEmphasis(value: string): string {
+  return value
+    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(?<![\w])__([^_\n]+)__(?![\w])/g, "<strong>$1</strong>")
+    .replace(/\*([^*\n]+)\*/g, "<em>$1</em>")
+    .replace(/(?<![\w])_([^_\n]+)_(?![\w])/g, "<em>$1</em>")
+    .replace(/~~([^~\n]+)~~/g, "<del>$1</del>");
+}
+
+function renderDocsMarkdownTextOutsideHtml(value: string): string {
+  let output = "";
+  let textStart = 0;
+  let index = 0;
+
+  while (index < value.length) {
+    const htmlTagEnd = readDocsMarkdownHtmlTagEnd(value, index);
+    if (htmlTagEnd < 0) {
+      index += 1;
+      continue;
+    }
+
+    output += renderDocsMarkdownEmphasis(value.slice(textStart, index));
+    output += value.slice(index, htmlTagEnd + 1);
+    index = htmlTagEnd + 1;
+    textStart = index;
+  }
+
+  output += renderDocsMarkdownEmphasis(value.slice(textStart));
+  return output;
+}
+
+export function renderDocsMarkdownInline(
+  value: string,
+  definitions: DocsMarkdownReferenceDefinitions,
+): string {
+  const literals: Array<{ html: string; token: string }> = [];
+  const literalTokens = new Set<string>();
+  const protectLiteral = (html: string): string => {
+    const token = createDocsMarkdownTransportToken(value, "inline", literals.length, literalTokens);
+    literalTokens.add(token);
+    literals.push({ html, token });
+    return token;
+  };
+  let protectedValue = value.replace(
+    /(`+)([\s\S]*?)\1/g,
+    (_match, _ticks: string, code: string) => {
+      const normalized = code.replace(/\s+/g, " ");
+      const visible =
+        normalized.length > 2 &&
+        normalized.startsWith(" ") &&
+        normalized.endsWith(" ") &&
+        normalized.trim()
+          ? normalized.slice(1, -1)
+          : normalized;
+      return protectLiteral(`<code>${escapeDocsMarkdownHtml(visible)}</code>`);
+    },
+  );
+  protectedValue = protectedValue.replace(
+    /\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/g,
+    (_match, punctuation: string) => protectLiteral(escapeDocsMarkdownHtml(punctuation)),
+  );
+
+  let rendered = renderDocsMarkdownTextOutsideHtml(
+    renderDocsMarkdownResources(protectedValue, definitions),
+  );
+  for (const literal of literals) {
+    rendered = rendered.split(literal.token).join(literal.html);
+  }
+  return rendered;
+}
+
+export function renderDocsMarkdownBlockContent(
+  value: string,
+  definitions: DocsMarkdownReferenceDefinitions,
+): string {
+  const output: string[] = [];
+  let paragraphLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) return;
+    output.push(
+      `<p>${paragraphLines
+        .map((line) => renderDocsMarkdownInline(line, definitions))
+        .join("<br />")}</p>`,
+    );
+    paragraphLines = [];
+  };
+
+  for (const line of value.trim().split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flushParagraph();
+      continue;
+    }
+
+    const heading = trimmed.match(/^<h([1-6])\b([^>]*)>([\s\S]*)<\/h\1>$/);
+    if (heading) {
+      flushParagraph();
+      output.push(
+        `<h${heading[1]}${heading[2]}>${renderDocsMarkdownInline(
+          heading[3],
+          definitions,
+        )}</h${heading[1]}>`,
+      );
+      continue;
+    }
+
+    if (/^<(?:pre|ul|ol|blockquote|hr|table|div|figure)\b/.test(trimmed)) {
+      flushParagraph();
+      output.push(trimmed);
+      continue;
+    }
+
+    if (/^%%CODEBLOCK_\d+%%$/.test(trimmed)) {
+      flushParagraph();
+      output.push(trimmed);
+      continue;
+    }
+
+    paragraphLines.push(trimmed);
+  }
+
+  flushParagraph();
+  return output.join("");
+}
+
+/**
+ * Hoist canonical headings out of component bodies before those bodies are
+ * rendered as cards, tabs, or literal prompt text.
+ *
+ * A heading must still carry an opening-tag transport token created by
+ * `renderDocsMarkdownHeadings`. Authored raw `<h*>` HTML is deliberately left
+ * in `content`, so a literal renderer such as Prompt can escape it instead of
+ * accidentally promoting its attributes to live HTML.
+ */
+export function extractDocsRenderedHeadingElements(
+  value: string,
+  definitions: DocsMarkdownReferenceDefinitions,
+  preserveText = true,
+  openingTags: readonly DocsMarkdownHeadingOpeningTag[] = [],
+): { headingsHtml: string; content: string } {
+  const headings: string[] = [];
+  const output: string[] = [];
+  const protectedHeadings = openingTags.flatMap((openingTag) => {
+    const level = openingTag.html.match(/^<h([1-6])\b[^>]*>$/)?.[1];
+    return level ? [{ ...openingTag, level }] : [];
+  });
+  let openFence:
+    | {
+        containers: DocsMarkdownFenceContainer[];
+        length: number;
+        marker: "`" | "~";
+      }
+    | undefined;
+
+  for (const lineWithEnding of value.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? []) {
+    if (!lineWithEnding) continue;
+    const ending = lineWithEnding.match(/(?:\r\n|\n|\r)$/)?.[0] ?? "";
+    const line = ending ? lineWithEnding.slice(0, -ending.length) : lineWithEnding;
+
+    if (openFence) {
+      const continuedContent =
+        openFence.containers.length === 0
+          ? line
+          : continueDocsMarkdownFenceContainerLine(line, openFence.containers);
+      if (continuedContent !== undefined) {
+        output.push(lineWithEnding);
+        const marker = openFence.marker === "`" ? "`" : "~";
+        if (new RegExp(`^ {0,3}${marker}{${openFence.length},}[\\t ]*$`).test(continuedContent)) {
+          openFence = undefined;
+        }
+        continue;
+      }
+      openFence = undefined;
+    }
+
+    const containerLine = splitDocsMarkdownFenceContainerLine(line);
+    const openingFence = containerLine.content.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (openingFence) {
+      openFence = {
+        containers: containerLine.containers,
+        length: openingFence[1].length,
+        marker: openingFence[1][0] as "`" | "~",
+      };
+      output.push(lineWithEnding);
+      continue;
+    }
+
+    let renderedLine = line;
+    for (const protectedHeading of protectedHeadings) {
+      const tokenIndex = renderedLine.indexOf(protectedHeading.token);
+      if (tokenIndex < 0) continue;
+      const contentStart = tokenIndex + protectedHeading.token.length;
+      const closingTag = `</h${protectedHeading.level}>`;
+      const contentEnd = renderedLine.indexOf(closingTag, contentStart);
+      if (contentEnd < 0) continue;
+
+      const inner = renderedLine.slice(contentStart, contentEnd);
+      headings.push(
+        `${protectedHeading.html}${renderDocsMarkdownInline(inner, definitions)}${closingTag}`,
+      );
+      renderedLine =
+        renderedLine.slice(0, tokenIndex) +
+        (preserveText ? inner.replace(/<[^>]+>/g, "").trim() : "") +
+        renderedLine.slice(contentEnd + closingTag.length);
+    }
+    output.push(`${renderedLine}${ending}`);
+  }
+
+  return { headingsHtml: headings.join("\n"), content: output.join("") };
+}

--- a/packages/docs/src/markdown-sections.test.ts
+++ b/packages/docs/src/markdown-sections.test.ts
@@ -6,8 +6,10 @@ import {
   applyDocsMarkdownHeadingAnchors,
   createDocsMarkdownHeadingAnchorResolver,
   createDocsRenderedHeadingAnchorResolver,
+  findDocsGeneratedAgentContractRanges,
   findDocsMarkdownSection,
   parseDocsMarkdownSections,
+  stripDocsGeneratedAgentContractMarkers,
 } from "./markdown-sections.js";
 
 interface TestMarkdownAstNode {
@@ -149,9 +151,68 @@ describe("canonical Markdown heading anchors", () => {
   });
 
   it("keeps Prompt headings excluded when malformed MDX requires the fallback parser", () => {
-    const markdown = ["<Prompt>", "## Hidden", "</Prompt>", "", "## Visible", "", "{invalid"].join(
-      "\n",
-    );
+    const markdown = [
+      "<Prompt>",
+      "## Hidden",
+      "</Prompt>",
+      "",
+      "## Use `<Prompt>` safely",
+      "",
+      "Visible code-span example.",
+      "",
+      "## [Read `<Prompt>` guidance](/prompt)",
+      "",
+      "Visible link-label example.",
+      "",
+      "{invalid",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "use-prompt-safely",
+      "read-prompt-guidance",
+    ]);
+  });
+
+  it("keeps multiline Prompt tags excluded when malformed MDX requires fallback", () => {
+    const markdown = [
+      "<Prompt",
+      '  title="Copy > safely"',
+      "  providers={[",
+      '    "openai",',
+      '    "anthropic",',
+      "  ]}",
+      ">",
+      "## Hidden",
+      "</Prompt>",
+      "",
+      "## Visible",
+      "",
+      "{invalid",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "visible",
+    ]);
+  });
+
+  it("tracks multiline Prompt tags through fallback block containers", () => {
+    const markdown = [
+      "> <Prompt",
+      '>   title="Quoted copy"',
+      "> >",
+      "> ## Quoted hidden",
+      "> </Prompt>",
+      "",
+      "- <Prompt",
+      '  title="Listed copy"',
+      "  >",
+      "  ## Listed hidden",
+      "  </Prompt>",
+      "",
+      "## Visible",
+      "",
+      "{invalid",
+    ].join("\n");
 
     expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
       "visible",
@@ -336,6 +397,76 @@ describe("canonical Markdown heading anchors", () => {
     expect(root.children[0]?.children[1]?.value).toBe("");
   });
 
+  it("preserves unresolved AST reference syntax when assigning rendered anchors", () => {
+    const root = {
+      type: "root",
+      children: [
+        {
+          type: "heading",
+          children: [
+            {
+              type: "linkReference",
+              identifier: "missing",
+              label: "missing",
+              referenceType: "full",
+              children: [{ type: "text", value: "Guide" }],
+            },
+            { type: "text", value: " Setup" },
+          ],
+        },
+        {
+          type: "heading",
+          children: [
+            {
+              type: "imageReference",
+              identifier: "missing-image",
+              label: "missing-image",
+              referenceType: "full",
+              alt: "Diagram",
+            },
+            { type: "text", value: " Setup" },
+          ],
+        },
+      ],
+    };
+
+    applyDocsMarkdownHeadingAnchors(root);
+
+    expect(
+      root.children.map(
+        (heading) =>
+          (heading as { data?: { hProperties?: { id?: string } } }).data?.hProperties?.id,
+      ),
+    ).toEqual(["guidemissing-setup", "diagrammissing-image-setup"]);
+  });
+
+  it("does not resolve outside headings from definitions inside literal Prompt content", () => {
+    const markdown = [
+      "## [Inside][prompt-ref] Setup",
+      "",
+      "## [Outside][outside-ref] Setup",
+      "",
+      "<Prompt>",
+      "[prompt-ref]: /prompt-only",
+      "</Prompt>",
+      "",
+      "[outside-ref]: /outside",
+    ].join("\n");
+
+    expect(
+      parseDocsMarkdownSections(markdown).map(({ title, anchor }) => ({ title, anchor })),
+    ).toEqual([
+      {
+        title: "[Inside][prompt-ref] Setup",
+        anchor: "insideprompt-ref-setup",
+      },
+      {
+        title: "Outside Setup",
+        anchor: "outside-setup",
+      },
+    ]);
+  });
+
   it("matches rendered AST labels for balanced destinations, escapes, tags, and containers", () => {
     const markdown = [
       "## [Balanced](https://example.com/a_(b)c) Link",
@@ -396,7 +527,8 @@ describe("canonical Markdown heading anchors", () => {
       "        [Indented definition]: /indented.png",
     ].join("\n");
 
-    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+    const sections = parseDocsMarkdownSections(markdown);
+    expect(sections.map((section) => section.anchor)).toEqual([
       "setup",
       "setup-1",
       "missing-shortcut-setup",
@@ -407,6 +539,29 @@ describe("canonical Markdown heading anchors", () => {
       "defined-link-setup",
       "missing-linkmissing-guide-setup",
     ]);
+    expect(sections[2]?.title).toBe("![Missing shortcut] Setup");
+    expect(sections[4]?.title).toBe("![Missing full][missing] Setup");
+    expect(sections[8]?.title).toBe("[Missing link][missing-guide] Setup");
+  });
+
+  it("keeps fenced contract-marker examples outside generated contract ranges", () => {
+    const markdown = [
+      "```md",
+      "<!-- farming-labs:agent-contract:start -->",
+      "<!-- farming-labs:agent-contract:end -->",
+      "```",
+      "",
+      "<!-- farming-labs:agent-contract:start -->",
+      "## Agent Contract",
+      "<!-- farming-labs:agent-contract:end -->",
+    ].join("\n");
+
+    expect(findDocsGeneratedAgentContractRanges(markdown)).toEqual([{ startLine: 6, endLine: 8 }]);
+    const cleaned = stripDocsGeneratedAgentContractMarkers(markdown);
+    expect(cleaned.match(/farming-labs:agent-contract:start/gu)).toHaveLength(1);
+    expect(cleaned.match(/farming-labs:agent-contract:end/gu)).toHaveLength(1);
+    expect(cleaned).toContain("```md\n<!-- farming-labs:agent-contract:start -->");
+    expect(cleaned).toContain("## Agent Contract");
   });
 
   it("ends container-scoped fences when their container ends", () => {

--- a/packages/docs/src/markdown-sections.test.ts
+++ b/packages/docs/src/markdown-sections.test.ts
@@ -1,0 +1,693 @@
+import { compile } from "@mdx-js/mdx";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vitest";
+import { renderPageAgentContractMarkdown } from "./agent-contract.js";
+import {
+  applyDocsMarkdownHeadingAnchors,
+  createDocsMarkdownHeadingAnchorResolver,
+  createDocsRenderedHeadingAnchorResolver,
+  findDocsMarkdownSection,
+  parseDocsMarkdownSections,
+} from "./markdown-sections.js";
+
+interface TestMarkdownAstNode {
+  type?: string;
+  children?: TestMarkdownAstNode[];
+  data?: {
+    hProperties?: {
+      id?: unknown;
+    };
+  };
+}
+
+async function compileDocsMarkdownHeadingAnchors(markdown: string): Promise<string[]> {
+  const anchors: string[] = [];
+
+  await compile(markdown, {
+    remarkPlugins: [
+      remarkGfm,
+      () => (tree: unknown) => {
+        applyDocsMarkdownHeadingAnchors(tree);
+        const visit = (node: TestMarkdownAstNode): void => {
+          if (node.type === "heading") {
+            const id = node.data?.hProperties?.id;
+            if (typeof id === "string") anchors.push(id);
+            return;
+          }
+          for (const child of node.children ?? []) visit(child);
+        };
+        visit(tree as TestMarkdownAstNode);
+      },
+    ],
+  });
+
+  return anchors;
+}
+
+describe("canonical Markdown heading anchors", () => {
+  it("assigns rendered headings before generated agent-only contract headings", () => {
+    const contract = renderPageAgentContractMarkdown({
+      task: "Run the generated contract task.",
+      outcome: "The generated contract outcome is available.",
+      prerequisites: ["Generated prerequisite collision marker."],
+    });
+    const markdown = [
+      contract,
+      "",
+      "## Authored [#agent-contract]",
+      "",
+      "Authored collision marker.",
+      "",
+      "## Prerequisites",
+      "",
+      "Authored prerequisite collision marker.",
+    ].join("\n");
+
+    for (const document of [markdown, `${markdown}\n\n{`]) {
+      expect(
+        parseDocsMarkdownSections(document).map(({ title, anchor }) => ({ title, anchor })),
+      ).toEqual([
+        { title: "Agent Contract", anchor: "agent-contract-1" },
+        { title: "Prerequisites", anchor: "prerequisites-1" },
+        { title: "Authored", anchor: "agent-contract" },
+        { title: "Prerequisites", anchor: "prerequisites" },
+      ]);
+      expect(findDocsMarkdownSection(document, "agent-contract")?.content).toContain(
+        "Authored collision marker.",
+      );
+      expect(findDocsMarkdownSection(document, "agent-contract-1")?.content).toContain(
+        "generated contract outcome",
+      );
+    }
+  });
+
+  it("preserves Unicode, explicit ids, duplicate order, and slug collisions", () => {
+    const markdown = [
+      "# Café 配置",
+      "",
+      "## Overview [#release-overview]",
+      "",
+      "## Repeat",
+      "",
+      "First.",
+      "",
+      "### Repeat",
+      "",
+      "Second.",
+      "",
+      "## Repeat",
+      "",
+      "Third.",
+      "",
+      "## Foo",
+      "",
+      "## Foo",
+      "",
+      "## Foo-1",
+      "",
+      "## 🚜",
+      "",
+      "Fallback.",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "café-配置",
+      "release-overview",
+      "repeat",
+      "repeat-1",
+      "repeat-2",
+      "foo",
+      "foo-1",
+      "foo-1-1",
+      "section-8",
+    ]);
+  });
+
+  it("excludes literal Prompt headings without reserving their anchors", () => {
+    const markdown = [
+      "<Prompt>",
+      "## Repeat [#prompt-only]",
+      "",
+      "Use this as literal input.",
+      "</Prompt>",
+      "",
+      "## Repeat",
+      "",
+      "Visible section.",
+      "",
+      "<Callout>",
+      "## Nested",
+      "</Callout>",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "repeat",
+      "nested",
+    ]);
+    expect(findDocsMarkdownSection(markdown, "#prompt-only")).toBeUndefined();
+    expect(findDocsMarkdownSection(markdown, "#repeat")?.content).toContain("Visible section.");
+  });
+
+  it("keeps Prompt headings excluded when malformed MDX requires the fallback parser", () => {
+    const markdown = ["<Prompt>", "## Hidden", "</Prompt>", "", "## Visible", "", "{invalid"].join(
+      "\n",
+    );
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "visible",
+    ]);
+  });
+
+  it("uses visible inline labels and resolves encoded fragments", () => {
+    const markdown = [
+      "## [Install the CLI](https://example.com) & `verify`",
+      "",
+      "Run the command.",
+      "",
+      "## API foo_bar",
+      "",
+      "Use the literal identifier.",
+      "",
+      "## Foo &eacute; Bar",
+      "",
+      "Decode named entities.",
+      "",
+      "## ![Rocket](rocket.png) Setup",
+      "",
+      "Ignore image alt text.",
+      "",
+      "## Use `[#literal-id]`",
+      "",
+      "Keep inline code literal.",
+      "",
+      "## &lt;API&gt; Setup",
+      "",
+      "Decode encoded tag-like text.",
+      "",
+      "## `&eacute;` code",
+      "",
+      "Do not decode entities inside code.",
+      "",
+      "## Invalid &#xD800; reference",
+      "",
+      "Use the HTML replacement character.",
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections[0]).toMatchObject({
+      title: "Install the CLI & verify",
+      anchor: "install-the-cli--verify",
+    });
+    expect(sections[1]).toMatchObject({
+      title: "API foo_bar",
+      anchor: "api-foo_bar",
+    });
+    expect(sections[2]).toMatchObject({
+      title: "Foo é Bar",
+      anchor: "foo-é-bar",
+    });
+    expect(sections[3]).toMatchObject({
+      title: "Setup",
+      anchor: "setup",
+    });
+    expect(sections[4]).toMatchObject({
+      title: "Use [#literal-id]",
+      anchor: "use-literal-id",
+    });
+    expect(sections[5]).toMatchObject({
+      title: "<API> Setup",
+      anchor: "api-setup",
+    });
+    expect(sections[6]).toMatchObject({
+      title: "&eacute; code",
+      anchor: "eacute-code",
+    });
+    expect(sections[7]).toMatchObject({
+      title: "Invalid � reference",
+      anchor: "invalid--reference",
+    });
+    expect(
+      findDocsMarkdownSection(markdown, "/docs/install#install-the-cli--verify")?.content,
+    ).toContain("Run the command.");
+  });
+
+  it("returns source without the custom-id marker for rendered headings", () => {
+    const resolveHeading = createDocsMarkdownHeadingAnchorResolver();
+
+    expect(resolveHeading("Overview [#release-overview]")).toEqual({
+      source: "Overview",
+      title: "Overview",
+      anchor: "release-overview",
+      explicit: true,
+    });
+    expect(resolveHeading("安装")).toMatchObject({
+      source: "安装",
+      title: "安装",
+      anchor: "安装",
+      explicit: false,
+    });
+  });
+
+  it("keeps generated, explicit, and case-sensitive anchors uniquely addressable", () => {
+    const markdown = [
+      "## Custom [#foo]",
+      "",
+      "First.",
+      "",
+      "## Foo",
+      "",
+      "Second.",
+      "",
+      "## Duplicate custom [#foo]",
+      "",
+      "Third.",
+      "",
+      "## Upper [#Foo]",
+      "",
+      "Uppercase.",
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections.map((section) => section.anchor)).toEqual(["foo", "foo-1", "foo-2", "Foo"]);
+    expect(findDocsMarkdownSection(markdown, "#foo")?.content).toContain("First.");
+    expect(findDocsMarkdownSection(markdown, "#Foo")?.content).toContain("Uppercase.");
+    expect(findDocsMarkdownSection(markdown, "#FOO")).toBeUndefined();
+  });
+
+  it("round-trips encoded reserved ids from full section URLs", () => {
+    const markdown = [
+      "## Hash [#foo#bar]",
+      "",
+      "Hash content.",
+      "",
+      "## Percent [#foo%23bar]",
+      "",
+      "Percent content.",
+      "",
+      "## Leading [##foo]",
+      "",
+      "Leading content.",
+    ].join("\n");
+
+    expect(
+      findDocsMarkdownSection(markdown, "https://example.com/docs/page#foo%23bar")?.anchor,
+    ).toBe("foo#bar");
+    expect(
+      findDocsMarkdownSection(markdown, "https://example.com/docs/page#foo%2523bar")?.anchor,
+    ).toBe("foo%23bar");
+    expect(findDocsMarkdownSection(markdown, "https://example.com/docs/page#%23foo")?.anchor).toBe(
+      "#foo",
+    );
+  });
+
+  it("separates raw Markdown parsing from flattened renderer text", () => {
+    const resolveRendered = createDocsRenderedHeadingAnchorResolver();
+
+    expect(resolveRendered("Use [#foo]")).toMatchObject({
+      title: "Use [#foo]",
+      anchor: "use-foo",
+      explicit: false,
+    });
+
+    const root = {
+      type: "root",
+      children: [
+        {
+          type: "heading",
+          children: [
+            { type: "text", value: "Custom " },
+            { type: "text", value: "[#foo]" },
+          ],
+        },
+        {
+          type: "heading",
+          children: [{ type: "text", value: "Foo" }],
+        },
+      ],
+    };
+    applyDocsMarkdownHeadingAnchors(root);
+
+    expect(
+      root.children.map(
+        (heading) =>
+          (heading as { data?: { hProperties?: { id?: string } } }).data?.hProperties?.id,
+      ),
+    ).toEqual(["foo", "foo-1"]);
+    expect(root.children[0]?.children[1]?.value).toBe("");
+  });
+
+  it("matches rendered AST labels for balanced destinations, escapes, tags, and containers", () => {
+    const markdown = [
+      "## [Balanced](https://example.com/a_(b)c) Link",
+      "",
+      "## ![Rocket](assets/a(b).png) Setup",
+      "",
+      "## ![Rocket] Shortcut setup",
+      "",
+      "## \\[literal\\](url) text",
+      "",
+      '## Hello <Badge title="a > b">New</Badge> World',
+      "",
+      "> ## Quoted",
+      "",
+      "- ## Listed",
+      "",
+      "[Rocket]: /rocket.png",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "balanced-link",
+      "setup",
+      "shortcut-setup",
+      "literalurl-text",
+      "hello-new-world",
+      "quoted",
+      "listed",
+    ]);
+  });
+
+  it("only removes reference images when their definitions resolve", () => {
+    const markdown = [
+      "## ![Inline](inline.png) Setup",
+      "",
+      "## ![Defined shortcut] Setup",
+      "",
+      "## ![Missing shortcut] Setup",
+      "",
+      "## ![Defined full][asset] Setup",
+      "",
+      "## ![Missing full][missing] Setup",
+      "",
+      "## ![Fenced shortcut] Setup",
+      "",
+      "## ![Indented definition] Setup",
+      "",
+      "## [Defined link][guide] Setup",
+      "",
+      "## [Missing link][missing-guide] Setup",
+      "",
+      "```md",
+      "[Fenced shortcut]: /ignored.png",
+      "```",
+      "",
+      "[Defined shortcut]: /shortcut.png",
+      "[asset]: /asset.png",
+      "[guide]: /guide",
+      "        [Indented definition]: /indented.png",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "setup",
+      "setup-1",
+      "missing-shortcut-setup",
+      "setup-2",
+      "missing-fullmissing-setup",
+      "fenced-shortcut-setup",
+      "setup-3",
+      "defined-link-setup",
+      "missing-linkmissing-guide-setup",
+    ]);
+  });
+
+  it("ends container-scoped fences when their container ends", () => {
+    const markdown = [
+      "> ```md",
+      "> # Quoted code",
+      "",
+      "## After quote fence",
+      "",
+      "- ```md",
+      "  # Listed code",
+      "",
+      "  ## Still listed code",
+      "  ```",
+      "",
+      "## After list fence",
+      "",
+      "```md",
+      "> ```",
+      "## Still top-level code",
+      "```",
+      "",
+      "## Visible",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(markdown).map((section) => section.anchor)).toEqual([
+      "after-quote-fence",
+      "after-list-fence",
+      "visible",
+    ]);
+  });
+
+  it("matches Setext underlines by semantic container nesting", () => {
+    const markdown = [
+      "> Quoted",
+      ">===",
+      "",
+      "- Listed",
+      "  ===",
+      "",
+      "> > Nested",
+      ">>---",
+      "",
+      "- Different item",
+      "- ---",
+    ].join("\n");
+
+    expect(
+      parseDocsMarkdownSections(markdown).map(({ anchor, level }) => ({ anchor, level })),
+    ).toEqual([
+      { anchor: "quoted", level: 1 },
+      { anchor: "listed", level: 1 },
+      { anchor: "nested", level: 2 },
+    ]);
+  });
+
+  it("uses the full Setext paragraph and ignores definitions before thematic breaks", async () => {
+    const markdown = [
+      "First line",
+      "second line",
+      "---",
+      "",
+      "Setext content.",
+      "",
+      "[guide]: /guide",
+      "---",
+      "",
+      "## Visible",
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections.map(({ title, anchor, startLine }) => ({ title, anchor, startLine }))).toEqual([
+      {
+        title: "First line second line",
+        anchor: "first-line-second-line",
+        startLine: 1,
+      },
+      { title: "Visible", anchor: "visible", startLine: 10 },
+    ]);
+    expect(sections.map((section) => section.anchor)).toEqual(
+      await compileDocsMarkdownHeadingAnchors(markdown),
+    );
+  });
+
+  it("matches the MDX AST for nested resources and strict destinations", async () => {
+    const markdown = [
+      "## [![Rocket](rocket.png)](/home) Setup",
+      "",
+      "## [Guide][missing] Setup",
+      "",
+      "## ![Rocket](not valid) Setup",
+      "",
+      '## [Reference](url "title) value")',
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections.map(({ title, anchor }) => ({ title, anchor }))).toEqual([
+      { title: "Setup", anchor: "setup" },
+      {
+        title: "[Guide][missing] Setup",
+        anchor: "guidemissing-setup",
+      },
+      {
+        title: "![Rocket](not valid) Setup",
+        anchor: "rocketnot-valid-setup",
+      },
+      { title: "Reference", anchor: "reference" },
+    ]);
+    expect(sections.map((section) => section.anchor)).toEqual(
+      await compileDocsMarkdownHeadingAnchors(markdown),
+    );
+  });
+
+  it("matches GFM footnotes, strikethrough, and reference-aware custom ids", async () => {
+    const markdown = [
+      "## Install[^note] ~~safely~~",
+      "",
+      "## Resolved marker [#linked-id]",
+      "",
+      "## Escaped marker \\[#explicit-id]",
+      "",
+      "## Plain marker [#plain-id]",
+      "",
+      "[^note]: Use the supported version.",
+      "",
+      "[#linked-id]: /reference",
+      "",
+      "[#explicit-id]: /also-a-reference",
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections.map(({ title, anchor, explicit }) => ({ title, anchor, explicit }))).toEqual([
+      { title: "Install safely", anchor: "install-safely", explicit: false },
+      {
+        title: "Resolved marker #linked-id",
+        anchor: "resolved-marker-linked-id",
+        explicit: false,
+      },
+      { title: "Escaped marker", anchor: "explicit-id", explicit: true },
+      { title: "Plain marker", anchor: "plain-id", explicit: true },
+    ]);
+    expect(sections.map((section) => section.anchor)).toEqual(
+      await compileDocsMarkdownHeadingAnchors(markdown),
+    );
+  });
+
+  it("skips MDX comments and ESM while retaining headings nested in components", async () => {
+    const markdown = [
+      "export const example = `",
+      "## Hidden ESM",
+      "`",
+      "",
+      "{/*",
+      "## Hidden comment",
+      "*/}",
+      "",
+      "<Callout>",
+      "## Nested visible",
+      "</Callout>",
+      "",
+      "# Visible",
+    ].join("\n");
+    const sections = parseDocsMarkdownSections(markdown);
+
+    expect(sections.map(({ title, anchor }) => ({ title, anchor }))).toEqual([
+      { title: "Nested visible", anchor: "nested-visible" },
+      { title: "Visible", anchor: "visible" },
+    ]);
+    expect(sections.map((section) => section.anchor)).toEqual(
+      await compileDocsMarkdownHeadingAnchors(markdown),
+    );
+  });
+
+  it("keeps frontmatter out of section discovery and falls back for malformed MDX", () => {
+    const withFrontmatter = ["---", "title: Not a heading", "---", "# Visible"].join("\n");
+    const withBomFrontmatter = `\uFEFF${withFrontmatter}`;
+    const malformed = [
+      "## Resolved [#linked-id]",
+      "",
+      "[#linked-id]: /reference",
+      "",
+      "## Explicit \\[#custom-id]",
+      "",
+      "{",
+      "",
+      "## After",
+    ].join("\n");
+
+    expect(parseDocsMarkdownSections(withFrontmatter)).toMatchObject([
+      { title: "Visible", anchor: "visible", startLine: 1 },
+    ]);
+    expect(parseDocsMarkdownSections(withBomFrontmatter)).toMatchObject([
+      { title: "Visible", anchor: "visible", startLine: 1 },
+    ]);
+    expect(
+      parseDocsMarkdownSections(malformed).map(({ title, anchor, explicit }) => ({
+        title,
+        anchor,
+        explicit,
+      })),
+    ).toEqual([
+      {
+        title: "Resolved #linked-id",
+        anchor: "resolved-linked-id",
+        explicit: false,
+      },
+      { title: "Explicit", anchor: "custom-id", explicit: true },
+      { title: "After", anchor: "after", explicit: false },
+    ]);
+  });
+
+  it("keeps malformed-MDX fallback out of ESM templates and comments", () => {
+    const malformed = [
+      "export const example = `",
+      "## Hidden ESM",
+      "[#visible-id]: /wrong-reference",
+      "`",
+      "",
+      "{/*",
+      "## Hidden MDX comment",
+      "[#visible-id]: /also-wrong",
+      "*/}",
+      "",
+      "<!--",
+      "## Hidden HTML comment",
+      "-->",
+      "",
+      "## Visible [#visible-id]",
+      "",
+      "{",
+      "",
+      "## After malformed expression",
+    ].join("\n");
+
+    expect(
+      parseDocsMarkdownSections(malformed).map(({ title, anchor, explicit }) => ({
+        title,
+        anchor,
+        explicit,
+      })),
+    ).toEqual([
+      { title: "Visible", anchor: "visible-id", explicit: true },
+      {
+        title: "After malformed expression",
+        anchor: "after-malformed-expression",
+        explicit: false,
+      },
+    ]);
+  });
+
+  it("keeps multiline Setext headings canonical in malformed-MDX fallback", () => {
+    const malformed = [
+      "First *line*",
+      "second `line`",
+      "---",
+      "",
+      "{",
+      "",
+      "## After malformed expression",
+    ].join("\n");
+
+    expect(
+      parseDocsMarkdownSections(malformed).map(({ title, anchor, level, startLine }) => ({
+        title,
+        anchor,
+        level,
+        startLine,
+      })),
+    ).toEqual([
+      {
+        title: "First line second line",
+        anchor: "first-line-second-line",
+        level: 2,
+        startLine: 1,
+      },
+      {
+        title: "After malformed expression",
+        anchor: "after-malformed-expression",
+        level: 2,
+        startLine: 7,
+      },
+    ]);
+  });
+});

--- a/packages/docs/src/markdown-sections.ts
+++ b/packages/docs/src/markdown-sections.ts
@@ -65,6 +65,13 @@ interface DocsMarkdownFallbackEsmState {
   quote?: "'" | '"' | "`";
 }
 
+interface DocsMarkdownFallbackPromptTagState {
+  braceDepth: number;
+  closing: boolean;
+  lastNonWhitespace: string;
+  quote?: "'" | '"' | "`";
+}
+
 export interface DocsMarkdownHeadingAnchor {
   /** Heading source without a trailing Fumadocs custom-id marker. */
   source: string;
@@ -91,6 +98,10 @@ interface DocsMarkdownAstNode {
   name?: unknown;
   depth?: unknown;
   value?: unknown;
+  alt?: unknown;
+  identifier?: unknown;
+  label?: unknown;
+  referenceType?: unknown;
   children?: DocsMarkdownAstNode[];
   position?: {
     start?: {
@@ -475,9 +486,70 @@ export function createDocsMarkdownHeadingAnchorResolver(): (
   return createDocsMarkdownHeadingAnchorResolverWithReferences();
 }
 
-function flattenDocsMarkdownAstNode(node: DocsMarkdownAstNode): string {
+function collectDocsMarkdownAstReferenceDefinitions(
+  root: DocsMarkdownAstNode,
+): ReadonlySet<string> {
+  const definitions = new Set<string>();
+
+  const visit = (node: DocsMarkdownAstNode): void => {
+    if (isDocsMarkdownLiteralPrompt(node)) return;
+    if (node.type === "definition" && typeof node.identifier === "string") {
+      definitions.add(normalizeDocsMarkdownReferenceLabel(node.identifier));
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+
+  visit(root);
+  return definitions;
+}
+
+function formatDocsMarkdownAstReference(
+  node: DocsMarkdownAstNode,
+  definedReferences: ReadonlySet<string>,
+): string {
+  const image = node.type === "imageReference";
+  const identifier =
+    typeof node.identifier === "string" ? normalizeDocsMarkdownReferenceLabel(node.identifier) : "";
+  const resolved = Boolean(identifier) && definedReferences.has(identifier);
+  if (resolved) {
+    return image
+      ? ""
+      : (node.children ?? [])
+          .map((child) => flattenDocsMarkdownAstNode(child, definedReferences))
+          .join("");
+  }
+
+  const visibleLabel = image
+    ? typeof node.alt === "string"
+      ? node.alt
+      : ""
+    : (node.children ?? [])
+        .map((child) => flattenDocsMarkdownAstNode(child, definedReferences))
+        .join("");
+  const referenceLabel =
+    typeof node.label === "string"
+      ? node.label
+      : typeof node.identifier === "string"
+        ? node.identifier
+        : visibleLabel;
+  const prefix = image ? "!" : "";
+
+  if (node.referenceType === "collapsed") return `${prefix}[${visibleLabel}][]`;
+  if (node.referenceType === "shortcut") return `${prefix}[${visibleLabel}]`;
+  return `${prefix}[${visibleLabel}][${referenceLabel}]`;
+}
+
+function flattenDocsMarkdownAstNode(
+  node: DocsMarkdownAstNode,
+  definedReferences: ReadonlySet<string>,
+): string {
+  if (node.type === "linkReference" || node.type === "imageReference") {
+    return formatDocsMarkdownAstReference(node, definedReferences);
+  }
   if (Array.isArray(node.children)) {
-    return node.children.map((child) => flattenDocsMarkdownAstNode(child)).join("");
+    return node.children
+      .map((child) => flattenDocsMarkdownAstNode(child, definedReferences))
+      .join("");
   }
   return typeof node.value === "string" ? node.value : "";
 }
@@ -497,6 +569,7 @@ function assignDocsMarkdownAstHeadingAnchors(
 ): DocsMarkdownAstHeadingCandidate[] {
   const customId = options.customId ?? true;
   const headings: DocsMarkdownAstHeadingCandidate[] = [];
+  const definedReferences = collectDocsMarkdownAstReferenceDefinitions(root);
 
   const visit = (node: DocsMarkdownAstNode): void => {
     if (isDocsMarkdownLiteralPrompt(node)) return;
@@ -515,7 +588,7 @@ function assignDocsMarkdownAstHeadingAnchors(
       const existingAnchor = node.data?.hProperties?.id;
       headings.push({
         node,
-        title: cleanDocsRenderedHeadingLabel(flattenDocsMarkdownAstNode(node)),
+        title: cleanDocsRenderedHeadingLabel(flattenDocsMarkdownAstNode(node, definedReferences)),
         explicit: Boolean(explicitAnchor),
         explicitAnchor:
           explicitAnchor || (typeof existingAnchor === "string" ? existingAnchor : undefined),
@@ -761,60 +834,96 @@ function scanDocsMarkdownFallbackEsmLine(
   );
 }
 
-function scanDocsMarkdownLiteralPromptTags(value: string): {
+function scanDocsMarkdownLiteralPromptTags(
+  value: string,
+  initialState?: DocsMarkdownFallbackPromptTagState,
+): {
   delta: number;
   found: boolean;
+  pending?: DocsMarkdownFallbackPromptTagState;
 } {
   let delta = 0;
-  let found = false;
+  let found = Boolean(initialState);
+  let pending = initialState;
+  let index = 0;
 
-  for (let index = 0; index < value.length; index += 1) {
-    if (value[index] !== "<") continue;
-    const closing = value[index + 1] === "/";
-    const nameStart = index + (closing ? 2 : 1);
-    if (value.slice(nameStart, nameStart + 6) !== "Prompt") continue;
-    const boundary = value[nameStart + 6];
-    if (boundary && !/[\t\n\r />]/u.test(boundary)) continue;
+  while (index < value.length) {
+    if (!pending) {
+      const tagStart = value.indexOf("<", index);
+      if (tagStart < 0) break;
+      // Prompt is a flow component in the docs renderer. Restrict fallback
+      // detection to a tag at the start of the logical line so literal examples
+      // in headings, code spans, and link labels cannot hide later headings.
+      if (!found && value.slice(0, tagStart).trim()) {
+        index = tagStart + 1;
+        continue;
+      }
 
-    let quote: "'" | '"' | "`" | undefined;
-    let braceDepth = 0;
-    let end = nameStart + 6;
-    for (; end < value.length; end += 1) {
-      const character = value[end];
-      if (quote) {
+      const closing = value[tagStart + 1] === "/";
+      const nameStart = tagStart + (closing ? 2 : 1);
+      if (value.slice(nameStart, nameStart + 6) !== "Prompt") {
+        index = tagStart + 1;
+        continue;
+      }
+      const boundary = value[nameStart + 6];
+      if (boundary && !/[\t\n\r />]/u.test(boundary)) {
+        index = tagStart + 1;
+        continue;
+      }
+
+      pending = {
+        braceDepth: 0,
+        closing,
+        lastNonWhitespace: "t",
+      };
+      found = true;
+      index = nameStart + 6;
+    }
+
+    while (pending && index < value.length) {
+      const character = value[index];
+      if (pending.quote) {
         if (character === "\\") {
-          end += 1;
+          index += 2;
           continue;
         }
-        if (character === quote) quote = undefined;
+        if (character === pending.quote) pending.quote = undefined;
+        index += 1;
         continue;
       }
       if (character === "'" || character === '"' || character === "`") {
-        quote = character;
+        pending.quote = character;
+        index += 1;
         continue;
       }
       if (character === "{") {
-        braceDepth += 1;
+        pending.braceDepth += 1;
+        pending.lastNonWhitespace = character;
+        index += 1;
         continue;
       }
       if (character === "}") {
-        braceDepth = Math.max(0, braceDepth - 1);
+        pending.braceDepth = Math.max(0, pending.braceDepth - 1);
+        pending.lastNonWhitespace = character;
+        index += 1;
         continue;
       }
-      if (character === ">" && braceDepth === 0) break;
+      if (character === ">" && pending.braceDepth === 0) {
+        if (pending.closing) {
+          delta -= 1;
+        } else if (pending.lastNonWhitespace !== "/") {
+          delta += 1;
+        }
+        pending = undefined;
+        index += 1;
+        break;
+      }
+      if (!/\s/u.test(character)) pending.lastNonWhitespace = character;
+      index += 1;
     }
-    if (end >= value.length) continue;
-
-    found = true;
-    if (closing) {
-      delta -= 1;
-    } else if (!/\/[\t ]*>$/u.test(value.slice(index, end + 1))) {
-      delta += 1;
-    }
-    index = end;
   }
 
-  return { delta, found };
+  return { delta, found, ...(pending ? { pending } : {}) };
 }
 
 function collectDocsMarkdownFallbackIgnoredLines(lines: readonly string[]): ReadonlySet<number> {
@@ -823,10 +932,28 @@ function collectDocsMarkdownFallbackIgnoredLines(lines: readonly string[]): Read
   let htmlComment = false;
   let mdxComment = false;
   let literalPromptDepth = 0;
+  let literalPromptTagContainers: DocsMarkdownContainer[] = [];
+  let literalPromptTagState: DocsMarkdownFallbackPromptTagState | undefined;
   let openFence: OpenMarkdownFence | undefined;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
+
+    if (literalPromptTagState) {
+      const continuation =
+        literalPromptTagContainers.length > 0
+          ? continueDocsMarkdownContainerLine(line, literalPromptTagContainers)
+          : { content: line };
+      const promptTags = scanDocsMarkdownLiteralPromptTags(
+        continuation?.content ?? line,
+        literalPromptTagState,
+      );
+      ignored.add(index);
+      literalPromptDepth = Math.max(0, literalPromptDepth + promptTags.delta);
+      literalPromptTagState = promptTags.pending;
+      if (!literalPromptTagState) literalPromptTagContainers = [];
+      continue;
+    }
 
     if (!esmState && !htmlComment && !mdxComment && openFence) {
       const fenceLine = readDocsMarkdownFenceLine(line, openFence);
@@ -893,6 +1020,12 @@ function collectDocsMarkdownFallbackIgnoredLines(lines: readonly string[]): Read
     if (literalPromptDepth > 0 || promptTags.found) {
       ignored.add(index);
       literalPromptDepth = Math.max(0, literalPromptDepth + promptTags.delta);
+      literalPromptTagState = promptTags.pending;
+      if (literalPromptTagState) {
+        literalPromptTagContainers = containerLine.containers.map((container) => ({
+          ...container,
+        }));
+      }
     }
   }
 
@@ -959,14 +1092,6 @@ function collectGeneratedAgentContractRanges(markdown: string): DocsMarkdownLine
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
 
-    if (contractStart !== undefined) {
-      if (isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_END_MARKER)) {
-        ranges.push({ start: contractStart, end: index });
-        contractStart = undefined;
-      }
-      continue;
-    }
-
     if (openFence) {
       const fenceLine = readDocsMarkdownFenceLine(line, openFence);
       if (fenceLine) {
@@ -986,15 +1111,64 @@ function collectGeneratedAgentContractRanges(markdown: string): DocsMarkdownLine
       continue;
     }
 
-    if (
-      containerLine.containers.length === 0 &&
-      isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_START_MARKER)
-    ) {
+    if (containerLine.containers.length > 0) continue;
+
+    if (contractStart !== undefined) {
+      if (isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_END_MARKER)) {
+        ranges.push({ start: contractStart, end: index });
+        contractStart = undefined;
+      }
+    } else if (isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_START_MARKER)) {
       contractStart = index;
     }
   }
 
   return ranges;
+}
+
+export interface DocsGeneratedAgentContractRange {
+  /** 1-based line containing the generated contract start marker. */
+  startLine: number;
+  /** 1-based line containing the generated contract end marker. */
+  endLine: number;
+}
+
+/** Locate complete generated contract blocks while keeping fenced marker examples inert. */
+export function findDocsGeneratedAgentContractRanges(
+  markdown: string,
+): DocsGeneratedAgentContractRange[] {
+  return collectGeneratedAgentContractRanges(markdown).map(({ start, end }) => ({
+    startLine: start + 1,
+    endLine: end + 1,
+  }));
+}
+
+/** Remove only generated boundary markers that overlap a full document or derived fragment. */
+export function stripDocsGeneratedAgentContractMarkers(
+  markdown: string,
+  location?: {
+    /** Full Markdown source from which this fragment was selected. */
+    sourceMarkdown: string;
+    /** 1-based source line corresponding to the fragment's first line. */
+    startLine: number;
+  },
+): string {
+  const ranges = findDocsGeneratedAgentContractRanges(location?.sourceMarkdown ?? markdown);
+  if (ranges.length === 0) return markdown;
+
+  const markerLines = new Set<number>();
+  for (const range of ranges) {
+    markerLines.add(range.startLine);
+    markerLines.add(range.endLine);
+  }
+
+  const newline = markdown.includes("\r\n") ? "\r\n" : "\n";
+  const startLine = location?.startLine ?? 1;
+  const output = markdown
+    .split(/\r?\n/u)
+    .filter((_line, index) => !markerLines.has(startLine + index));
+  while (output[0] === "") output.shift();
+  return output.join(newline);
 }
 
 function isDocsMarkdownLineInRanges(

--- a/packages/docs/src/markdown-sections.ts
+++ b/packages/docs/src/markdown-sections.ts
@@ -1,6 +1,17 @@
+import { createProcessor } from "@mdx-js/mdx";
+import { slug as githubSlug } from "github-slugger";
+import { parseEntities } from "parse-entities";
+import remarkGfm from "remark-gfm";
+import {
+  PAGE_AGENT_CONTRACT_END_MARKER,
+  PAGE_AGENT_CONTRACT_START_MARKER,
+} from "./agent-contract.js";
+
 export interface DocsMarkdownSection {
   title: string;
   anchor: string;
+  /** Whether the heading consumed a trailing Fumadocs `[#custom-id]` marker. */
+  explicit: boolean;
   level: number;
   content: string;
   /** 1-based line containing the heading, relative to the Markdown body. */
@@ -12,72 +23,554 @@ export interface DocsMarkdownSection {
 interface ParsedDocsMarkdownHeading {
   title: string;
   anchor: string;
+  explicit: boolean;
   level: number;
   start: number;
+}
+
+interface UnresolvedDocsMarkdownHeading {
+  source: string;
+  level: number;
+  start: number;
+  resolved?: DocsMarkdownHeadingAnchor;
+}
+
+interface DocsMarkdownLineRange {
+  start: number;
+  end: number;
 }
 
 interface OpenMarkdownFence {
   marker: "`" | "~";
   length: number;
+  containers: DocsMarkdownContainer[];
 }
 
-const HTML_ENTITIES: Record<string, string> = {
-  amp: "&",
-  apos: "'",
-  gt: ">",
-  lt: "<",
-  nbsp: " ",
-  quot: '"',
-};
+interface DocsMarkdownContainer {
+  type: "blockquote" | "list";
+  continuationIndent: number;
+}
+
+interface DocsMarkdownContainerLine {
+  prefix: string;
+  content: string;
+  containers: DocsMarkdownContainer[];
+}
+
+interface DocsMarkdownFallbackEsmState {
+  blockComment: boolean;
+  braceDepth: number;
+  bracketDepth: number;
+  parenDepth: number;
+  quote?: "'" | '"' | "`";
+}
+
+export interface DocsMarkdownHeadingAnchor {
+  /** Heading source without a trailing Fumadocs custom-id marker. */
+  source: string;
+  /** Visible heading label with common inline Markdown removed. */
+  title: string;
+  /** Canonical fragment identifier shared by rendered and agent surfaces. */
+  anchor: string;
+  /** Whether the anchor came from a trailing `[#custom-id]` marker. */
+  explicit: boolean;
+}
+
+export interface DocsRenderedHeadingAnchorOptions {
+  /** An author-provided or previously assigned fragment identifier. */
+  explicitAnchor?: string;
+}
+
+export interface ApplyDocsMarkdownHeadingAnchorsOptions {
+  /** Honor trailing Fumadocs `[#custom-id]` markers. */
+  customId?: boolean;
+}
+
+interface DocsMarkdownAstNode {
+  type?: string;
+  name?: unknown;
+  depth?: unknown;
+  value?: unknown;
+  children?: DocsMarkdownAstNode[];
+  position?: {
+    start?: {
+      line?: unknown;
+    };
+  };
+  data?: {
+    hProperties?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+}
+
+const docsMarkdownMdxProcessor = createProcessor({
+  remarkPlugins: [remarkGfm],
+});
+
+function isDocsMarkdownLiteralPrompt(node: DocsMarkdownAstNode): boolean {
+  return (
+    (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+    node.name === "Prompt"
+  );
+}
+
+function collectDocsMarkdownLiteralPromptHeadings(
+  root: DocsMarkdownAstNode,
+): DocsMarkdownAstNode[] {
+  const headings: DocsMarkdownAstNode[] = [];
+
+  const visit = (node: DocsMarkdownAstNode, insidePrompt: boolean): void => {
+    const literal = insidePrompt || isDocsMarkdownLiteralPrompt(node);
+    if (literal && node.type === "heading") {
+      headings.push(node);
+      return;
+    }
+    for (const child of node.children ?? []) visit(child, literal);
+  };
+
+  visit(root, false);
+  return headings;
+}
+
+/**
+ * Run a third-party heading visitor without exposing headings inside `<Prompt>`.
+ *
+ * Prompt children are literal, copyable input rather than rendered page content.
+ * The node types are restored synchronously even when the visitor throws.
+ */
+export function withDocsMarkdownRenderableHeadings<T>(root: unknown, visitor: () => T): T {
+  if (!root || typeof root !== "object") return visitor();
+  const hiddenHeadings = collectDocsMarkdownLiteralPromptHeadings(root as DocsMarkdownAstNode);
+  for (const heading of hiddenHeadings) heading.type = "docsLiteralPromptHeading";
+
+  try {
+    return visitor();
+  } finally {
+    for (const heading of hiddenHeadings) heading.type = "heading";
+  }
+}
+
+function protectDocsMarkdownCodeSpans(value: string): {
+  value: string;
+  restore: (resolved: string) => string;
+} {
+  const spans: string[] = [];
+  const protectedValue = value.replace(
+    /(`+)([^]*?)\1/gu,
+    (_match, _ticks: string, code: string) => {
+      const normalized = code.replace(/\s+/gu, " ");
+      const visible =
+        normalized.length > 2 &&
+        normalized.startsWith(" ") &&
+        normalized.endsWith(" ") &&
+        normalized.trim()
+          ? normalized.slice(1, -1)
+          : normalized;
+      return `\uE000${spans.push(visible) - 1}\uE001`;
+    },
+  );
+
+  return {
+    value: protectedValue,
+    restore: (resolved) =>
+      resolved.replace(
+        /\uE000(\d+)\uE001/gu,
+        (_match, index: string) => spans[Number(index)] ?? "",
+      ),
+  };
+}
+
+function protectDocsMarkdownEscapes(value: string): {
+  value: string;
+  restore: (resolved: string) => string;
+} {
+  const escapes: string[] = [];
+  const protectedValue = value.replace(
+    /\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/gu,
+    (_match, punctuation: string) => `\uE002${escapes.push(punctuation) - 1}\uE003`,
+  );
+
+  return {
+    value: protectedValue,
+    restore: (resolved) =>
+      resolved.replace(
+        /\uE002(\d+)\uE003/gu,
+        (_match, index: string) => escapes[Number(index)] ?? "",
+      ),
+  };
+}
+
+function findDocsMarkdownClosingDelimiter(
+  value: string,
+  start: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 0;
+  for (let index = start; index < value.length; index += 1) {
+    if (value[index] === "\\") {
+      index += 1;
+      continue;
+    }
+    if (value[index] === open) depth += 1;
+    if (value[index] !== close) continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+  return -1;
+}
+
+function normalizeDocsMarkdownReferenceLabel(value: string): string {
+  return parseEntities(value.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/gu, "$1"), {
+    nonTerminated: false,
+  })
+    .replace(/\s+/gu, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function cleanDocsMarkdownLinksAndImages(
+  value: string,
+  definedReferences?: ReadonlySet<string>,
+  restoreEscapes: (value: string) => string = (input) => input,
+): string {
+  let output = "";
+  let index = 0;
+
+  while (index < value.length) {
+    const image = value[index] === "!" && value[index + 1] === "[";
+    const link = value[index] === "[";
+    if (!image && !link) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+
+    const labelStart = index + (image ? 2 : 1);
+    const labelEnd = findDocsMarkdownClosingDelimiter(value, labelStart - 1, "[", "]");
+    if (labelEnd < 0) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+
+    const label = value.slice(labelStart, labelEnd);
+    let end = labelEnd + 1;
+    let inlineDestination = false;
+    let referenceLabel: string | undefined;
+    if (value[end] === "(") {
+      const destinationEnd = findDocsMarkdownClosingDelimiter(value, end, "(", ")");
+      if (destinationEnd < 0) {
+        output += value[index];
+        index += 1;
+        continue;
+      }
+      end = destinationEnd + 1;
+      inlineDestination = true;
+    } else if (value[end] === "[") {
+      const referenceEnd = findDocsMarkdownClosingDelimiter(value, end, "[", "]");
+      if (referenceEnd < 0) {
+        output += value[index];
+        index += 1;
+        continue;
+      }
+      referenceLabel = value.slice(end + 1, referenceEnd) || label;
+      end = referenceEnd + 1;
+    } else {
+      referenceLabel = label;
+    }
+
+    const hasMatchingDefinition =
+      referenceLabel !== undefined &&
+      definedReferences?.has(
+        normalizeDocsMarkdownReferenceLabel(restoreEscapes(referenceLabel)),
+      ) === true;
+    if (!image && (inlineDestination || hasMatchingDefinition)) {
+      output += label;
+    } else if (!inlineDestination && !hasMatchingDefinition) {
+      output += value.slice(index, end);
+    }
+    index = end;
+  }
+
+  return output;
+}
+
+function stripDocsMarkdownTags(value: string): string {
+  let output = "";
+  let index = 0;
+
+  while (index < value.length) {
+    if (value[index] !== "<" || !/[A-Za-z/!?]/u.test(value[index + 1] ?? "")) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+
+    let quote: "'" | '"' | undefined;
+    let braceDepth = 0;
+    let end = index + 1;
+    for (; end < value.length; end += 1) {
+      const character = value[end];
+      if (quote) {
+        if (character === quote && value[end - 1] !== "\\") quote = undefined;
+        continue;
+      }
+      if (character === "'" || character === '"') {
+        quote = character;
+        continue;
+      }
+      if (character === "{") {
+        braceDepth += 1;
+        continue;
+      }
+      if (character === "}") {
+        braceDepth = Math.max(0, braceDepth - 1);
+        continue;
+      }
+      if (character === ">" && braceDepth === 0) break;
+    }
+
+    if (end >= value.length) {
+      output += value[index];
+      index += 1;
+      continue;
+    }
+    index = end + 1;
+  }
+
+  return output;
+}
 
 /**
  * Reduce inline Markdown in a heading to the visible label used by search and anchors.
  * This intentionally covers the common inline constructs without adding a Markdown parser
  * dependency to the runtime package.
  */
-export function cleanDocsMarkdownHeadingLabel(value: string): string {
-  return value
-    .replace(/!\[([^\]]*)\]\([^)]*\)/gu, "$1")
-    .replace(/\[([^\]]+)\]\([^)]*\)/gu, "$1")
-    .replace(/!\[([^\]]*)\]\[[^\]]*\]/gu, "$1")
-    .replace(/\[([^\]]+)\]\[[^\]]*\]/gu, "$1")
-    .replace(/<((?:https?:\/\/|mailto:)[^>]+)>/giu, "$1")
-    .replace(/<[^>]+>/gu, "")
+function cleanDocsMarkdownHeadingLabelWithReferences(
+  value: string,
+  definedReferences?: ReadonlySet<string>,
+): string {
+  const codeSpans = protectDocsMarkdownCodeSpans(value);
+  const escapes = protectDocsMarkdownEscapes(codeSpans.value);
+  const visible = stripDocsMarkdownTags(
+    cleanDocsMarkdownLinksAndImages(escapes.value, definedReferences, escapes.restore).replace(
+      /<((?:https?:\/\/|mailto:)[^>]+)>/giu,
+      "$1",
+    ),
+  )
     .replace(/`+([^`]*?)`+/gu, "$1")
-    .replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/gu, "$1")
-    .replace(/[*_~]/gu, "")
-    .replace(/&(#(?:x[0-9a-f]+|\d+)|[a-z]+);/giu, (_match, entity: string) => {
-      if (entity.startsWith("#x") || entity.startsWith("#X")) {
-        const codePoint = Number.parseInt(entity.slice(2), 16);
-        return Number.isSafeInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-          ? String.fromCodePoint(codePoint)
-          : _match;
-      }
-      if (entity.startsWith("#")) {
-        const codePoint = Number.parseInt(entity.slice(1), 10);
-        return Number.isSafeInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
-          ? String.fromCodePoint(codePoint)
-          : _match;
-      }
-      return HTML_ENTITIES[entity.toLowerCase()] ?? _match;
-    })
+    .replace(/\*\*([^*\n]+)\*\*/gu, "$1")
+    .replace(/(?<![\\\p{L}\p{N}])__([^_\n]+)__(?![\p{L}\p{N}])/gu, "$1")
+    .replace(/\*([^*\n]+)\*/gu, "$1")
+    .replace(/(?<![\\\p{L}\p{N}])_([^_\n]+)_(?![\p{L}\p{N}])/gu, "$1")
+    .replace(/~~([^~\n]+)~~/gu, "$1")
+    .trim();
+
+  return codeSpans
+    .restore(escapes.restore(parseEntities(visible, { nonTerminated: false })))
     .replace(/\s+/gu, " ")
     .trim();
 }
 
-/** Keep anchors aligned with the framework's existing ASCII heading-slug behavior. */
-export function slugifyDocsMarkdownHeading(value: string): string {
-  return cleanDocsMarkdownHeadingLabel(value)
-    .toLowerCase()
-    .replace(/[`'"‘’“”]/gu, "")
-    .replace(/&/gu, " and ")
-    .replace(/[^a-z0-9\s-]/gu, "")
-    .replace(/\s+/gu, "-")
-    .replace(/-+/gu, "-")
-    .replace(/^-|-$/gu, "");
+export function cleanDocsMarkdownHeadingLabel(value: string): string {
+  return cleanDocsMarkdownHeadingLabelWithReferences(value);
 }
 
-function readOpeningFence(line: string): OpenMarkdownFence | undefined {
+const EXPLICIT_DOCS_MARKDOWN_HEADING_ID = /\s*\\?\[#([^\]\r\n]+)\]\s*$/u;
+
+function createDocsHeadingAnchorState() {
+  const used = new Set<string>();
+  const suffixes = new Map<string, number>();
+  let headingIndex = 0;
+
+  return (title: string, explicitAnchor?: string): string => {
+    const fallback = `section-${headingIndex}`;
+    headingIndex += 1;
+    const original = explicitAnchor?.trim() || githubSlug(title) || fallback;
+    let anchor = original;
+    let suffix = suffixes.get(original) ?? 0;
+
+    while (used.has(anchor)) {
+      suffix += 1;
+      anchor = `${original}-${suffix}`;
+    }
+
+    suffixes.set(original, suffix);
+    used.add(anchor);
+    return anchor;
+  };
+}
+
+/** Normalize text that has already been flattened from a rendered heading AST. */
+export function cleanDocsRenderedHeadingLabel(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+/**
+ * Create a stateful resolver for text already flattened by an MDX renderer.
+ *
+ * Unlike the raw-Markdown resolver, this does not reinterpret inline code or a
+ * literal `[#id]` as Markdown syntax.
+ */
+export function createDocsRenderedHeadingAnchorResolver(): (
+  value: string,
+  options?: DocsRenderedHeadingAnchorOptions,
+) => DocsMarkdownHeadingAnchor {
+  const reserveAnchor = createDocsHeadingAnchorState();
+
+  return (value, options = {}) => {
+    const title = cleanDocsRenderedHeadingLabel(value);
+    const explicitAnchor = options.explicitAnchor?.trim();
+    return {
+      source: title,
+      title,
+      anchor: reserveAnchor(title, explicitAnchor),
+      explicit: Boolean(explicitAnchor),
+    };
+  };
+}
+
+/**
+ * Create a stateful heading resolver compatible with Fumadocs' GitHub-style rendered IDs.
+ *
+ * A fresh resolver must be used for each document so duplicate and collision suffixes
+ * remain deterministic in source order.
+ */
+function createDocsMarkdownHeadingAnchorResolverWithReferences(
+  definedReferences?: ReadonlySet<string>,
+): (value: string) => DocsMarkdownHeadingAnchor {
+  const reserveAnchor = createDocsHeadingAnchorState();
+
+  return (value) => {
+    const explicitMatch = value.match(EXPLICIT_DOCS_MARKDOWN_HEADING_ID);
+    const rawExplicitAnchor = explicitMatch?.[1]?.trim();
+    const explicitMarker =
+      explicitMatch?.index === undefined ? "" : value.slice(explicitMatch.index).trimStart();
+    const resolvesAsReference =
+      Boolean(rawExplicitAnchor) &&
+      !explicitMarker.startsWith("\\[") &&
+      definedReferences?.has(normalizeDocsMarkdownReferenceLabel(`#${rawExplicitAnchor}`)) === true;
+    const explicitAnchor =
+      rawExplicitAnchor && !resolvesAsReference
+        ? parseEntities(rawExplicitAnchor, { nonTerminated: false })
+        : undefined;
+    const source = (
+      explicitAnchor && explicitMatch ? value.slice(0, explicitMatch.index) : value
+    ).trim();
+    const title = cleanDocsMarkdownHeadingLabelWithReferences(source, definedReferences);
+
+    return {
+      source,
+      title,
+      anchor: reserveAnchor(title, explicitAnchor),
+      explicit: Boolean(explicitAnchor),
+    };
+  };
+}
+
+export function createDocsMarkdownHeadingAnchorResolver(): (
+  value: string,
+) => DocsMarkdownHeadingAnchor {
+  return createDocsMarkdownHeadingAnchorResolverWithReferences();
+}
+
+function flattenDocsMarkdownAstNode(node: DocsMarkdownAstNode): string {
+  if (Array.isArray(node.children)) {
+    return node.children.map((child) => flattenDocsMarkdownAstNode(child)).join("");
+  }
+  return typeof node.value === "string" ? node.value : "";
+}
+
+interface DocsMarkdownAstHeadingCandidate {
+  node: DocsMarkdownAstNode;
+  title: string;
+  explicit: boolean;
+  explicitAnchor?: string;
+  start: number;
+}
+
+function assignDocsMarkdownAstHeadingAnchors(
+  root: DocsMarkdownAstNode,
+  options: ApplyDocsMarkdownHeadingAnchorsOptions,
+  deferHeading?: (start: number) => boolean,
+): DocsMarkdownAstHeadingCandidate[] {
+  const customId = options.customId ?? true;
+  const headings: DocsMarkdownAstHeadingCandidate[] = [];
+
+  const visit = (node: DocsMarkdownAstNode): void => {
+    if (isDocsMarkdownLiteralPrompt(node)) return;
+
+    if (node.type === "heading") {
+      const lastNode = node.children?.at(-1);
+      let explicitAnchor: string | undefined;
+      if (customId && lastNode?.type === "text" && typeof lastNode.value === "string") {
+        const match = lastNode.value.match(EXPLICIT_DOCS_MARKDOWN_HEADING_ID);
+        explicitAnchor = match?.[1]?.trim();
+        if (explicitAnchor && match?.index !== undefined) {
+          lastNode.value = lastNode.value.slice(0, match.index);
+        }
+      }
+
+      const existingAnchor = node.data?.hProperties?.id;
+      headings.push({
+        node,
+        title: cleanDocsRenderedHeadingLabel(flattenDocsMarkdownAstNode(node)),
+        explicit: Boolean(explicitAnchor),
+        explicitAnchor:
+          explicitAnchor || (typeof existingAnchor === "string" ? existingAnchor : undefined),
+        start:
+          typeof node.position?.start?.line === "number"
+            ? node.position.start.line - 1
+            : Number.NaN,
+      });
+      return;
+    }
+
+    for (const child of node.children ?? []) visit(child);
+  };
+
+  visit(root);
+
+  const ordered = deferHeading
+    ? [
+        ...headings.filter((heading) => !deferHeading(heading.start)),
+        ...headings.filter((heading) => deferHeading(heading.start)),
+      ]
+    : headings;
+  const resolveHeading = createDocsRenderedHeadingAnchorResolver();
+  for (const heading of ordered) {
+    const resolved = resolveHeading(heading.title, {
+      explicitAnchor: heading.explicitAnchor,
+    });
+    heading.node.data ??= {};
+    heading.node.data.hProperties ??= {};
+    heading.node.data.hProperties.id = resolved.anchor;
+  }
+
+  return headings;
+}
+
+/**
+ * Assign canonical IDs to every heading in an MDX syntax tree.
+ *
+ * Render adapters call this before Fumadocs extracts its TOC, ensuring HTML,
+ * Markdown retrieval, search, Ask AI, and MCP all use the same fragments.
+ */
+export function applyDocsMarkdownHeadingAnchors(
+  root: unknown,
+  options: ApplyDocsMarkdownHeadingAnchorsOptions = {},
+): void {
+  if (!root || typeof root !== "object") return;
+  assignDocsMarkdownAstHeadingAnchors(root as DocsMarkdownAstNode, options);
+}
+
+/** Resolve one heading with the canonical GitHub-style anchor algorithm. */
+export function slugifyDocsMarkdownHeading(value: string): string {
+  return createDocsMarkdownHeadingAnchorResolver()(value).anchor;
+}
+
+function readOpeningFence(line: string): Pick<OpenMarkdownFence, "marker" | "length"> | undefined {
   const match = line.match(/^ {0,3}(`{3,}|~{3,})/u);
   if (!match) return undefined;
   return { marker: match[1][0] as "`" | "~", length: match[1].length };
@@ -89,13 +582,330 @@ function isClosingFence(line: string, fence: OpenMarkdownFence): boolean {
   return Boolean(match);
 }
 
-function readAtxHeading(line: string): { title: string; level: number } | undefined {
+function splitDocsMarkdownContainerLine(line: string): DocsMarkdownContainerLine {
+  let prefix = "";
+  let content = line;
+  const containers: DocsMarkdownContainer[] = [];
+
+  while (content) {
+    const blockquote = content.match(/^ {0,3}>[\t ]?/u);
+    if (blockquote) {
+      prefix += blockquote[0];
+      content = content.slice(blockquote[0].length);
+      containers.push({ type: "blockquote", continuationIndent: 0 });
+      continue;
+    }
+
+    const listItem = content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[\t ]+/u);
+    if (listItem) {
+      prefix += listItem[0];
+      content = content.slice(listItem[0].length);
+      containers.push({
+        type: "list",
+        continuationIndent: listItem[0].length,
+      });
+      continue;
+    }
+
+    break;
+  }
+
+  return { prefix, content, containers };
+}
+
+function continueDocsMarkdownContainerLine(
+  line: string,
+  containers: readonly DocsMarkdownContainer[],
+): DocsMarkdownContainerLine | undefined {
+  let prefix = "";
+  let content = line;
+
+  for (const container of containers) {
+    if (container.type === "blockquote") {
+      const blockquote = content.match(/^ {0,3}>[\t ]?/u);
+      if (!blockquote) return undefined;
+      prefix += blockquote[0];
+      content = content.slice(blockquote[0].length);
+      continue;
+    }
+
+    if (!content.trim()) {
+      prefix += content;
+      content = "";
+      continue;
+    }
+
+    const indentation = content.match(/^[\t ]*/u)?.[0] ?? "";
+    const indentationWidth = indentation.replace(/\t/gu, "    ").length;
+    if (indentationWidth < container.continuationIndent) return undefined;
+
+    let consumedWidth = 0;
+    let consumedLength = 0;
+    while (consumedLength < indentation.length) {
+      consumedWidth += indentation[consumedLength] === "\t" ? 4 : 1;
+      consumedLength += 1;
+      if (consumedWidth >= container.continuationIndent) break;
+    }
+    const consumed = content.slice(0, consumedLength);
+    prefix += consumed;
+    content = content.slice(consumedLength);
+  }
+
+  return {
+    prefix,
+    content,
+    containers: containers.map((container) => ({ ...container })),
+  };
+}
+
+function readDocsMarkdownFenceLine(
+  line: string,
+  fence: OpenMarkdownFence,
+): DocsMarkdownContainerLine | undefined {
+  if (fence.containers.length === 0) {
+    return { prefix: "", content: line, containers: [] };
+  }
+  return continueDocsMarkdownContainerLine(line, fence.containers);
+}
+
+function readDocsMarkdownReferenceDefinition(line: string): string | undefined {
+  const content = line.trimStart();
+  if (!content.startsWith("[")) return undefined;
+  const labelEnd = findDocsMarkdownClosingDelimiter(content, 0, "[", "]");
+  if (labelEnd <= 1 || content[labelEnd + 1] !== ":") return undefined;
+  const label = normalizeDocsMarkdownReferenceLabel(content.slice(1, labelEnd));
+  return label || undefined;
+}
+
+function collectDocsMarkdownReferenceDefinitions(lines: readonly string[]): ReadonlySet<string> {
+  const definitions = new Set<string>();
+  let openFence: OpenMarkdownFence | undefined;
+
+  for (const line of lines) {
+    if (openFence) {
+      const fenceLine = readDocsMarkdownFenceLine(line, openFence);
+      if (fenceLine) {
+        if (isClosingFence(fenceLine.content, openFence)) openFence = undefined;
+        continue;
+      }
+      openFence = undefined;
+    }
+
+    const containerLine = splitDocsMarkdownContainerLine(line);
+    const openingFence = readOpeningFence(containerLine.content);
+    if (openingFence) {
+      openFence = {
+        ...openingFence,
+        containers: containerLine.containers,
+      };
+      continue;
+    }
+
+    const definition = readDocsMarkdownReferenceDefinition(containerLine.content);
+    if (definition) definitions.add(definition);
+  }
+
+  return definitions;
+}
+
+function scanDocsMarkdownFallbackEsmLine(
+  line: string,
+  state: DocsMarkdownFallbackEsmState,
+): boolean {
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    const next = line[index + 1];
+
+    if (state.blockComment) {
+      if (character === "*" && next === "/") {
+        state.blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (state.quote) {
+      if (character === "\\") {
+        index += 1;
+        continue;
+      }
+      if (character === state.quote) state.quote = undefined;
+      continue;
+    }
+
+    if (character === "/" && next === "*") {
+      state.blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "/" && next === "/") break;
+    if (character === "'" || character === '"' || character === "`") {
+      state.quote = character;
+      continue;
+    }
+    if (character === "{") state.braceDepth += 1;
+    if (character === "}") state.braceDepth = Math.max(0, state.braceDepth - 1);
+    if (character === "[") state.bracketDepth += 1;
+    if (character === "]") state.bracketDepth = Math.max(0, state.bracketDepth - 1);
+    if (character === "(") state.parenDepth += 1;
+    if (character === ")") state.parenDepth = Math.max(0, state.parenDepth - 1);
+  }
+
+  return Boolean(
+    state.blockComment ||
+    state.quote ||
+    state.braceDepth ||
+    state.bracketDepth ||
+    state.parenDepth ||
+    /(?:[=,]|=>)\s*$/u.test(line),
+  );
+}
+
+function scanDocsMarkdownLiteralPromptTags(value: string): {
+  delta: number;
+  found: boolean;
+} {
+  let delta = 0;
+  let found = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "<") continue;
+    const closing = value[index + 1] === "/";
+    const nameStart = index + (closing ? 2 : 1);
+    if (value.slice(nameStart, nameStart + 6) !== "Prompt") continue;
+    const boundary = value[nameStart + 6];
+    if (boundary && !/[\t\n\r />]/u.test(boundary)) continue;
+
+    let quote: "'" | '"' | "`" | undefined;
+    let braceDepth = 0;
+    let end = nameStart + 6;
+    for (; end < value.length; end += 1) {
+      const character = value[end];
+      if (quote) {
+        if (character === "\\") {
+          end += 1;
+          continue;
+        }
+        if (character === quote) quote = undefined;
+        continue;
+      }
+      if (character === "'" || character === '"' || character === "`") {
+        quote = character;
+        continue;
+      }
+      if (character === "{") {
+        braceDepth += 1;
+        continue;
+      }
+      if (character === "}") {
+        braceDepth = Math.max(0, braceDepth - 1);
+        continue;
+      }
+      if (character === ">" && braceDepth === 0) break;
+    }
+    if (end >= value.length) continue;
+
+    found = true;
+    if (closing) {
+      delta -= 1;
+    } else if (!/\/[\t ]*>$/u.test(value.slice(index, end + 1))) {
+      delta += 1;
+    }
+    index = end;
+  }
+
+  return { delta, found };
+}
+
+function collectDocsMarkdownFallbackIgnoredLines(lines: readonly string[]): ReadonlySet<number> {
+  const ignored = new Set<number>();
+  let esmState: DocsMarkdownFallbackEsmState | undefined;
+  let htmlComment = false;
+  let mdxComment = false;
+  let literalPromptDepth = 0;
+  let openFence: OpenMarkdownFence | undefined;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (!esmState && !htmlComment && !mdxComment && openFence) {
+      const fenceLine = readDocsMarkdownFenceLine(line, openFence);
+      if (fenceLine) {
+        if (isClosingFence(fenceLine.content, openFence)) openFence = undefined;
+        continue;
+      }
+      openFence = undefined;
+    }
+
+    const containerLine = splitDocsMarkdownContainerLine(line);
+    const logicalLine = containerLine.content;
+    if (!esmState && !htmlComment && !mdxComment) {
+      const openingFence = readOpeningFence(logicalLine);
+      if (openingFence) {
+        openFence = {
+          ...openingFence,
+          containers: containerLine.containers,
+        };
+        continue;
+      }
+    }
+
+    if (mdxComment) {
+      ignored.add(index);
+      if (logicalLine.includes("*/}")) mdxComment = false;
+      continue;
+    }
+    if (htmlComment) {
+      ignored.add(index);
+      if (logicalLine.includes("-->")) htmlComment = false;
+      continue;
+    }
+    if (esmState) {
+      ignored.add(index);
+      if (!scanDocsMarkdownFallbackEsmLine(logicalLine, esmState)) esmState = undefined;
+      continue;
+    }
+
+    const trimmed = logicalLine.trimStart();
+    if (trimmed.startsWith("{/*")) {
+      ignored.add(index);
+      mdxComment = !trimmed.includes("*/}");
+      continue;
+    }
+    if (trimmed.startsWith("<!--")) {
+      ignored.add(index);
+      htmlComment = !trimmed.includes("-->");
+      continue;
+    }
+    if (/^(?:import|export)(?:[\t ]|[{*]|$)/u.test(trimmed)) {
+      ignored.add(index);
+      const state: DocsMarkdownFallbackEsmState = {
+        blockComment: false,
+        braceDepth: 0,
+        bracketDepth: 0,
+        parenDepth: 0,
+      };
+      if (scanDocsMarkdownFallbackEsmLine(logicalLine, state)) esmState = state;
+      continue;
+    }
+
+    const promptTags = scanDocsMarkdownLiteralPromptTags(logicalLine);
+    if (literalPromptDepth > 0 || promptTags.found) {
+      ignored.add(index);
+      literalPromptDepth = Math.max(0, literalPromptDepth + promptTags.delta);
+    }
+  }
+
+  return ignored;
+}
+
+function readAtxHeading(line: string): { source: string; level: number } | undefined {
   const match = line.match(/^ {0,3}(#{1,6})(?:[\t ]+|$)(.*)$/u);
   if (!match) return undefined;
 
   const rawTitle = match[2].replace(/[\t ]+#+[\t ]*$/u, "").trim();
   return {
-    title: cleanDocsMarkdownHeadingLabel(rawTitle),
+    source: rawTitle,
     level: match[1].length,
   };
 }
@@ -106,9 +916,23 @@ function readSetextLevel(line: string): number | undefined {
   return match[1][0] === "=" ? 1 : 2;
 }
 
-function normalizeDocsSectionSelector(value: string): string {
+function normalizeDocsSectionSelector(value: string, extractFragment = true): string {
   let selector = value.trim();
-  const hashIndex = selector.lastIndexOf("#");
+  const hashIndex = selector.indexOf("#");
+  if (extractFragment && hashIndex >= 0) selector = selector.slice(hashIndex + 1);
+
+  try {
+    selector = decodeURIComponent(selector);
+  } catch {
+    // Keep malformed URL fragments usable as literal selectors.
+  }
+
+  return cleanDocsMarkdownHeadingLabel(selector).toLowerCase();
+}
+
+function decodeDocsSectionSelector(value: string): string {
+  let selector = value.trim();
+  const hashIndex = selector.indexOf("#");
   if (hashIndex >= 0) selector = selector.slice(hashIndex + 1);
 
   try {
@@ -117,7 +941,67 @@ function normalizeDocsSectionSelector(value: string): string {
     // Keep malformed URL fragments usable as literal selectors.
   }
 
-  return cleanDocsMarkdownHeadingLabel(selector.replace(/^#+/u, "")).toLowerCase();
+  return selector;
+}
+
+function isTopLevelDocsMarkdownMarker(line: string, marker: string): boolean {
+  if (line.trim() !== marker) return false;
+  const markerIndex = line.indexOf(marker);
+  return markerIndex <= 3 && /^ *$/u.test(line.slice(0, markerIndex));
+}
+
+function collectGeneratedAgentContractRanges(markdown: string): DocsMarkdownLineRange[] {
+  const lines = markdown.split(/\r?\n/u);
+  const ranges: DocsMarkdownLineRange[] = [];
+  let openFence: OpenMarkdownFence | undefined;
+  let contractStart: number | undefined;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (contractStart !== undefined) {
+      if (isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_END_MARKER)) {
+        ranges.push({ start: contractStart, end: index });
+        contractStart = undefined;
+      }
+      continue;
+    }
+
+    if (openFence) {
+      const fenceLine = readDocsMarkdownFenceLine(line, openFence);
+      if (fenceLine) {
+        if (isClosingFence(fenceLine.content, openFence)) openFence = undefined;
+        continue;
+      }
+      openFence = undefined;
+    }
+
+    const containerLine = splitDocsMarkdownContainerLine(line);
+    const openingFence = readOpeningFence(containerLine.content);
+    if (openingFence) {
+      openFence = {
+        ...openingFence,
+        containers: containerLine.containers,
+      };
+      continue;
+    }
+
+    if (
+      containerLine.containers.length === 0 &&
+      isTopLevelDocsMarkdownMarker(line, PAGE_AGENT_CONTRACT_START_MARKER)
+    ) {
+      contractStart = index;
+    }
+  }
+
+  return ranges;
+}
+
+function isDocsMarkdownLineInRanges(
+  line: number,
+  ranges: readonly DocsMarkdownLineRange[],
+): boolean {
+  return ranges.some((range) => line >= range.start && line <= range.end);
 }
 
 /**
@@ -125,20 +1009,29 @@ function normalizeDocsSectionSelector(value: string): string {
  * Supports CommonMark ATX indentation, Setext headings, fenced-code exclusion,
  * visible inline labels, and stable duplicate anchors.
  */
-export function parseDocsMarkdownSections(markdown: string): DocsMarkdownSection[] {
+function parseDocsMarkdownSectionsFallback(
+  markdown: string,
+  generatedContractRanges: readonly DocsMarkdownLineRange[],
+): DocsMarkdownSection[] {
   const lines = markdown.split(/\r?\n/u);
-  const headings: ParsedDocsMarkdownHeading[] = [];
-  const headingCounts = new Map<string, number>();
+  const headings: UnresolvedDocsMarkdownHeading[] = [];
+  const ignoredLines = collectDocsMarkdownFallbackIgnoredLines(lines);
+  const definedReferences = collectDocsMarkdownReferenceDefinitions(
+    lines.map((line, index) => (ignoredLines.has(index) ? "" : line)),
+  );
   let openFence: OpenMarkdownFence | undefined;
-  let setextCandidate: { index: number; value: string } | undefined;
+  let setextCandidate:
+    | {
+        index: number;
+        lastIndex: number;
+        values: string[];
+        containers: DocsMarkdownContainer[];
+      }
+    | undefined;
 
-  const pushHeading = (title: string, level: number, start: number) => {
-    const baseAnchor = slugifyDocsMarkdownHeading(title) || `section-${headings.length}`;
-    const seen = headingCounts.get(baseAnchor) ?? 0;
-    headingCounts.set(baseAnchor, seen + 1);
+  const pushHeading = (value: string, level: number, start: number) => {
     headings.push({
-      title,
-      anchor: seen === 0 ? baseAnchor : `${baseAnchor}-${seen}`,
+      source: value,
       level,
       start,
     });
@@ -148,47 +1041,104 @@ export function parseDocsMarkdownSections(markdown: string): DocsMarkdownSection
     const line = lines[index];
 
     if (openFence) {
-      if (isClosingFence(line, openFence)) openFence = undefined;
+      const fenceLine = readDocsMarkdownFenceLine(line, openFence);
+      if (fenceLine) {
+        if (isClosingFence(fenceLine.content, openFence)) openFence = undefined;
+        setextCandidate = undefined;
+        continue;
+      }
+      openFence = undefined;
+    }
+
+    if (ignoredLines.has(index)) {
       setextCandidate = undefined;
       continue;
     }
 
-    const openingFence = readOpeningFence(line);
+    const containerLine = splitDocsMarkdownContainerLine(line);
+    const logicalLine = containerLine.content;
+    const openingFence = readOpeningFence(logicalLine);
     if (openingFence) {
-      openFence = openingFence;
+      openFence = {
+        ...openingFence,
+        containers: containerLine.containers,
+      };
       setextCandidate = undefined;
       continue;
     }
 
-    const setextLevel = readSetextLevel(line);
-    if (setextLevel && setextCandidate?.index === index - 1) {
-      const title = cleanDocsMarkdownHeadingLabel(setextCandidate.value.trim());
-      if (title) pushHeading(title, setextLevel, setextCandidate.index);
+    const setextLine = setextCandidate
+      ? continueDocsMarkdownContainerLine(line, setextCandidate.containers)
+      : undefined;
+    const setextLevel = setextLine ? readSetextLevel(setextLine.content) : undefined;
+    if (setextLevel && setextCandidate?.lastIndex === index - 1) {
+      const source = setextCandidate.values.join("\n").trim();
+      if (!source.startsWith("<")) {
+        pushHeading(source, setextLevel, setextCandidate.index);
+      }
       setextCandidate = undefined;
       continue;
     }
 
-    const atxHeading = readAtxHeading(line);
+    const atxHeading = readAtxHeading(logicalLine);
     if (atxHeading) {
-      pushHeading(atxHeading.title, atxHeading.level, index);
+      pushHeading(atxHeading.source, atxHeading.level, index);
       setextCandidate = undefined;
       continue;
     }
 
-    if (!line.trim() || /^ {4}|^\t/u.test(line)) {
+    if (!logicalLine.trim() || /^ {4}|^\t/u.test(logicalLine)) {
       setextCandidate = undefined;
       continue;
     }
 
-    setextCandidate = { index, value: line };
+    if (readDocsMarkdownReferenceDefinition(logicalLine)) {
+      setextCandidate = undefined;
+      continue;
+    }
+
+    const candidate = setextCandidate;
+    const paragraphContinuation =
+      candidate?.lastIndex === index - 1
+        ? continueDocsMarkdownContainerLine(line, candidate.containers)
+        : undefined;
+    if (candidate && paragraphContinuation) {
+      candidate.values.push(paragraphContinuation.content);
+      candidate.lastIndex = index;
+      continue;
+    }
+
+    setextCandidate = {
+      index,
+      lastIndex: index,
+      values: [logicalLine],
+      containers: containerLine.containers,
+    };
+  }
+
+  const resolveHeadingAnchor =
+    createDocsMarkdownHeadingAnchorResolverWithReferences(definedReferences);
+  const orderedHeadings = [
+    ...headings.filter(
+      (heading) => !isDocsMarkdownLineInRanges(heading.start, generatedContractRanges),
+    ),
+    ...headings.filter((heading) =>
+      isDocsMarkdownLineInRanges(heading.start, generatedContractRanges),
+    ),
+  ];
+  for (const heading of orderedHeadings) {
+    heading.resolved = resolveHeadingAnchor(heading.source);
   }
 
   return headings.map((heading, index) => {
     const next = headings.slice(index + 1).find((candidate) => candidate.level <= heading.level);
     const end = next?.start ?? lines.length;
+    const resolved = heading.resolved;
+    if (!resolved) throw new Error("Failed to resolve a Markdown heading anchor.");
     return {
-      title: heading.title,
-      anchor: heading.anchor,
+      title: resolved.title,
+      anchor: resolved.anchor,
+      explicit: resolved.explicit,
       level: heading.level,
       content: lines.slice(heading.start, end).join("\n").trim(),
       startLine: heading.start + 1,
@@ -197,15 +1147,97 @@ export function parseDocsMarkdownSections(markdown: string): DocsMarkdownSection
   });
 }
 
+function stripDocsMarkdownSectionFrontmatter(markdown: string): string {
+  const frontmatter = markdown.match(/^\uFEFF?---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)([\s\S]*)$/u);
+  return frontmatter?.[1] ?? markdown;
+}
+
+function parseDocsMarkdownAstSections(
+  markdown: string,
+  generatedContractRanges: readonly DocsMarkdownLineRange[],
+): DocsMarkdownSection[] | undefined {
+  let root: DocsMarkdownAstNode;
+  try {
+    root = docsMarkdownMdxProcessor.parse(markdown) as DocsMarkdownAstNode;
+  } catch {
+    return undefined;
+  }
+
+  const assignedHeadings = assignDocsMarkdownAstHeadingAnchors(root, {}, (start) =>
+    isDocsMarkdownLineInRanges(start, generatedContractRanges),
+  );
+  const headings = assignedHeadings.flatMap((heading): ParsedDocsMarkdownHeading[] => {
+    const level = typeof heading.node.depth === "number" ? heading.node.depth : Number.NaN;
+    const anchor = heading.node.data?.hProperties?.id;
+    if (
+      !Number.isInteger(level) ||
+      level < 1 ||
+      level > 6 ||
+      !Number.isInteger(heading.start) ||
+      heading.start < 0 ||
+      typeof anchor !== "string"
+    ) {
+      return [];
+    }
+    return [
+      {
+        title: heading.title,
+        anchor,
+        explicit: heading.explicit,
+        level,
+        start: heading.start,
+      },
+    ];
+  });
+
+  const lines = markdown.split(/\r?\n/u);
+  return headings.map((heading, index) => {
+    const next = headings.slice(index + 1).find((candidate) => candidate.level <= heading.level);
+    const end = next?.start ?? lines.length;
+    return {
+      title: heading.title,
+      anchor: heading.anchor,
+      explicit: heading.explicit,
+      level: heading.level,
+      content: lines.slice(heading.start, end).join("\n").trim(),
+      startLine: heading.start + 1,
+      endLine: end,
+    };
+  });
+}
+
+export function parseDocsMarkdownSections(markdown: string): DocsMarkdownSection[] {
+  const body = stripDocsMarkdownSectionFrontmatter(markdown);
+  const generatedContractRanges = collectGeneratedAgentContractRanges(body);
+  return (
+    parseDocsMarkdownAstSections(body, generatedContractRanges) ??
+    parseDocsMarkdownSectionsFallback(body, generatedContractRanges)
+  );
+}
+
 export function findDocsMarkdownSection(
   markdown: string,
   requestedSection: string,
 ): DocsMarkdownSection | undefined {
+  const sections = parseDocsMarkdownSections(markdown);
+  const rawSelector = requestedSection.trim();
+  const rawAnchor = sections.find((section) => section.anchor === rawSelector);
+  if (rawAnchor) return rawAnchor;
+
+  const decodedSelector = decodeDocsSectionSelector(requestedSection);
+  const exactAnchor = sections.find((section) => section.anchor === decodedSelector);
+  if (exactAnchor) return exactAnchor;
+
+  const caseInsensitiveAnchors = sections.filter(
+    (section) => section.anchor.toLowerCase() === decodedSelector.toLowerCase(),
+  );
+  if (caseInsensitiveAnchors.length === 1) return caseInsensitiveAnchors[0];
+  if (caseInsensitiveAnchors.length > 1) return undefined;
+
   const selector = normalizeDocsSectionSelector(requestedSection);
   if (!selector) return undefined;
 
-  return parseDocsMarkdownSections(markdown).find(
-    (section) =>
-      normalizeDocsSectionSelector(section.title) === selector || section.anchor === selector,
+  return sections.find(
+    (section) => normalizeDocsSectionSelector(section.title, false) === selector,
   );
 }

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -581,6 +581,76 @@ describe("MCP context and schema APIs", () => {
     expect(result.context).not.toContain("Human screenshot walkthrough");
   });
 
+  it("keeps reserved section anchors distinct through search and MCP hydration", async () => {
+    const rawContent = [
+      "# Reserved anchors",
+      "",
+      "## Hash [#foo#bar]",
+      "",
+      "Reserved anchor marker hash content.",
+      "",
+      "## Percent [#foo%23bar]",
+      "",
+      "Reserved anchor marker percent content.",
+    ].join("\n");
+    const result = await buildDocsMcpContext({
+      pages: [
+        page("reserved", {
+          title: "Reserved anchors",
+          content: rawContent,
+          rawContent,
+        }),
+      ],
+      query: "reserved anchor marker",
+      tokenBudget: 8_000,
+    });
+
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          anchor: "foo#bar",
+          url: "/docs/reserved#foo%23bar",
+          content: expect.stringContaining("hash content"),
+        }),
+        expect.objectContaining({
+          anchor: "foo%23bar",
+          url: "/docs/reserved#foo%2523bar",
+          content: expect.stringContaining("percent content"),
+        }),
+      ]),
+    );
+  });
+
+  it("hydrates authored custom anchors ahead of generated contract-only headings", async () => {
+    const rawContent = "## Authored [#agent-contract]\n\nAuthored collision retrieval marker.";
+    const result = await buildDocsMcpContext({
+      pages: [
+        page("contract-collision", {
+          title: "Contract collision",
+          content: rawContent,
+          rawContent,
+          agent: {
+            task: "Run the generated contract task.",
+            outcome: "The generated contract outcome is available.",
+          },
+        }),
+      ],
+      query: "authored collision retrieval marker",
+      tokenBudget: 8_000,
+      maxResults: 1,
+    });
+
+    expect(result.sources).toEqual([
+      expect.objectContaining({
+        section: "Authored",
+        anchor: "agent-contract",
+        url: "/docs/contract-collision#agent-contract",
+        content: expect.stringContaining("Authored collision retrieval marker."),
+      }),
+    ]);
+    expect(result.context).not.toContain("generated contract outcome");
+  });
+
   it("returns deep-cloned schema options and examples while freezing the public template", () => {
     const first = getDocsConfigSchema();
     const mode = findSchemaOption(first.options, "review.ci.mode");
@@ -2143,6 +2213,115 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
       title: "Available heading 1",
       anchor: "available-heading-1",
     });
+  });
+
+  it("reads duplicate Unicode sections with the canonical rendered anchor", async () => {
+    const rawContent = [
+      "# International setup",
+      "",
+      "## Café 配置",
+      "",
+      "First configuration.",
+      "",
+      "## Café 配置",
+      "",
+      "Second configuration.",
+    ].join("\n");
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        getPages: () => [
+          {
+            slug: "international",
+            url: "/docs/international",
+            title: "International setup",
+            content: rawContent,
+            rawContent,
+          },
+        ],
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+    const payload = await parseMcpPayload<{
+      result?: {
+        content?: Array<{ text?: string }>;
+        structuredContent?: {
+          document?: string;
+          section?: string;
+          anchor?: string;
+        };
+      };
+    }>(
+      await callMcpTool(handlers, "read_page", {
+        path: "/docs/international",
+        section: "café-配置-1",
+      }),
+    );
+
+    expect(payload.result?.structuredContent).toMatchObject({
+      section: "Café 配置",
+      anchor: "café-配置-1",
+      document: expect.stringContaining("Second configuration."),
+    });
+    expect(payload.result?.content?.[0]?.text).not.toContain("First configuration.");
+  });
+
+  it("does not let the synthetic page title shift an MCP contract anchor", async () => {
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        getPages: () => [
+          {
+            slug: "agent-contract",
+            url: "/docs/agent-contract",
+            title: "Agent Contract",
+            content: "Use the generated contract.",
+            rawContent: "Use the generated contract.",
+            agent: {
+              task: "Read the generated contract.",
+              outcome: "The canonical contract section is returned.",
+            },
+          },
+        ],
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+    const canonical = await parseMcpPayload<{
+      result?: {
+        content?: Array<{ text?: string }>;
+        structuredContent?: {
+          document?: string;
+          section?: string;
+          anchor?: string;
+        };
+      };
+    }>(
+      await callMcpTool(handlers, "read_page", {
+        path: "/docs/agent-contract",
+        section: "agent-contract",
+      }),
+    );
+
+    expect(canonical.result?.structuredContent).toMatchObject({
+      section: "Agent Contract",
+      anchor: "agent-contract",
+      document: expect.stringContaining("## Agent Contract"),
+    });
+    expect(canonical.result?.structuredContent?.document).not.toContain("URL:");
+
+    const shifted = await parseMcpPayload<{
+      result?: {
+        isError?: boolean;
+        content?: Array<{ text?: string }>;
+      };
+    }>(
+      await callMcpTool(handlers, "read_page", {
+        path: "/docs/agent-contract",
+        section: "agent-contract-1",
+      }),
+    );
+    expect(shifted.result?.isError).toBe(true);
+    expect(shifted.result?.content?.[0]?.text).toContain('"agent-contract"');
   });
 
   it("rejects invalid supplied Origins before authentication", async () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -3893,19 +3893,16 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           }
 
           const fullDocument = renderPageDocument(page);
-          const sectionDocument = getDocsMcpSourceMarkdown(page);
+          const sectionDocument = upsertPageAgentContractMarkdown(
+            getDocsMcpSourceMarkdown(page),
+            page.agent,
+          );
           const selectedSection = section
-            ? (findDocsMarkdownSection(sectionDocument, section) ??
-              (sectionDocument !== fullDocument
-                ? findDocsMarkdownSection(fullDocument, section)
-                : undefined))
+            ? findDocsMarkdownSection(sectionDocument, section)
             : undefined;
 
           if (section && !selectedSection) {
-            const sourceSections = parseDocsMarkdownSections(sectionDocument);
-            const availableSections = (
-              sourceSections.length > 0 ? sourceSections : parseDocsMarkdownSections(fullDocument)
-            ).map((item) => ({
+            const availableSections = parseDocsMarkdownSections(sectionDocument).map((item) => ({
               title: item.title,
               anchor: item.anchor,
             }));
@@ -5947,7 +5944,8 @@ function getDocsMcpResultPageUrl(value: string): string {
 }
 
 function getDocsMcpResultAnchor(value: string): string | undefined {
-  const anchor = value.split("#", 2)[1];
+  const hashIndex = value.indexOf("#");
+  const anchor = hashIndex >= 0 ? value.slice(hashIndex + 1) : "";
   if (!anchor) return undefined;
 
   try {
@@ -6051,7 +6049,9 @@ export async function buildDocsMcpContext(
 
   for (const { result, page, scope, selectedSection, rawContent } of resolvedCandidates) {
     const anchor = selectedSection?.anchor;
-    const sourceUrl = anchor ? `${page.url}#${anchor}` : page.url;
+    const sourceUrl = anchor
+      ? `${page.url.split("#", 1)[0]}#${encodeURIComponent(anchor)}`
+      : page.url;
     const headerLines = [`## ${page.title}`, `Source: ${sourceUrl}`];
     if (selectedSection?.title) headerLines.push(`Section: ${selectedSection.title}`);
     if (scope.framework) headerLines.push(`Framework: ${scope.framework}`);

--- a/packages/docs/src/prompt-references.test.ts
+++ b/packages/docs/src/prompt-references.test.ts
@@ -1,0 +1,129 @@
+import { compile } from "@mdx-js/mdx";
+import { describe, expect, it } from "vitest";
+import { isolateDocsMarkdownPromptReferences } from "./prompt-references.js";
+
+interface PromptReferenceTestNode {
+  type?: string;
+  name?: unknown;
+  value?: unknown;
+  identifier?: unknown;
+  label?: unknown;
+  referenceType?: unknown;
+  url?: unknown;
+  children?: PromptReferenceTestNode[];
+}
+
+describe("isolateDocsMarkdownPromptReferences", () => {
+  it("aligns source slices with MDX offsets after a leading Unicode BOM", async () => {
+    const markdown = [
+      "\uFEFF<Prompt>",
+      "[X][x]",
+      "",
+      "[x]: /prompt-only",
+      "</Prompt>",
+      "",
+      "## [X][x]",
+    ].join("\n");
+    let transformedRoot: PromptReferenceTestNode | undefined;
+    const isolateReferences = () => (root: PromptReferenceTestNode, file: { value: unknown }) => {
+      isolateDocsMarkdownPromptReferences(root, file.value);
+      isolateDocsMarkdownPromptReferences(root, file.value);
+      transformedRoot = root;
+    };
+
+    await compile(markdown, { remarkPlugins: [isolateReferences] });
+
+    const prompt = transformedRoot?.children?.find(
+      (node) => node.type === "mdxJsxFlowElement" && node.name === "Prompt",
+    );
+    const heading = transformedRoot?.children?.find((node) => node.type === "heading");
+    expect(prompt?.children).toEqual([
+      {
+        type: "text",
+        value: "\n[X][x]\n\n[x]: /prompt-only\n",
+      },
+    ]);
+    expect(heading?.children?.[0]?.value).toBe("[X][x]");
+  });
+
+  it("keeps an attributed Prompt body as one exact literal source node", async () => {
+    const promptBody = [
+      "",
+      "[a]: /a",
+      "[b]: /b",
+      "Use [A][a] and [B][b].  ",
+      "",
+      '<Prompt title="Nested > prompt">',
+      "## Nested [A][a]",
+      "</Prompt>",
+      "",
+    ].join("\n");
+    const markdown = [
+      "<Prompt",
+      '  title="Literal > source"',
+      "  actions={['copy', '>']}",
+      `>${promptBody}</Prompt>`,
+      "",
+      "## [Outside][a]",
+    ].join("\n");
+    let transformedRoot: PromptReferenceTestNode | undefined;
+    const isolateReferences = () => (root: PromptReferenceTestNode, file: { value: unknown }) => {
+      isolateDocsMarkdownPromptReferences(root, file.value);
+      isolateDocsMarkdownPromptReferences(root, file.value);
+      transformedRoot = root;
+    };
+
+    await compile(markdown, { remarkPlugins: [isolateReferences] });
+
+    const prompt = transformedRoot?.children?.find(
+      (node) => node.type === "mdxJsxFlowElement" && node.name === "Prompt",
+    );
+    const heading = transformedRoot?.children?.find((node) => node.type === "heading");
+    expect(prompt?.children).toEqual([{ type: "text", value: promptBody }]);
+    expect(heading?.children?.[0]?.value).toBe("[Outside][a]");
+  });
+
+  it("falls back to node-level isolation when source positions are unavailable", () => {
+    const root: PromptReferenceTestNode = {
+      type: "root",
+      children: [
+        {
+          type: "mdxJsxFlowElement",
+          name: "Prompt",
+          children: [
+            {
+              type: "paragraph",
+              children: [
+                {
+                  type: "linkReference",
+                  identifier: "prompt-link",
+                  label: "prompt-link",
+                  referenceType: "full",
+                  children: [{ type: "text", value: "Prompt link" }],
+                },
+              ],
+            },
+            {
+              type: "definition",
+              identifier: "prompt-link",
+              label: "prompt-link",
+              url: "/prompt-only",
+            },
+          ],
+        },
+      ],
+    };
+
+    isolateDocsMarkdownPromptReferences(root);
+
+    const prompt = root.children?.[0];
+    expect(prompt?.children?.[0]?.children?.[0]).toMatchObject({
+      type: "text",
+      value: "[Prompt link][prompt-link]",
+    });
+    expect(prompt?.children?.[1]).toMatchObject({
+      type: "paragraph",
+      children: [{ type: "text", value: "[prompt-link]: /prompt-only" }],
+    });
+  });
+});

--- a/packages/docs/src/prompt-references.ts
+++ b/packages/docs/src/prompt-references.ts
@@ -1,0 +1,253 @@
+interface DocsMarkdownPromptReferenceNode {
+  type?: string;
+  name?: unknown;
+  value?: unknown;
+  alt?: unknown;
+  identifier?: unknown;
+  label?: unknown;
+  referenceType?: unknown;
+  url?: unknown;
+  title?: unknown;
+  children?: DocsMarkdownPromptReferenceNode[];
+  position?: {
+    start?: {
+      offset?: unknown;
+    };
+    end?: {
+      offset?: unknown;
+    };
+  };
+}
+
+function isDocsMarkdownPromptNode(node: DocsMarkdownPromptReferenceNode): boolean {
+  return (
+    (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+    node.name === "Prompt"
+  );
+}
+
+function normalizeDocsMarkdownReferenceIdentifier(value: unknown): string {
+  return typeof value === "string" ? value.trim().replace(/\s+/gu, " ").toLowerCase() : "";
+}
+
+function readDocsMarkdownPromptReferenceSource(value: unknown): string | undefined {
+  const source =
+    typeof value === "string"
+      ? value
+      : value instanceof Uint8Array
+        ? new TextDecoder().decode(value)
+        : undefined;
+  if (source === undefined) return undefined;
+
+  // Micromark removes one leading Unicode BOM before assigning node offsets.
+  // Keep the source used for slices aligned with those parser positions.
+  return source.startsWith("\uFEFF") ? source.slice(1) : source;
+}
+
+function sliceDocsMarkdownPromptReferenceSource(
+  node: DocsMarkdownPromptReferenceNode,
+  source: string | undefined,
+): string | undefined {
+  if (source === undefined) return undefined;
+  const start = node.position?.start?.offset;
+  const end = node.position?.end?.offset;
+  if (
+    typeof start !== "number" ||
+    typeof end !== "number" ||
+    !Number.isInteger(start) ||
+    !Number.isInteger(end) ||
+    start < 0 ||
+    end < start ||
+    end > source.length
+  ) {
+    return undefined;
+  }
+  return source.slice(start, end);
+}
+
+function sliceDocsMarkdownPromptChildrenSource(
+  node: DocsMarkdownPromptReferenceNode,
+  source: string | undefined,
+): string | undefined {
+  const nodeSource = sliceDocsMarkdownPromptReferenceSource(node, source);
+  if (nodeSource === undefined) return undefined;
+
+  const closingStart = nodeSource.lastIndexOf("</Prompt");
+  if (closingStart < 0) return undefined;
+
+  const children = node.children ?? [];
+  const isolatedChild = children.length === 1 ? children[0] : undefined;
+  if (
+    isolatedChild?.type === "text" &&
+    typeof isolatedChild.value === "string" &&
+    isolatedChild.position === undefined
+  ) {
+    return isolatedChild.value;
+  }
+
+  const nodeStart = node.position?.start?.offset;
+  if (typeof nodeStart !== "number") return undefined;
+  let firstChildStart: number | undefined;
+  for (const child of children) {
+    const childStart = child.position?.start?.offset;
+    if (
+      typeof childStart === "number" &&
+      Number.isInteger(childStart) &&
+      childStart >= nodeStart &&
+      (firstChildStart === undefined || childStart - nodeStart < firstChildStart)
+    ) {
+      firstChildStart = childStart - nodeStart;
+    }
+  }
+  if (children.length > 0 && firstChildStart === undefined) return undefined;
+
+  const openingEnd = nodeSource.lastIndexOf(">", (firstChildStart ?? closingStart) - 1);
+  if (openingEnd < 0 || openingEnd >= closingStart) return undefined;
+  return nodeSource.slice(openingEnd + 1, closingStart);
+}
+
+function flattenDocsMarkdownPromptReferenceNode(node: DocsMarkdownPromptReferenceNode): string {
+  if (typeof node.value === "string") return node.value;
+  return (node.children ?? [])
+    .map((child) => flattenDocsMarkdownPromptReferenceNode(child))
+    .join("");
+}
+
+function formatDocsMarkdownPromptReference(node: DocsMarkdownPromptReferenceNode): string {
+  const image = node.type === "imageReference";
+  const visibleLabel = image
+    ? typeof node.alt === "string"
+      ? node.alt
+      : ""
+    : flattenDocsMarkdownPromptReferenceNode(node);
+  const referenceLabel =
+    typeof node.label === "string"
+      ? node.label
+      : typeof node.identifier === "string"
+        ? node.identifier
+        : visibleLabel;
+  const prefix = image ? "!" : "";
+
+  if (node.referenceType === "collapsed") return `${prefix}[${visibleLabel}][]`;
+  if (node.referenceType === "shortcut") return `${prefix}[${visibleLabel}]`;
+  return `${prefix}[${visibleLabel}][${referenceLabel}]`;
+}
+
+function formatDocsMarkdownPromptDefinition(node: DocsMarkdownPromptReferenceNode): string {
+  const label =
+    typeof node.label === "string"
+      ? node.label
+      : typeof node.identifier === "string"
+        ? node.identifier
+        : "";
+  const rawUrl = typeof node.url === "string" ? node.url : "";
+  const url = /[<>\s]/u.test(rawUrl) ? `<${rawUrl.replace(/>/gu, "\\>")}>` : rawUrl;
+  const title = typeof node.title === "string" ? ` "${node.title.replace(/"/gu, '\\"')}"` : "";
+  return `[${label}]: ${url}${title}`;
+}
+
+function createDocsMarkdownPromptReferenceText(
+  node: DocsMarkdownPromptReferenceNode,
+  source: string | undefined,
+): DocsMarkdownPromptReferenceNode {
+  return {
+    type: "text",
+    value:
+      sliceDocsMarkdownPromptReferenceSource(node, source) ??
+      formatDocsMarkdownPromptReference(node),
+    position: node.position,
+  };
+}
+
+function createDocsMarkdownPromptDefinitionParagraph(
+  node: DocsMarkdownPromptReferenceNode,
+  source: string | undefined,
+): DocsMarkdownPromptReferenceNode {
+  return {
+    type: "paragraph",
+    children: [
+      {
+        type: "text",
+        value:
+          sliceDocsMarkdownPromptReferenceSource(node, source) ??
+          formatDocsMarkdownPromptDefinition(node),
+        position: node.position,
+      },
+    ],
+    position: node.position,
+  };
+}
+
+/**
+ * Keep `<Prompt>` children literal before Markdown reference definitions are
+ * resolved by the MDX compiler.
+ *
+ * Definitions inside Prompt are copyable source, not page-level definitions.
+ * References inside Prompt always remain source text, while references outside
+ * Prompt only remain live when they have a definition outside Prompt.
+ */
+export function isolateDocsMarkdownPromptReferences(root: unknown, value?: unknown): void {
+  if (!root || typeof root !== "object") return;
+
+  const source = readDocsMarkdownPromptReferenceSource(value);
+  const promptDefinitions = new Set<string>();
+  const pageDefinitions = new Set<string>();
+  let hasPrompt = false;
+
+  const collectDefinitions = (
+    node: DocsMarkdownPromptReferenceNode,
+    insidePrompt: boolean,
+  ): void => {
+    const prompt = isDocsMarkdownPromptNode(node);
+    const literal = insidePrompt || prompt;
+    if (prompt) hasPrompt = true;
+    if (node.type === "definition") {
+      const identifier = normalizeDocsMarkdownReferenceIdentifier(node.identifier);
+      if (identifier) (literal ? promptDefinitions : pageDefinitions).add(identifier);
+    }
+    for (const child of node.children ?? []) collectDefinitions(child, literal);
+  };
+
+  collectDefinitions(root as DocsMarkdownPromptReferenceNode, false);
+  if (!hasPrompt) return;
+
+  const isolateReferences = (
+    node: DocsMarkdownPromptReferenceNode,
+    insidePrompt: boolean,
+  ): void => {
+    const prompt = isDocsMarkdownPromptNode(node);
+    if (prompt) {
+      const promptSource = sliceDocsMarkdownPromptChildrenSource(node, source);
+      if (promptSource !== undefined) {
+        node.children = [{ type: "text", value: promptSource }];
+        return;
+      }
+    }
+
+    const literal = insidePrompt || prompt;
+    const children = node.children;
+    if (!children) return;
+
+    node.children = children.map((child) => {
+      const childInsidePrompt = literal || isDocsMarkdownPromptNode(child);
+      if (childInsidePrompt && child.type === "definition") {
+        return createDocsMarkdownPromptDefinitionParagraph(child, source);
+      }
+
+      if (child.type === "linkReference" || child.type === "imageReference") {
+        const identifier = normalizeDocsMarkdownReferenceIdentifier(child.identifier);
+        if (
+          childInsidePrompt ||
+          (promptDefinitions.has(identifier) && !pageDefinitions.has(identifier))
+        ) {
+          return createDocsMarkdownPromptReferenceText(child, source);
+        }
+      }
+
+      isolateReferences(child, childInsidePrompt);
+      return child;
+    });
+  };
+
+  isolateReferences(root as DocsMarkdownPromptReferenceNode, false);
+}

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -802,6 +802,117 @@ describe("performDocsSearch", () => {
     }
   });
 
+  it("starts provider search before building local documents and skips unused sync projections", async () => {
+    let adapterStarted = false;
+    let agentProjectionReads = 0;
+    let humanProjectionReads = 0;
+    let projectedAfterAdapterStarted = false;
+    const sourcePages = [
+      {
+        title: "Lazy agent search",
+        url: "/docs/lazy-agent-search",
+        content: "Human coral walkthrough.",
+        get rawContent() {
+          humanProjectionReads += 1;
+          return "# Lazy agent search\n\nHuman coral walkthrough.";
+        },
+        get agentRawContent() {
+          agentProjectionReads += 1;
+          projectedAfterAdapterStarted ||= adapterStarted;
+          return "# Lazy agent search\n\nAgent indigo procedure.";
+        },
+      },
+    ];
+
+    const results = await performDocsSearch({
+      pages: sourcePages,
+      query: "agent indigo procedure",
+      audience: "agent",
+      search: createCustomSearchAdapter({
+        name: "lazy-provider",
+        async search() {
+          adapterStarted = true;
+          return [];
+        },
+      }),
+    });
+
+    expect(adapterStarted).toBe(true);
+    expect(projectedAfterAdapterStarted).toBe(true);
+    expect(agentProjectionReads).toBeGreaterThan(0);
+    expect(humanProjectionReads).toBe(0);
+    expect(results[0]?.url).toBe("/docs/lazy-agent-search");
+  });
+
+  it("preserves writable adapter document contexts while materializing lazily", async () => {
+    const replacementDocuments = buildDocsSearchDocuments([
+      {
+        title: "Adapter replacement",
+        url: "/docs/adapter-replacement",
+        content: "Replacement indigo procedure.",
+        rawContent: "# Adapter replacement\n\nReplacement indigo procedure.",
+      },
+    ]);
+
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Unread source",
+          url: "/docs/unread-source",
+          content: "Unread source content.",
+          get rawContent(): string {
+            throw new Error("The replaced document context should not be materialized.");
+          },
+        },
+      ],
+      query: "replacement indigo procedure",
+      search: createCustomSearchAdapter({
+        name: "document-replacement-provider",
+        search(_query, context) {
+          context.documents = replacementDocuments;
+          return Promise.resolve([]);
+        },
+      }),
+    });
+
+    expect(results[0]?.url).toBe("/docs/adapter-replacement");
+  });
+
+  it("observes an in-flight provider rejection when local projection fails", async () => {
+    let rejectProvider: ((reason?: unknown) => void) | undefined;
+    const providerSearch = new Promise<never>((_resolve, reject) => {
+      rejectProvider = reject;
+    });
+    const catchSpy = vi.spyOn(providerSearch, "catch");
+
+    await expect(
+      performDocsSearch({
+        pages: [
+          {
+            title: "Broken projection",
+            url: "/docs/broken-projection",
+            content: "Broken projection content.",
+            get rawContent(): string {
+              throw new Error("Local projection failed.");
+            },
+          },
+        ],
+        query: "broken projection",
+        failureMode: "throw",
+        search: createCustomSearchAdapter({
+          name: "rejecting-provider",
+          search() {
+            return providerSearch;
+          },
+        }),
+      }),
+    ).rejects.toThrow("Local projection failed.");
+
+    expect(catchSpy).toHaveBeenCalledOnce();
+    rejectProvider?.(new Error("Provider failed after local projection."));
+    await Promise.resolve();
+  });
+
   it("returns simple search results with snippets", async () => {
     const results = await performDocsSearch({
       pages,
@@ -2333,6 +2444,71 @@ describe("remote search adapters", () => {
       type: "string[]",
       optional: true,
     });
+  });
+
+  it("starts non-sync MCP I/O before agent projection without building the human corpus", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              serverInfo: { name: "docs-mcp", version: "1.0.0" },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            result: {
+              content: [{ type: "text", text: JSON.stringify({ results: [] }) }],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    let agentProjectionReads = 0;
+    let humanProjectionReads = 0;
+    let mcpStartedBeforeProjection = false;
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Lazy MCP search",
+          url: "/docs/lazy-mcp-search",
+          content: "Human coral walkthrough.",
+          get rawContent() {
+            humanProjectionReads += 1;
+            return "# Lazy MCP search\n\nHuman coral walkthrough.";
+          },
+          get agentRawContent() {
+            agentProjectionReads += 1;
+            mcpStartedBeforeProjection ||= vi.mocked(globalThis.fetch).mock.calls.length > 0;
+            return "# Lazy MCP search\n\nAgent indigo procedure.";
+          },
+        },
+      ],
+      query: "agent indigo procedure",
+      audience: "agent",
+      search: {
+        provider: "mcp",
+        endpoint: "https://docs.example.com/mcp",
+        forwardAudience: true,
+      },
+      baseUrl: "https://docs.example.com",
+    });
+
+    expect(mcpStartedBeforeProjection).toBe(true);
+    expect(agentProjectionReads).toBeGreaterThan(0);
+    expect(humanProjectionReads).toBe(0);
+    expect(results[0]?.url).toBe("/docs/lazy-mcp-search");
   });
 
   it("maps legacy MCP search_docs payloads into docs search results", async () => {

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -176,6 +176,35 @@ Second.
     ]);
   });
 
+  it("keeps contract-marker examples in fences inert for agent section filtering", () => {
+    const documents = buildDocsSearchDocuments(
+      [
+        {
+          title: "Contract marker examples",
+          url: "/docs/contract-marker-examples",
+          content: "Explain contract marker examples.",
+          rawContent: [
+            "```md",
+            "<!-- farming-labs:agent-contract:start -->",
+            "```",
+            "",
+            "## Keep this section",
+            "",
+            "Authored retrieval guidance.",
+            "",
+            "<!-- farming-labs:agent-contract:end -->",
+          ].join("\n"),
+        },
+      ],
+      {},
+      "agent",
+    );
+
+    expect(
+      documents.filter((document) => document.type === "heading").map((document) => document.url),
+    ).toContain("/docs/contract-marker-examples#keep-this-section");
+  });
+
   it("builds distinct human and agent audience indexes", () => {
     const audiencePages = [
       {

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -68,6 +68,114 @@ Second section.
     ]);
   });
 
+  it("uses canonical Unicode, explicit, and collision-safe heading anchors", () => {
+    const documents = buildDocsSearchDocuments([
+      {
+        title: "Anchor guide",
+        url: "/docs/anchors",
+        content: "Canonical anchor guidance.",
+        rawContent: `# Café 配置
+
+## Overview [#release-overview]
+
+## Repeat
+
+First.
+
+## Repeat
+
+Second.
+
+## Foo
+
+## Foo
+
+## Foo-1
+`,
+      },
+    ]);
+
+    expect(
+      documents.filter((document) => document.type === "heading").map((document) => document.url),
+    ).toEqual([
+      "/docs/anchors#caf%C3%A9-%E9%85%8D%E7%BD%AE",
+      "/docs/anchors#release-overview",
+      "/docs/anchors#repeat",
+      "/docs/anchors#repeat-1",
+      "/docs/anchors#foo",
+      "/docs/anchors#foo-1",
+      "/docs/anchors#foo-1-1",
+    ]);
+  });
+
+  it("keeps reserved explicit anchors distinct and URL-safe", () => {
+    const documents = buildDocsSearchDocuments([
+      {
+        title: "Reserved anchors",
+        url: "/docs/reserved",
+        content: "Reserved anchor guidance.",
+        rawContent: [
+          "## Hash [#foo#bar]",
+          "",
+          "Hash content.",
+          "",
+          "## Percent [#foo%23bar]",
+          "",
+          "Percent content.",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(
+      documents.filter((document) => document.type === "heading").map((document) => document.url),
+    ).toEqual(["/docs/reserved#foo%23bar", "/docs/reserved#foo%2523bar"]);
+  });
+
+  it("keeps authored DOM anchors ahead of generated contract-only headings", () => {
+    const documents = buildDocsSearchDocuments(
+      [
+        {
+          title: "Contract collision",
+          url: "/docs/contract-collision",
+          content: "Authored contract collision guidance.",
+          rawContent: [
+            "## Authored [#agent-contract]",
+            "",
+            "Authored collision marker.",
+            "",
+            "## Prerequisites",
+            "",
+            "Authored prerequisite collision marker.",
+          ].join("\n"),
+          agent: {
+            task: "Run the generated contract task.",
+            outcome: "The generated contract outcome is available.",
+            prerequisites: ["Generated prerequisite collision marker."],
+          },
+        },
+      ],
+      {},
+      "agent",
+    );
+
+    expect(
+      documents
+        .filter((document) => document.type === "heading")
+        .map(({ id, section, url }) => ({ id, section, url })),
+    ).toEqual([
+      {
+        id: "/docs/contract-collision#section-0",
+        section: "Authored",
+        url: "/docs/contract-collision#agent-contract",
+      },
+      {
+        id: "/docs/contract-collision#section-1",
+        section: "Prerequisites",
+        url: "/docs/contract-collision#prerequisites",
+      },
+    ]);
+  });
+
   it("builds distinct human and agent audience indexes", () => {
     const audiencePages = [
       {
@@ -1341,6 +1449,35 @@ describe("buildDocsAskAIContext", () => {
     expect(context.results[0]?.url).toBe("/docs/audience-aware#automation");
     expect(context.context).toContain("zircon handshake nonce");
     expect(context.context).not.toContain("Human screenshot walkthrough");
+  });
+
+  it("keeps case-sensitive custom section anchors distinct", async () => {
+    const context = await buildDocsAskAIContext({
+      pages: [
+        {
+          title: "Case-sensitive anchors",
+          url: "/docs/case-sensitive",
+          content: "Case-sensitive anchor guidance.",
+          rawContent: [
+            "## Upper [#Foo]",
+            "",
+            "Shared case-sensitive marker for the uppercase section.",
+            "",
+            "## Lower [#foo]",
+            "",
+            "Shared case-sensitive marker for the lowercase section.",
+          ].join("\n"),
+        },
+      ],
+      query: "shared case-sensitive marker",
+      limit: 5,
+    });
+
+    expect(context.results.map((result) => result.url)).toEqual(
+      expect.arrayContaining(["/docs/case-sensitive#Foo", "/docs/case-sensitive#foo"]),
+    );
+    expect(context.context).toContain("uppercase section");
+    expect(context.context).toContain("lowercase section");
   });
 
   it("retrieves and includes a contract when only its task terms match", async () => {

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -34,7 +34,12 @@ import {
   normalizeAgentVersion,
 } from "./agent-scope.js";
 import { resolveDocsAudienceMdxContent, type DocsContentAudience } from "./audience.js";
-import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
+import {
+  findDocsGeneratedAgentContractRanges,
+  findDocsMarkdownSection,
+  parseDocsMarkdownSections,
+  stripDocsGeneratedAgentContractMarkers,
+} from "./markdown-sections.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;
 const MAX_SEARCH_SNIPPET_CHARS = 160;
@@ -502,10 +507,7 @@ function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
 }
 
 function cleanGeneratedAgentContractMarkers(content: string): string {
-  return content
-    .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
-    .replace(PAGE_AGENT_CONTRACT_END_MARKER, "")
-    .replace(/^\r?\n+/, "");
+  return stripDocsGeneratedAgentContractMarkers(content);
 }
 
 function getAskAIPageSectionContent(page: DocsSearchSourcePage): string {
@@ -928,22 +930,6 @@ function getPageAudienceSectionContent(
   return audience === "agent" ? upsertPageAgentContractMarkdown(content, page.agent) : content;
 }
 
-function getGeneratedAgentContractLineRange(
-  content: string,
-): { startLine: number; endLine: number } | undefined {
-  const lines = content.split(/\r?\n/u);
-  const startIndex = lines.findIndex((line) => line.trim() === PAGE_AGENT_CONTRACT_START_MARKER);
-  if (startIndex < 0) return undefined;
-  const relativeEndIndex = lines
-    .slice(startIndex + 1)
-    .findIndex((line) => line.trim() === PAGE_AGENT_CONTRACT_END_MARKER);
-  if (relativeEndIndex < 0) return undefined;
-  return {
-    startLine: startIndex + 1,
-    endLine: startIndex + relativeEndIndex + 2,
-  };
-}
-
 function getPageAudienceSearchText(
   page: DocsSearchSourcePage,
   audience: DocsContentAudience,
@@ -1127,7 +1113,7 @@ function splitPageIntoSections(
   // authored/rendered anchors before marker-wrapped contract headings, preserving DOM citations.
   const raw = getPageAudienceSectionContent(page, audience);
   const generatedContract =
-    audience === "agent" ? getGeneratedAgentContractLineRange(raw) : undefined;
+    audience === "agent" ? findDocsGeneratedAgentContractRanges(raw)[0] : undefined;
   const scope = resolveDocsSearchPageScope(page);
   let documentIndex = 0;
   return parseDocsMarkdownSections(raw).flatMap((section) => {

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -501,11 +501,19 @@ function resolveAskAIContextUrl(value: string, baseUrl?: string): string {
   }
 }
 
-function getAskAIPageContent(page: DocsSearchSourcePage): string {
-  return upsertPageAgentContractMarkdown(getPageAudienceRawContent(page, "agent"), page.agent)
+function cleanGeneratedAgentContractMarkers(content: string): string {
+  return content
     .replace(PAGE_AGENT_CONTRACT_START_MARKER, "")
     .replace(PAGE_AGENT_CONTRACT_END_MARKER, "")
     .replace(/^\r?\n+/, "");
+}
+
+function getAskAIPageSectionContent(page: DocsSearchSourcePage): string {
+  return getPageAudienceSectionContent(page, "agent");
+}
+
+function getAskAIPageContent(page: DocsSearchSourcePage): string {
+  return cleanGeneratedAgentContractMarkers(getAskAIPageSectionContent(page));
 }
 
 function getPageAgentContractSearchText(page: DocsSearchSourcePage): string {
@@ -713,7 +721,9 @@ function formatAskAIContextResult(options: {
   const sectionSelector = anchor ?? section;
   const rawContent = page
     ? sectionSelector
-      ? (findDocsMarkdownSection(getAskAIPageContent(page), sectionSelector)?.content ?? "")
+      ? cleanGeneratedAgentContractMarkers(
+          findDocsMarkdownSection(getAskAIPageSectionContent(page), sectionSelector)?.content ?? "",
+        )
       : getAskAIPageContent(page)
     : [result.content, result.description].filter(Boolean).join("\n\n");
   const contextContent = clampText(cleanAskAIContextMarkdown(rawContent), maxChars);
@@ -727,17 +737,9 @@ function formatAskAIContextResult(options: {
 }
 
 function getSearchResultKey(result: DocsSearchResult): string {
-  let hash = "";
-
-  try {
-    hash = new URL(result.url, "https://docs.local").hash.replace(/^#/, "");
-  } catch {
-    hash = result.url.split("#")[1]?.split(/[?&]/)[0] ?? "";
-  }
-
-  return `${normalizeUrlPathname(result.url)}#${normalizeWhitespace(
-    hash || result.section || "",
-  ).toLowerCase()}`;
+  const anchor = getSearchResultAnchor(result.url);
+  const sectionFallback = normalizeWhitespace(result.section ?? "").toLowerCase();
+  return `${normalizeUrlPathname(result.url)}#${anchor ?? sectionFallback}`;
 }
 
 function getSearchResultAnchor(value: string): string | undefined {
@@ -746,7 +748,8 @@ function getSearchResultAnchor(value: string): string | undefined {
   try {
     hash = new URL(value, "https://docs.local").hash.replace(/^#/, "");
   } catch {
-    hash = value.split("#")[1]?.split(/[?&]/)[0] ?? "";
+    const hashIndex = value.indexOf("#");
+    hash = hashIndex >= 0 ? value.slice(hashIndex + 1) : "";
   }
 
   if (!hash) return undefined;
@@ -782,9 +785,13 @@ function getAskAIResultKey(
   baseUrl?: string,
   strictExternalOrigins = false,
 ): string {
-  return `${getAskAIResultPageKey(result.url, baseUrl, strictExternalOrigins)}#${normalizeWhitespace(
-    getSearchResultAnchor(result.url) || result.section || "",
-  ).toLowerCase()}`;
+  const anchor = getSearchResultAnchor(result.url);
+  const sectionFallback = normalizeWhitespace(result.section ?? "").toLowerCase();
+  return `${getAskAIResultPageKey(
+    result.url,
+    baseUrl,
+    strictExternalOrigins,
+  )}#${anchor ?? sectionFallback}`;
 }
 
 function mergeSearchResults(
@@ -911,6 +918,30 @@ function getPageAudienceRawContent(
       : (page.rawContent ?? page.content);
 
   return resolveDocsAudienceMdxContent(source, audience);
+}
+
+function getPageAudienceSectionContent(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string {
+  const content = getPageAudienceRawContent(page, audience);
+  return audience === "agent" ? upsertPageAgentContractMarkdown(content, page.agent) : content;
+}
+
+function getGeneratedAgentContractLineRange(
+  content: string,
+): { startLine: number; endLine: number } | undefined {
+  const lines = content.split(/\r?\n/u);
+  const startIndex = lines.findIndex((line) => line.trim() === PAGE_AGENT_CONTRACT_START_MARKER);
+  if (startIndex < 0) return undefined;
+  const relativeEndIndex = lines
+    .slice(startIndex + 1)
+    .findIndex((line) => line.trim() === PAGE_AGENT_CONTRACT_END_MARKER);
+  if (relativeEndIndex < 0) return undefined;
+  return {
+    startLine: startIndex + 1,
+    endLine: startIndex + relativeEndIndex + 2,
+  };
 }
 
 function getPageAudienceSearchText(
@@ -1092,16 +1123,32 @@ function splitPageIntoSections(
   page: DocsSearchSourcePage,
   audience: DocsContentAudience = "human",
 ): DocsSearchDocument[] {
-  const raw = getPageAudienceRawContent(page, audience);
+  // Search, Ask AI, and MCP parse the same agent document. The shared section parser assigns
+  // authored/rendered anchors before marker-wrapped contract headings, preserving DOM citations.
+  const raw = getPageAudienceSectionContent(page, audience);
+  const generatedContract =
+    audience === "agent" ? getGeneratedAgentContractLineRange(raw) : undefined;
   const scope = resolveDocsSearchPageScope(page);
-  return parseDocsMarkdownSections(raw).flatMap((section, index) => {
+  let documentIndex = 0;
+  return parseDocsMarkdownSections(raw).flatMap((section) => {
+    // Contract metadata remains searchable through the page summary. Its generated headings stay
+    // MCP-addressable but do not become duplicate search chunks.
+    if (
+      generatedContract &&
+      section.startLine > generatedContract.startLine &&
+      section.startLine < generatedContract.endLine
+    ) {
+      return [];
+    }
     const content = normalizeWhitespace(stripMarkdownText(section.content));
     if (!content) return [];
+    const index = documentIndex;
+    documentIndex += 1;
 
     return [
       {
         id: makeDocumentId(page.url, `section-${index}`),
-        url: `${page.url}#${section.anchor}`,
+        url: `${page.url.split("#", 1)[0]}#${encodeURIComponent(section.anchor)}`,
         title: page.title,
         section: section.title,
         content,

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -2262,10 +2262,23 @@ export async function performDocsSearch(
         docsSearchPageMatchesFilters(resolveDocsSearchPageScope(page), filters),
       )
     : options.pages;
-  const documents = buildDocsSearchDocuments(scopedPages, search.chunking, audience);
+  let resolvedDocuments: DocsSearchDocument[] | undefined;
+  const getDocuments = (): DocsSearchDocument[] => {
+    if (!resolvedDocuments) {
+      resolvedDocuments = buildDocsSearchDocuments(scopedPages, search.chunking, audience);
+    }
+    return resolvedDocuments;
+  };
   const context: DocsSearchAdapterContext = {
     pages: scopedPages,
-    documents,
+    // Keep document construction lazy so remote providers can begin I/O before the local
+    // audience projection is materialized. Adapters retain the existing array contract.
+    get documents() {
+      return getDocuments();
+    },
+    set documents(documents) {
+      resolvedDocuments = documents;
+    },
     audience,
     locale: options.locale,
     pathname: options.pathname,
@@ -2284,17 +2297,36 @@ export async function performDocsSearch(
 
   try {
     const adapter = await resolveSearchAdapter(search, context);
-    const syncContext =
-      audience === "agent" || hasFilters
-        ? {
-            ...context,
-            pages: options.pages,
-            documents: buildDocsSearchDocuments(options.pages, search.chunking, "human"),
-            audience: "human" as const,
-          }
-        : context;
-    await maybeSyncSearchIndex(adapter, search, syncContext);
-    const results = await adapter.search(query, context);
+    if (shouldSyncOnSearch(search) && typeof adapter.index === "function") {
+      const syncContext: DocsSearchAdapterContext =
+        audience === "agent" || hasFilters
+          ? {
+              pages: options.pages,
+              documents: buildDocsSearchDocuments(options.pages, search.chunking, "human"),
+              audience: "human",
+              locale: options.locale,
+              pathname: options.pathname,
+              siteTitle: options.siteTitle,
+              signal: options.signal,
+            }
+          : context;
+      await maybeSyncSearchIndex(adapter, search, syncContext);
+    }
+
+    // Async adapters execute through their first await immediately, which starts remote
+    // provider work before the CPU-heavy local projection below. Filtered providers that
+    // require local document IDs still materialize the getter synchronously as before.
+    const adapterSearch = adapter.search(query, context);
+    let documents: DocsSearchDocument[];
+    try {
+      documents = getDocuments();
+    } catch (error) {
+      // The provider may still be in flight. Observe a later rejection before falling
+      // through to the configured local-fallback/error path.
+      void adapterSearch.catch(() => undefined);
+      throw error;
+    }
+    const results = await adapterSearch;
     if (search.provider === "simple") return results;
 
     const localAudienceProjectionResults = buildAudienceProjectionSearchResults(

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -127,6 +127,8 @@ export {
   serializeOpenDocsProvider,
   serializeOpenDocsProviders,
 } from "./prompt-utils.js";
+export { extractDocsMarkdownPromptBlocks } from "./audience.js";
+export type { DocsMarkdownPromptBlock, ExtractedDocsMarkdownPromptBlocks } from "./audience.js";
 export {
   DEFAULT_SITEMAP_MANIFEST_PATH,
   DEFAULT_SITEMAP_MD_DOCS_ROUTE,

--- a/packages/docs/src/standards-discovery.ts
+++ b/packages/docs/src/standards-discovery.ts
@@ -45,9 +45,10 @@ export const DEFAULT_A2A_PROTOCOL_BINDING = "HTTP+JSON";
 export const DEFAULT_A2A_PROTOCOL_VERSION = "1.0";
 export const AGENT_SKILLS_DISCOVERY_SCHEMA_URI =
   "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
-export const DOCS_AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v1";
+export const DOCS_AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v2";
+export const DOCS_AGENT_MANIFEST_VERSION = "2";
 export const DOCS_AGENT_MANIFEST_SCHEMA_URI =
-  "https://docs.farming-labs.dev/schema/agent-manifest.v1.json";
+  "https://docs.farming-labs.dev/schema/agent-manifest.v2.json";
 export const DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE = "application/schema+json";
 
 const DEFAULT_DOCS_API_ROUTE = "/api/docs";

--- a/packages/docs/tsdown.config.ts
+++ b/packages/docs/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/server.ts",
+    "src/markdown-rendering.ts",
     "src/agent-skills-spec.ts",
     "src/agent-skills-bundle.ts",
     "src/agent-skills-vite.ts",

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -7,6 +7,7 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@farming-labs/docs/markdown-rendering": resolve(rootDir, "src/markdown-rendering.ts"),
       "@farming-labs/docs/client/react": resolve(rootDir, "src/client/react.ts"),
       "@farming-labs/docs/cloud/server": resolve(rootDir, "src/docs-cloud-server.ts"),
       "@farming-labs/docs/server": resolve(rootDir, "src/server.ts"),

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -14,12 +14,13 @@ import {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
 } from "@farming-labs/docs";
 import { createDocsAPI, createDocsMCPAPI } from "./docs-api.js";
 
 const agentManifestSchema = JSON.parse(
   fs.readFileSync(
-    new URL("../../../website/public/schema/agent-manifest.v1.json", import.meta.url),
+    new URL("../../../website/public/schema/agent-manifest.v2.json", import.meta.url),
     "utf8",
   ),
 ) as Record<string, unknown>;
@@ -862,20 +863,15 @@ The docs app starts.
 
     expect(indexResponse.status).toBe(200);
     expect(indexResponse.headers.get("content-type")).toBe("application/json; charset=utf-8");
-    expect(indexResponse.headers.get("x-docs-markdown-section-count")).toBe("4");
+    expect(indexResponse.headers.get("x-docs-markdown-section-count")).toBe("3");
     expect(index).toMatchObject({
-      format: "docs-markdown-sections.v1",
-      sectionCount: 4,
+      format: "docs-markdown-sections.v2",
+      sectionCount: 3,
       sections: [
         {
           id: "installation",
           heading: "Installation",
           markdownUrl: "http://localhost/docs/installation.md?section=installation",
-        },
-        {
-          id: "installation-2",
-          heading: "Installation",
-          markdownUrl: "http://localhost/docs/installation.md?section=installation-2",
         },
         {
           id: "prerequisites",
@@ -3327,7 +3323,7 @@ description: "Start building quickly"
 
     expect(spec.$schema).toBe(DOCS_AGENT_MANIFEST_SCHEMA_URI);
     expect(spec.format).toBe(DOCS_AGENT_MANIFEST_FORMAT);
-    expect(spec.version).toBe("1");
+    expect(spec.version).toBe(DOCS_AGENT_MANIFEST_VERSION);
     expect(validateAgentManifest(spec), JSON.stringify(validateAgentManifest.errors, null, 2)).toBe(
       true,
     );

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -34,6 +34,7 @@ import {
   DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
+  DOCS_AGENT_MANIFEST_VERSION,
   getDocsMcpProtectedResourceMetadataRoutes,
   acceptsDocsMarkdown,
   normalizeDocsRelated,
@@ -535,7 +536,7 @@ function buildAgentSpec({
   return {
     $schema: DOCS_AGENT_MANIFEST_SCHEMA_URI,
     format: DOCS_AGENT_MANIFEST_FORMAT,
-    version: "1",
+    version: DOCS_AGENT_MANIFEST_VERSION,
     name: "@farming-labs/docs",
     baseUrl: origin,
     site: {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -111,6 +111,7 @@
     "@babel/types": "7.29.7",
     "@farming-labs/docs": "workspace:*",
     "@farming-labs/theme": "workspace:*",
+    "@mdx-js/mdx": "^3.1.1",
     "@types/node": "^22.10.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
@@ -119,7 +120,7 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
-    "@farming-labs/docs": ">=0.2.61",
+    "@farming-labs/docs": ">=0.2.73",
     "@farming-labs/theme": ">=0.0.1",
     "next": ">=16.0.0",
     "react": ">=19.2.0",

--- a/packages/next/src/changelog.test.ts
+++ b/packages/next/src/changelog.test.ts
@@ -21,7 +21,7 @@ describe("changelog rendering", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("preserves explicit heading ids in the changelog TOC", async () => {
+  it("uses canonical explicit, Unicode, duplicate, and collision-safe ids in the TOC", async () => {
     const sourcePath = "app/docs/changelog/2026-04-15/page.mdx";
     mkdirSync(join(tempDir, "app", "docs", "changelog", "2026-04-15"), { recursive: true });
     writeFileSync(
@@ -30,9 +30,35 @@ describe("changelog rendering", () => {
 title: "Release"
 ---
 
+# Repeat
+
 ## Overview [#release-overview]
 
 Release notes.
+
+## Café 配置
+
+International notes.
+
+## Repeat
+
+First.
+
+## Repeat
+
+Second.
+
+##### Foo
+
+## Foo
+
+## Foo
+
+## Foo-1
+
+## Hash [#foo#bar]
+
+## Percent [#foo%23bar]
 `,
       "utf-8",
     );
@@ -65,6 +91,14 @@ Release notes.
     );
 
     expect(html).toContain('href="#release-overview"');
+    expect(html).toContain('href="#caf%C3%A9-%E9%85%8D%E7%BD%AE"');
+    expect(html).toContain('href="#repeat-1"');
+    expect(html).toContain('href="#repeat-2"');
+    expect(html).not.toContain('href="#repeat"');
+    expect(html).toContain('href="#foo-1"');
+    expect(html).toContain('href="#foo-1-1"');
+    expect(html).toContain('href="#foo%23bar"');
+    expect(html).toContain('href="#foo%2523bar"');
   });
 
   it("renders the changelog TOC without injecting an inline script", () => {

--- a/packages/next/src/changelog.tsx
+++ b/packages/next/src/changelog.tsx
@@ -4,8 +4,11 @@ import { notFound } from "next/navigation";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createPageMetadata, type DocsConfig } from "@farming-labs/theme";
-import type { ChangelogFrontmatter } from "@farming-labs/docs";
-import { resolveChangelogConfig } from "@farming-labs/docs";
+import {
+  collectDocsMarkdownSections,
+  resolveChangelogConfig,
+  type ChangelogFrontmatter,
+} from "@farming-labs/docs";
 import { createElement, isValidElement, type ComponentType, type ReactNode } from "react";
 import {
   ChangelogDirectory,
@@ -94,91 +97,16 @@ function truncatePaginationDescription(value: string, maxLength = 110) {
   return truncatePaginationText(value, maxLength);
 }
 
-function stripInlineMarkdown(value: string) {
-  return normalizeWhitespace(
-    value
-      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, "$1")
-      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
-      .replace(/`([^`]+)`/g, "$1")
-      .replace(/\*\*([^*]+)\*\*/g, "$1")
-      .replace(/\*([^*]+)\*/g, "$1")
-      .replace(/__([^_]+)__/g, "$1")
-      .replace(/_([^_]+)_/g, "$1")
-      .replace(/<[^>]+>/g, ""),
-  );
-}
-
-function slugifyHeading(text: string) {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/[`'"‘’“”]/g, "")
-    .replace(/&/g, " and ")
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
-function extractHeadingId(value: string): { title: string; id?: string } {
-  const match = value.match(/\s+(?:\[#([A-Za-z0-9._:-]+)\]|\{#([A-Za-z0-9._:-]+)\})\s*$/);
-  if (!match) return { title: value };
-
-  return {
-    title: value.slice(0, match.index).trimEnd(),
-    id: match[1] ?? match[2],
-  };
-}
-
 function extractChangelogToc(sourcePath: string): TOCItem[] {
   try {
     const content = readFileSync(join(process.cwd(), sourcePath), "utf-8");
-    const lines = content.split(/\r?\n/);
-    const items: TOCItem[] = [];
-    const seenSlugs = new Map<string, number>();
-    let inFrontmatter = false;
-    let frontmatterDone = false;
-    let inFence = false;
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-
-      if (!frontmatterDone && trimmed === "---") {
-        inFrontmatter = !inFrontmatter;
-        if (!inFrontmatter) frontmatterDone = true;
-        continue;
-      }
-
-      if (inFrontmatter) continue;
-
-      if (/^(```|~~~)/.test(trimmed)) {
-        inFence = !inFence;
-        continue;
-      }
-
-      if (inFence) continue;
-
-      const headingMatch = line.match(/^(#{2,4})\s+(.+?)\s*#*\s*$/);
-      if (!headingMatch) continue;
-
-      const depth = headingMatch[1].length;
-      const resolvedHeading = extractHeadingId(headingMatch[2]);
-      const title = stripInlineMarkdown(resolvedHeading.title);
-      if (!title) continue;
-
-      const baseSlug = resolvedHeading.id || slugifyHeading(title) || `section-${items.length + 1}`;
-      const seen = seenSlugs.get(baseSlug) ?? 0;
-      seenSlugs.set(baseSlug, seen + 1);
-      const slug = resolvedHeading.id ? baseSlug : seen === 0 ? baseSlug : `${baseSlug}-${seen}`;
-
-      items.push({
-        title,
-        url: `#${slug}`,
-        depth,
-      });
-    }
-
-    return items;
+    return collectDocsMarkdownSections(content)
+      .filter((heading) => heading.level >= 2 && heading.level <= 4 && heading.heading)
+      .map((heading) => ({
+        title: heading.heading,
+        url: `#${encodeURIComponent(heading.id)}`,
+        depth: heading.level,
+      }));
   } catch {
     return [];
   }

--- a/packages/next/src/layout.tsx
+++ b/packages/next/src/layout.tsx
@@ -55,7 +55,9 @@ function withAnalyticsAction(route: string): string {
       ? url.toString()
       : `${url.pathname}${url.search}${url.hash}`;
   } catch {
-    const [pathAndQuery, hash = ""] = route.split("#", 2);
+    const hashIndex = route.indexOf("#");
+    const pathAndQuery = hashIndex >= 0 ? route.slice(0, hashIndex) : route;
+    const hash = hashIndex >= 0 ? route.slice(hashIndex + 1) : "";
     const separator = pathAndQuery.includes("?") ? "&" : "?";
     return `${pathAndQuery}${separator}action=analytics${hash ? `#${hash}` : ""}`;
   }

--- a/packages/next/src/mdx-plugins/remark-heading.test.ts
+++ b/packages/next/src/mdx-plugins/remark-heading.test.ts
@@ -158,14 +158,215 @@ Visible section.
     expect(agentUrls).toEqual(renderedUrls);
   });
 
+  it("keeps Prompt-only reference definitions literal before MDX resolves them", async () => {
+    const markdown = [
+      "## [Inside][prompt-ref] Setup",
+      "",
+      "<Prompt>",
+      "Use [prompt-ref].",
+      "",
+      '[prompt-ref]: /prompt-only "Prompt only"',
+      "</Prompt>",
+      "",
+      "## [Outside][outside-ref] Setup",
+      "",
+      "[outside-ref]: /outside",
+    ].join("\n");
+    let transformedRoot: unknown;
+    const captureTree = () => (root: unknown) => {
+      transformedRoot = root;
+    };
+    const rendered = await compile(markdown, {
+      remarkPlugins: [remarkHeading, captureTree],
+    });
+    const root = transformedRoot as {
+      children?: Array<{
+        type?: string;
+        name?: unknown;
+        value?: unknown;
+        children?: Array<{
+          type?: string;
+          value?: unknown;
+          children?: Array<{ type?: string; value?: unknown }>;
+        }>;
+      }>;
+    };
+    const headings = root.children?.filter((node) => node.type === "heading") ?? [];
+    const prompt = root.children?.find(
+      (node) => node.type === "mdxJsxFlowElement" && node.name === "Prompt",
+    );
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "[Inside][prompt-ref] Setup",
+        url: "#insideprompt-ref-setup",
+        depth: 2,
+      },
+      {
+        title: "Outside Setup",
+        url: "#outside-setup",
+        depth: 2,
+      },
+    ]);
+    expect(headings[0]?.children?.map((node) => node.value).join("")).toBe(
+      "[Inside][prompt-ref] Setup",
+    );
+    expect(headings[1]?.children?.[0]?.type).toBe("linkReference");
+    expect(prompt?.children).toEqual([
+      {
+        type: "text",
+        value: '\nUse [prompt-ref].\n\n[prompt-ref]: /prompt-only "Prompt only"\n',
+      },
+    ]);
+    expect(String(rendered)).toContain('[prompt-ref]: /prompt-only \\"Prompt only\\"');
+    expect(String(rendered)).toContain('href: "/outside"');
+    expect(String(rendered)).not.toContain('href: "/prompt-only"');
+  });
+
+  it("uses a page definition when Prompt repeats the same reference identifier", async () => {
+    const markdown = [
+      "## [Outside][shared]",
+      "",
+      "<Prompt>",
+      "[shared]: /prompt-only",
+      "</Prompt>",
+      "",
+      "[shared]: /outside",
+    ].join("\n");
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "Outside",
+        url: "#outside",
+        depth: 2,
+      },
+    ]);
+    expect(String(rendered)).toContain("[shared]: /prompt-only");
+    expect(String(rendered)).toContain('href: "/outside"');
+    expect(String(rendered)).not.toContain('href: "/prompt-only"');
+  });
+
+  it("preserves adjacent definitions as one literal Prompt child", async () => {
+    const markdown = ["<Prompt>", "[a]: /a", "[b]: /b", "Use [A][a] and [B][b].", "</Prompt>"].join(
+      "\n",
+    );
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+
+    expect(String(rendered)).toContain(
+      'children: "\\n[a]: /a\\n[b]: /b\\nUse [A][a] and [B][b].\\n"',
+    );
+    expect(String(rendered)).not.toContain("href:");
+  });
+
+  it("keeps every prompt-only reference form literal outside Prompt", async () => {
+    const title = [
+      "[Full][full]",
+      "[Collapsed][]",
+      "[Shortcut]",
+      "![Image][image]",
+      "![Collapsed image][]",
+      "![Shortcut image]",
+    ].join(" ");
+    const markdown = [
+      `## ${title}`,
+      "",
+      "<Prompt>",
+      "[full]: /full",
+      "[Collapsed]: /collapsed",
+      "[Shortcut]: /shortcut",
+      "[image]: /image.png",
+      "[Collapsed image]: /collapsed.png",
+      "[Shortcut image]: /shortcut.png",
+      "</Prompt>",
+    ].join("\n");
+    let transformedRoot: unknown;
+    const captureTree = () => (root: unknown) => {
+      transformedRoot = root;
+    };
+    const rendered = await compile(markdown, {
+      remarkPlugins: [remarkHeading, captureTree],
+    });
+    const root = transformedRoot as {
+      children?: Array<{
+        type?: string;
+        value?: unknown;
+        children?: Array<{ type?: string; value?: unknown }>;
+      }>;
+    };
+    const heading = root.children?.find((node) => node.type === "heading");
+
+    expect(
+      heading?.children
+        ?.filter((node) => node.value !== " ")
+        .map(({ type, value }) => ({ type, value })),
+    ).toEqual([
+      { type: "text", value: "[Full][full]" },
+      { type: "text", value: "[Collapsed][]" },
+      { type: "text", value: "[Shortcut]" },
+      { type: "text", value: "![Image][image]" },
+      { type: "text", value: "![Collapsed image][]" },
+      { type: "text", value: "![Shortcut image]" },
+    ]);
+    expect((rendered.data.toc as Array<{ title: string }> | undefined)?.[0]?.title).toBe(title);
+    expect(String(rendered)).not.toContain("href:");
+    expect(String(rendered)).not.toContain("src:");
+  });
+
+  it("keeps Prompt references literal when their definitions belong to the page", async () => {
+    const markdown = [
+      "<Prompt>",
+      "Keep [shared] as source.",
+      "</Prompt>",
+      "",
+      "## [Shared][shared]",
+      "",
+      "[shared]: /outside",
+    ].join("\n");
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "Shared",
+        url: "#shared",
+        depth: 2,
+      },
+    ]);
+    expect(String(rendered)).toContain("Keep [shared] as source.");
+    expect(String(rendered).match(/href: "\/outside"/gu)).toHaveLength(1);
+  });
+
+  it("preserves Prompt reference source in BOM-prefixed MDX", async () => {
+    const markdown = [
+      "\uFEFF<Prompt>",
+      "[X][x]",
+      "",
+      "[x]: /prompt-only",
+      "</Prompt>",
+      "",
+      "## [X][x]",
+    ].join("\n");
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "[X][x]",
+        url: "#xx",
+        depth: 2,
+      },
+    ]);
+    expect(String(rendered).match(/children: "\[X\]\[x\]"/gu)).toHaveLength(1);
+    expect(String(rendered)).toContain('children: "\\n[X][x]\\n\\n[x]: /prompt-only\\n"');
+  });
+
   it("keeps Prompt headings out when a custom slug callback is configured", async () => {
-    const rendered = await compile(`<Prompt>\n## Hidden\n</Prompt>\n\n## Visible\n`, {
+    const rendered = await compile(`<Prompt>\n## Hidden\n</Prompt>\n\n## Café 配置\n`, {
       remarkPlugins: [
         [
           remarkHeading,
           {
             slug: (_root: unknown, _heading: unknown, text: string) =>
-              `custom-${text.toLowerCase()}`,
+              `custom-${text.toLowerCase()}#v2`,
           },
         ],
       ],
@@ -173,8 +374,8 @@ Visible section.
 
     expect(rendered.data.toc).toEqual([
       {
-        title: "Visible",
-        url: "#custom-visible",
+        title: "Café 配置",
+        url: "#custom-caf%C3%A9%20%E9%85%8D%E7%BD%AE%23v2",
         depth: 2,
       },
     ]);

--- a/packages/next/src/mdx-plugins/remark-heading.test.ts
+++ b/packages/next/src/mdx-plugins/remark-heading.test.ts
@@ -1,0 +1,182 @@
+import { compile } from "@mdx-js/mdx";
+import { collectDocsMarkdownSections, upsertPageAgentContractMarkdown } from "@farming-labs/docs";
+import { describe, expect, it } from "vitest";
+import remarkHeading from "./remark-heading.js";
+
+describe("remarkHeading", () => {
+  it("keeps authored DOM ids stable when agent-only contracts use the same headings", async () => {
+    const markdown = [
+      "## Authored [#agent-contract]",
+      "",
+      "Authored collision marker.",
+      "",
+      "## Prerequisites",
+      "",
+      "Authored prerequisite marker.",
+    ].join("\n");
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+    const renderedUrls = (rendered.data.toc as Array<{ url: string }> | undefined)?.map(
+      (item) => item.url,
+    );
+    const agentDocument = upsertPageAgentContractMarkdown(markdown, {
+      task: "Run the generated contract task.",
+      outcome: "The generated contract outcome is available.",
+      prerequisites: ["Generated prerequisite marker."],
+    });
+
+    expect(renderedUrls).toEqual(["#agent-contract", "#prerequisites"]);
+    expect(
+      collectDocsMarkdownSections(agentDocument).map(({ heading, id }) => ({
+        title: heading,
+        anchor: id,
+      })),
+    ).toEqual([
+      { title: "Agent Contract", anchor: "agent-contract-1" },
+      { title: "Prerequisites", anchor: "prerequisites-1" },
+      { title: "Authored", anchor: "agent-contract" },
+      { title: "Prerequisites", anchor: "prerequisites" },
+    ]);
+  });
+
+  it("keeps rendered and agent anchors identical for complex headings", async () => {
+    const markdown = `# Café 配置
+
+## Foo &eacute; Bar
+
+## ![Rocket](assets/a(b).png) Setup
+
+## ![Rocket] Shortcut setup
+
+## Use \`[#literal-id]\`
+
+## &lt;API&gt; Setup
+
+## \`&eacute;\` code
+
+## \\[literal\\](url) text
+
+## Hello <Badge title="a > b">New</Badge> World
+
+## Overview [#release-overview]
+
+## Entity [#foo&amp;bar]
+
+## Hash [#foo#bar]
+
+## Percent [#foo%23bar]
+
+## Repeat
+
+## Repeat
+
+## Custom [#foo]
+
+## Foo
+
+## Duplicate custom [#foo]
+
+## Foo-1
+
+> ## Quoted
+
+- ## Listed
+
+<Callout>
+## Nested
+</Callout>
+
+[Rocket]: /rocket.png
+`;
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+    const renderedUrls = (rendered.data.toc as Array<{ url: string }> | undefined)?.map(
+      (item) => item.url,
+    );
+    const renderedAnchors = renderedUrls?.map((url) => decodeURIComponent(url.slice(1)));
+    const agentAnchors = collectDocsMarkdownSections(markdown).map((section) => section.id);
+
+    expect(renderedAnchors).toEqual(agentAnchors);
+    expect(renderedAnchors).toEqual([
+      "café-配置",
+      "foo-é-bar",
+      "setup",
+      "shortcut-setup",
+      "use-literal-id",
+      "api-setup",
+      "eacute-code",
+      "literalurl-text",
+      "hello-new-world",
+      "release-overview",
+      "foo&bar",
+      "foo#bar",
+      "foo%23bar",
+      "repeat",
+      "repeat-1",
+      "foo",
+      "foo-1",
+      "foo-2",
+      "foo-1-1",
+      "quoted",
+      "listed",
+      "nested",
+    ]);
+    expect(renderedUrls).toContain("#foo%23bar");
+    expect(renderedUrls).toContain("#foo%2523bar");
+  });
+
+  it("honors customId false without treating visible text as raw Markdown", async () => {
+    const rendered = await compile("## Plain [#fixed]\n", {
+      remarkPlugins: [[remarkHeading, { customId: false }]],
+    });
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "Plain [#fixed]",
+        url: "#plain-fixed",
+        depth: 2,
+      },
+    ]);
+  });
+
+  it("keeps literal Prompt headings out of rendered and agent TOCs", async () => {
+    const markdown = `<Prompt>
+## Repeat [#prompt-only]
+
+Use this as literal input.
+</Prompt>
+
+## Repeat
+
+Visible section.
+`;
+    const rendered = await compile(markdown, { remarkPlugins: [remarkHeading] });
+    const renderedUrls = (rendered.data.toc as Array<{ url: string }> | undefined)?.map(
+      (item) => item.url,
+    );
+    const agentUrls = collectDocsMarkdownSections(markdown).map((section) => `#${section.id}`);
+
+    expect(renderedUrls).toEqual(["#repeat"]);
+    expect(agentUrls).toEqual(renderedUrls);
+  });
+
+  it("keeps Prompt headings out when a custom slug callback is configured", async () => {
+    const rendered = await compile(`<Prompt>\n## Hidden\n</Prompt>\n\n## Visible\n`, {
+      remarkPlugins: [
+        [
+          remarkHeading,
+          {
+            slug: (_root: unknown, _heading: unknown, text: string) =>
+              `custom-${text.toLowerCase()}`,
+          },
+        ],
+      ],
+    });
+
+    expect(rendered.data.toc).toEqual([
+      {
+        title: "Visible",
+        url: "#custom-visible",
+        depth: 2,
+      },
+    ]);
+  });
+});

--- a/packages/next/src/mdx-plugins/remark-heading.ts
+++ b/packages/next/src/mdx-plugins/remark-heading.ts
@@ -1,40 +1,28 @@
 import {
   applyDocsMarkdownHeadingAnchors,
+  encodeDocsHeadingTocUrls,
+  isolateDocsMarkdownPromptReferences,
   withDocsMarkdownRenderableHeadings,
 } from "@farming-labs/docs";
 import { remarkHeading as createFumadocsRemarkHeading } from "fumadocs-core/mdx-plugins/remark-heading";
-
-function encodeDocsHeadingTocUrls(value: unknown): void {
-  if (Array.isArray(value)) {
-    for (const item of value) encodeDocsHeadingTocUrls(item);
-    return;
-  }
-  if (!value || typeof value !== "object") return;
-
-  const item = value as { url?: unknown; children?: unknown };
-  if (typeof item.url === "string") {
-    const hashIndex = item.url.indexOf("#");
-    if (hashIndex >= 0) {
-      item.url = `${item.url.slice(0, hashIndex)}#${encodeURIComponent(
-        item.url.slice(hashIndex + 1),
-      )}`;
-    }
-  }
-  encodeDocsHeadingTocUrls(item.children);
-}
 
 export default function remarkHeading(
   options: Parameters<typeof createFumadocsRemarkHeading>[0] = {},
 ): ReturnType<typeof createFumadocsRemarkHeading> {
   if (options.slug) {
     const customRemarkHeading = createFumadocsRemarkHeading(options);
-    return (root, file) =>
-      withDocsMarkdownRenderableHeadings(root, () =>
+    return (root, file) => {
+      isolateDocsMarkdownPromptReferences(root, file.value);
+      const result = withDocsMarkdownRenderableHeadings(root, () =>
         customRemarkHeading(root, file, () => undefined),
       );
+      encodeDocsHeadingTocUrls(file.data.toc);
+      return result;
+    };
   }
 
   return (root, file) => {
+    isolateDocsMarkdownPromptReferences(root, file.value);
     applyDocsMarkdownHeadingAnchors(root, { customId: options.customId });
     withDocsMarkdownRenderableHeadings(root, () =>
       createFumadocsRemarkHeading({

--- a/packages/next/src/mdx-plugins/remark-heading.ts
+++ b/packages/next/src/mdx-plugins/remark-heading.ts
@@ -1,1 +1,48 @@
-export { remarkHeading as default } from "fumadocs-core/mdx-plugins/remark-heading";
+import {
+  applyDocsMarkdownHeadingAnchors,
+  withDocsMarkdownRenderableHeadings,
+} from "@farming-labs/docs";
+import { remarkHeading as createFumadocsRemarkHeading } from "fumadocs-core/mdx-plugins/remark-heading";
+
+function encodeDocsHeadingTocUrls(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) encodeDocsHeadingTocUrls(item);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  const item = value as { url?: unknown; children?: unknown };
+  if (typeof item.url === "string") {
+    const hashIndex = item.url.indexOf("#");
+    if (hashIndex >= 0) {
+      item.url = `${item.url.slice(0, hashIndex)}#${encodeURIComponent(
+        item.url.slice(hashIndex + 1),
+      )}`;
+    }
+  }
+  encodeDocsHeadingTocUrls(item.children);
+}
+
+export default function remarkHeading(
+  options: Parameters<typeof createFumadocsRemarkHeading>[0] = {},
+): ReturnType<typeof createFumadocsRemarkHeading> {
+  if (options.slug) {
+    const customRemarkHeading = createFumadocsRemarkHeading(options);
+    return (root, file) =>
+      withDocsMarkdownRenderableHeadings(root, () =>
+        customRemarkHeading(root, file, () => undefined),
+      );
+  }
+
+  return (root, file) => {
+    applyDocsMarkdownHeadingAnchors(root, { customId: options.customId });
+    withDocsMarkdownRenderableHeadings(root, () =>
+      createFumadocsRemarkHeading({
+        ...options,
+        customId: false,
+      })(root, file, () => undefined),
+    );
+    encodeDocsHeadingTocUrls(file.data.toc);
+    return root;
+  };
+}

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -62,6 +62,6 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
-    "@farming-labs/docs": "*"
+    "@farming-labs/docs": ">=0.2.73"
   }
 }

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -11,6 +11,7 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  createDocsMarkdownBlockPlaceholderAllocator,
   extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
   extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
   prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
@@ -23,6 +24,7 @@ import {
   type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
 } from "@farming-labs/docs/markdown-rendering";
 import {
+  extractDocsMarkdownPromptBlocks,
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -99,6 +101,11 @@ interface RenderMarkdownOptions {
   theme?: DocsTheme;
   icons?: Record<string, string>;
   openDocsProviders?: SerializedOpenDocsProvider[];
+}
+
+interface RenderedMarkdownBlock {
+  html: string;
+  token: string;
 }
 
 function escapeHtml(value: string): string {
@@ -603,7 +610,15 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAudienceMdxContent(content, "human");
+  // Prompt children are literal copyable text, not renderable Markdown. Protect
+  // them before audience projection, reference collection, and heading
+  // preparation so none of those document-level passes can consume or interpret
+  // Prompt-only syntax.
+  const extractedPrompts = extractDocsMarkdownPromptBlocks(content);
+  const promptBlocks = extractedPrompts.blocks;
+  let result = extractedPrompts.markdown;
+  result = resolveDocsAudienceMdxContent(result, "human");
+  const allocateBlockPlaceholder = createDocsMarkdownBlockPlaceholderAllocator(result);
   const extractedReferences = extractMarkdownReferenceDefinitions(result);
   const referenceDefinitions = extractedReferences.definitions;
   const preparedHeadings = prepareMarkdownHeadings(result);
@@ -618,7 +633,7 @@ export async function renderMarkdown(
   const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
-  const tabsBlocks: string[] = [];
+  const tabsBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
     (_: string, attrSource: string | undefined, body: string) => {
@@ -663,8 +678,8 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
@@ -722,78 +737,60 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
 
-  // Prompt bodies are literal copyable text. Protect them before fenced code
-  // rendering so examples remain escaped text rather than injected figures.
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      const extractedHeadings = extractRenderedHeadingElements(
-        children,
-        referenceDefinitions,
-        true,
-        headingOpeningTags,
-      );
-      promptBlocks.push(
-        extractedHeadings.headingsHtml +
-          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
-      );
-      return placeholder;
-    },
-  );
-
-  const hoverLinkBlocks: string[] = [];
+  const hoverLinkBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
-      const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
+      const placeholder = allocateBlockPlaceholder("HOVERLINK");
       const extractedHeadings = extractRenderedHeadingElements(
         children,
         referenceDefinitions,
         false,
         headingOpeningTags,
       );
-      hoverLinkBlocks.push(
-        extractedHeadings.headingsHtml +
+      hoverLinkBlocks.push({
+        html:
+          extractedHeadings.headingsHtml +
           renderHoverLink(attrSource, extractedHeadings.content, options.theme),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
 
   // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  const codeBlocks: RenderedMarkdownBlock[] = [];
   result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
     const { lang, title } = parseMeta(info);
     const { html, raw } = highlightCode(hl, code, lang);
-    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    const placeholder = allocateBlockPlaceholder("CODEBLOCK");
+    codeBlocks.push({ html: wrapCodeWithCopy(html, raw, title, lang), token: placeholder });
     return placeholder;
   });
 
-  const calloutBlocks: string[] = [];
+  const calloutBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
     (_: string, attrSource: string | undefined, children: string) => {
       const attrs = parseJsxAttributes(attrSource ?? "");
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(
-        renderCallout(
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(
           type,
           restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
           title,
           referenceDefinitions,
         ),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
@@ -810,8 +807,11 @@ export async function renderMarkdown(
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
@@ -819,15 +819,19 @@ export async function renderMarkdown(
     if (boldMatch) {
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
-    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-    calloutBlocks.push(
-      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
-    );
+    const placeholder = allocateBlockPlaceholder("CALLOUT");
+    calloutBlocks.push({
+      html: `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+      token: placeholder,
+    });
     return placeholder;
   });
 
@@ -862,24 +866,47 @@ export async function renderMarkdown(
   );
 
   // Unordered lists
-  result = result.replace(/(?:^- .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => l.startsWith("- "))
-      .map((l: string) => `<li>${l.slice(2)}</li>`)
-      .join("");
-    return `<ul>${items}</ul>`;
-  });
+  result = result.replace(
+    /(?:^[-+*] [^\r\n]+(?:\r?\n(?:(?: {2,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        if (/^[-+*] /.test(line)) {
+          items.push(line.slice(2));
+          continue;
+        }
+        if (items.length > 0) {
+          items[items.length - 1] += `\n${line.replace(/^(?: {2}|\t)/, "")}`;
+        }
+      }
+      return `<ul>${items.map((item) => `<li>${item}</li>`).join("")}</ul>`;
+    },
+  );
 
   // Ordered lists
-  result = result.replace(/(?:^\d+\. .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => /^\d+\. /.test(l))
-      .map((l: string) => `<li>${l.replace(/^\d+\. /, "")}</li>`)
-      .join("");
-    return `<ol>${items}</ol>`;
-  });
+  result = result.replace(
+    /(?:^\d{1,9}[.)] [^\r\n]+(?:\r?\n(?:(?: {3,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      let continuationIndent = 0;
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        const marker = /^(\d{1,9}[.)]) (.*)$/.exec(line);
+        if (marker) {
+          items.push(marker[2]);
+          continuationIndent = marker[1].length + 1;
+          continue;
+        }
+        if (items.length > 0) {
+          const content =
+            line[0] === "\t"
+              ? line.slice(1)
+              : line.slice(Math.min(continuationIndent, /^ */.exec(line)?.[0].length ?? 0));
+          items[items.length - 1] += `\n${content}`;
+        }
+      }
+      return `<ol>${items.map((item) => `<li>${item}</li>`).join("")}</ol>`;
+    },
+  );
 
   // Wrap remaining bare text in <p> tags
   result = result
@@ -897,24 +924,27 @@ export async function renderMarkdown(
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < calloutBlocks.length; i++) {
-    result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
+  for (const block of calloutBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < tabsBlocks.length; i++) {
-    result = result.replace(`%%TABS_${i}%%`, tabsBlocks[i]);
+  for (const block of tabsBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < hoverLinkBlocks.length; i++) {
-    result = result.replace(`%%HOVERLINK_${i}%%`, hoverLinkBlocks[i]);
+  for (const block of hoverLinkBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < promptBlocks.length; i++) {
-    result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
-  }
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  for (const block of codeBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
 
-  return restoreMarkdownHeadingOpeningTags(
+  result = restoreMarkdownHeadingOpeningTags(
     stripPreparedMarkdownHeadingTokens(result),
     headingOpeningTags,
   );
+  for (const block of promptBlocks) {
+    result = result.replace(block.token, () =>
+      renderPrompt(block.attributes, block.children, options),
+    );
+  }
+  return result;
 }

--- a/packages/nuxt/src/markdown.ts
+++ b/packages/nuxt/src/markdown.ts
@@ -11,6 +11,18 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
+  extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
+  prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
+  replaceDocsMarkdownFencedCodeBlocks as replaceMarkdownFencedCodeBlocks,
+  renderDocsMarkdownBlockContent as renderMarkdownBlockContent,
+  renderDocsMarkdownHeadings as renderMarkdownHeadings,
+  renderDocsMarkdownInline as renderMarkdownInline,
+  restoreDocsMarkdownHeadingOpeningTags as restoreMarkdownHeadingOpeningTags,
+  stripPreparedDocsMarkdownHeadingTokens as stripPreparedMarkdownHeadingTokens,
+  type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
+} from "@farming-labs/docs/markdown-rendering";
+import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -45,16 +57,6 @@ function getHighlighter(): Promise<Highlighter> {
   return highlighterPromise;
 }
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/<[^>]+>/g, "")
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .trim();
-}
-
 const hoverLinkDefaults = {
   linkLabel: "Open page",
   showIndicator: false,
@@ -72,6 +74,16 @@ const promptDefaults = {
   copiedIcon: "check",
   openIcon: "arrowUpRight",
 } as const;
+
+function slugifyCodeGroupTab(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
 
 const promptActionIcons: Record<string, string> = {
   copy: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>',
@@ -408,23 +420,17 @@ function normalizeCalloutType(type: string): string {
   return calloutIcons[aliased] ? aliased : "note";
 }
 
-function renderInlineCalloutContent(content: string): string {
-  return content
-    .trim()
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
-    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/\n+/g, "<br />");
-}
-
-function renderCallout(type: string, content: string, title?: string | null): string {
+function renderCallout(
+  type: string,
+  content: string,
+  title: string | null | undefined,
+  definitions: MarkdownReferenceDefinitions,
+): string {
   const normalizedType = normalizeCalloutType(type);
   const icon = calloutIcons[normalizedType] || calloutIcons.note;
   const label = title?.trim() || calloutLabels[normalizedType] || "Note";
-  const renderedContent = renderInlineCalloutContent(content);
-  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
+  const renderedContent = renderMarkdownBlockContent(content, definitions);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p>${renderedContent}</div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -515,7 +521,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
 }
 
 function createCodeGroupTabValue(label: string, used: Set<string>): string {
-  const slug = slugify(label) || `code-${used.size + 1}`;
+  const slug = slugifyCodeGroupTab(label) || `code-${used.size + 1}`;
   let value = slug;
   let suffix = 2;
 
@@ -598,6 +604,18 @@ export async function renderMarkdown(
 
   const hl = await getHighlighter();
   let result = resolveDocsAudienceMdxContent(content, "human");
+  const extractedReferences = extractMarkdownReferenceDefinitions(result);
+  const referenceDefinitions = extractedReferences.definitions;
+  const preparedHeadings = prepareMarkdownHeadings(result);
+  const preparedWithoutReferences = extractMarkdownReferenceDefinitions(
+    preparedHeadings.markdown,
+  ).markdown;
+  const renderedHeadings = renderMarkdownHeadings(
+    preparedWithoutReferences,
+    preparedHeadings.headings,
+  );
+  result = renderedHeadings.markdown;
+  const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
@@ -608,25 +626,31 @@ export async function renderMarkdown(
       const dropdown = toBoolean(attrs.dropdown, false);
       const usedValues = new Set<string>();
       const panels: { label: string; value: string; html: string }[] = [];
-      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
-      let codeMatch: RegExpExecArray | null;
-
-      while ((codeMatch = codeRegex.exec(body)) !== null) {
-        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+      replaceMarkdownFencedCodeBlocks(body, ({ code, info }) => {
+        const { lang, title } = parseCodeGroupMeta(info);
         const label = title || lang || `Code ${panels.length + 1}`;
         const value = createCodeGroupTabValue(label, usedValues);
-        const dedented = dedentCode(codeMatch[2]);
+        const dedented = dedentCode(code);
         const { html, raw } = highlightCode(hl, dedented, lang);
         panels.push({
           label,
           value,
           html: wrapCodeWithCopy(html, raw, null, lang),
         });
-      }
+        return "";
+      });
 
       if (panels.length === 0) return body;
+      const extractedHeadings = extractRenderedHeadingElements(
+        body,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
 
-      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      let tabsHtml =
+        extractedHeadings.headingsHtml +
+        `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
       tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
         const state = i === 0 ? "active" : "inactive";
@@ -655,15 +679,33 @@ export async function renderMarkdown(
       let tabMatch: RegExpExecArray | null;
       while ((tabMatch = tabRegex.exec(body)) !== null) {
         const tabValue = tabMatch[1];
-        const tabContent = tabMatch[2].trim();
-        const codeMatch = tabContent.match(/```([^\n]*)\n([\s\S]*?)```/);
-        if (codeMatch) {
-          const { lang, title } = parseMeta(codeMatch[1]);
-          const dedented = dedentCode(codeMatch[2]);
+        const extractedHeadings = extractRenderedHeadingElements(
+          tabMatch[2].trim(),
+          referenceDefinitions,
+          false,
+          headingOpeningTags,
+        );
+        let renderedCode: string | undefined;
+        replaceMarkdownFencedCodeBlocks(extractedHeadings.content, ({ code, info }) => {
+          if (renderedCode !== undefined) return "";
+          const { lang, title } = parseMeta(info);
+          const dedented = dedentCode(code);
           const { html, raw } = highlightCode(hl, dedented, lang);
-          panels.push({ value: tabValue, html: wrapCodeWithCopy(html, raw, title, lang) });
+          renderedCode = wrapCodeWithCopy(html, raw, title, lang);
+          return "";
+        });
+        if (renderedCode !== undefined) {
+          panels.push({
+            value: tabValue,
+            html: extractedHeadings.headingsHtml + renderedCode,
+          });
         } else {
-          panels.push({ value: tabValue, html: `<p>${tabContent}</p>` });
+          panels.push({
+            value: tabValue,
+            html:
+              extractedHeadings.headingsHtml +
+              renderMarkdownBlockContent(extractedHeadings.content, referenceDefinitions),
+          });
         }
       }
 
@@ -686,15 +728,23 @@ export async function renderMarkdown(
     },
   );
 
-  // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  // Prompt bodies are literal copyable text. Protect them before fenced code
+  // rendering so examples remain escaped text rather than injected figures.
+  const promptBlocks: string[] = [];
   result = result.replace(
-    /```([^\n]*)\n([\s\S]*?)```/g,
-    (_: string, meta: string, code: string) => {
-      const { lang, title } = parseMeta(meta);
-      const { html, raw } = highlightCode(hl, code, lang);
-      const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-      codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        true,
+        headingOpeningTags,
+      );
+      promptBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
+      );
       return placeholder;
     },
   );
@@ -704,20 +754,29 @@ export async function renderMarkdown(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
       const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
-      hoverLinkBlocks.push(renderHoverLink(attrSource, children, options.theme));
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
+      hoverLinkBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderHoverLink(attrSource, extractedHeadings.content, options.theme),
+      );
       return placeholder;
     },
   );
 
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      promptBlocks.push(renderPrompt(attrSource ?? "", children, options));
-      return placeholder;
-    },
-  );
+  // ── Fenced code blocks ──
+  const codeBlocks: string[] = [];
+  result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
+    const { lang, title } = parseMeta(info);
+    const { html, raw } = highlightCode(hl, code, lang);
+    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
+    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    return placeholder;
+  });
 
   const calloutBlocks: string[] = [];
   result = result.replace(
@@ -727,37 +786,32 @@ export async function renderMarkdown(
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, children, title));
+      calloutBlocks.push(
+        renderCallout(
+          type,
+          restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
+          title,
+          referenceDefinitions,
+        ),
+      );
       return placeholder;
     },
   );
 
-  // Inline code
-  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
-
-  // Headings (h4 → h1 order to avoid prefix collisions)
-  result = result.replace(/^#### (.+)$/gm, (_: string, text: string) => {
-    return `<h4 id="${slugify(text)}">${text}</h4>`;
-  });
-  result = result.replace(/^### (.+)$/gm, (_: string, text: string) => {
-    return `<h3 id="${slugify(text)}">${text}</h3>`;
-  });
-  result = result.replace(/^## (.+)$/gm, (_: string, text: string) => {
-    return `<h2 id="${slugify(text)}">${text}</h2>`;
-  });
-  result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
-
   // ── Callouts / blockquotes (before inline formatting) ──
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
-    const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");
+    const inner = restoreMarkdownHeadingOpeningTags(
+      lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n"),
+      headingOpeningTags,
+    );
 
     const ghMatch = inner.match(/^\[!(NOTE|WARNING|TIP|IMPORTANT|CAUTION)\]\s*\n?([\s\S]*)/i);
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
@@ -766,26 +820,18 @@ export async function renderMarkdown(
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
-    return `<blockquote><p>${inner}</p></blockquote>`;
+    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+    calloutBlocks.push(
+      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+    );
+    return placeholder;
   });
 
-  // Inline formatting
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
-  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
-
-  // Images — before links so ![alt](url) is not captured as a link
-  result = result.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (_: string, alt: string, src: string) =>
-      `<img src="${src}" alt="${alt.replace(/"/g, "&quot;")}" class="fd-docs-content-img" loading="lazy" decoding="async" />`,
-  );
-  // Links
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  result = renderMarkdownInline(result, referenceDefinitions);
 
   // Horizontal rules
   result = result.replace(/^---$/gm, "<hr />");
@@ -842,15 +888,15 @@ export async function renderMarkdown(
       block = block.trim();
       if (!block) return "";
       if (/^<(h[1-6]|pre|ul|ol|blockquote|hr|table|div)/.test(block)) return block;
-      if (/^%%(CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%$/.test(block)) return block;
+      if (/^%%FARMINGLABS_DOCS_HEADING_OPEN_\d+%%/.test(block)) return block;
+      if (/^%%(?:CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%/.test(block)) {
+        return block;
+      }
       return `<p>${block}</p>`;
     })
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
-  }
   for (let i = 0; i < calloutBlocks.length; i++) {
     result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
   }
@@ -863,6 +909,12 @@ export async function renderMarkdown(
   for (let i = 0; i < promptBlocks.length; i++) {
     result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
   }
+  for (let i = 0; i < codeBlocks.length; i++) {
+    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  }
 
-  return result;
+  return restoreMarkdownHeadingOpeningTags(
+    stripPreparedMarkdownHeadingTokens(result),
+    headingOpeningTags,
+  );
 }

--- a/packages/nuxt/test/markdown-placeholders.test.ts
+++ b/packages/nuxt/test/markdown-placeholders.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown block placeholders", () => {
+  it("keeps authored placeholder-like text separate from rendered blocks", async () => {
+    const html = await renderMarkdown(
+      [
+        "%%CALLOUT_0%%",
+        "",
+        "%%CODEBLOCK_0%%",
+        "",
+        "<Callout>Real callout content.</Callout>",
+        "",
+        "```js",
+        'console.log("real code");',
+        "```",
+      ].join("\n"),
+    );
+
+    expect(html).toContain("%%CALLOUT_0%%");
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html.match(/class="fd-callout fd-callout-/gu)).toHaveLength(1);
+    expect(html.match(/console\.log/gu)).toHaveLength(1);
+    expect(html.indexOf("%%CALLOUT_0%%")).toBeLessThan(html.indexOf("Real callout content."));
+    expect(html.indexOf("%%CODEBLOCK_0%%")).toBeLessThan(html.indexOf("console.log"));
+  });
+});

--- a/packages/nuxt/test/markdown.test.ts
+++ b/packages/nuxt/test/markdown.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown heading anchors", () => {
+  it("uses canonical Unicode, explicit, duplicate, and collision-safe ids", async () => {
+    const html = await renderMarkdown(`# Café 配置
+
+## Overview [#release-overview]
+
+## Entity [#foo&amp;bar]
+
+## Repeat
+
+First.
+
+### Repeat
+
+Second.
+
+## Foo
+
+## Foo
+
+## Foo-1
+
+Setext heading
+---------------
+`);
+
+    expect(html).toContain('<h1 id="café-配置">Café 配置</h1>');
+    expect(html).toContain('<h2 id="release-overview">Overview</h2>');
+    expect(html).toContain('<h2 id="foo&amp;bar">Entity</h2>');
+    expect(html).not.toContain("foo&amp;amp;bar");
+    expect(html).toContain('<h2 id="repeat">Repeat</h2>');
+    expect(html).toContain('<h3 id="repeat-1">Repeat</h3>');
+    expect(html).toContain('<h2 id="foo">Foo</h2>');
+    expect(html).toContain('<h2 id="foo-1">Foo</h2>');
+    expect(html).toContain('<h2 id="foo-1-1">Foo-1</h2>');
+    expect(html).toContain('<h2 id="setext-heading">Setext heading</h2>');
+    expect(html).not.toContain("[#release-overview]");
+  });
+
+  it("renders addressable headings inside custom MDX blocks", async () => {
+    const html = await renderMarkdown(`<Callout>
+## Repeat
+</Callout>
+
+<Tabs items={["One"]}>
+<Tab value="One">
+### Repeat
+</Tab>
+</Tabs>
+
+## Repeat
+`);
+
+    expect(html).toContain('<h2 id="repeat">Repeat</h2>');
+    expect(html).toContain('<h3 id="repeat-1">Repeat</h3>');
+    expect(html).toContain('<h2 id="repeat-2">Repeat</h2>');
+    expect(html).not.toContain("FARMINGLABS_DOCS_HEADING_ANCHOR");
+  });
+
+  it("normalizes CRLF input without changing canonical anchors", async () => {
+    const html = await renderMarkdown("## Repeat\r\n\r\n## Repeat\r\n");
+
+    expect(html).toContain('<h2 id="repeat">Repeat</h2>');
+    expect(html).toContain('<h2 id="repeat-1">Repeat</h2>');
+    expect(html).not.toContain("\r");
+  });
+
+  it("renders complex and container heading anchors consistently", async () => {
+    const html = await renderMarkdown(`## [Balanced](https://example.com/a_(b)c) Link
+
+## ![Rocket](assets/a(b).png) Setup
+
+## \\[literal\\](url) text
+
+## Hello <Badge title="a > b">New</Badge> World
+
+> ## Quoted
+
+- ## Listed
+`);
+
+    expect(html).toContain('id="balanced-link"');
+    expect(html).toContain('id="setup"');
+    expect(html).toContain('id="literalurl-text"');
+    expect(html).toContain('id="hello-new-world"');
+    expect(html).toContain('id="quoted"');
+    expect(html).toContain('id="listed"');
+  });
+
+  it("renders balanced, reference, unresolved, and escaped inline resources safely", async () => {
+    const html = await renderMarkdown(`## ![Rocket](assets/a(b).png) Setup
+
+## ![Rocket] Shortcut setup
+
+## ![Missing] Literal setup
+
+## \\[literal\\](url) text
+
+[Rocket]: /rocket.png "Rocket ship"
+`);
+
+    expect(html).toContain('<img src="assets/a(b).png" alt="Rocket" class="fd-docs-content-img"');
+    expect(html).toContain('<img src="/rocket.png" alt="Rocket" class="fd-docs-content-img');
+    expect(html).toContain('title="Rocket ship"');
+    expect(html).toContain('<h2 id="missing-literal-setup">![Missing] Literal setup</h2>');
+    expect(html).toContain('<h2 id="literalurl-text">[literal](url) text</h2>');
+    expect(html).not.toContain('href="url"');
+    expect(html).not.toContain("[Rocket]:");
+    expect(html).not.toContain(".png) Setup");
+  });
+
+  it("renders a resolved hash shortcut link without treating it as a custom id", async () => {
+    const html = await renderMarkdown(`## [#foo]
+
+[#foo]: /guide
+`);
+
+    expect(html).toContain('<h2 id="foo"><a href="/guide">#foo</a></h2>');
+    expect(html).not.toContain('<h2 id="foo"></h2>');
+  });
+
+  it("keeps nested heading markup valid and protects explicit ids from inline formatting", async () => {
+    const html = await renderMarkdown(`> ## Quoted
+
+<Callout>
+## Nested
+
+Body.
+</Callout>
+
+## *Styled* [#foo*bar]
+`);
+
+    expect(html).toContain('<blockquote><h2 id="quoted">Quoted</h2></blockquote>');
+    expect(html).toContain(
+      '<div class="fd-callout-content"><p class="fd-callout-title">Note</p><h2 id="nested">Nested</h2><p>Body.</p></div>',
+    );
+    expect(html).toContain('<h2 id="foo*bar"><em>Styled</em></h2>');
+    expect(html).not.toMatch(/<p>\s*<(?:h[1-6]|blockquote|div)\b/);
+  });
+
+  it("keeps literal Prompt headings out while preserving rendered component headings", async () => {
+    const html = await renderMarkdown(`<Prompt>
+## Prompt heading [#prompt-only]
+
+Do this.
+</Prompt>
+
+## Prompt heading
+
+<HoverLink href="/guide" title="Guide" description="Read it">
+## Hover heading
+</HoverLink>
+
+<CodeGroup>
+## Code heading
+
+\`\`\`ts title="example.ts"
+const value = 1
+\`\`\`
+</CodeGroup>
+`);
+
+    expect(html).toContain('<h2 id="prompt-heading">Prompt heading</h2>');
+    expect(html.match(/<h2 id="prompt-heading">/g)).toHaveLength(1);
+    expect(html).not.toContain('id="prompt-only"');
+    expect(html).toContain("## Prompt heading [#prompt-only]");
+    expect(html).toContain('<h2 id="hover-heading">Hover heading</h2>');
+    expect(html).toContain('<h2 id="code-heading">Code heading</h2>');
+    expect(html).toContain("data-prompt-card");
+    expect(html).toContain("data-hover-link");
+    expect(html).toContain("data-code-group");
+    expect(html).not.toContain("FARMINGLABS_DOCS_HEADING_OPEN");
+  });
+
+  it("keeps heading-shaped HTML inside tab code fences as code", async () => {
+    const html = await renderMarkdown(`<Tabs items={["HTML"]}>
+<Tab value="HTML">
+\`\`\`html
+<h2>Example only</h2>
+\`\`\`
+</Tab>
+</Tabs>
+
+## Real heading
+`);
+
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).not.toContain("<h2>Example only</h2>");
+    expect(html).toContain("&lt;h2");
+    expect(html).toContain("Example only");
+    expect(html).toContain("&lt;/h2");
+  });
+
+  it("keeps heading-shaped HTML inside tilde and longer outer fences as code", async () => {
+    const html = await renderMarkdown(`~~~html
+<h2 id="tilde-example">Tilde example only</h2>
+~~~
+
+\`\`\`\`markdown
+\`\`\`html
+<h2 id="nested-example">Nested example only</h2>
+\`\`\`
+\`\`\`\`
+
+## Real heading
+`);
+
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).not.toContain('<h2 id="tilde-example">');
+    expect(html).not.toContain('<h2 id="nested-example">');
+    expect(html).toContain("&lt;h2 id=&quot;tilde-example&quot;&gt;");
+    expect(html).toContain("&lt;h2 id=&quot;nested-example&quot;&gt;");
+  });
+
+  it("keeps heading-shaped HTML inside EOF-closed fences as code", async () => {
+    const [tildeHtml, backtickHtml] = await Promise.all([
+      renderMarkdown(`~~~html
+<h2 id="tilde-eof-example">Tilde EOF example only</h2>`),
+      renderMarkdown(`\`\`\`\`markdown
+\`\`\`html
+<h2 id="backtick-eof-example">Backtick EOF example only</h2>
+\`\`\``),
+    ]);
+
+    expect(tildeHtml).not.toContain('<h2 id="tilde-eof-example">');
+    expect(backtickHtml).not.toContain('<h2 id="backtick-eof-example">');
+    expect(tildeHtml).toContain("&lt;h2 id=&quot;tilde-eof-example&quot;&gt;");
+    expect(backtickHtml).toContain("&lt;h2 id=&quot;backtick-eof-example&quot;&gt;");
+  });
+
+  it("keeps fenced Prompt content as escaped copyable text", async () => {
+    const html = await renderMarkdown(`<Prompt>
+\`\`\`html
+<h2 id="prompt-example">Prompt example only</h2>
+\`\`\`
+</Prompt>
+
+<HoverLink href="/guide" title="Guide" description="Read it">
+\`\`\`html
+<h2 id="hover-example">Hover example only</h2>
+\`\`\`
+</HoverLink>`);
+
+    expect(html).toContain("data-prompt-card");
+    expect(html).toContain("data-hover-link");
+    expect(html).toContain("&lt;h2 id=&quot;prompt-example&quot;&gt;");
+    expect(html).toContain("&lt;h2 id=&quot;hover-example&quot;&gt;");
+    expect(html).not.toContain('<h2 id="prompt-example">');
+    expect(html).not.toContain('<h2 id="hover-example">');
+    expect(html).not.toContain("<figure");
+    expect(html).not.toContain("%%CODEBLOCK_");
+  });
+
+  it("keeps authored Markdown and HTML headings inside Prompt escaped and inert", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+## Indexed heading
+
+<h2 id="authored-heading" onclick="alert(1)">Authored heading</h2>
+</Prompt>`);
+
+    expect(html).toContain("## Indexed heading");
+    expect(html).not.toContain('<h2 id="indexed-heading">');
+    expect(html).toContain(
+      "&lt;h2 id=&quot;authored-heading&quot; onclick=&quot;alert(1)&quot;&gt;Authored heading&lt;/h2&gt;",
+    );
+    expect(html).not.toContain('<h2 id="authored-heading"');
+    expect(html).not.toContain("FARMINGLABS_DOCS_HEADING_OPEN");
+  });
+
+  it("keeps heading-shaped HTML inside blockquote and list fences as code", async () => {
+    const html = await renderMarkdown(`> ~~~html
+> <h2 id="quote-example">Quote example only</h2>
+> ~~~
+
+- \`\`\`\`markdown
+  \`\`\`html
+  <h2 id="list-example">List example only</h2>
+  \`\`\`
+  \`\`\`\`
+
+<CodeGroup>
+> ~~~html
+> <h2 id="code-group-example">Code group example only</h2>
+> ~~~
+</CodeGroup>
+
+## Real heading
+`);
+
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).not.toContain('<h2 id="quote-example">');
+    expect(html).not.toContain('<h2 id="list-example">');
+    expect(html).not.toContain('<h2 id="code-group-example">');
+    expect(html).toContain("&lt;h2 id=&quot;quote-example&quot;&gt;");
+    expect(html).toContain("&lt;h2 id=&quot;list-example&quot;&gt;");
+    expect(html).toContain("&lt;h2 id=&quot;code-group-example&quot;&gt;");
+    expect(html).not.toContain("<blockquote><p><figure");
+    expect(html).not.toContain("<p><figure");
+    expect(html).not.toContain("<p><blockquote");
+  });
+
+  it("keeps container fence and Setext rendering aligned with the canonical parser", async () => {
+    const html = await renderMarkdown(`> \`\`\`
+> code
+
+## Outside
+
+> Quoted
+>===
+
+- Listed
+  ===
+`);
+
+    expect(html).toContain('<h2 id="outside">Outside</h2>');
+    expect(html).toContain('<h1 id="quoted">Quoted</h1>');
+    expect(html).toContain('<h1 id="listed">Listed</h1>');
+  });
+
+  it("renders complete multiline Setext headings without leaving an extra rule", async () => {
+    const html = await renderMarkdown(`First *line*
+second \`line\`
+---
+
+Custom first
+custom second [#custom-setext]
+---
+`);
+
+    expect(html).toContain(
+      '<h2 id="first-line-second-line">First <em>line</em> second <code>line</code></h2>',
+    );
+    expect(html).toContain('<h2 id="custom-setext">Custom first custom second</h2>');
+    expect(html).not.toContain("[#custom-setext]");
+    expect(html).not.toContain("<hr");
+  });
+
+  it("keeps canonical line mapping after frontmatter", async () => {
+    const html = await renderMarkdown(`---
+title: Anchors
+---
+
+# Overview
+
+## Install
+`);
+
+    expect(html).toContain('<h1 id="overview">Overview</h1>');
+    expect(html).toContain('<h2 id="install">Install</h2>');
+  });
+});

--- a/packages/nuxt/test/markdown.test.ts
+++ b/packages/nuxt/test/markdown.test.ts
@@ -271,6 +271,112 @@ const value = 1
     expect(html).not.toContain("FARMINGLABS_DOCS_HEADING_OPEN");
   });
 
+  it("preserves literal Prompt definitions without exposing them to document links", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+Use [prompt-only].
+[prompt-only]: /from-prompt "Prompt only"
+<Agent>Keep this literal.</Agent>
+</Prompt>
+
+Outside [prompt-only].
+
+[public]: /outside
+
+Outside [public].`);
+
+    expect(html).toContain("Use [prompt-only].");
+    expect(html).toContain("[prompt-only]: /from-prompt &quot;Prompt only&quot;");
+    expect(html).toContain("&lt;Agent&gt;Keep this literal.&lt;/Agent&gt;");
+    expect(html).toContain("Outside [prompt-only].");
+    expect(html).not.toContain('href="/from-prompt"');
+    expect(html).toContain('Outside <a href="/outside">public</a>.');
+    expect(html).not.toContain("[public]: /outside");
+  });
+
+  it("keeps Prompt-looking Markdown literals inert", async () => {
+    const literalSources = [
+      [
+        "FENCED_PROMPT_LITERAL",
+        ["```mdx", "<Prompt>", "FENCED_PROMPT_LITERAL", "</Prompt>", "```"].join("\n"),
+      ],
+      [
+        "QUOTED_PROMPT_LITERAL",
+        ["> ~~~~mdx", "> <Prompt>", "> QUOTED_PROMPT_LITERAL", "> </Prompt>", "> ~~~~"].join("\n"),
+      ],
+      [
+        "LIST_PROMPT_LITERAL",
+        ["- ~~~mdx", "  <Prompt>", "  LIST_PROMPT_LITERAL", "  </Prompt>", "  ~~~"].join("\n"),
+      ],
+      ["INLINE_PROMPT_LITERAL", "`<Prompt>INLINE_PROMPT_LITERAL</Prompt>`"],
+      [
+        "LINK_PROMPT_LITERAL",
+        '[Example](https://example.com "Use <Prompt>LINK_PROMPT_LITERAL</Prompt>")',
+      ],
+      [
+        "LINK_LABEL_PROMPT_LITERAL",
+        "[<Prompt>LINK_LABEL_PROMPT_LITERAL</Prompt>](https://example.com)",
+      ],
+      ["EXPRESSION_PROMPT_LITERAL", "{<Prompt>EXPRESSION_PROMPT_LITERAL</Prompt>}"],
+      [
+        "PROP_PROMPT_LITERAL",
+        "<Card example={<Prompt>PROP_PROMPT_LITERAL</Prompt>}>Card body</Card>",
+      ],
+      ["UNRESOLVED_PROMPT_LITERAL", "[<Prompt>UNRESOLVED_PROMPT_LITERAL</Prompt>][]"],
+      ["UNRESOLVED_IMAGE_PROMPT_LITERAL", "![<Prompt>UNRESOLVED_IMAGE_PROMPT_LITERAL</Prompt>]"],
+      [
+        "RAW_HTML_PROMPT_LITERAL",
+        ["<pre>", "<Prompt>RAW_HTML_PROMPT_LITERAL</Prompt>", "</pre>"].join("\n"),
+      ],
+      [
+        "UPPERCASE_RAW_HTML_PROMPT_LITERAL",
+        ["<SCRIPT>", "<Prompt>UPPERCASE_RAW_HTML_PROMPT_LITERAL</Prompt>", "</SCRIPT>"].join("\n"),
+      ],
+      ["SVG_PROMPT_LITERAL", "<svg><Prompt>SVG_PROMPT_LITERAL</Prompt></svg>"],
+      ["UPPERCASE_SVG_PROMPT_LITERAL", "<SVG><Prompt>UPPERCASE_SVG_PROMPT_LITERAL</Prompt></SVG>"],
+      ["MATH_PROMPT_LITERAL", "<math><Prompt>MATH_PROMPT_LITERAL</Prompt></math>"],
+      [
+        "UPPERCASE_MATH_PROMPT_LITERAL",
+        "<MATH><Prompt>UPPERCASE_MATH_PROMPT_LITERAL</Prompt></MATH>",
+      ],
+      ["CDATA_PROMPT_LITERAL", "<![CDATA[<Prompt>CDATA_PROMPT_LITERAL</Prompt>]]>"],
+    ] as const;
+
+    for (const [marker, source] of literalSources) {
+      const html = await renderMarkdown(source);
+      expect(html).toContain(marker);
+      expect(html).not.toContain("data-prompt-card");
+    }
+
+    const liveHtml = await renderMarkdown("<Prompt showPrompt>LIVE_PROMPT</Prompt>");
+    expect(liveHtml).toContain("LIVE_PROMPT");
+    expect(liveHtml.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("preserves flow boundaries and complete nested Prompt copy", async () => {
+    const html = await renderMarkdown(`Before.
+<Prompt showPrompt>
+Run the check.
+</Prompt>
+After.
+
+---
+
+Done.`);
+
+    expect(html).toContain("<p>Before.</p>");
+    expect(html).toContain("<p>After.</p>");
+    expect(html).toContain("<hr />");
+    expect(html).toContain("<p>Done.</p>");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(html).not.toMatch(/<(?:p|h[1-6])[^>]*>\s*<div class="fd-prompt"/);
+
+    const nested = await renderMarkdown(
+      "<Prompt showPrompt>outer <Prompt>inner</Prompt> tail</Prompt>",
+    );
+    expect(nested.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(nested).toContain("outer &lt;Prompt&gt;inner&lt;/Prompt&gt; tail");
+  });
+
   it("keeps heading-shaped HTML inside blockquote and list fences as code", async () => {
     const html = await renderMarkdown(`> ~~~html
 > <h2 id="quote-example">Quote example only</h2>
@@ -351,5 +457,96 @@ title: Anchors
 
     expect(html).toContain('<h1 id="overview">Overview</h1>');
     expect(html).toContain('<h2 id="install">Install</h2>');
+  });
+
+  it("restores Prompt after downstream code and heading transport tokens", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+%%CODEBLOCK_0%%
+%%FARMINGLABS_DOCS_HEADING_OPEN_0%%
+</Prompt>
+
+## Real heading
+
+\`\`\`ts
+const real = true;
+\`\`\``);
+
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html).toContain("%%FARMINGLABS_DOCS_HEADING_OPEN_0%%");
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).toContain("real");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("keeps live Prompt cards and copied text inside blockquote and list containers", async () => {
+    const html = await renderMarkdown(`> Before
+> <Prompt showPrompt>
+> Quote task
+> </Prompt>
+> After
+
+- Before
+  <Prompt showPrompt>
+  List task
+  </Prompt>
+  After`);
+
+    expect(html).toMatch(
+      /<blockquote>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/blockquote>/,
+    );
+    expect(html).toMatch(/<li>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/li>/);
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">Quote task</div>');
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">List task</div>');
+    expect(html).not.toContain("&gt; Quote task");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(2);
+  });
+
+  it("keeps Prompt cards inside every unordered and ordered list marker", async () => {
+    const html = await renderMarkdown(`+ <Prompt showPrompt>
+  Plus task
+  </Prompt>
+
+* <Prompt showPrompt>
+  Star task
+  </Prompt>
+
+1. Before
+   <Prompt showPrompt>
+   Ordered task
+   </Prompt>
+   After
+
+2) <Prompt showPrompt>
+   Parenthesized task
+   </Prompt>`);
+
+    expect(html.match(/data-prompt-card/g)).toHaveLength(4);
+    expect(html.match(/<ul><li><div class="fd-prompt"/g)).toHaveLength(2);
+    expect(html).toMatch(/<ol><li>Before[\s\S]*data-prompt-card[\s\S]*After<\/li><\/ol>/);
+    expect(html).toContain('<ol><li><div class="fd-prompt"');
+    for (const task of ["Plus task", "Star task", "Ordered task", "Parenthesized task"]) {
+      expect(html).toContain(`<div data-prompt-text hidden aria-hidden="true">${task}</div>`);
+    }
+
+    const simple = await renderMarkdown(
+      ["- One", "+ Two", "* Three", "", "1. First", "2. Second"].join("\n"),
+    );
+    expect(simple).toContain("<ul><li>One</li><li>Two</li><li>Three</li></ul>");
+    expect(simple).toContain("<ol><li>First</li><li>Second</li></ol>");
+  });
+
+  it("keeps standalone Prompt cards separate from Setext markers for LF and CRLF", async () => {
+    for (const newline of ["\n", "\r\n"]) {
+      for (const marker of ["---", "==="]) {
+        const html = await renderMarkdown(
+          `<Prompt showPrompt>x</Prompt>${newline}${marker}${newline}After`,
+        );
+        expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+        expect(html).not.toMatch(/<h[12][^>]*>\s*<div class="fd-prompt"/);
+      }
+    }
+
+    const inline = await renderMarkdown("Before <Prompt showPrompt>x</Prompt> after");
+    expect(inline).toContain('<p>Before <div class="fd-prompt"');
   });
 });

--- a/packages/nuxt/vitest.config.ts
+++ b/packages/nuxt/vitest.config.ts
@@ -7,6 +7,10 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      "@farming-labs/docs/markdown-rendering": resolve(
+        rootDir,
+        "../docs/src/markdown-rendering.ts",
+      ),
       "@farming-labs/docs/server": resolve(rootDir, "../docs/src/server.ts"),
       "@farming-labs/docs": resolve(rootDir, "../docs/src/index.ts"),
     },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -51,6 +51,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -61,7 +63,8 @@
   "devDependencies": {
     "@farming-labs/docs": "workspace:*",
     "@types/node": "^22.10.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "@farming-labs/docs": ">=0.2.73"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -64,6 +64,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@farming-labs/docs": "*"
+    "@farming-labs/docs": ">=0.2.73"
   }
 }

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -11,6 +11,7 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  createDocsMarkdownBlockPlaceholderAllocator,
   extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
   extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
   prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
@@ -23,6 +24,7 @@ import {
   type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
 } from "@farming-labs/docs/markdown-rendering";
 import {
+  extractDocsMarkdownPromptBlocks,
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -99,6 +101,11 @@ interface RenderMarkdownOptions {
   theme?: DocsTheme;
   icons?: Record<string, string>;
   openDocsProviders?: SerializedOpenDocsProvider[];
+}
+
+interface RenderedMarkdownBlock {
+  html: string;
+  token: string;
 }
 
 function escapeHtml(value: string): string {
@@ -603,7 +610,15 @@ export async function renderMarkdown(
   if (!content) return "";
 
   const hl = await getHighlighter();
-  let result = resolveDocsAudienceMdxContent(content, "human");
+  // Prompt children are literal copyable text, not renderable Markdown. Protect
+  // them before audience projection, reference collection, and heading
+  // preparation so none of those document-level passes can consume or interpret
+  // Prompt-only syntax.
+  const extractedPrompts = extractDocsMarkdownPromptBlocks(content);
+  const promptBlocks = extractedPrompts.blocks;
+  let result = extractedPrompts.markdown;
+  result = resolveDocsAudienceMdxContent(result, "human");
+  const allocateBlockPlaceholder = createDocsMarkdownBlockPlaceholderAllocator(result);
   const extractedReferences = extractMarkdownReferenceDefinitions(result);
   const referenceDefinitions = extractedReferences.definitions;
   const preparedHeadings = prepareMarkdownHeadings(result);
@@ -618,7 +633,7 @@ export async function renderMarkdown(
   const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
-  const tabsBlocks: string[] = [];
+  const tabsBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<CodeGroup(?:\s+([^>]*?))?>([\s\S]*?)<\/CodeGroup>/g,
     (_: string, attrSource: string | undefined, body: string) => {
@@ -663,8 +678,8 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
@@ -722,78 +737,60 @@ export async function renderMarkdown(
       }
       tabsHtml += `</div>`;
 
-      const placeholder = `%%TABS_${tabsBlocks.length}%%`;
-      tabsBlocks.push(tabsHtml);
+      const placeholder = allocateBlockPlaceholder("TABS");
+      tabsBlocks.push({ html: tabsHtml, token: placeholder });
       return placeholder;
     },
   );
 
-  // Prompt bodies are literal copyable text. Protect them before fenced code
-  // rendering so examples remain escaped text rather than injected figures.
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      const extractedHeadings = extractRenderedHeadingElements(
-        children,
-        referenceDefinitions,
-        true,
-        headingOpeningTags,
-      );
-      promptBlocks.push(
-        extractedHeadings.headingsHtml +
-          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
-      );
-      return placeholder;
-    },
-  );
-
-  const hoverLinkBlocks: string[] = [];
+  const hoverLinkBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
-      const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
+      const placeholder = allocateBlockPlaceholder("HOVERLINK");
       const extractedHeadings = extractRenderedHeadingElements(
         children,
         referenceDefinitions,
         false,
         headingOpeningTags,
       );
-      hoverLinkBlocks.push(
-        extractedHeadings.headingsHtml +
+      hoverLinkBlocks.push({
+        html:
+          extractedHeadings.headingsHtml +
           renderHoverLink(attrSource, extractedHeadings.content, options.theme),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
 
   // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  const codeBlocks: RenderedMarkdownBlock[] = [];
   result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
     const { lang, title } = parseMeta(info);
     const { html, raw } = highlightCode(hl, code, lang);
-    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    const placeholder = allocateBlockPlaceholder("CODEBLOCK");
+    codeBlocks.push({ html: wrapCodeWithCopy(html, raw, title, lang), token: placeholder });
     return placeholder;
   });
 
-  const calloutBlocks: string[] = [];
+  const calloutBlocks: RenderedMarkdownBlock[] = [];
   result = result.replace(
     /<Callout(?:\s+([^>]*?))?>([\s\S]*?)<\/Callout>/g,
     (_: string, attrSource: string | undefined, children: string) => {
       const attrs = parseJsxAttributes(attrSource ?? "");
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(
-        renderCallout(
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(
           type,
           restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
           title,
           referenceDefinitions,
         ),
-      );
+        token: placeholder,
+      });
       return placeholder;
     },
   );
@@ -810,8 +807,11 @@ export async function renderMarkdown(
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
@@ -819,15 +819,19 @@ export async function renderMarkdown(
     if (boldMatch) {
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
-      const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
+      const placeholder = allocateBlockPlaceholder("CALLOUT");
+      calloutBlocks.push({
+        html: renderCallout(type, calloutContent, undefined, referenceDefinitions),
+        token: placeholder,
+      });
       return placeholder;
     }
 
-    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-    calloutBlocks.push(
-      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
-    );
+    const placeholder = allocateBlockPlaceholder("CALLOUT");
+    calloutBlocks.push({
+      html: `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+      token: placeholder,
+    });
     return placeholder;
   });
 
@@ -862,24 +866,47 @@ export async function renderMarkdown(
   );
 
   // Unordered lists
-  result = result.replace(/(?:^- .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => l.startsWith("- "))
-      .map((l: string) => `<li>${l.slice(2)}</li>`)
-      .join("");
-    return `<ul>${items}</ul>`;
-  });
+  result = result.replace(
+    /(?:^[-+*] [^\r\n]+(?:\r?\n(?:(?: {2,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        if (/^[-+*] /.test(line)) {
+          items.push(line.slice(2));
+          continue;
+        }
+        if (items.length > 0) {
+          items[items.length - 1] += `\n${line.replace(/^(?: {2}|\t)/, "")}`;
+        }
+      }
+      return `<ul>${items.map((item) => `<li>${item}</li>`).join("")}</ul>`;
+    },
+  );
 
   // Ordered lists
-  result = result.replace(/(?:^\d+\. .+\n?)+/gm, (block: string) => {
-    const items = block
-      .split("\n")
-      .filter((l: string) => /^\d+\. /.test(l))
-      .map((l: string) => `<li>${l.replace(/^\d+\. /, "")}</li>`)
-      .join("");
-    return `<ol>${items}</ol>`;
-  });
+  result = result.replace(
+    /(?:^\d{1,9}[.)] [^\r\n]+(?:\r?\n(?:(?: {3,}|\t)[^\r\n]+))*(?:\r?\n|$))+/gm,
+    (block: string) => {
+      const items: string[] = [];
+      let continuationIndent = 0;
+      for (const line of block.trimEnd().split(/\r?\n/)) {
+        const marker = /^(\d{1,9}[.)]) (.*)$/.exec(line);
+        if (marker) {
+          items.push(marker[2]);
+          continuationIndent = marker[1].length + 1;
+          continue;
+        }
+        if (items.length > 0) {
+          const content =
+            line[0] === "\t"
+              ? line.slice(1)
+              : line.slice(Math.min(continuationIndent, /^ */.exec(line)?.[0].length ?? 0));
+          items[items.length - 1] += `\n${content}`;
+        }
+      }
+      return `<ol>${items.map((item) => `<li>${item}</li>`).join("")}</ol>`;
+    },
+  );
 
   // Wrap remaining bare text in <p> tags
   result = result
@@ -897,24 +924,27 @@ export async function renderMarkdown(
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < calloutBlocks.length; i++) {
-    result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
+  for (const block of calloutBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < tabsBlocks.length; i++) {
-    result = result.replace(`%%TABS_${i}%%`, tabsBlocks[i]);
+  for (const block of tabsBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < hoverLinkBlocks.length; i++) {
-    result = result.replace(`%%HOVERLINK_${i}%%`, hoverLinkBlocks[i]);
+  for (const block of hoverLinkBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
-  for (let i = 0; i < promptBlocks.length; i++) {
-    result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
-  }
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  for (const block of codeBlocks) {
+    result = result.replace(block.token, () => block.html);
   }
 
-  return restoreMarkdownHeadingOpeningTags(
+  result = restoreMarkdownHeadingOpeningTags(
     stripPreparedMarkdownHeadingTokens(result),
     headingOpeningTags,
   );
+  for (const block of promptBlocks) {
+    result = result.replace(block.token, () =>
+      renderPrompt(block.attributes, block.children, options),
+    );
+  }
+  return result;
 }

--- a/packages/svelte/src/markdown.ts
+++ b/packages/svelte/src/markdown.ts
@@ -11,6 +11,18 @@
 
 import { resolveDocsAudienceMdxContent, type DocsTheme } from "@farming-labs/docs";
 import {
+  extractDocsMarkdownReferenceDefinitions as extractMarkdownReferenceDefinitions,
+  extractDocsRenderedHeadingElements as extractRenderedHeadingElements,
+  prepareDocsMarkdownHeadings as prepareMarkdownHeadings,
+  replaceDocsMarkdownFencedCodeBlocks as replaceMarkdownFencedCodeBlocks,
+  renderDocsMarkdownBlockContent as renderMarkdownBlockContent,
+  renderDocsMarkdownHeadings as renderMarkdownHeadings,
+  renderDocsMarkdownInline as renderMarkdownInline,
+  restoreDocsMarkdownHeadingOpeningTags as restoreMarkdownHeadingOpeningTags,
+  stripPreparedDocsMarkdownHeadingTokens as stripPreparedMarkdownHeadingTokens,
+  type DocsMarkdownReferenceDefinitions as MarkdownReferenceDefinitions,
+} from "@farming-labs/docs/markdown-rendering";
+import {
   parsePromptStringArray,
   resolvePromptProviderChoices,
   sanitizePromptText,
@@ -45,16 +57,6 @@ function getHighlighter(): Promise<Highlighter> {
   return highlighterPromise;
 }
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/<[^>]+>/g, "")
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .trim();
-}
-
 const hoverLinkDefaults = {
   linkLabel: "Open page",
   showIndicator: false,
@@ -72,6 +74,16 @@ const promptDefaults = {
   copiedIcon: "check",
   openIcon: "arrowUpRight",
 } as const;
+
+function slugifyCodeGroupTab(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}
 
 const promptActionIcons: Record<string, string> = {
   copy: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>',
@@ -408,23 +420,17 @@ function normalizeCalloutType(type: string): string {
   return calloutIcons[aliased] ? aliased : "note";
 }
 
-function renderInlineCalloutContent(content: string): string {
-  return content
-    .trim()
-    .replace(/`([^`]+)`/g, "<code>$1</code>")
-    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
-    .replace(/\n+/g, "<br />");
-}
-
-function renderCallout(type: string, content: string, title?: string | null): string {
+function renderCallout(
+  type: string,
+  content: string,
+  title: string | null | undefined,
+  definitions: MarkdownReferenceDefinitions,
+): string {
   const normalizedType = normalizeCalloutType(type);
   const icon = calloutIcons[normalizedType] || calloutIcons.note;
   const label = title?.trim() || calloutLabels[normalizedType] || "Note";
-  const renderedContent = renderInlineCalloutContent(content);
-  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p><p>${renderedContent}</p></div></div>`;
+  const renderedContent = renderMarkdownBlockContent(content, definitions);
+  return `<div class="fd-callout fd-callout-${normalizedType}" role="note"><div class="fd-callout-indicator" role="none"></div><div class="fd-callout-icon">${icon}</div><div class="fd-callout-content"><p class="fd-callout-title">${escapeHtml(label)}</p>${renderedContent}</div></div>`;
 }
 
 function highlightCode(hl: Highlighter, code: string, lang: string): { html: string; raw: string } {
@@ -515,7 +521,7 @@ function parseCodeGroupMeta(meta: string): { lang: string; title: string | null 
 }
 
 function createCodeGroupTabValue(label: string, used: Set<string>): string {
-  const slug = slugify(label) || `code-${used.size + 1}`;
+  const slug = slugifyCodeGroupTab(label) || `code-${used.size + 1}`;
   let value = slug;
   let suffix = 2;
 
@@ -598,6 +604,18 @@ export async function renderMarkdown(
 
   const hl = await getHighlighter();
   let result = resolveDocsAudienceMdxContent(content, "human");
+  const extractedReferences = extractMarkdownReferenceDefinitions(result);
+  const referenceDefinitions = extractedReferences.definitions;
+  const preparedHeadings = prepareMarkdownHeadings(result);
+  const preparedWithoutReferences = extractMarkdownReferenceDefinitions(
+    preparedHeadings.markdown,
+  ).markdown;
+  const renderedHeadings = renderMarkdownHeadings(
+    preparedWithoutReferences,
+    preparedHeadings.headings,
+  );
+  result = renderedHeadings.markdown;
+  const headingOpeningTags = renderedHeadings.openingTags;
 
   // ── Mintlify-style code groups: <CodeGroup> fenced code blocks </CodeGroup> ──
   const tabsBlocks: string[] = [];
@@ -608,25 +626,31 @@ export async function renderMarkdown(
       const dropdown = toBoolean(attrs.dropdown, false);
       const usedValues = new Set<string>();
       const panels: { label: string; value: string; html: string }[] = [];
-      const codeRegex = /```([^\n]*)\n([\s\S]*?)```/g;
-      let codeMatch: RegExpExecArray | null;
-
-      while ((codeMatch = codeRegex.exec(body)) !== null) {
-        const { lang, title } = parseCodeGroupMeta(codeMatch[1]);
+      replaceMarkdownFencedCodeBlocks(body, ({ code, info }) => {
+        const { lang, title } = parseCodeGroupMeta(info);
         const label = title || lang || `Code ${panels.length + 1}`;
         const value = createCodeGroupTabValue(label, usedValues);
-        const dedented = dedentCode(codeMatch[2]);
+        const dedented = dedentCode(code);
         const { html, raw } = highlightCode(hl, dedented, lang);
         panels.push({
           label,
           value,
           html: wrapCodeWithCopy(html, raw, null, lang),
         });
-      }
+        return "";
+      });
 
       if (panels.length === 0) return body;
+      const extractedHeadings = extractRenderedHeadingElements(
+        body,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
 
-      let tabsHtml = `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
+      let tabsHtml =
+        extractedHeadings.headingsHtml +
+        `<div class="fd-tabs fd-code-group" data-tabs data-code-group data-fd-code-group${dropdown ? ' data-dropdown="true"' : ""}>`;
       tabsHtml += `<div class="fd-tabs-list fd-code-group-list" role="tablist">`;
       for (let i = 0; i < panels.length; i++) {
         const state = i === 0 ? "active" : "inactive";
@@ -655,15 +679,33 @@ export async function renderMarkdown(
       let tabMatch: RegExpExecArray | null;
       while ((tabMatch = tabRegex.exec(body)) !== null) {
         const tabValue = tabMatch[1];
-        const tabContent = tabMatch[2].trim();
-        const codeMatch = tabContent.match(/```([^\n]*)\n([\s\S]*?)```/);
-        if (codeMatch) {
-          const { lang, title } = parseMeta(codeMatch[1]);
-          const dedented = dedentCode(codeMatch[2]);
+        const extractedHeadings = extractRenderedHeadingElements(
+          tabMatch[2].trim(),
+          referenceDefinitions,
+          false,
+          headingOpeningTags,
+        );
+        let renderedCode: string | undefined;
+        replaceMarkdownFencedCodeBlocks(extractedHeadings.content, ({ code, info }) => {
+          if (renderedCode !== undefined) return "";
+          const { lang, title } = parseMeta(info);
+          const dedented = dedentCode(code);
           const { html, raw } = highlightCode(hl, dedented, lang);
-          panels.push({ value: tabValue, html: wrapCodeWithCopy(html, raw, title, lang) });
+          renderedCode = wrapCodeWithCopy(html, raw, title, lang);
+          return "";
+        });
+        if (renderedCode !== undefined) {
+          panels.push({
+            value: tabValue,
+            html: extractedHeadings.headingsHtml + renderedCode,
+          });
         } else {
-          panels.push({ value: tabValue, html: `<p>${tabContent}</p>` });
+          panels.push({
+            value: tabValue,
+            html:
+              extractedHeadings.headingsHtml +
+              renderMarkdownBlockContent(extractedHeadings.content, referenceDefinitions),
+          });
         }
       }
 
@@ -686,15 +728,23 @@ export async function renderMarkdown(
     },
   );
 
-  // ── Fenced code blocks ──
-  const codeBlocks: string[] = [];
+  // Prompt bodies are literal copyable text. Protect them before fenced code
+  // rendering so examples remain escaped text rather than injected figures.
+  const promptBlocks: string[] = [];
   result = result.replace(
-    /```([^\n]*)\n([\s\S]*?)```/g,
-    (_: string, meta: string, code: string) => {
-      const { lang, title } = parseMeta(meta);
-      const { html, raw } = highlightCode(hl, code, lang);
-      const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
-      codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
+    (_: string, attrSource: string | undefined, children: string) => {
+      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        true,
+        headingOpeningTags,
+      );
+      promptBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderPrompt(attrSource ?? "", extractedHeadings.content, options),
+      );
       return placeholder;
     },
   );
@@ -704,20 +754,29 @@ export async function renderMarkdown(
     /<HoverLink\s+([^>]*?)>([\s\S]*?)<\/HoverLink>/g,
     (_: string, attrSource: string, children: string) => {
       const placeholder = `%%HOVERLINK_${hoverLinkBlocks.length}%%`;
-      hoverLinkBlocks.push(renderHoverLink(attrSource, children, options.theme));
+      const extractedHeadings = extractRenderedHeadingElements(
+        children,
+        referenceDefinitions,
+        false,
+        headingOpeningTags,
+      );
+      hoverLinkBlocks.push(
+        extractedHeadings.headingsHtml +
+          renderHoverLink(attrSource, extractedHeadings.content, options.theme),
+      );
       return placeholder;
     },
   );
 
-  const promptBlocks: string[] = [];
-  result = result.replace(
-    /<Prompt(?:\s+([^>]*?))?>([\s\S]*?)<\/Prompt>/g,
-    (_: string, attrSource: string | undefined, children: string) => {
-      const placeholder = `%%PROMPT_${promptBlocks.length}%%`;
-      promptBlocks.push(renderPrompt(attrSource ?? "", children, options));
-      return placeholder;
-    },
-  );
+  // ── Fenced code blocks ──
+  const codeBlocks: string[] = [];
+  result = replaceMarkdownFencedCodeBlocks(result, ({ code, info }) => {
+    const { lang, title } = parseMeta(info);
+    const { html, raw } = highlightCode(hl, code, lang);
+    const placeholder = `%%CODEBLOCK_${codeBlocks.length}%%`;
+    codeBlocks.push(wrapCodeWithCopy(html, raw, title, lang));
+    return placeholder;
+  });
 
   const calloutBlocks: string[] = [];
   result = result.replace(
@@ -727,37 +786,32 @@ export async function renderMarkdown(
       const type = toStringValue(attrs.type) ?? toStringValue(attrs.kind) ?? "note";
       const title = toStringValue(attrs.title);
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, children, title));
+      calloutBlocks.push(
+        renderCallout(
+          type,
+          restoreMarkdownHeadingOpeningTags(children, headingOpeningTags),
+          title,
+          referenceDefinitions,
+        ),
+      );
       return placeholder;
     },
   );
 
-  // Inline code
-  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
-
-  // Headings (h4 → h1 order to avoid prefix collisions)
-  result = result.replace(/^#### (.+)$/gm, (_: string, text: string) => {
-    return `<h4 id="${slugify(text)}">${text}</h4>`;
-  });
-  result = result.replace(/^### (.+)$/gm, (_: string, text: string) => {
-    return `<h3 id="${slugify(text)}">${text}</h3>`;
-  });
-  result = result.replace(/^## (.+)$/gm, (_: string, text: string) => {
-    return `<h2 id="${slugify(text)}">${text}</h2>`;
-  });
-  result = result.replace(/^# (.+)$/gm, "<h1>$1</h1>");
-
   // ── Callouts / blockquotes (before inline formatting) ──
   result = result.replace(/(?:^>\s*.+\n?)+/gm, (block: string) => {
     const lines = block.split("\n").filter(Boolean);
-    const inner = lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n");
+    const inner = restoreMarkdownHeadingOpeningTags(
+      lines.map((l: string) => l.replace(/^>\s?/, "")).join("\n"),
+      headingOpeningTags,
+    );
 
     const ghMatch = inner.match(/^\[!(NOTE|WARNING|TIP|IMPORTANT|CAUTION)\]\s*\n?([\s\S]*)/i);
     if (ghMatch) {
       const type = ghMatch[1].toLowerCase();
       const calloutContent = ghMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
@@ -766,26 +820,18 @@ export async function renderMarkdown(
       const type = boldMatch[1].toLowerCase();
       const calloutContent = boldMatch[2].trim();
       const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
-      calloutBlocks.push(renderCallout(type, calloutContent));
+      calloutBlocks.push(renderCallout(type, calloutContent, undefined, referenceDefinitions));
       return placeholder;
     }
 
-    return `<blockquote><p>${inner}</p></blockquote>`;
+    const placeholder = `%%CALLOUT_${calloutBlocks.length}%%`;
+    calloutBlocks.push(
+      `<blockquote>${renderMarkdownBlockContent(inner, referenceDefinitions)}</blockquote>`,
+    );
+    return placeholder;
   });
 
-  // Inline formatting
-  result = result.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
-  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
-
-  // Images — before links so ![alt](url) is not captured as a link
-  result = result.replace(
-    /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (_: string, alt: string, src: string) =>
-      `<img src="${src}" alt="${alt.replace(/"/g, "&quot;")}" class="fd-docs-content-img" loading="lazy" decoding="async" />`,
-  );
-  // Links
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  result = renderMarkdownInline(result, referenceDefinitions);
 
   // Horizontal rules
   result = result.replace(/^---$/gm, "<hr />");
@@ -842,15 +888,15 @@ export async function renderMarkdown(
       block = block.trim();
       if (!block) return "";
       if (/^<(h[1-6]|pre|ul|ol|blockquote|hr|table|div)/.test(block)) return block;
-      if (/^%%(CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%$/.test(block)) return block;
+      if (/^%%FARMINGLABS_DOCS_HEADING_OPEN_\d+%%/.test(block)) return block;
+      if (/^%%(?:CODEBLOCK|CALLOUT|TABS|PROMPT|HOVERLINK)_\d+%%/.test(block)) {
+        return block;
+      }
       return `<p>${block}</p>`;
     })
     .join("\n");
 
   // Restore placeholders
-  for (let i = 0; i < codeBlocks.length; i++) {
-    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
-  }
   for (let i = 0; i < calloutBlocks.length; i++) {
     result = result.replace(`%%CALLOUT_${i}%%`, calloutBlocks[i]);
   }
@@ -863,6 +909,12 @@ export async function renderMarkdown(
   for (let i = 0; i < promptBlocks.length; i++) {
     result = result.replace(`%%PROMPT_${i}%%`, promptBlocks[i]);
   }
+  for (let i = 0; i < codeBlocks.length; i++) {
+    result = result.replace(`%%CODEBLOCK_${i}%%`, codeBlocks[i]);
+  }
 
-  return result;
+  return restoreMarkdownHeadingOpeningTags(
+    stripPreparedMarkdownHeadingTokens(result),
+    headingOpeningTags,
+  );
 }

--- a/packages/svelte/test/markdown-placeholders.test.ts
+++ b/packages/svelte/test/markdown-placeholders.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown block placeholders", () => {
+  it("keeps authored placeholder-like text separate from rendered blocks", async () => {
+    const html = await renderMarkdown(
+      [
+        "%%CALLOUT_0%%",
+        "",
+        "%%CODEBLOCK_0%%",
+        "",
+        "<Callout>Real callout content.</Callout>",
+        "",
+        "```js",
+        'console.log("real code");',
+        "```",
+      ].join("\n"),
+    );
+
+    expect(html).toContain("%%CALLOUT_0%%");
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html.match(/class="fd-callout fd-callout-/gu)).toHaveLength(1);
+    expect(html.match(/console\.log/gu)).toHaveLength(1);
+    expect(html.indexOf("%%CALLOUT_0%%")).toBeLessThan(html.indexOf("Real callout content."));
+    expect(html.indexOf("%%CODEBLOCK_0%%")).toBeLessThan(html.indexOf("console.log"));
+  });
+});

--- a/packages/svelte/test/markdown.test.ts
+++ b/packages/svelte/test/markdown.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown.js";
+
+describe("renderMarkdown Prompt reference definitions", () => {
+  it("preserves literal Prompt definitions without exposing them to document links", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+Use [prompt-only].
+[prompt-only]: /from-prompt "Prompt only"
+<Agent>Keep this literal.</Agent>
+</Prompt>
+
+Outside [prompt-only].
+
+[public]: /outside
+
+Outside [public].`);
+
+    expect(html).toContain("Use [prompt-only].");
+    expect(html).toContain("[prompt-only]: /from-prompt &quot;Prompt only&quot;");
+    expect(html).toContain("&lt;Agent&gt;Keep this literal.&lt;/Agent&gt;");
+    expect(html).toContain("Outside [prompt-only].");
+    expect(html).not.toContain('href="/from-prompt"');
+    expect(html).toContain('Outside <a href="/outside">public</a>.');
+    expect(html).not.toContain("[public]: /outside");
+  });
+
+  it("keeps Prompt-looking Markdown literals inert", async () => {
+    const literalSources = [
+      [
+        "FENCED_PROMPT_LITERAL",
+        ["```mdx", "<Prompt>", "FENCED_PROMPT_LITERAL", "</Prompt>", "```"].join("\n"),
+      ],
+      [
+        "QUOTED_PROMPT_LITERAL",
+        ["> ~~~~mdx", "> <Prompt>", "> QUOTED_PROMPT_LITERAL", "> </Prompt>", "> ~~~~"].join("\n"),
+      ],
+      [
+        "LIST_PROMPT_LITERAL",
+        ["- ~~~mdx", "  <Prompt>", "  LIST_PROMPT_LITERAL", "  </Prompt>", "  ~~~"].join("\n"),
+      ],
+      ["INLINE_PROMPT_LITERAL", "`<Prompt>INLINE_PROMPT_LITERAL</Prompt>`"],
+      [
+        "LINK_PROMPT_LITERAL",
+        '[Example](https://example.com "Use <Prompt>LINK_PROMPT_LITERAL</Prompt>")',
+      ],
+      [
+        "LINK_LABEL_PROMPT_LITERAL",
+        "[<Prompt>LINK_LABEL_PROMPT_LITERAL</Prompt>](https://example.com)",
+      ],
+      ["EXPRESSION_PROMPT_LITERAL", "{<Prompt>EXPRESSION_PROMPT_LITERAL</Prompt>}"],
+      [
+        "PROP_PROMPT_LITERAL",
+        "<Card example={<Prompt>PROP_PROMPT_LITERAL</Prompt>}>Card body</Card>",
+      ],
+      ["UNRESOLVED_PROMPT_LITERAL", "[<Prompt>UNRESOLVED_PROMPT_LITERAL</Prompt>][]"],
+      ["UNRESOLVED_IMAGE_PROMPT_LITERAL", "![<Prompt>UNRESOLVED_IMAGE_PROMPT_LITERAL</Prompt>]"],
+      [
+        "RAW_HTML_PROMPT_LITERAL",
+        ["<pre>", "<Prompt>RAW_HTML_PROMPT_LITERAL</Prompt>", "</pre>"].join("\n"),
+      ],
+      [
+        "UPPERCASE_RAW_HTML_PROMPT_LITERAL",
+        ["<SCRIPT>", "<Prompt>UPPERCASE_RAW_HTML_PROMPT_LITERAL</Prompt>", "</SCRIPT>"].join("\n"),
+      ],
+      ["SVG_PROMPT_LITERAL", "<svg><Prompt>SVG_PROMPT_LITERAL</Prompt></svg>"],
+      ["UPPERCASE_SVG_PROMPT_LITERAL", "<SVG><Prompt>UPPERCASE_SVG_PROMPT_LITERAL</Prompt></SVG>"],
+      ["MATH_PROMPT_LITERAL", "<math><Prompt>MATH_PROMPT_LITERAL</Prompt></math>"],
+      [
+        "UPPERCASE_MATH_PROMPT_LITERAL",
+        "<MATH><Prompt>UPPERCASE_MATH_PROMPT_LITERAL</Prompt></MATH>",
+      ],
+      ["CDATA_PROMPT_LITERAL", "<![CDATA[<Prompt>CDATA_PROMPT_LITERAL</Prompt>]]>"],
+    ] as const;
+
+    for (const [marker, source] of literalSources) {
+      const html = await renderMarkdown(source);
+      expect(html).toContain(marker);
+      expect(html).not.toContain("data-prompt-card");
+    }
+
+    const liveHtml = await renderMarkdown("<Prompt showPrompt>LIVE_PROMPT</Prompt>");
+    expect(liveHtml).toContain("LIVE_PROMPT");
+    expect(liveHtml.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("preserves flow boundaries and complete nested Prompt copy", async () => {
+    const html = await renderMarkdown(`Before.
+<Prompt showPrompt>
+Run the check.
+</Prompt>
+After.
+
+---
+
+Done.`);
+
+    expect(html).toContain("<p>Before.</p>");
+    expect(html).toContain("<p>After.</p>");
+    expect(html).toContain("<hr />");
+    expect(html).toContain("<p>Done.</p>");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(html).not.toMatch(/<(?:p|h[1-6])[^>]*>\s*<div class="fd-prompt"/);
+
+    const nested = await renderMarkdown(
+      "<Prompt showPrompt>outer <Prompt>inner</Prompt> tail</Prompt>",
+    );
+    expect(nested.match(/data-prompt-card/g)).toHaveLength(1);
+    expect(nested).toContain("outer &lt;Prompt&gt;inner&lt;/Prompt&gt; tail");
+  });
+
+  it("restores Prompt after downstream code and heading transport tokens", async () => {
+    const html = await renderMarkdown(`<Prompt showPrompt>
+%%CODEBLOCK_0%%
+%%FARMINGLABS_DOCS_HEADING_OPEN_0%%
+</Prompt>
+
+## Real heading
+
+\`\`\`ts
+const real = true;
+\`\`\``);
+
+    expect(html).toContain("%%CODEBLOCK_0%%");
+    expect(html).toContain("%%FARMINGLABS_DOCS_HEADING_OPEN_0%%");
+    expect(html).toContain('<h2 id="real-heading">Real heading</h2>');
+    expect(html).toContain("real");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+  });
+
+  it("keeps live Prompt cards and copied text inside blockquote and list containers", async () => {
+    const html = await renderMarkdown(`> Before
+> <Prompt showPrompt>
+> Quote task
+> </Prompt>
+> After
+
+- Before
+  <Prompt showPrompt>
+  List task
+  </Prompt>
+  After`);
+
+    expect(html).toMatch(
+      /<blockquote>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/blockquote>/,
+    );
+    expect(html).toMatch(/<li>[\s\S]*Before[\s\S]*data-prompt-card[\s\S]*After[\s\S]*<\/li>/);
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">Quote task</div>');
+    expect(html).toContain('<div data-prompt-text hidden aria-hidden="true">List task</div>');
+    expect(html).not.toContain("&gt; Quote task");
+    expect(html.match(/data-prompt-card/g)).toHaveLength(2);
+  });
+
+  it("keeps Prompt cards inside every unordered and ordered list marker", async () => {
+    const html = await renderMarkdown(`+ <Prompt showPrompt>
+  Plus task
+  </Prompt>
+
+* <Prompt showPrompt>
+  Star task
+  </Prompt>
+
+1. Before
+   <Prompt showPrompt>
+   Ordered task
+   </Prompt>
+   After
+
+2) <Prompt showPrompt>
+   Parenthesized task
+   </Prompt>`);
+
+    expect(html.match(/data-prompt-card/g)).toHaveLength(4);
+    expect(html.match(/<ul><li><div class="fd-prompt"/g)).toHaveLength(2);
+    expect(html).toMatch(/<ol><li>Before[\s\S]*data-prompt-card[\s\S]*After<\/li><\/ol>/);
+    expect(html).toContain('<ol><li><div class="fd-prompt"');
+    for (const task of ["Plus task", "Star task", "Ordered task", "Parenthesized task"]) {
+      expect(html).toContain(`<div data-prompt-text hidden aria-hidden="true">${task}</div>`);
+    }
+
+    const simple = await renderMarkdown(
+      ["- One", "+ Two", "* Three", "", "1. First", "2. Second"].join("\n"),
+    );
+    expect(simple).toContain("<ul><li>One</li><li>Two</li><li>Three</li></ul>");
+    expect(simple).toContain("<ol><li>First</li><li>Second</li></ol>");
+  });
+
+  it("keeps standalone Prompt cards separate from Setext markers for LF and CRLF", async () => {
+    for (const newline of ["\n", "\r\n"]) {
+      for (const marker of ["---", "==="]) {
+        const html = await renderMarkdown(
+          `<Prompt showPrompt>x</Prompt>${newline}${marker}${newline}After`,
+        );
+        expect(html.match(/data-prompt-card/g)).toHaveLength(1);
+        expect(html).not.toMatch(/<h[12][^>]*>\s*<div class="fd-prompt"/);
+      }
+    }
+
+    const inline = await renderMarkdown("Before <Prompt showPrompt>x</Prompt> after");
+    expect(inline).toContain('<p>Before <div class="fd-prompt"');
+  });
+});

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@farming-labs/docs": "*",
+    "@farming-labs/docs": ">=0.2.73",
     "@farming-labs/theme": "*",
     "react": "^19.0.0"
   }

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -51,6 +51,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -66,11 +68,13 @@
   "devDependencies": {
     "@farming-labs/docs": "workspace:*",
     "@farming-labs/theme": "workspace:*",
-    "@types/react": "^19.2.2",
+    "@mdx-js/mdx": "^3.1.1",
     "@types/node": "^22.10.0",
+    "@types/react": "^19.2.2",
     "react": "^19.2.0",
+    "typescript": "^5.9.3",
     "vite": "^7.3.5",
-    "typescript": "^5.9.3"
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "@farming-labs/docs": ">=0.2.73",

--- a/packages/tanstack-start/src/vite.ts
+++ b/packages/tanstack-start/src/vite.ts
@@ -2,14 +2,48 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import mdx from "@mdx-js/rollup";
+import {
+  applyDocsMarkdownHeadingAnchors,
+  withDocsMarkdownRenderableHeadings,
+} from "@farming-labs/docs";
 import { remarkCodeGroup } from "@farming-labs/docs/server";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
-import { remarkHeading } from "fumadocs-core/mdx-plugins/remark-heading";
+import { remarkHeading as createFumadocsRemarkHeading } from "fumadocs-core/mdx-plugins/remark-heading";
 import { rehypeToc } from "fumadocs-core/mdx-plugins/rehype-toc";
 import { rehypeCode } from "fumadocs-core/mdx-plugins/rehype-code";
 import { normalizePath, type PluginOption } from "vite";
+
+function encodeDocsHeadingTocUrls(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) encodeDocsHeadingTocUrls(item);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  const item = value as { url?: unknown; children?: unknown };
+  if (typeof item.url === "string") {
+    const hashIndex = item.url.indexOf("#");
+    if (hashIndex >= 0) {
+      item.url = `${item.url.slice(0, hashIndex)}#${encodeURIComponent(
+        item.url.slice(hashIndex + 1),
+      )}`;
+    }
+  }
+  encodeDocsHeadingTocUrls(item.children);
+}
+
+function canonicalRemarkHeading(): ReturnType<typeof createFumadocsRemarkHeading> {
+  return (root, file) => {
+    applyDocsMarkdownHeadingAnchors(root);
+    withDocsMarkdownRenderableHeadings(root, () =>
+      createFumadocsRemarkHeading({ customId: false })(root, file, () => undefined),
+    );
+    encodeDocsHeadingTocUrls(file.data.toc);
+    return root;
+  };
+}
 
 function findWorkspaceRoot(startDir: string): string | null {
   let current = startDir;
@@ -143,7 +177,7 @@ export function docsMdx(): PluginOption {
         remarkFrontmatter,
         [remarkMdxFrontmatter, { name: "metadata" }],
         remarkCodeGroup,
-        remarkHeading,
+        canonicalRemarkHeading,
       ],
       rehypePlugins: [
         rehypeToc,

--- a/packages/tanstack-start/src/vite.ts
+++ b/packages/tanstack-start/src/vite.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 import mdx from "@mdx-js/rollup";
 import {
   applyDocsMarkdownHeadingAnchors,
+  encodeDocsHeadingTocUrls,
+  isolateDocsMarkdownPromptReferences,
   withDocsMarkdownRenderableHeadings,
 } from "@farming-labs/docs";
 import { remarkCodeGroup } from "@farming-labs/docs/server";
@@ -15,27 +17,9 @@ import { rehypeToc } from "fumadocs-core/mdx-plugins/rehype-toc";
 import { rehypeCode } from "fumadocs-core/mdx-plugins/rehype-code";
 import { normalizePath, type PluginOption } from "vite";
 
-function encodeDocsHeadingTocUrls(value: unknown): void {
-  if (Array.isArray(value)) {
-    for (const item of value) encodeDocsHeadingTocUrls(item);
-    return;
-  }
-  if (!value || typeof value !== "object") return;
-
-  const item = value as { url?: unknown; children?: unknown };
-  if (typeof item.url === "string") {
-    const hashIndex = item.url.indexOf("#");
-    if (hashIndex >= 0) {
-      item.url = `${item.url.slice(0, hashIndex)}#${encodeURIComponent(
-        item.url.slice(hashIndex + 1),
-      )}`;
-    }
-  }
-  encodeDocsHeadingTocUrls(item.children);
-}
-
-function canonicalRemarkHeading(): ReturnType<typeof createFumadocsRemarkHeading> {
+export function createCanonicalDocsRemarkHeading(): ReturnType<typeof createFumadocsRemarkHeading> {
   return (root, file) => {
+    isolateDocsMarkdownPromptReferences(root, file.value);
     applyDocsMarkdownHeadingAnchors(root);
     withDocsMarkdownRenderableHeadings(root, () =>
       createFumadocsRemarkHeading({ customId: false })(root, file, () => undefined),
@@ -177,7 +161,7 @@ export function docsMdx(): PluginOption {
         remarkFrontmatter,
         [remarkMdxFrontmatter, { name: "metadata" }],
         remarkCodeGroup,
-        canonicalRemarkHeading,
+        createCanonicalDocsRemarkHeading,
       ],
       rehypePlugins: [
         rehypeToc,

--- a/packages/tanstack-start/test/vite.test.ts
+++ b/packages/tanstack-start/test/vite.test.ts
@@ -1,0 +1,37 @@
+import { compile } from "@mdx-js/mdx";
+import { describe, expect, it } from "vitest";
+import { createCanonicalDocsRemarkHeading } from "../src/vite.js";
+
+describe("createCanonicalDocsRemarkHeading", () => {
+  it("encodes canonical TOC fragments and isolates Prompt-only references", async () => {
+    const rendered = await compile(
+      [
+        "## Hash [#foo#bar]",
+        "",
+        "## Percent [#foo%23bar]",
+        "",
+        "## [Inside][prompt-ref] Setup",
+        "",
+        "<Prompt>",
+        "Use [prompt-ref].",
+        "",
+        '[prompt-ref]: /prompt-only "Prompt only"',
+        "</Prompt>",
+      ].join("\n"),
+      { remarkPlugins: [createCanonicalDocsRemarkHeading] },
+    );
+
+    expect(rendered.data.toc).toEqual([
+      { title: "Hash", url: "#foo%23bar", depth: 2 },
+      { title: "Percent", url: "#foo%2523bar", depth: 2 },
+      {
+        title: "[Inside][prompt-ref] Setup",
+        url: "#insideprompt-ref-setup",
+        depth: 2,
+      },
+    ]);
+    expect(String(rendered)).toContain("Use [prompt-ref].");
+    expect(String(rendered)).toContain('[prompt-ref]: /prompt-only \\"Prompt only\\"');
+    expect(String(rendered)).not.toContain('href: "/prompt-only"');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/astro-theme:
     dependencies:
@@ -634,6 +637,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/svelte-theme:
     dependencies:
@@ -686,6 +692,9 @@ importers:
       '@farming-labs/theme':
         specifier: workspace:*
         version: link:../fumadocs
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.11
@@ -701,6 +710,9 @@ importers:
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.11)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   website:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,15 +383,24 @@ importers:
       '@vercel/sandbox':
         specifier: ^2.0.0
         version: 2.0.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      parse-entities:
+        specifier: ^4.0.2
+        version: 4.0.2
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
@@ -539,6 +548,9 @@ importers:
       '@farming-labs/theme':
         specifier: workspace:*
         version: link:../fumadocs
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.11

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -7,10 +7,11 @@ import { gunzipSync } from "node:zlib";
 
 const DEFAULT_BASE_URL = "https://docs.farming-labs.dev";
 const AGENT_SKILLS_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
-const AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v1";
-const AGENT_MANIFEST_SCHEMA = "https://docs.farming-labs.dev/schema/agent-manifest.v1.json";
+const AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v2";
+const AGENT_MANIFEST_VERSION = "2";
+const AGENT_MANIFEST_SCHEMA = "https://docs.farming-labs.dev/schema/agent-manifest.v2.json";
 const AGENT_MANIFEST_SCHEMA_MEDIA_TYPE = "application/schema+json";
-const AGENT_MANIFEST_SCHEMA_ROUTE = "/schema/agent-manifest.v1.json";
+const AGENT_MANIFEST_SCHEMA_ROUTE = "/schema/agent-manifest.v2.json";
 const API_CATALOG_PROFILE = "https://www.rfc-editor.org/info/rfc9727";
 const API_CATALOG_ROUTE = "/.well-known/api-catalog";
 const AGENT_SKILLS_INDEX_ROUTE = "/.well-known/agent-skills/index.json";
@@ -506,7 +507,10 @@ function validateManifest(json, route, response) {
     manifest.format === AGENT_MANIFEST_FORMAT,
     `${route} did not declare the Farming Labs manifest format`,
   );
-  assert(manifest.version === "1", `${route} did not declare agent manifest version 1`);
+  assert(
+    manifest.version === AGENT_MANIFEST_VERSION,
+    `${route} did not declare agent manifest version ${AGENT_MANIFEST_VERSION}`,
+  );
   assert(isNonEmptyString(manifest.name), `${route} did not declare a name`);
   assert(
     includesTypedLinkRelation(
@@ -587,6 +591,10 @@ async function validateAgentManifestSchema(request) {
   assert(
     asRecord(properties?.format)?.const === AGENT_MANIFEST_FORMAT,
     `${AGENT_MANIFEST_SCHEMA_ROUTE} did not define the manifest format`,
+  );
+  assert(
+    asRecord(properties?.version)?.const === AGENT_MANIFEST_VERSION,
+    `${AGENT_MANIFEST_SCHEMA_ROUTE} did not define the manifest version`,
   );
 }
 

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -7,10 +7,11 @@ import { runAgentSurfaceSmoke } from "./smoke-agent-surfaces.mjs";
 
 const BASE_URL = "https://deployment.example.com";
 const AGENT_SKILLS_SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
-const AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v1";
-const AGENT_MANIFEST_SCHEMA = "https://docs.farming-labs.dev/schema/agent-manifest.v1.json";
+const AGENT_MANIFEST_FORMAT = "farming-labs-agent-manifest.v2";
+const AGENT_MANIFEST_VERSION = "2";
+const AGENT_MANIFEST_SCHEMA = "https://docs.farming-labs.dev/schema/agent-manifest.v2.json";
 const AGENT_MANIFEST_SCHEMA_MEDIA_TYPE = "application/schema+json";
-const AGENT_MANIFEST_SCHEMA_ROUTE = "/schema/agent-manifest.v1.json";
+const AGENT_MANIFEST_SCHEMA_ROUTE = "/schema/agent-manifest.v2.json";
 const API_CATALOG_PROFILE = "https://www.rfc-editor.org/info/rfc9727";
 const API_CATALOG_ROUTE = "/.well-known/api-catalog";
 const AGENT_SKILLS_INDEX_ROUTE = "/.well-known/agent-skills/index.json";
@@ -128,7 +129,7 @@ function createFixtureFetch(options = {}) {
   const manifest = {
     $schema: AGENT_MANIFEST_SCHEMA,
     format: AGENT_MANIFEST_FORMAT,
-    version: "1",
+    version: AGENT_MANIFEST_VERSION,
     name: "@farming-labs/docs",
     site: { baseUrl: canonicalBaseUrl, entry: "docs" },
     capabilities: {
@@ -345,6 +346,7 @@ function createFixtureFetch(options = {}) {
           $id: AGENT_MANIFEST_SCHEMA,
           properties: {
             format: { const: AGENT_MANIFEST_FORMAT },
+            version: { const: AGENT_MANIFEST_VERSION },
           },
         },
         { contentType: `${AGENT_MANIFEST_SCHEMA_MEDIA_TYPE}; charset=utf-8` },

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -15,6 +15,15 @@ export default withDocs({
           },
         ],
       },
+      {
+        source: "/schema/agent-manifest.v2.json",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/schema+json; charset=utf-8",
+          },
+        ],
+      },
     ];
   },
   turbopack: {

--- a/website/public/schema/agent-manifest.v2.json
+++ b/website/public/schema/agent-manifest.v2.json
@@ -1,0 +1,1322 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.farming-labs.dev/schema/agent-manifest.v2.json",
+  "title": "Farming Labs docs agent manifest v2",
+  "description": "Schema for the Farming Labs documentation discovery extension published at /.well-known/agent.json. This is not an A2A Agent Card; A2A services use /.well-known/agent-card.json.",
+  "type": "object",
+  "additionalProperties": true,
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nullableString": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "route": {
+      "type": "string",
+      "minLength": 1
+    },
+    "booleanMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "publishedSkillFile": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "url": {
+          "$ref": "#/$defs/route"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      },
+      "required": [
+        "path",
+        "url",
+        "digest"
+      ]
+    },
+    "publishedSkill": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "type": {
+          "enum": [
+            "skill-md",
+            "archive"
+          ]
+        },
+        "url": {
+          "$ref": "#/$defs/route"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/publishedSkillFile"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "type",
+        "url",
+        "digest",
+        "files"
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "const": "https://docs.farming-labs.dev/schema/agent-manifest.v2.json",
+      "description": "Immutable JSON Schema for this manifest version."
+    },
+    "format": {
+      "const": "farming-labs-agent-manifest.v2",
+      "description": "Farming Labs extension identifier. It intentionally does not identify this document as an A2A Agent Card."
+    },
+    "supportedInterfaces": false,
+    "version": {
+      "const": "2"
+    },
+    "name": {
+      "const": "@farming-labs/docs"
+    },
+    "baseUrl": {
+      "$ref": "#/$defs/nonEmptyString",
+      "description": "Deployment origin or a relative base used by portable static exports."
+    },
+    "site": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "type": "string"
+        },
+        "entry": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "baseUrl": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      },
+      "required": [
+        "title",
+        "entry",
+        "baseUrl"
+      ]
+    },
+    "locales": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "available": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "default": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "queryParam": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "fallbackQueryParam": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      },
+      "required": [
+        "enabled",
+        "available",
+        "default",
+        "queryParam",
+        "fallbackQueryParam"
+      ]
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "properties": {
+        "markdownRoutes": {
+          "type": "boolean"
+        },
+        "markdownSectionDiscovery": {
+          "type": "boolean"
+        },
+        "agentMdOverrides": {
+          "type": "boolean"
+        },
+        "agentBlocks": {
+          "type": "boolean"
+        },
+        "structuredAgentContracts": {
+          "type": "boolean"
+        },
+        "agents": {
+          "type": "boolean"
+        },
+        "llms": {
+          "type": "boolean"
+        },
+        "skills": {
+          "type": "boolean"
+        },
+        "apiCatalog": {
+          "type": "boolean"
+        },
+        "agentSkillsDiscovery": {
+          "type": "boolean"
+        },
+        "mcp": {
+          "type": "boolean"
+        },
+        "search": {
+          "type": "boolean"
+        },
+        "sitemap": {
+          "type": "boolean"
+        },
+        "robots": {
+          "type": "boolean"
+        },
+        "structuredData": {
+          "type": "boolean"
+        },
+        "apiReference": {
+          "type": "boolean"
+        },
+        "openapi": {
+          "type": "boolean"
+        },
+        "agentFeedback": {
+          "type": "boolean"
+        },
+        "locales": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "markdownRoutes",
+        "agentMdOverrides",
+        "agentBlocks",
+        "structuredAgentContracts",
+        "agents",
+        "llms",
+        "skills",
+        "apiCatalog",
+        "agentSkillsDiscovery",
+        "mcp",
+        "search",
+        "sitemap",
+        "robots",
+        "structuredData",
+        "apiReference",
+        "openapi",
+        "agentFeedback",
+        "locales"
+      ]
+    },
+    "api": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "docs": {
+          "$ref": "#/$defs/route"
+        },
+        "config": {
+          "$ref": "#/$defs/route"
+        },
+        "diagnostics": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpec": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpecDefault": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpecFallback": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpecWellKnown": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpecWellKnownJson": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSpecQuery": {
+          "$ref": "#/$defs/route"
+        },
+        "agents": {
+          "$ref": "#/$defs/route"
+        },
+        "apiCatalog": {
+          "$ref": "#/$defs/route"
+        },
+        "apiCatalogQuery": {
+          "$ref": "#/$defs/route"
+        },
+        "agentSkillsIndex": {
+          "$ref": "#/$defs/route"
+        },
+        "legacySkillsIndex": {
+          "$ref": "#/$defs/route"
+        },
+        "agentCard": {
+          "$ref": "#/$defs/route"
+        },
+        "openapi": {
+          "$ref": "#/$defs/route"
+        }
+      },
+      "required": [
+        "docs",
+        "config",
+        "diagnostics",
+        "agentSpec",
+        "agentSpecDefault",
+        "agentSpecFallback",
+        "agentSpecWellKnown",
+        "agentSpecWellKnownJson",
+        "agentSpecQuery",
+        "agents",
+        "agentSkillsIndex",
+        "legacySkillsIndex",
+        "openapi"
+      ]
+    },
+    "apiCatalog": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "route": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "api": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "mediaType": {
+          "const": "application/linkset+json"
+        },
+        "profile": {
+          "const": "https://www.rfc-editor.org/info/rfc9727"
+        }
+      },
+      "required": [
+        "enabled",
+        "route",
+        "api",
+        "mediaType",
+        "profile"
+      ]
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "format": {
+          "const": "docs-config-map.v1"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/route"
+        }
+      },
+      "required": [
+        "format",
+        "endpoint"
+      ]
+    },
+    "markdown": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "const": true
+        },
+        "acceptHeader": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "signatureAgentHeader": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "pagePattern": {
+          "$ref": "#/$defs/route"
+        },
+        "rootPage": {
+          "$ref": "#/$defs/route"
+        },
+        "apiPattern": {
+          "$ref": "#/$defs/route"
+        },
+        "sectionDiscovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "format": {
+              "const": "docs-markdown-sections.v2"
+            },
+            "indexParam": {
+              "const": "sections"
+            },
+            "sectionParam": {
+              "const": "section"
+            },
+            "tokenBudgetParam": {
+              "const": "tokenBudget"
+            },
+            "byteBudgetParam": {
+              "const": "byteBudget"
+            }
+          },
+          "required": [
+            "enabled"
+          ]
+        },
+        "resolutionOrder": {
+          "$ref": "#/$defs/stringArray"
+        }
+      },
+      "required": [
+        "enabled",
+        "acceptHeader",
+        "pagePattern",
+        "rootPage",
+        "apiPattern",
+        "resolutionOrder"
+      ]
+    },
+    "agentContract": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "const": true
+        },
+        "schemaVersion": {
+          "const": "page-agent-contract.v1"
+        },
+        "source": {
+          "const": "page-frontmatter"
+        },
+        "frontmatterPath": {
+          "const": "agent"
+        },
+        "markdownSection": {
+          "const": "Agent Contract"
+        },
+        "mcpField": {
+          "const": "agent"
+        },
+        "mcpTools": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "list": {
+              "const": "list_tasks"
+            },
+            "read": {
+              "const": "read_task"
+            }
+          },
+          "minProperties": 1
+        },
+        "usefulContractFields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "contains": {
+            "const": "task"
+          }
+        },
+        "fields": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "enabled",
+        "schemaVersion",
+        "source",
+        "frontmatterPath",
+        "markdownSection",
+        "mcpField",
+        "usefulContractFields",
+        "fields"
+      ]
+    },
+    "llms": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "defaultTxt": {
+          "$ref": "#/$defs/route"
+        },
+        "defaultFull": {
+          "$ref": "#/$defs/route"
+        },
+        "txt": {
+          "$ref": "#/$defs/route"
+        },
+        "full": {
+          "$ref": "#/$defs/route"
+        },
+        "publicTxt": {
+          "$ref": "#/$defs/route"
+        },
+        "publicFull": {
+          "$ref": "#/$defs/route"
+        },
+        "wellKnownTxt": {
+          "$ref": "#/$defs/route"
+        },
+        "wellKnownFull": {
+          "$ref": "#/$defs/route"
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "title": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "description": {
+                "type": "string"
+              },
+              "match": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/$defs/stringArray"
+                  }
+                ]
+              },
+              "txt": {
+                "$ref": "#/$defs/route"
+              },
+              "full": {
+                "$ref": "#/$defs/route"
+              }
+            },
+            "required": [
+              "title",
+              "match",
+              "txt",
+              "full"
+            ]
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "defaultTxt",
+        "defaultFull",
+        "txt",
+        "full",
+        "publicTxt",
+        "publicFull",
+        "wellKnownTxt",
+        "wellKnownFull"
+      ]
+    },
+    "sitemap": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "xml": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "route": {
+              "$ref": "#/$defs/route"
+            },
+            "api": {
+              "$ref": "#/$defs/route"
+            },
+            "defaultRoute": {
+              "$ref": "#/$defs/route"
+            }
+          },
+          "required": [
+            "enabled",
+            "route",
+            "api"
+          ]
+        },
+        "markdown": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "route": {
+              "$ref": "#/$defs/route"
+            },
+            "docsRoute": {
+              "$ref": "#/$defs/route"
+            },
+            "wellKnownRoute": {
+              "$ref": "#/$defs/route"
+            },
+            "api": {
+              "$ref": "#/$defs/route"
+            },
+            "defaultRoute": {
+              "$ref": "#/$defs/route"
+            },
+            "defaultDocsRoute": {
+              "$ref": "#/$defs/route"
+            },
+            "defaultWellKnownRoute": {
+              "$ref": "#/$defs/route"
+            }
+          },
+          "required": [
+            "enabled",
+            "route",
+            "docsRoute",
+            "wellKnownRoute",
+            "api",
+            "defaultDocsRoute"
+          ]
+        }
+      },
+      "required": [
+        "enabled",
+        "xml",
+        "markdown"
+      ]
+    },
+    "robots": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "route": {
+          "$ref": "#/$defs/route"
+        },
+        "defaultRoute": {
+          "$ref": "#/$defs/route"
+        }
+      },
+      "required": [
+        "enabled",
+        "route",
+        "defaultRoute"
+      ]
+    },
+    "structuredData": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "const": true
+        },
+        "format": {
+          "const": "application/ld+json"
+        },
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        },
+        "fields": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "canonicalUrlField": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "breadcrumbType": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "agentContractType": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      },
+      "required": [
+        "enabled",
+        "format",
+        "schema",
+        "fields",
+        "canonicalUrlField",
+        "breadcrumbType",
+        "agentContractType"
+      ]
+    },
+    "openapi": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "url": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "generated",
+            "configured",
+            null
+          ]
+        },
+        "specUrl": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "apiReferencePath": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "format": {
+          "const": "OpenAPI 3.1"
+        }
+      },
+      "required": [
+        "enabled",
+        "url",
+        "source",
+        "specUrl",
+        "apiReferencePath",
+        "format"
+      ]
+    },
+    "search": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "agentEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "structuredAgentEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "method": {
+          "const": "GET"
+        },
+        "queryParam": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "localeParam": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "audienceParam": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "defaultAudience": {
+          "const": "human"
+        },
+        "supportedAudiences": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {
+              "const": "human"
+            },
+            {
+              "const": "agent"
+            }
+          ],
+          "items": false
+        },
+        "responseParam": {
+          "const": "response"
+        },
+        "structuredResponseValue": {
+          "const": "structured"
+        },
+        "responseFormat": {
+          "const": "docs-search.v1"
+        },
+        "filterParams": {
+          "const": {
+            "framework": "framework",
+            "version": "version",
+            "package": "package",
+            "tags": "tags"
+          }
+        },
+        "repeatedFilterParams": {
+          "const": [
+            "framework",
+            "version",
+            "package",
+            "tags"
+          ]
+        },
+        "warningsField": {
+          "const": "warnings"
+        }
+      },
+      "dependentRequired": {
+        "structuredAgentEndpoint": [
+          "responseParam",
+          "structuredResponseValue",
+          "responseFormat",
+          "filterParams",
+          "repeatedFilterParams",
+          "warningsField"
+        ],
+        "responseParam": [
+          "structuredAgentEndpoint",
+          "structuredResponseValue",
+          "responseFormat",
+          "filterParams",
+          "repeatedFilterParams",
+          "warningsField"
+        ],
+        "structuredResponseValue": [
+          "structuredAgentEndpoint",
+          "responseParam",
+          "responseFormat",
+          "filterParams",
+          "repeatedFilterParams",
+          "warningsField"
+        ],
+        "responseFormat": [
+          "structuredAgentEndpoint",
+          "responseParam",
+          "structuredResponseValue",
+          "filterParams",
+          "repeatedFilterParams",
+          "warningsField"
+        ],
+        "filterParams": [
+          "structuredAgentEndpoint",
+          "responseParam",
+          "structuredResponseValue",
+          "responseFormat",
+          "repeatedFilterParams",
+          "warningsField"
+        ],
+        "repeatedFilterParams": [
+          "structuredAgentEndpoint",
+          "responseParam",
+          "structuredResponseValue",
+          "responseFormat",
+          "filterParams",
+          "warningsField"
+        ],
+        "warningsField": [
+          "structuredAgentEndpoint",
+          "responseParam",
+          "structuredResponseValue",
+          "responseFormat",
+          "filterParams",
+          "repeatedFilterParams"
+        ]
+      },
+      "required": [
+        "enabled",
+        "endpoint",
+        "agentEndpoint",
+        "method",
+        "queryParam",
+        "localeParam",
+        "audienceParam",
+        "defaultAudience",
+        "supportedAudiences"
+      ]
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "const": true
+        },
+        "file": {
+          "const": "AGENTS.md"
+        },
+        "route": {
+          "$ref": "#/$defs/route"
+        },
+        "wellKnown": {
+          "$ref": "#/$defs/route"
+        },
+        "api": {
+          "$ref": "#/$defs/route"
+        },
+        "generatedFallback": {
+          "type": "boolean"
+        },
+        "aliases": {
+          "$ref": "#/$defs/stringArray"
+        }
+      },
+      "required": [
+        "enabled",
+        "file",
+        "route",
+        "wellKnown",
+        "api",
+        "generatedFallback",
+        "aliases"
+      ]
+    },
+    "skills": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "const": true
+        },
+        "file": {
+          "const": "skill.md"
+        },
+        "route": {
+          "$ref": "#/$defs/route"
+        },
+        "wellKnown": {
+          "$ref": "#/$defs/route"
+        },
+        "api": {
+          "$ref": "#/$defs/route"
+        },
+        "generatedFallback": {
+          "type": "boolean"
+        },
+        "registry": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "install": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "discovery": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            },
+            "index": {
+              "$ref": "#/$defs/route"
+            },
+            "artifact": {
+              "$ref": "#/$defs/route"
+            },
+            "archive": {
+              "$ref": "#/$defs/route"
+            },
+            "file": {
+              "$ref": "#/$defs/route"
+            },
+            "legacyIndex": {
+              "$ref": "#/$defs/route"
+            },
+            "apiIndex": {
+              "$ref": "#/$defs/route"
+            },
+            "apiArtifact": {
+              "$ref": "#/$defs/route"
+            },
+            "apiFile": {
+              "$ref": "#/$defs/route"
+            },
+            "digest": {
+              "const": "sha256"
+            }
+          },
+          "required": [
+            "schema",
+            "index",
+            "artifact",
+            "archive",
+            "file",
+            "legacyIndex",
+            "apiIndex",
+            "apiArtifact",
+            "apiFile",
+            "digest"
+          ]
+        },
+        "published": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/publishedSkill"
+          }
+        },
+        "recommended": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "description": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "required": [
+              "name",
+              "description"
+            ]
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "file",
+        "route",
+        "wellKnown",
+        "api",
+        "generatedFallback",
+        "registry",
+        "install",
+        "discovery",
+        "published",
+        "recommended"
+      ]
+    },
+    "mcp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "defaultEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "publicEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "wellKnownEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "publicEndpoints": {
+          "$ref": "#/$defs/stringArray"
+        },
+        "canonicalEndpoint": {
+          "$ref": "#/$defs/route"
+        },
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "version": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tools": {
+          "$ref": "#/$defs/booleanMap"
+        },
+        "protectedResource": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "metadataEndpoints": {
+              "$ref": "#/$defs/stringArray"
+            },
+            "authorizationServers": {
+              "$ref": "#/$defs/stringArray"
+            },
+            "scopesSupported": {
+              "$ref": "#/$defs/stringArray"
+            },
+            "requiredScopes": {
+              "$ref": "#/$defs/stringArray"
+            }
+          },
+          "required": [
+            "metadataEndpoints",
+            "authorizationServers",
+            "scopesSupported",
+            "requiredScopes"
+          ]
+        }
+      },
+      "required": [
+        "enabled",
+        "endpoint",
+        "defaultEndpoint",
+        "publicEndpoint",
+        "wellKnownEndpoint",
+        "publicEndpoints",
+        "canonicalEndpoint",
+        "name",
+        "version",
+        "tools"
+      ]
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schema": {
+          "$ref": "#/$defs/route"
+        },
+        "submit": {
+          "$ref": "#/$defs/route"
+        },
+        "schemaQuery": {
+          "$ref": "#/$defs/route"
+        },
+        "submitQuery": {
+          "$ref": "#/$defs/route"
+        }
+      },
+      "required": [
+        "enabled",
+        "schema",
+        "submit",
+        "schemaQuery",
+        "submitQuery"
+      ]
+    },
+    "instructions": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "preferMarkdownRoutes": {
+          "type": "boolean"
+        },
+        "useMcpWhenAvailable": {
+          "type": "boolean"
+        },
+        "useOpenApiWhenAvailable": {
+          "type": "boolean"
+        },
+        "readFeedbackSchemaBeforeSubmitting": {
+          "type": "boolean"
+        },
+        "doNotAssumeFeedbackPayloadShape": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "preferMarkdownRoutes",
+        "useMcpWhenAvailable",
+        "useOpenApiWhenAvailable",
+        "readFeedbackSchemaBeforeSubmitting",
+        "doNotAssumeFeedbackPayloadShape"
+      ]
+    },
+    "staticBundle": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "format": {
+          "const": "farming-labs-agent-bundle.v1"
+        },
+        "manifest": {
+          "$ref": "#/$defs/route"
+        },
+        "check": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "locales": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "pathPattern": {
+              "$ref": "#/$defs/route"
+            }
+          },
+          "required": [
+            "default",
+            "pathPattern"
+          ]
+        }
+      },
+      "required": [
+        "format",
+        "manifest",
+        "check"
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "markdownSectionDiscovery": {
+              "const": true
+            }
+          },
+          "required": [
+            "markdownSectionDiscovery"
+          ]
+        },
+        "markdown": {
+          "type": "object",
+          "properties": {
+            "sectionDiscovery": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "const": true
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            }
+          },
+          "required": [
+            "sectionDiscovery"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "markdownSectionDiscovery": {
+              "const": false
+            }
+          },
+          "required": [
+            "markdownSectionDiscovery"
+          ]
+        },
+        "markdown": {
+          "type": "object",
+          "properties": {
+            "sectionDiscovery": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "const": false
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            }
+          },
+          "required": [
+            "sectionDiscovery"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "capabilities": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "const": "markdownSectionDiscovery"
+            }
+          }
+        },
+        "markdown": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "const": "sectionDiscovery"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "$schema",
+    "format",
+    "version",
+    "name",
+    "baseUrl",
+    "site",
+    "locales",
+    "capabilities",
+    "api",
+    "apiCatalog",
+    "config",
+    "markdown",
+    "agentContract",
+    "llms",
+    "sitemap",
+    "robots",
+    "structuredData",
+    "openapi",
+    "search",
+    "agents",
+    "skills",
+    "mcp",
+    "feedback",
+    "instructions"
+  ]
+}


### PR DESCRIPTION
## Summary

- add one canonical MDX + GFM heading/section resolver for rendered HTML, Markdown section discovery, search, Ask AI, MCP, eval citations, changelog TOCs, and every framework adapter
- keep Unicode, custom IDs, duplicate headings, reserved characters, Setext headings, fenced code, generated preambles, and malformed-MDX fallback behavior deterministic
- exclude literal `<Prompt>` headings from anchor reservation and TOCs across Next, TanStack Start, Astro, Nuxt, and Svelte; keep raw Prompt HTML escaped and inert
- preserve authored DOM anchors when generated Agent Contract headings collide, while keeping generated sections addressable with safe suffixes
- publish `docs-markdown-sections.v2` through the Farming Labs custom manifest v2 and immutable v2 schema; retain the v1 schema unchanged
- update deployed discovery smoke coverage to validate the v2 manifest/schema contract

## Compatibility

Section consumers should rediscover anchors through `?sections`; duplicate/accent/custom-ID edge cases may resolve differently under the canonical v2 algorithm. The retained v1 manifest schema is byte-for-byte unchanged.

Website documentation and the configuration skill are intentionally not regenerated in this PR. The Farming Labs docs-generation bot should update their v1 examples and section-index references in its follow-up.

## Validation

- `@farming-labs/docs`: 62 files, 1,112 tests
- `@farming-labs/next`: 7 files, 113 tests
- `@farming-labs/nuxt`: 2 files, 23 tests
- deployed-surface smoke suite: 24 passed, 1 intentional skip
- package-wide typecheck passed
- monorepo build passed
- format check passed
- lint passed with 0 errors (43 existing warnings)
- offline frozen lockfile verification passed
- final independent review of anchor parity/security fixes: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies heading and section anchors across renderers, search, MCP, and adapters, and upgrades section indexes and the agent manifest to v2 for consistent, URL-safe linking. Adds TOC fragment encoding and isolates Prompt-only references to keep page links clean, while reducing agent search latency.

- **New Features**
  - Canonical anchor resolver for rendered HTML, Markdown discovery, search, MCP, eval citations, changelog TOCs, and adapters (`next`, `@tanstack/router-start`, `astro`, `nuxt`, `svelte`).
  - Deterministic handling of Unicode, explicit IDs (including `#` and `%`), duplicates, Setext headings, fenced code, and malformed-MDX fallback.
  - `<Prompt>`: headings are excluded from anchors/TOCs; raw HTML stays escaped; Prompt-only reference definitions are isolated and do not affect document links.
  - Preserves authored DOM ids when agent-only generated headings collide; generated sections remain addressable via safe suffixes.
  - New helpers in `@farming-labs/docs/markdown-rendering`; exposes anchor APIs, `encodeDocsHeadingTocUrls`, and `isolateDocsMarkdownPromptReferences` from `@farming-labs/docs`.
  - Section index format set to `docs-markdown-sections.v2`; agent manifest set to `farming-labs-agent-manifest.v2` with `version: "2"` and schema at `/schema/agent-manifest.v2.json`.
  - Faster agent search and MCP hydration by using pre-parsed section content and stripping generated contract markers.

- **Migration**
  - Update to `@farming-labs/docs@>=0.2.73` (peer dep bumps in adapters).
  - Re-fetch `?sections` and expect `docs-markdown-sections.v2`; anchors may change for duplicate/Unicode/custom-ID/reserved cases.
  - If you consume the agent manifest, expect `format: "farming-labs-agent-manifest.v2"`, `version: "2"`, and the new schema URL; v1 schema remains available unchanged.

<sup>Written for commit 1b9b9c2e95c12efe92dd1d3851b7fec69fc21878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

