### PR TITLE
feat: add retrieval source provenance

### DIFF
--- a/packages/astro/src/content.ts
+++ b/packages/astro/src/content.ts
@@ -53,6 +53,7 @@ export interface ContentPage {
   agent?: PageAgentFrontmatter;
   icon?: string;
   sourcePath?: string;
+  lastmod?: string;
   lastModified?: string;
   locale?: string;
   framework?: string;
@@ -62,8 +63,15 @@ export interface ContentPage {
   rawContent: string;
   agentContent?: string;
   agentRawContent?: string;
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
+}
+
+export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  return undefined;
 }
 
 /**
@@ -120,6 +128,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         agent: normalizePageAgentFrontmatter(data.agent),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
+        lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
         lastModified: stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
@@ -154,6 +163,7 @@ function readAgentDoc(dir: string) {
   return {
     agentContent: stripMarkdown(agentRawContent),
     agentRawContent,
+    agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
   };
 }
 

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -82,6 +82,7 @@ import {
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
+  resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
   resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
@@ -107,7 +108,12 @@ import {
   serializeOpenDocsProviders,
 } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
-import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
+import {
+  loadDocsNavTree,
+  loadDocsContent,
+  flattenNavTree,
+  normalizeDocsFrontmatterLastmod,
+} from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createAstroApiReference } from "./api-reference.js";
@@ -496,6 +502,8 @@ function searchIndexFromMap(
   contentMap: ContentFileMap,
   dirPrefix: string,
   entry: string,
+  locale?: string,
+  sitemapManifest?: ReturnType<typeof readDocsSitemapManifestFromContentMap>,
 ): ContentPage[] {
   const pages: ContentPage[] = [];
 
@@ -510,6 +518,13 @@ function searchIndexFromMap(
     const isIdx = base === "page" || base === "index" || base === "+page";
     const slug = isIdx ? segments.join("/") : [...segments, base].join("/");
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
+    const manifestLastmod =
+      (locale
+        ? resolveDocsSitemapPageLastmod(
+            sitemapManifest,
+            `${url}?lang=${encodeURIComponent(locale)}`,
+          )
+        : undefined) ?? resolveDocsSitemapPageLastmod(sitemapManifest, url);
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
@@ -527,6 +542,7 @@ function searchIndexFromMap(
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
       icon: data.icon as string | undefined,
+      lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
       framework: typeof data.framework === "string" ? data.framework : undefined,
       version: typeof data.version === "string" ? data.version : undefined,
@@ -535,6 +551,7 @@ function searchIndexFromMap(
         : undefined,
       content: stripMarkdownText(humanRawContent),
       rawContent: humanRawContent,
+      ...(manifestLastmod ? { lastModified: `${manifestLastmod}T00:00:00.000Z` } : {}),
       ...(pageAgentRawContent !== humanRawContent
         ? {
             agentFallbackContent: stripMarkdownText(pageAgentRawContent),
@@ -866,7 +883,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const cached = searchIndexByEntry.get(key);
     if (cached) return cached;
     const index = preloaded
-      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry)
+      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry, ctx.locale, preloadedSitemapManifest)
       : loadDocsContent(ctx.contentDirAbs, entry);
     searchIndexByEntry.set(key, index);
     return index;
@@ -992,7 +1009,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return page
       ? {
           document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
   }
@@ -1332,27 +1349,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const filters = resolveDocsSearchFilters(url.searchParams);
     const structured = url.searchParams.get("response") === "structured";
-    if (!query) {
-      const searchResponse = structured
-        ? {
-            format: "docs-search.v1",
-            query: "",
-            audience,
-            filters,
-            resultCount: 0,
-            results: [],
-            warnings: [],
-          }
-        : [];
-      return new Response(JSON.stringify(searchResponse), {
+    if (!query && !structured) {
+      return new Response("[]", {
         headers: { "Content-Type": "application/json" },
       });
     }
-
-    const searchStartedAt = Date.now();
     const searchOptions = {
       pages: getSearchIndex(ctx),
-      query,
+      query: query ?? "",
       search: resolveSearchRequestConfig(config.search, context.request.url),
       audience,
       filters,
@@ -1360,7 +1364,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
       baseUrl: markdownMetadataBaseUrl || url.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
     };
+    if (!query) {
+      const searchResponse = structured ? await performDocsSearchWithMetadata(searchOptions) : [];
+      return new Response(JSON.stringify(searchResponse), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const searchStartedAt = Date.now();
     const searchResponse = structured
       ? await performDocsSearchWithMetadata(searchOptions)
       : await performDocsSearch(searchOptions);
@@ -1685,7 +1698,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
-      baseUrl: requestUrl.origin,
+      baseUrl: markdownMetadataBaseUrl || requestUrl.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
       limit: maxResults,
     });
     const scored = retrieval.results;
@@ -1985,6 +1999,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     source: {
       entry,
       siteTitle: mcpSiteTitle,
+      baseUrl: markdownMetadataBaseUrl || undefined,
+      resolveLocale: resolveLocaleForMcp,
       getPages(locale) {
         const ctx = resolveContextFromPath(`/${entry}`, resolveLocaleForMcp(locale));
         return getSearchIndex(ctx);

--- a/packages/astro/test/content.test.ts
+++ b/packages/astro/test/content.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadDocsContent } from "../src/content.js";
+
+describe("loadDocsContent", () => {
+  it("tracks the explicit agent.md modified time separately from the page source", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "farming-labs-astro-content-"));
+
+    try {
+      const pageDir = join(rootDir, "guide");
+      const pagePath = join(pageDir, "page.mdx");
+      const agentPath = join(pageDir, "agent.md");
+      mkdirSync(pageDir, { recursive: true });
+      writeFileSync(
+        pagePath,
+        "---\ntitle: Guide\nlastmod: 2026-07-17\n---\n\n# Guide\n\nHuman source.\n",
+      );
+      writeFileSync(agentPath, "# Guide\n\nAgent source.\n");
+
+      const pageModified = new Date("2026-07-18T08:00:00.000Z");
+      const agentModified = new Date("2026-07-19T09:30:00.000Z");
+      utimesSync(pagePath, pageModified, pageModified);
+      utimesSync(agentPath, agentModified, agentModified);
+
+      expect(loadDocsContent(rootDir)).toEqual([
+        expect.objectContaining({
+          url: "/docs/guide",
+          lastmod: "2026-07-17T00:00:00.000Z",
+          lastModified: pageModified.toISOString(),
+          agentLastModified: agentModified.toISOString(),
+          agentRawContent: "# Guide\n\nAgent source.\n",
+        }),
+      ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/astro/test/server-search.test.ts
+++ b/packages/astro/test/server-search.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { createDocsServer } from "../src/server.js";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const sitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Astro provenance",
+      lastmod: "2026-07-27",
+    },
+  ],
+});
+const source = `---
+title: "Astro provenance"
+framework: "Astro"
+version: "5"
+lastmod: 2026-07-26
+tags:
+  - retrieval
+---
+
+# Astro provenance
+
+Unique retrieval provenance needle.
+`;
+const localizedSource = source.replace("lastmod: 2026-07-26\n", "");
+const localizedSitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Astro fallback provenance",
+      lastmod: "2026-07-20",
+    },
+    {
+      url: "/docs?lang=fr",
+      markdownUrl: "/docs.md?lang=fr",
+      title: "Astro localized provenance",
+      lastmod: "2026-07-21",
+    },
+    {
+      url: "/docs/fallback",
+      markdownUrl: "/docs/fallback.md",
+      title: "Astro fallback freshness",
+      lastmod: "2026-07-22",
+    },
+  ],
+});
+const fallbackSource = `---
+title: "Astro fallback freshness"
+framework: "Astro"
+---
+
+# Astro fallback freshness
+
+Unique fallback freshness needle.
+`;
+
+describe("createDocsServer structured search provenance", () => {
+  it("uses the shared metadata pipeline without changing legacy response envelopes", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/page.md": source,
+        "/.farming-labs/sitemap-manifest.json": sitemapManifest,
+      },
+    });
+
+    const legacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance"),
+    });
+    expect(await legacy.json()).toEqual(expect.any(Array));
+
+    const structured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance&response=structured"),
+    });
+    const payload = await structured.json();
+
+    expect(payload.indexGeneration).toMatch(digestPattern);
+    expect(payload.results.length).toBeGreaterThan(0);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringMatching(/^https:\/\/docs\.example\.com\/docs(?:#|$)/),
+            scope: expect.objectContaining({ audience: "human", framework: ["astro"] }),
+            lastModified: "2026-07-26T00:00:00.000Z",
+            digest: expect.stringMatching(digestPattern),
+            indexGeneration: payload.indexGeneration,
+          }),
+        }),
+      ]),
+    );
+
+    const blankLegacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20"),
+    });
+    await expect(blankLegacy.json()).resolves.toEqual([]);
+
+    const blankStructured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20&response=structured"),
+    });
+    const blankPayload = await blankStructured.json();
+    expect(blankPayload).toMatchObject({
+      format: "docs-search.v1",
+      query: "",
+      resultCount: 0,
+      results: [],
+    });
+    expect(blankPayload.indexGeneration).toMatch(digestPattern);
+  });
+
+  it("prefers locale-qualified manifest freshness and falls back to the base page URL", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/fr/page.md": localizedSource,
+        "/docs/fr/fallback.md": fallbackSource,
+        "/.farming-labs/sitemap-manifest.json": localizedSitemapManifest,
+      },
+    });
+
+    const localized = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=provenance&response=structured&lang=fr",
+      ),
+    });
+    const localizedPayload = await localized.json();
+    expect(localizedPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-21T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+
+    const fallback = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=fallback&response=structured&lang=fr",
+      ),
+    });
+    const fallbackPayload = await fallback.json();
+    expect(fallbackPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs/fallback?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-22T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -547,7 +547,10 @@ Scoped Setup Token for Astro.`,
       request: new Request(blankUrl),
       url: blankUrl,
     });
-    await expect(blankStructuredResponse.json()).resolves.toEqual({
+    const blankStructuredPayload = (await blankStructuredResponse.json()) as {
+      indexGeneration: string;
+    };
+    expect(blankStructuredPayload).toMatchObject({
       format: "docs-search.v1",
       query: "",
       audience: "agent",
@@ -559,6 +562,7 @@ Scoped Setup Token for Astro.`,
       results: [],
       warnings: [],
     });
+    expect(blankStructuredPayload.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
 
   it("uses a build-time skill snapshot without touching unavailable source paths", async () => {

--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -177,6 +177,43 @@ describe("runDocsGoldenTasks", () => {
     expect(result.score).toBe(100);
   });
 
+  it("uses the configured canonical base URL for MCP evaluation provenance", async () => {
+    const canonicalBasePage = page({
+      slug: "mcp-canonical-base",
+      url: "/docs/mcp-canonical-base",
+      title: "MCP canonical base",
+      rawContent:
+        "# MCP canonical base\n\n## Verify source\n\nVerify the canonical MCP source URL.",
+    });
+    const report = await runDocsGoldenTasks(
+      [canonicalBasePage],
+      [
+        {
+          id: "mcp-canonical-base",
+          query: "canonical MCP source URL",
+          surface: "mcp-context",
+          topK: 1,
+          tokenBudget: 2_000,
+          expect: {
+            relevantSources: ["/docs/mcp-canonical-base#verify-source"],
+            requiredCitations: ["/docs/mcp-canonical-base#verify-source"],
+          },
+        },
+      ],
+      { baseUrl: "https://docs.example.com" },
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.tasks[0].context).toContain(
+      "Source: https://docs.example.com/docs/mcp-canonical-base#verify-source",
+    );
+    expect(report.tasks[0].citations).toMatchObject({
+      actual: ["https://docs.example.com/docs/mcp-canonical-base#verify-source"],
+      integrity: true,
+      passed: true,
+    });
+  });
+
   it("fails explicit version selection when the retrieved page is version-ambiguous", async () => {
     const ambiguousPage = page({
       slug: "install",
@@ -378,6 +415,50 @@ ${"Useful café guidance 🚜. ".repeat(60)}
     }
   });
 
+  it("prefers Ask AI canonical provenance over the transport URL for citations", async () => {
+    const canonicalOverridePage = Object.assign(
+      page({
+        slug: "ask-ai-canonical-override",
+        url: "/docs/ask-ai-canonical-override",
+        title: "Ask AI canonical override",
+        rawContent:
+          "# Ask AI canonical override\n\n## Verify canonical source\n\nUse the stable canonical source.",
+      }),
+      { canonicalUrl: "/guides/stable-canonical-source" },
+    );
+    const canonicalSource = "/guides/stable-canonical-source#verify-canonical-source";
+    const report = await runDocsGoldenTasks(
+      [canonicalOverridePage],
+      [
+        {
+          id: "ask-ai-canonical-override",
+          query: "stable canonical source",
+          surface: "ask-ai-context",
+          topK: 1,
+          tokenBudget: 2_000,
+          expect: {
+            relevantSources: [canonicalSource],
+            requiredCitations: [canonicalSource],
+          },
+        },
+      ],
+      { baseUrl: "https://docs.example.com" },
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.tasks[0].context).toContain(
+      "URL: https://docs.example.com/docs/ask-ai-canonical-override#verify-canonical-source",
+    );
+    expect(report.tasks[0].context).toContain(
+      "Canonical URL: https://docs.example.com/guides/stable-canonical-source#verify-canonical-source",
+    );
+    expect(report.tasks[0].citations).toMatchObject({
+      actual: [canonicalSource],
+      integrity: true,
+      passed: true,
+    });
+  });
+
   it("hydrates authored DOM anchors ahead of generated contracts on the Ask AI surface", async () => {
     const collisionPage = page({
       slug: "contract-collision-evaluation",
@@ -519,6 +600,83 @@ ${"Useful café guidance 🚜. ".repeat(60)}
 
     expect(generatedSource?.content).toContain("## Agent Contract");
     expect(generatedSource?.content).not.toContain("farming-labs:agent-contract");
+  });
+
+  it("retains retrieval source provenance while hydrating evaluation context", () => {
+    const provenancePage = page({
+      slug: "hydrated-provenance",
+      url: "/docs/hydrated-provenance",
+      title: "Hydrated provenance",
+      lastModified: "2026-07-18T08:00:00.000Z",
+      rawContent: "## Verify provenance\n\nRun the verification command.",
+    });
+    const provenance = {
+      canonicalUrl: "https://docs.example.com/guides/hydrated-provenance#verify-provenance",
+      scope: {
+        audience: "agent" as const,
+        framework: ["nextjs"],
+        version: ["16"],
+        tags: ["retrieval"],
+      },
+      lastModified: "2026-07-19T09:30:00.000Z",
+      digest: `sha256:${"a".repeat(64)}`,
+      indexGeneration: `sha256:${"b".repeat(64)}`,
+    };
+
+    const source = hydrateDocsEvaluationSearchSource(
+      {
+        id: "hydrated-provenance",
+        url: "/docs/hydrated-provenance#verify-provenance",
+        content: "Provider snippet.",
+        type: "heading",
+        source: provenance,
+      },
+      0,
+      new Map([[provenancePage.url, provenancePage]]),
+      "page-section",
+      "https://docs.example.com",
+    );
+
+    expect(source).toMatchObject({
+      url: "/guides/hydrated-provenance#verify-provenance",
+      pageUrl: "/guides/hydrated-provenance",
+      anchor: "verify-provenance",
+      lastModified: provenance.lastModified,
+      source: provenance,
+    });
+    expect(source?.source).toBe(provenance);
+
+    const providerOnlySource = hydrateDocsEvaluationSearchSource(
+      {
+        id: "provider-only-provenance",
+        url: "https://remote.example/docs/install?transport=preview",
+        content: "Provider-only installation.",
+        type: "page",
+        source: {
+          ...provenance,
+          canonicalUrl: "https://remote.example/docs/install?lang=fr",
+          scope: {
+            audience: "agent",
+            locale: ["fr"],
+            framework: ["astro"],
+            version: ["5"],
+            package: ["@farming-labs/astro"],
+            tags: ["retrieval"],
+          },
+        },
+      },
+      1,
+      new Map(),
+      "result",
+    );
+    expect(providerOnlySource).toMatchObject({
+      url: "https://remote.example/docs/install?lang=fr",
+      locale: "fr",
+      framework: "astro",
+      version: "5",
+      package: ["@farming-labs/astro"],
+      tags: ["retrieval"],
+    });
   });
 
   it("does not count a source when the budget can render only its header", async () => {

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -1,6 +1,7 @@
 import { createJiti } from "jiti";
 import {
   agentVersionConstraintMatches,
+  agentVersionConstraintGroupsOverlap,
   agentVersionConstraintsOverlap,
   normalizeAgentFramework,
   normalizeAgentLocale,
@@ -225,11 +226,14 @@ export interface DocsGoldenTasksReport {
 interface NormalizedScope {
   framework: string[];
   version: string[];
+  versionGroups?: string[][];
   package: string[];
   tags: string[];
   locale: string[];
   frameworkAmbiguous: boolean;
   versionAmbiguous: boolean;
+  packageAmbiguous?: boolean;
+  tagsAmbiguous?: boolean;
 }
 
 interface ContextCandidate {
@@ -654,6 +658,7 @@ function safeDecode(value: string): string {
 function canonicalizeSource(value: string, baseUrl?: string): string {
   const rawValue = value.trim();
   let pathname: string;
+  let search: string;
   let hash: string;
   let origin = "";
 
@@ -673,6 +678,7 @@ function canonicalizeSource(value: string, baseUrl?: string): string {
     const base = configuredBase ?? new URL("https://docs.local");
     const parsed = new URL(rawValue, base);
     pathname = parsed.pathname;
+    search = parsed.search;
     hash = parsed.hash;
     const explicitlySchemed = /^[a-z][a-z\d+.-]*:/iu.test(rawValue);
     const explicitlyHosted =
@@ -690,7 +696,9 @@ function canonicalizeSource(value: string, baseUrl?: string): string {
     const hashIndex = rawValue.indexOf("#");
     const pathAndQuery = hashIndex >= 0 ? rawValue.slice(0, hashIndex) : rawValue || "/";
     const fragment = hashIndex >= 0 ? rawValue.slice(hashIndex + 1) : "";
-    pathname = pathAndQuery.split("?", 1)[0] || "/";
+    const queryIndex = pathAndQuery.indexOf("?");
+    pathname = (queryIndex >= 0 ? pathAndQuery.slice(0, queryIndex) : pathAndQuery) || "/";
+    search = queryIndex >= 0 ? pathAndQuery.slice(queryIndex) : "";
     hash = fragment ? `#${fragment}` : "";
   }
 
@@ -703,7 +711,7 @@ function canonicalizeSource(value: string, baseUrl?: string): string {
   // later canonicalization pass to reinterpret it as the distinct `foo#bar` identifier.
   const decodedHash = hash ? safeDecode(hash.slice(1)).trim() : "";
   const normalizedHash = decodedHash ? `#${encodeURIComponent(decodedHash)}` : "";
-  return `${origin}${pathname || "/"}${normalizedHash === "#" ? "" : normalizedHash}`;
+  return `${origin}${pathname || "/"}${search}${normalizedHash === "#" ? "" : normalizedHash}`;
 }
 
 function sourcePage(value: string): string {
@@ -711,8 +719,15 @@ function sourcePage(value: string): string {
 }
 
 function sourceMatches(actual: string, expected: string, baseUrl?: string): boolean {
-  const canonicalActual = canonicalizeSource(actual, baseUrl);
+  let canonicalActual = canonicalizeSource(actual, baseUrl);
   const canonicalExpected = canonicalizeSource(expected, baseUrl);
+  const expectedPage = canonicalExpected.split("#", 1)[0] ?? canonicalExpected;
+  if (!expectedPage.includes("?")) {
+    const hashIndex = canonicalActual.indexOf("#");
+    const hash = hashIndex >= 0 ? canonicalActual.slice(hashIndex) : "";
+    const page = hashIndex >= 0 ? canonicalActual.slice(0, hashIndex) : canonicalActual;
+    canonicalActual = `${page.split("?", 1)[0]}${hash}`;
+  }
   return canonicalExpected.includes("#")
     ? canonicalActual === canonicalExpected
     : sourcePage(canonicalActual) === sourcePage(canonicalExpected);
@@ -747,6 +762,7 @@ function getPageScope(page: DocsMcpPage): NormalizedScope {
   return {
     framework: Array.from(new Set([...topFramework, ...contractFramework])),
     version: Array.from(new Set([...topVersion, ...contractVersion])),
+    versionGroups: [topVersion, contractVersion].filter((group) => group.length > 0),
     package: packageValues,
     tags,
     locale,
@@ -758,6 +774,8 @@ function getPageScope(page: DocsMcpPage): NormalizedScope {
       topVersion.length > 0 &&
       contractVersion.length > 0 &&
       !valuesOverlap(topVersion, contractVersion, agentVersionConstraintsOverlap),
+    packageAmbiguous: false,
+    tagsAmbiguous: false,
   };
 }
 
@@ -790,7 +808,7 @@ function toContextCandidates(
   pagesByUrl: ReadonlyMap<string, DocsMcpPage>,
 ): ContextCandidate[] {
   return sources.flatMap((source): ContextCandidate[] => {
-    const page = pagesByUrl.get(sourcePage(source.pageUrl));
+    const page = findPageForSource(pagesByUrl, source.pageUrl);
     if (!page) return [];
     return [
       {
@@ -872,7 +890,8 @@ function findPageForSource(
   pagesByUrl: ReadonlyMap<string, DocsMcpPage>,
   value: string,
 ): DocsMcpPage | undefined {
-  return pagesByUrl.get(sourcePage(value));
+  const canonicalPage = sourcePage(value);
+  return pagesByUrl.get(canonicalPage) ?? pagesByUrl.get(canonicalPage.split("?", 1)[0] ?? "/");
 }
 
 function getResultAnchor(value: string): string | undefined {
@@ -890,9 +909,15 @@ export function hydrateDocsEvaluationSearchSource(
   contentMode: "result" | "page-section",
   baseUrl?: string,
 ): DocsMcpContextSource | undefined {
-  const normalizedResultUrl = canonicalizeSource(result.url, baseUrl);
-  const page = findPageForSource(pagesByUrl, normalizedResultUrl);
-  const anchor = getResultAnchor(result.url);
+  const normalizedTransportUrl = canonicalizeSource(result.url, baseUrl);
+  const normalizedResultUrl = canonicalizeSource(
+    result.source?.canonicalUrl ?? result.url,
+    baseUrl,
+  );
+  const page =
+    findPageForSource(pagesByUrl, normalizedResultUrl) ??
+    findPageForSource(pagesByUrl, normalizedTransportUrl);
+  const anchor = getResultAnchor(result.source?.canonicalUrl ?? result.url);
   const section = anchor ?? result.section;
   const sectionMarkdown = page ? getPageAgentSectionMarkdown(page) : undefined;
   const pageSection =
@@ -907,6 +932,7 @@ export function hydrateDocsEvaluationSearchSource(
         ).trim()
       : [result.content, result.description].filter(Boolean).join("\n\n").trim();
   const scope = page ? getPageScope(page) : undefined;
+  const provenanceScope = result.source?.scope;
   const url = normalizedResultUrl;
 
   return {
@@ -917,12 +943,21 @@ export function hydrateDocsEvaluationSearchSource(
     section: pageSection?.title ?? result.section,
     anchor: pageSection?.anchor ?? anchor,
     sourcePath: page?.sourcePath,
-    lastModified: page?.lastModified,
-    locale: scope?.locale[0],
-    framework: scope?.framework[0],
-    version: scope?.version[0],
-    package: scope?.package.length ? [...scope.package] : undefined,
-    tags: scope?.tags.length ? [...scope.tags] : undefined,
+    lastModified: result.source?.lastModified ?? page?.lastModified,
+    locale: scope?.locale[0] ?? provenanceScope?.locale?.[0],
+    framework: scope?.framework[0] ?? provenanceScope?.framework?.[0],
+    version: scope?.version[0] ?? provenanceScope?.version?.[0],
+    package: scope?.package.length
+      ? [...scope.package]
+      : provenanceScope?.package?.length
+        ? [...provenanceScope.package]
+        : undefined,
+    tags: scope?.tags.length
+      ? [...scope.tags]
+      : provenanceScope?.tags?.length
+        ? [...provenanceScope.tags]
+        : undefined,
+    source: result.source,
     score: result.score,
     content,
     chars: content.length,
@@ -1199,12 +1234,16 @@ function parseAskAIContextSources(options: {
       continue;
     }
     const header = block.slice(0, contentStart);
-    const urlLines = header
-      .split(/\r?\n/u)
+    const headerLines = header.split(/\r?\n/u);
+    const urlLines = headerLines
       .map((line) => line.match(/^URL:\s+(.+)$/u)?.[1]?.trim())
       .filter((value): value is string => Boolean(value));
+    const canonicalUrlLines = headerLines
+      .map((line) => line.match(/^Canonical URL:\s+(.+)$/u)?.[1]?.trim())
+      .filter((value): value is string => Boolean(value));
     if (urlLines.length !== 1) integrity = false;
-    const url = canonicalizeSource(urlLines[0] ?? "/", options.baseUrl);
+    if (canonicalUrlLines.length > 1) integrity = false;
+    const url = canonicalizeSource(canonicalUrlLines[0] ?? urlLines[0] ?? "/", options.baseUrl);
     const expected = options.results[index];
     if (
       !expected ||
@@ -1263,6 +1302,7 @@ async function buildGoldenSurface(options: {
       tags: options.task.filters?.tags,
       locale: options.task.filters?.locale,
       maxResults: options.topK,
+      baseUrl: options.runOptions.baseUrl,
     };
     const [rankedContext, budgetedContext] = await Promise.all([
       buildDocsMcpContext({ ...contextOptions, tokenBudget: Number.MAX_SAFE_INTEGER }),
@@ -1364,7 +1404,10 @@ async function buildGoldenSurface(options: {
         integrity: rankedSources.every(
           (source, index) =>
             source.url ===
-            canonicalizeSource(results[index]?.url ?? "", options.runOptions.baseUrl),
+            canonicalizeSource(
+              results[index]?.source?.canonicalUrl ?? results[index]?.url ?? "",
+              options.runOptions.baseUrl,
+            ),
         ),
       },
     };
@@ -2324,16 +2367,49 @@ function buildSelectionMetrics(
   const locale = expectedLocale ? normalizeAgentLocale(expectedLocale) : undefined;
   const candidates = sources.map((source) => {
     const page = findPageForSource(pagesByUrl, source.pageUrl || source.url);
+    const provenance = source.source?.scope;
+    const conflicts = new Set(provenance?.conflicts ?? []);
+    const truncated = new Set(provenance?.truncated ?? []);
     const scope = page
       ? getPageScope(page)
       : {
-          framework: normalizeAgentScopeValues(source.framework).map(normalizeAgentFramework),
-          version: normalizeAgentScopeValues(source.version).map(normalizeAgentVersion),
-          package: normalizeDocsSearchFilters({ package: source.package }).package ?? [],
-          tags: normalizeDocsSearchFilters({ tags: source.tags }).tags ?? [],
-          locale: normalizeAgentScopeValues(source.locale).map(normalizeAgentLocale),
-          frameworkAmbiguous: false,
-          versionAmbiguous: false,
+          framework: Array.from(
+            new Set(
+              [
+                ...normalizeAgentScopeValues(source.framework),
+                ...(provenance?.framework ?? []),
+              ].map(normalizeAgentFramework),
+            ),
+          ),
+          version: Array.from(
+            new Set(
+              [...normalizeAgentScopeValues(source.version), ...(provenance?.version ?? [])].map(
+                normalizeAgentVersion,
+              ),
+            ),
+          ),
+          versionGroups: provenance?.versionGroups?.map((group) =>
+            group.map(normalizeAgentVersion),
+          ),
+          package:
+            normalizeDocsSearchFilters({
+              package: provenance?.package?.length ? provenance.package : source.package,
+            }).package ?? [],
+          tags:
+            normalizeDocsSearchFilters({
+              tags: provenance?.tags?.length ? provenance.tags : source.tags,
+            }).tags ?? [],
+          locale: Array.from(
+            new Set(
+              [...normalizeAgentScopeValues(source.locale), ...(provenance?.locale ?? [])].map(
+                normalizeAgentLocale,
+              ),
+            ),
+          ),
+          frameworkAmbiguous: conflicts.has("framework") || truncated.has("framework"),
+          versionAmbiguous: conflicts.has("version") || truncated.has("version"),
+          packageAmbiguous: conflicts.has("package") || truncated.has("package"),
+          tagsAmbiguous: conflicts.has("tags") || truncated.has("tags"),
         };
     return { source: canonicalizeSource(source.url), scope };
   });
@@ -2342,9 +2418,14 @@ function buildSelectionMetrics(
     : null;
   const firstVersionMatchRank = expectedVersion
     ? candidates.findIndex((candidate) =>
-        candidate.scope.version.some((version) =>
-          agentVersionConstraintMatches(expectedVersion, version),
-        ),
+        candidate.scope.versionGroups?.length
+          ? agentVersionConstraintGroupsOverlap([
+              [normalizeAgentVersion(expectedVersion)],
+              ...candidate.scope.versionGroups,
+            ])
+          : candidate.scope.version.some((version) =>
+              agentVersionConstraintMatches(expectedVersion, version),
+            ),
       ) + 1 || null
     : null;
   const firstPackageMatchRank = expectedSearchScope.package
@@ -2376,9 +2457,14 @@ function buildSelectionMetrics(
           !candidate.scope.framework.includes(framework)) ||
         (expectedVersion &&
           candidate.scope.version.length > 0 &&
-          !candidate.scope.version.some((version) =>
-            agentVersionConstraintMatches(expectedVersion, version),
-          )) ||
+          !(candidate.scope.versionGroups?.length
+            ? agentVersionConstraintGroupsOverlap([
+                [normalizeAgentVersion(expectedVersion)],
+                ...candidate.scope.versionGroups,
+              ])
+            : candidate.scope.version.some((version) =>
+                agentVersionConstraintMatches(expectedVersion, version),
+              ))) ||
         (expectedSearchScope.package &&
           candidate.scope.package.length > 0 &&
           !valuesOverlap(
@@ -2401,6 +2487,8 @@ function buildSelectionMetrics(
       (candidate) =>
         candidate.scope.frameworkAmbiguous ||
         candidate.scope.versionAmbiguous ||
+        Boolean(expectedSearchScope.package && candidate.scope.packageAmbiguous) ||
+        Boolean(expectedSearchScope.tags && candidate.scope.tagsAmbiguous) ||
         Boolean(framework && candidate.scope.framework.length === 0) ||
         Boolean(expectedVersion && candidate.scope.version.length === 0) ||
         Boolean(expectedSearchScope.package && candidate.scope.package.length === 0) ||

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1571,6 +1571,16 @@ function validateDocsDiagnosticsSearchConfig(
     requireString("endpoint");
   }
 
+  const syncNamespace = stringConfigValue(search.syncNamespace);
+  if (syncNamespace && syncNamespace.length > 1_024) {
+    errors.push({
+      severity: "error",
+      code: "invalid-search-sync-namespace",
+      path: "/search/syncNamespace",
+      message: "search.syncNamespace must be 1024 characters or fewer.",
+    });
+  }
+
   if (provider === "custom" && !("adapter" in search)) {
     errors.push({
       severity: "error",

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -108,6 +108,7 @@ async function main() {
     typesense: typeof flags.typesense === "boolean" ? flags.typesense : undefined,
     algolia: typeof flags.algolia === "boolean" ? flags.algolia : undefined,
     baseUrl: typeof flags["base-url"] === "string" ? flags["base-url"] : undefined,
+    siteUrl: typeof flags["site-url"] === "string" ? flags["site-url"] : undefined,
     collection: typeof flags.collection === "string" ? flags.collection : undefined,
     apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
     adminApiKey: typeof flags["admin-api-key"] === "string" ? flags["admin-api-key"] : undefined,
@@ -118,6 +119,8 @@ async function main() {
     appId: typeof flags["app-id"] === "string" ? flags["app-id"] : undefined,
     indexName: typeof flags["index-name"] === "string" ? flags["index-name"] : undefined,
     searchApiKey: typeof flags["search-api-key"] === "string" ? flags["search-api-key"] : undefined,
+    syncNamespace:
+      typeof flags["sync-namespace"] === "string" ? flags["sync-namespace"] : undefined,
   };
   const cloudOptions = {
     configPath: typeof flags.config === "string" ? flags.config : undefined,
@@ -450,6 +453,8 @@ ${pc.dim("Options for search sync:")}
   ${pc.cyan("--typesense")}                        Shortcut for ${pc.cyan("--provider typesense")}
   ${pc.cyan("--algolia")}                          Shortcut for ${pc.cyan("--provider algolia")}
   ${pc.cyan("--base-url <url>")}                   Typesense base URL (or use ${pc.dim("TYPESENSE_URL")})
+  ${pc.cyan("--site-url <url>")}                   Canonical public docs URL for source provenance
+  ${pc.cyan("--sync-namespace <name>")}            Stable ownership namespace for a shared hosted index
   ${pc.cyan("--collection <name>")}                Typesense collection name (default ${pc.dim("docs")})
   ${pc.cyan("--api-key <key>")}                    Typesense search/api key (or use ${pc.dim("TYPESENSE_API_KEY")})
   ${pc.cyan("--admin-api-key <key>")}              Admin-capable sync key for Typesense/Algolia

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -8,6 +8,7 @@ import {
   runDocsMcpStdio,
 } from "../server.js";
 import { resolveDocsPublishedAgentSkill } from "../agent.js";
+import { resolveDocsMetadataBaseUrl } from "../metadata.js";
 import type { DocsMcpConfig } from "../types.js";
 import {
   extractObjectLiteral,
@@ -71,6 +72,7 @@ export async function runMcp(options: RunMcpOptions = {}): Promise<void> {
     entry,
     contentDir,
     siteTitle: navTitle ?? "Documentation",
+    baseUrl: loadedConfig ? resolveDocsMetadataBaseUrl(loadedConfig) : undefined,
   });
 
   const resolvedMcp = resolveDocsMcpConfig(mcp ?? true, {

--- a/packages/docs/src/cli/search.test.ts
+++ b/packages/docs/src/cli/search.test.ts
@@ -49,6 +49,20 @@ describe("search sync cli", () => {
     ).toThrow(/TYPESENSE_OLLAMA_MODEL/);
   });
 
+  it("reads a stable hosted corpus namespace from env", () => {
+    expect(
+      resolveTypesenseSyncConfig(
+        {},
+        {
+          TYPESENSE_URL: "https://typesense.example.com",
+          TYPESENSE_API_KEY: "search-key",
+          TYPESENSE_ADMIN_API_KEY: "admin-key",
+          DOCS_SEARCH_SYNC_NAMESPACE: "product-docs",
+        },
+      ).syncNamespace,
+    ).toBe("product-docs");
+  });
+
   it("builds an algolia sync config from env", () => {
     expect(
       resolveAlgoliaSyncConfig(

--- a/packages/docs/src/cli/search.ts
+++ b/packages/docs/src/cli/search.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import pc from "picocolors";
 import {
   buildDocsSearchDocuments,
@@ -11,7 +12,10 @@ import type {
   DocsSearchAdapterContext,
   TypesenseDocsSearchConfig,
 } from "../types.js";
+import { resolveDocsI18n } from "../i18n.js";
+import { resolveDocsMetadataBaseUrl } from "../metadata.js";
 import {
+  loadDocsConfigModuleResultWithProjectEnv,
   loadProjectEnv,
   readTopLevelStringProperty,
   resolveDocsConfigPath,
@@ -26,6 +30,7 @@ export interface SearchSyncOptions {
   typesense?: boolean;
   algolia?: boolean;
   baseUrl?: string;
+  siteUrl?: string;
   collection?: string;
   apiKey?: string;
   adminApiKey?: string;
@@ -35,6 +40,7 @@ export interface SearchSyncOptions {
   appId?: string;
   indexName?: string;
   searchApiKey?: string;
+  syncNamespace?: string;
 }
 
 function getEnvValue(loadedEnv: Record<string, string>, key: string): string | undefined {
@@ -89,6 +95,8 @@ export function resolveTypesenseSyncConfig(
   const ollamaModel = options.ollamaModel ?? getEnvValue(loadedEnv, "TYPESENSE_OLLAMA_MODEL");
   const ollamaBaseUrl =
     options.ollamaBaseUrl ?? getEnvValue(loadedEnv, "TYPESENSE_OLLAMA_BASE_URL");
+  const syncNamespace =
+    options.syncNamespace ?? getEnvValue(loadedEnv, "DOCS_SEARCH_SYNC_NAMESPACE");
 
   if (!baseUrl) {
     throw new Error("Missing Typesense base URL. Set TYPESENSE_URL or pass --base-url.");
@@ -111,6 +119,7 @@ export function resolveTypesenseSyncConfig(
     apiKey,
     adminApiKey,
     mode,
+    ...(syncNamespace ? { syncNamespace } : {}),
     ...(mode === "hybrid"
       ? ollamaModel
         ? {
@@ -138,6 +147,8 @@ export function resolveAlgoliaSyncConfig(
   const adminApiKey = options.adminApiKey ?? getEnvValue(loadedEnv, "ALGOLIA_ADMIN_API_KEY");
   const searchApiKey =
     options.searchApiKey ?? getEnvValue(loadedEnv, "ALGOLIA_SEARCH_API_KEY") ?? adminApiKey;
+  const syncNamespace =
+    options.syncNamespace ?? getEnvValue(loadedEnv, "DOCS_SEARCH_SYNC_NAMESPACE");
 
   if (!appId) {
     throw new Error("Missing Algolia app id. Set ALGOLIA_APP_ID or pass --app-id.");
@@ -161,6 +172,7 @@ export function resolveAlgoliaSyncConfig(
     indexName,
     searchApiKey,
     adminApiKey,
+    ...(syncNamespace ? { syncNamespace } : {}),
   };
 }
 
@@ -168,38 +180,76 @@ export async function syncSearch(options: SearchSyncOptions = {}): Promise<void>
   const rootDir = process.cwd();
   const configPath = resolveDocsConfigPath(rootDir, options.configPath);
   const configContent = readFileSync(configPath, "utf-8");
+  const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, options.configPath);
+  const canonicalBaseUrl =
+    options.siteUrl ??
+    (configLoad.status === "evaluated" ? resolveDocsMetadataBaseUrl(configLoad.config) : undefined);
+  if (canonicalBaseUrl) {
+    try {
+      const parsed = new URL(canonicalBaseUrl);
+      if (
+        (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+        parsed.username ||
+        parsed.password
+      ) {
+        throw new Error();
+      }
+    } catch {
+      throw new Error(
+        "The canonical docs URL must be an absolute HTTP(S) URL without credentials.",
+      );
+    }
+  }
   const loadedEnv = loadProjectEnv(rootDir);
 
   const provider = resolveSearchSyncProvider(options, loadedEnv);
   const entry = readTopLevelStringProperty(configContent, "entry") ?? "docs";
   const contentDir = resolveDocsContentDir(rootDir, configContent, entry);
+  const i18n = configLoad.status === "evaluated" ? resolveDocsI18n(configLoad.config.i18n) : null;
+  const localizedSources = i18n
+    ? i18n.locales.map((locale) => ({
+        locale,
+        contentDir: path.join(contentDir, locale),
+      }))
+    : [{ locale: undefined, contentDir }];
+  const contexts: DocsSearchAdapterContext[] = [];
 
-  const source = createFilesystemDocsMcpSource({
-    rootDir,
-    entry,
-    contentDir,
-    siteTitle: "Documentation",
-  });
+  for (const localized of localizedSources) {
+    const source = createFilesystemDocsMcpSource({
+      rootDir,
+      entry,
+      contentDir: localized.contentDir,
+      siteTitle: "Documentation",
+      baseUrl: canonicalBaseUrl,
+    });
+    const scannedPages = await source.getPages();
+    if (scannedPages.length === 0) continue;
+    const pages = localized.locale
+      ? scannedPages.map((page) => ({ ...page, locale: localized.locale }))
+      : scannedPages;
+    contexts.push({
+      pages,
+      documents: buildDocsSearchDocuments(pages),
+      audience: "human",
+      locale: localized.locale,
+      siteTitle: source.siteTitle,
+      baseUrl: canonicalBaseUrl,
+      indexBaseUrl: canonicalBaseUrl,
+    });
+  }
 
-  const pages = await source.getPages();
-  const documents = buildDocsSearchDocuments(pages);
-  const context: DocsSearchAdapterContext = {
-    pages,
-    documents,
-    siteTitle: source.siteTitle,
-  };
-
-  if (documents.length === 0) {
+  const documentCount = contexts.reduce((count, context) => count + context.documents.length, 0);
+  if (documentCount === 0) {
     throw new Error(`No docs content was found under ${contentDir}.`);
   }
 
   if (provider === "typesense") {
     const config = resolveTypesenseSyncConfig(options, loadedEnv);
     const adapter = createTypesenseSearchAdapter(config);
-    await adapter.index?.(context);
+    for (const context of contexts) await adapter.index?.(context);
     console.log(
       pc.green(
-        `Synced ${documents.length} docs search documents to Typesense collection "${config.collection}".`,
+        `Synced ${documentCount} docs search documents to Typesense collection "${config.collection}".`,
       ),
     );
     return;
@@ -207,10 +257,10 @@ export async function syncSearch(options: SearchSyncOptions = {}): Promise<void>
 
   const config = resolveAlgoliaSyncConfig(options, loadedEnv);
   const adapter = createAlgoliaSearchAdapter(config);
-  await adapter.index?.(context);
+  for (const context of contexts) await adapter.index?.(context);
   console.log(
     pc.green(
-      `Synced ${documents.length} docs search documents to Algolia index "${config.indexName}".`,
+      `Synced ${documentCount} docs search documents to Algolia index "${config.indexName}".`,
     ),
   );
 }

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -346,12 +346,14 @@ export type {
 } from "./robots.js";
 export {
   buildDocsSearchDocuments,
+  buildDocsRetrievalDigestProjection,
   buildDocsAskAIContext,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
   createMcpSearchAdapter,
   createSimpleSearchAdapter,
   createTypesenseSearchAdapter,
+  enrichDocsSearchDocumentsWithProvenance,
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   normalizeDocsSearchFilters,
@@ -360,10 +362,14 @@ export {
   resolveDocsSearchAudience,
   resolveDocsSearchFilters,
   resolveDocsSearchRequest,
+  resolveDocsRetrievalLastModified,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
-export type { PerformDocsSearchOptions } from "./search.js";
+export type {
+  EnrichDocsSearchDocumentsWithProvenanceOptions,
+  PerformDocsSearchOptions,
+} from "./search.js";
 export type { GeneratedAgentProvenance, GeneratedAgentSourceKind } from "./agent-provenance.js";
 export type {
   DocsConfig,
@@ -502,6 +508,8 @@ export type {
   DocsSearchFilters,
   DocsSearchQuery,
   DocsSearchRequest,
+  DocsRetrievalSourceProvenance,
+  DocsRetrievalSourceScope,
   DocsSearchResult,
   DocsSearchResponse,
   DocsSearchResultType,
@@ -547,6 +555,8 @@ export type {
   DocsAgentTraceEventType,
   DocsAgentTraceStatus,
 } from "./types.js";
+
+export { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 export type {
   DocsAgentTraceContext,
   ResolvedDocsAnalyticsConfig,

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types";
@@ -7,6 +7,7 @@ import type {
   DocsAnalyticsEvent,
   DocsMcpAuthenticateContext,
   DocsObservabilityEvent,
+  DocsSearchAdapterContext,
 } from "./types.js";
 import type {
   DocsMcpConfigSchemaOption,
@@ -51,9 +52,10 @@ async function callMcpTool(
   handlers: ReturnType<typeof createDocsMcpHttpHandler>,
   name: string,
   args: Record<string, unknown>,
+  requestUrl = "http://localhost/api/docs/mcp",
 ) {
   return handlers.POST({
-    request: new Request("http://localhost/api/docs/mcp", {
+    request: new Request(requestUrl, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -905,6 +907,393 @@ Validate the generated example paths before editing this guide.
     });
   });
 
+  it("preserves explicit agent-source provenance across search_docs and get_context", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-mcp-provenance-"));
+    tempDirs.push(rootDir);
+
+    const pageDir = join(rootDir, "docs", "provenance");
+    const pagePath = join(pageDir, "page.mdx");
+    const agentPath = join(pageDir, "agent.md");
+    mkdirSync(pageDir, { recursive: true });
+    writeFileSync(
+      pagePath,
+      `---
+title: "Retrieval provenance"
+framework: nextjs
+version: "16"
+lastmod: 2026-07-17
+tags:
+  - retrieval
+---
+
+# Retrieval provenance
+
+Human-facing overview.
+`,
+    );
+    writeFileSync(
+      agentPath,
+      `# Retrieval provenance
+
+## Verify source provenance
+
+Run the provenance-exclusive verification command.
+`,
+    );
+    const pageModified = new Date("2026-07-18T08:00:00.000Z");
+    const agentModified = new Date("2026-07-19T09:30:00.000Z");
+    utimesSync(pagePath, pageModified, pageModified);
+    utimesSync(agentPath, agentModified, agentModified);
+    const otherPageDir = join(rootDir, "docs", "other");
+    mkdirSync(otherPageDir, { recursive: true });
+    writeFileSync(
+      join(otherPageDir, "page.mdx"),
+      `---
+title: "Other framework"
+framework: astro
+---
+
+# Other framework
+
+Unrelated corpus content still belongs to the complete index generation.
+`,
+    );
+
+    const handlers = createDocsMcpHttpHandler({
+      source: createFilesystemDocsMcpSource({
+        rootDir,
+        entry: "docs",
+        contentDir: "docs",
+        siteTitle: "Provenance docs",
+      }),
+    });
+    const requestUrl = "https://preview.docs.example/api/docs/mcp";
+    const digestPattern = /^sha256:[a-f0-9]{64}$/;
+
+    type RetrievalSource = {
+      canonicalUrl: string;
+      scope: { audience: string; framework?: string[]; version?: string[]; tags?: string[] };
+      lastModified?: string;
+      digest: string;
+      indexGeneration: string;
+    };
+    const searchPayload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          indexGeneration: string;
+          results: Array<{ url: string; source?: RetrievalSource }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "search_docs",
+        { query: "provenance-exclusive", audience: "agent" },
+        requestUrl,
+      ),
+    );
+    const search = searchPayload.result?.structuredContent;
+    const searchResult = search?.results.find((result) =>
+      result.url.startsWith("/docs/provenance"),
+    );
+
+    expect(search?.indexGeneration).toMatch(digestPattern);
+    expect(searchResult?.source).toMatchObject({
+      canonicalUrl: expect.stringMatching(
+        /^https:\/\/preview\.docs\.example\/docs\/provenance(?:#|$)/,
+      ),
+      scope: {
+        audience: "agent",
+        framework: ["nextjs"],
+        version: ["16"],
+        tags: ["retrieval"],
+      },
+      lastModified: agentModified.toISOString(),
+      digest: expect.stringMatching(digestPattern),
+      indexGeneration: search?.indexGeneration,
+    });
+    expect(searchResult?.source?.lastModified).not.toBe(pageModified.toISOString());
+
+    const humanPayload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          results: Array<{ url: string; source?: RetrievalSource }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "search_docs",
+        { query: "human-facing overview", audience: "human" },
+        requestUrl,
+      ),
+    );
+    expect(
+      humanPayload.result?.structuredContent?.results.find((result) =>
+        result.url.startsWith("/docs/provenance"),
+      )?.source?.lastModified,
+    ).toBe("2026-07-17T00:00:00.000Z");
+
+    const contextPayload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          context: string;
+          sources: Array<{
+            pageUrl: string;
+            url: string;
+            lastModified?: string;
+            source?: RetrievalSource;
+          }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "get_context",
+        {
+          query: "provenance-exclusive",
+          framework: "nextjs",
+          tokenBudget: 2_000,
+        },
+        requestUrl,
+      ),
+    );
+    const contextResult = contextPayload.result?.structuredContent;
+    const contextSource = contextResult?.sources.find(
+      (source) => source.pageUrl === "/docs/provenance",
+    );
+
+    expect(contextSource).toMatchObject({
+      pageUrl: "/docs/provenance",
+      url: "https://preview.docs.example/docs/provenance#verify-source-provenance",
+      lastModified: agentModified.toISOString(),
+      source: {
+        canonicalUrl: "https://preview.docs.example/docs/provenance#verify-source-provenance",
+        scope: {
+          audience: "agent",
+          framework: ["nextjs"],
+          version: ["16"],
+          tags: ["retrieval"],
+        },
+        lastModified: agentModified.toISOString(),
+        digest: searchResult?.source?.digest,
+        indexGeneration: search?.indexGeneration,
+      },
+    });
+    expect(contextResult?.context).toContain(
+      "Source: https://preview.docs.example/docs/provenance#verify-source-provenance",
+    );
+
+    const canonicalHandlers = createDocsMcpHttpHandler({
+      source: createFilesystemDocsMcpSource({
+        rootDir,
+        entry: "docs",
+        contentDir: "docs",
+        siteTitle: "Provenance docs",
+        baseUrl: "https://canonical.docs.example",
+      }),
+    });
+    const canonicalPayload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          results: Array<{ source?: RetrievalSource }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        canonicalHandlers,
+        "search_docs",
+        { query: "provenance-exclusive", audience: "agent" },
+        requestUrl,
+      ),
+    );
+    expect(canonicalPayload.result?.structuredContent?.results[0]?.source?.canonicalUrl).toMatch(
+      /^https:\/\/canonical\.docs\.example\/docs\/provenance(?:#|$)/,
+    );
+  });
+
+  it("does not trust the request origin for hosted-index ownership", async () => {
+    let observedContext: Pick<DocsSearchAdapterContext, "baseUrl" | "indexBaseUrl"> | undefined;
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        siteTitle: "Unconfigured origin docs",
+        getPages: () => [
+          {
+            slug: "install",
+            url: "/docs/install",
+            title: "Install",
+            content: "Install the origin-safe package.",
+          },
+        ],
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+      search: {
+        provider: "custom",
+        adapter: {
+          name: "capture-index-origin",
+          async search(_query, context) {
+            observedContext = {
+              baseUrl: context.baseUrl,
+              indexBaseUrl: context.indexBaseUrl,
+            };
+            return [];
+          },
+        },
+      },
+    });
+
+    const payload = await parseMcpPayload<{
+      result?: {
+        content?: Array<{ text?: string }>;
+        structuredContent?: unknown;
+        isError?: boolean;
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "search_docs",
+        { query: "origin-safe" },
+        "https://attacker-controlled.example/api/docs/mcp",
+      ),
+    );
+    expectSuccessfulStructuredTextResult(payload);
+
+    expect(observedContext).toEqual({
+      baseUrl: "https://attacker-controlled.example",
+      indexBaseUrl: undefined,
+    });
+  });
+
+  it("ignores request-controlled locales for locale-agnostic filesystem sources", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "docs-mcp-locale-agnostic-"));
+    tempDirs.push(rootDir);
+    mkdirSync(join(rootDir, "docs", "install"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "docs", "install", "page.mdx"),
+      "# Install\n\nInstall the locale-safe package.",
+    );
+    let observedLocale: string | undefined = "not-called";
+    let observedUrls: string[] = [];
+    const handlers = createDocsMcpHttpHandler({
+      source: createFilesystemDocsMcpSource({ rootDir, entry: "docs", contentDir: "docs" }),
+      search: {
+        provider: "custom",
+        adapter: {
+          name: "capture-filesystem-locale",
+          async search(query, context) {
+            observedLocale = query.locale;
+            observedUrls = context.pages.map((page) => page.url);
+            return [];
+          },
+        },
+      },
+    });
+    const payload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          results: Array<{
+            source?: { canonicalUrl: string; scope: { locale?: string[] } };
+          }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "search_docs",
+        { query: "locale-safe", locale: "attacker-controlled" },
+        "https://docs.example.com/api/docs/mcp",
+      ),
+    );
+
+    expect(observedLocale).toBeUndefined();
+    expect(observedUrls).toEqual(["/docs/install"]);
+    expect(payload.result?.structuredContent?.results[0]?.source).toMatchObject({
+      canonicalUrl: "https://docs.example.com/docs/install",
+      scope: { audience: "agent" },
+    });
+    expect(payload.result?.structuredContent?.results[0]?.source?.scope.locale).toBeUndefined();
+  });
+
+  it("attributes provenance to the locale actually selected by the source", async () => {
+    const requestedLocales: Array<string | undefined> = [];
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        siteTitle: "Localized docs",
+        resolveLocale(locale) {
+          if (locale === "fr") return "fr-CA";
+          if (locale === "fr-CA") return "en";
+          return "en";
+        },
+        getPages(locale) {
+          requestedLocales.push(locale);
+          return [
+            {
+              slug: "install",
+              url: "/docs/install",
+              title: "Install",
+              content: "Localized provenance needle.",
+              rawContent: "# Install\n\nLocalized provenance needle.",
+            },
+          ];
+        },
+        getNavigation() {
+          return { name: "Localized docs", children: [] };
+        },
+      },
+    });
+
+    const payload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          results: Array<{
+            source?: {
+              canonicalUrl: string;
+              scope: { locale?: string[] };
+            };
+          }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "search_docs",
+        { query: "localized provenance", locale: "fr", audience: "agent" },
+        "https://docs.example.com/mcp",
+      ),
+    );
+
+    expect(requestedLocales.at(-1)).toBe("fr-CA");
+    expect(payload.result?.structuredContent?.results[0]?.source).toMatchObject({
+      canonicalUrl: expect.stringContaining("?lang=fr-CA"),
+      scope: { locale: ["fr-ca"] },
+    });
+
+    const contextPayload = await parseMcpPayload<{
+      result?: {
+        structuredContent?: {
+          sources: Array<{
+            url: string;
+            source?: { scope: { locale?: string[] } };
+          }>;
+        };
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "get_context",
+        { query: "localized provenance", locale: "fr", tokenBudget: 512 },
+        "https://docs.example.com/mcp",
+      ),
+    );
+    expect(requestedLocales.at(-1)).toBe("fr-CA");
+    expect(contextPayload.result?.structuredContent?.sources[0]).toMatchObject({
+      url: expect.stringContaining("?lang=fr-CA"),
+      source: { scope: { locale: ["fr-ca"] } },
+    });
+  });
+
   it("uses the current file name for non-index fallback titles", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "docs-mcp-fallback-title-"));
     tempDirs.push(rootDir);
@@ -1751,7 +2140,7 @@ sidebar:
     expect(context?.sources).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          url: "/docs/guides/quickstart#verify-generated-paths",
+          url: "http://localhost/docs/guides/quickstart#verify-generated-paths",
           pageUrl: "/docs/guides/quickstart",
           section: "Verify generated paths",
           anchor: "verify-generated-paths",
@@ -1782,7 +2171,7 @@ sidebar:
     expect(pageHeadingContextPayload.result?.structuredContent?.sources).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          url: "/docs/guides/quickstart#quickstart",
+          url: "http://localhost/docs/guides/quickstart#quickstart",
           content: expect.stringContaining("Build your first app."),
         }),
       ]),
@@ -2081,7 +2470,7 @@ General operational guidance.
       resultCount: 1,
       sources: [
         expect.objectContaining({
-          url: "/docs/credential-rotation",
+          url: "http://localhost/docs/credential-rotation",
           content: expect.stringContaining("Task: Rotate quasar production credentials"),
         }),
       ],

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -26,6 +26,7 @@ import {
   performDocsSearch,
   performDocsSearchWithMetadata,
 } from "./search.js";
+import { isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
 import { resolvePageSidebarFolderIndexBehavior } from "./sidebar.js";
 import type { DocsPublishedAgentSkill } from "./standards-discovery.js";
@@ -59,6 +60,7 @@ import type {
   DocsMcpCorsConfig,
   DocsMcpProtectedResourceConfig,
   DocsObservabilityConfig,
+  DocsRetrievalSourceProvenance,
   DocsSearchConfig,
   DocsSearchSourcePage,
   DocsTelemetryConfig,
@@ -77,6 +79,7 @@ export interface DocsMcpPage {
   agent?: PageAgentFrontmatter;
   icon?: string;
   sourcePath?: string;
+  lastmod?: string;
   lastModified?: string;
   locale?: string;
   framework?: string;
@@ -86,6 +89,7 @@ export interface DocsMcpPage {
   rawContent?: string;
   agentContent?: string;
   agentRawContent?: string;
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
 }
@@ -200,6 +204,8 @@ export interface DocsMcpContextSource {
   version?: string;
   package?: string[];
   tags?: string[];
+  /** Canonical, scope-aware provenance for this retrieved source. */
+  source?: DocsRetrievalSourceProvenance;
   score?: number;
   content: string;
   /** JavaScript string length for this source's content only. */
@@ -249,6 +255,8 @@ export interface DocsMcpContextOptions {
   tokenBudget: number;
   entry?: string;
   siteTitle?: string;
+  /** Public docs origin used to resolve canonical source URLs. */
+  baseUrl?: string;
   /** Maximum number of ranked, deduplicated candidates to render. Defaults to 50. */
   maxResults?: number;
 }
@@ -279,6 +287,10 @@ export interface DocsMcpNavigationTree {
 export interface DocsMcpSource {
   entry?: string;
   siteTitle?: string;
+  /** Canonical public docs origin used for retrieval source URLs. */
+  baseUrl?: string;
+  /** Resolve a requested locale to the locale whose pages will actually be returned. */
+  resolveLocale?(locale?: string, context?: DocsMcpRequestContext): string | undefined;
   getPages(
     locale?: string,
     context?: DocsMcpRequestContext,
@@ -371,6 +383,7 @@ interface CreateFilesystemDocsMcpSourceOptions {
   entry?: string;
   contentDir?: string;
   siteTitle?: string;
+  baseUrl?: string;
   ordering?: "alphabetical" | "numeric" | OrderingItem[];
 }
 
@@ -1690,6 +1703,13 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
         type: "number",
         description: "Maximum result count returned by search requests.",
       },
+      {
+        path: "search.syncNamespace",
+        name: "syncNamespace",
+        type: "string",
+        description:
+          "Stable ownership namespace used to isolate and safely prune this corpus in a shared hosted index.",
+      },
     ],
   },
   {
@@ -2150,7 +2170,7 @@ const searchFilterValueSchema = z.union([
 const searchDocsInputSchema = z.object({
   query: z.string().trim().min(1),
   limit: z.number().int().min(1).max(25).optional(),
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
   audience: z.enum(["human", "agent"]).optional(),
   framework: searchFilterValueSchema.optional(),
   version: searchFilterValueSchema.optional(),
@@ -2160,7 +2180,7 @@ const searchDocsInputSchema = z.object({
 
 const readPageInputSchema = z.object({
   path: z.string().min(1),
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
   section: z.string().trim().min(1).optional(),
   maxChars: z.number().int().min(256).max(1_000_000).optional(),
 });
@@ -2170,7 +2190,7 @@ const listTasksInputSchema = z.object({
   framework: z.string().trim().min(1).optional(),
   version: z.string().trim().min(1).optional(),
   package: z.string().trim().min(1).optional(),
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
 });
 
 const readTaskInputSchema = readPageInputSchema;
@@ -2249,16 +2269,16 @@ const readTaskOutputSchema = z.object({
 });
 
 const listPagesInputSchema = z.object({
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
 });
 
 const listDocsInputSchema = z.object({
   section: z.string().trim().min(1).optional(),
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
 });
 
 const getNavigationInputSchema = z.object({
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
 });
 
 const getConfigSchemaInputSchema = z.object({
@@ -2274,7 +2294,7 @@ const getCodeExamplesInputSchema = z.object({
   language: z.string().trim().min(1).optional(),
   runnable: z.boolean().optional(),
   limit: z.number().int().min(1).max(50).optional(),
-  locale: z.string().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
 });
 
 const getContextInputSchema = z.object({
@@ -2283,7 +2303,7 @@ const getContextInputSchema = z.object({
   version: z.string().trim().min(1).optional(),
   package: searchFilterValueSchema.optional(),
   tags: searchFilterValueSchema.optional(),
-  locale: z.string().trim().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
   tokenBudget: z
     .number()
     .int()
@@ -2356,6 +2376,40 @@ const navigationOutputSchema = z.object({
   }),
   markdown: z.string(),
 });
+const retrievalSourceValueOutputSchema = z.string().max(128);
+const retrievalSourceValuesOutputSchema = z.array(retrievalSourceValueOutputSchema).max(16);
+const retrievalSourceScopeOutputSchema = z.object({
+  audience: z.enum(["human", "agent"]),
+  locale: retrievalSourceValuesOutputSchema.optional(),
+  framework: retrievalSourceValuesOutputSchema.optional(),
+  version: retrievalSourceValuesOutputSchema.optional(),
+  versionGroups: z.array(retrievalSourceValuesOutputSchema).max(16).optional(),
+  package: retrievalSourceValuesOutputSchema.optional(),
+  tags: retrievalSourceValuesOutputSchema.optional(),
+  truncated: z
+    .array(z.enum(["framework", "version", "package", "tags"]))
+    .max(4)
+    .optional(),
+  conflicts: z
+    .array(z.enum(["framework", "version", "package", "tags"]))
+    .max(4)
+    .optional(),
+});
+const retrievalSourceDigestOutputSchema = z.string().regex(/^sha256:[a-f\d]{64}$/iu);
+const retrievalSourceOutputSchema = z.object({
+  canonicalUrl: z
+    .string()
+    .max(4_096)
+    .refine(isDocsRetrievalCanonicalUrl, "Expected a safe HTTP(S) URL or root-relative path"),
+  scope: retrievalSourceScopeOutputSchema,
+  lastModified: z
+    .string()
+    .max(256)
+    .refine((value) => Number.isFinite(Date.parse(value)), "Expected a parseable modified time")
+    .optional(),
+  digest: retrievalSourceDigestOutputSchema,
+  indexGeneration: retrievalSourceDigestOutputSchema,
+});
 const searchResultOutputSchema = z.object({
   id: z.string(),
   url: z.string(),
@@ -2364,6 +2418,7 @@ const searchResultOutputSchema = z.object({
   type: z.enum(["page", "heading", "text"]),
   score: z.number().optional(),
   section: z.string().optional(),
+  source: retrievalSourceOutputSchema.optional(),
 });
 const searchFiltersOutputSchema = z.object({
   framework: z.array(z.string()).optional(),
@@ -2389,6 +2444,7 @@ const searchDocsOutputSchema = z.object({
   query: z.string(),
   audience: z.enum(["human", "agent"]),
   filters: searchFiltersOutputSchema,
+  indexGeneration: retrievalSourceDigestOutputSchema,
   resultCount: z.number().int().nonnegative(),
   results: z.array(searchResultOutputSchema),
   warnings: z.array(searchWarningOutputSchema),
@@ -2474,6 +2530,7 @@ const contextSourceOutputSchema = z.object({
   version: z.string().optional(),
   package: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
+  source: retrievalSourceOutputSchema.optional(),
   score: z.number().optional(),
   content: z.string(),
   chars: z.number().int().nonnegative(),
@@ -2746,6 +2803,10 @@ export function createFilesystemDocsMcpSource(
   return {
     entry,
     siteTitle: options.siteTitle ?? "Documentation",
+    baseUrl: options.baseUrl,
+    // Filesystem sources are locale-agnostic. Returning undefined prevents
+    // request-controlled locale strings from creating synthetic index variants.
+    resolveLocale: () => undefined,
     getPages,
     getNavigation,
   };
@@ -2790,11 +2851,17 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   const telemetryFramework = options.telemetryFramework ?? "mcp";
 
   function getSourcePages(locale?: string) {
-    return options.source.getPages(locale, options.requestContext);
+    return options.source.getPages(resolveSourceLocale(locale), options.requestContext);
   }
 
   function getSourceNavigation(locale?: string) {
-    return options.source.getNavigation(locale, options.requestContext);
+    return options.source.getNavigation(resolveSourceLocale(locale), options.requestContext);
+  }
+
+  function resolveSourceLocale(locale?: string) {
+    return options.source.resolveLocale
+      ? options.source.resolveLocale(locale, options.requestContext)
+      : locale;
   }
 
   function getSourceSkills() {
@@ -3463,6 +3530,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         const startedAt = nowMs();
         const resolvedLimit = limit ?? 10;
         const resolvedAudience = audience ?? "agent";
+        const resolvedLocale = resolveSourceLocale(locale);
         const filters = {
           framework,
           version,
@@ -3493,15 +3561,25 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(await getSourcePages(locale));
+          const pages = dedupePages(
+            await options.source.getPages(resolvedLocale, options.requestContext),
+          );
           const searchResponse = await performDocsSearchWithMetadata({
             pages: toSearchSourcePages(pages),
             query,
             search: toolSearchConfig ?? true,
             audience: resolvedAudience,
             filters,
-            locale,
+            locale: resolvedLocale,
             siteTitle: options.source.siteTitle,
+            baseUrl:
+              options.source.baseUrl ??
+              (options.requestContext?.request
+                ? new URL(options.requestContext.request.url).origin
+                : undefined),
+            // The request origin is safe for response links, but must never become
+            // hosted-index ownership. Only an explicitly configured source base is trusted.
+            syncBaseUrl: options.source.baseUrl ?? null,
             limit: resolvedLimit,
           });
           const elapsed = durationMs(startedAt);
@@ -3697,6 +3775,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
       },
       async ({ query, framework, version, package: packageName, tags, locale, tokenBudget }) => {
         const startedAt = nowMs();
+        const resolvedLocale = resolveSourceLocale(locale);
         const trace = createDocsAgentTraceContext("mcp.tool.get_context");
         const callSpanId = createDocsAgentTraceId("span");
         await emitDocsAgentTraceEvent(options.observability, {
@@ -3721,7 +3800,9 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(await getSourcePages(locale));
+          const pages = dedupePages(
+            await options.source.getPages(resolvedLocale, options.requestContext),
+          );
           const result = await buildDocsMcpContext({
             pages,
             query,
@@ -3729,10 +3810,15 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             version,
             package: packageName,
             tags,
-            locale,
+            locale: resolvedLocale,
             tokenBudget,
             entry: options.source.entry,
             siteTitle: options.source.siteTitle,
+            baseUrl:
+              options.source.baseUrl ??
+              (options.requestContext?.request
+                ? new URL(options.requestContext.request.url).origin
+                : undefined),
           });
           const elapsed = durationMs(startedAt);
           await emitDocsAnalyticsEvent(options.analytics, {
@@ -4806,6 +4892,13 @@ function hasVisibleDescendantFilesystemDocsPage(dir: string): boolean {
   return false;
 }
 
+function normalizeFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  return value instanceof Date && Number.isFinite(value.getTime())
+    ? value.toISOString()
+    : undefined;
+}
+
 function scanFilesystemDocsPages(
   contentDirAbs: string,
   entry: string,
@@ -4866,6 +4959,7 @@ function scanFilesystemDocsPages(
         agent: normalizePageAgentFrontmatter(data.agent),
         icon: data.icon as string | undefined,
         sourcePath: path.relative(rootDir, full).replace(/\\/g, "/"),
+        lastmod: normalizeFrontmatterLastmod(data.lastmod),
         lastModified: stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
@@ -4898,6 +4992,7 @@ function readFilesystemAgentDoc(dir: string) {
   return {
     agentContent: stripMarkdownForMcp(agentContent),
     agentRawContent: agentContent,
+    agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
   };
 }
 
@@ -5048,25 +5143,7 @@ function dedupePages(pages: DocsMcpPage[]): DocsMcpPage[] {
 }
 
 function toSearchSourcePages(pages: DocsMcpPage[]): DocsSearchSourcePage[] {
-  return pages.map((page) => ({
-    title: page.title,
-    url: page.url,
-    content: page.content,
-    rawContent: page.rawContent,
-    sourcePath: page.sourcePath,
-    lastModified: page.lastModified,
-    locale: page.locale,
-    framework: page.framework,
-    version: page.version,
-    tags: page.tags,
-    agentContent: page.agentContent,
-    agentRawContent: page.agentRawContent,
-    agentFallbackContent: page.agentFallbackContent,
-    agentFallbackRawContent: page.agentFallbackRawContent,
-    description: page.description,
-    related: page.related,
-    agent: page.agent,
-  }));
+  return pages;
 }
 
 export function getDocsConfigSchema(
@@ -5969,13 +6046,18 @@ export async function buildDocsMcpContext(
     return scope.matches && !scope.conflict ? [{ page, scope }] : [];
   });
   const scopedPages = scopedPageEntries.map(({ page }) => page);
+  const allSearchPages = toSearchSourcePages([...options.pages]);
+  const searchPageBySource = new Map(
+    options.pages.map((page, index) => [page, allSearchPages[index]!] as const),
+  );
   const scopeByPage = new Map(scopedPageEntries.map(({ page, scope }) => [page, scope]));
   const maxResults =
     typeof options.maxResults === "number" && Number.isFinite(options.maxResults)
       ? Math.max(1, Math.min(50, Math.floor(options.maxResults)))
       : 50;
   const searchResults = await performDocsSearch({
-    pages: toSearchSourcePages(scopedPages),
+    pages: scopedPages.map((page) => searchPageBySource.get(page)!),
+    generationPages: allSearchPages,
     query: options.query,
     search: {
       enabled: true,
@@ -5986,6 +6068,7 @@ export async function buildDocsMcpContext(
     audience: "agent",
     locale: options.locale,
     siteTitle: options.siteTitle,
+    baseUrl: options.baseUrl,
     limit: 50,
   });
   const orderedResults = [...searchResults].sort((left, right) => {
@@ -6049,9 +6132,9 @@ export async function buildDocsMcpContext(
 
   for (const { result, page, scope, selectedSection, rawContent } of resolvedCandidates) {
     const anchor = selectedSection?.anchor;
-    const sourceUrl = anchor
-      ? `${page.url.split("#", 1)[0]}#${encodeURIComponent(anchor)}`
-      : page.url;
+    const sourceUrl =
+      result.source?.canonicalUrl ??
+      (anchor ? `${page.url.split("#", 1)[0]}#${encodeURIComponent(anchor)}` : page.url);
     const headerLines = [`## ${page.title}`, `Source: ${sourceUrl}`];
     if (selectedSection?.title) headerLines.push(`Section: ${selectedSection.title}`);
     if (scope.framework) headerLines.push(`Framework: ${scope.framework}`);
@@ -6079,12 +6162,13 @@ export async function buildDocsMcpContext(
       section: selectedSection?.title,
       anchor,
       sourcePath: page.sourcePath,
-      lastModified: page.lastModified,
+      lastModified: result.source?.lastModified ?? page.lastModified,
       locale: scope.locale,
       framework: scope.framework,
       version: scope.version,
       package: scope.package.length > 0 ? [...scope.package] : undefined,
       tags: scope.tags.length > 0 ? [...scope.tags] : undefined,
+      source: result.source,
       score: result.score,
       content: limited.text,
       chars: limited.text.length,
@@ -6136,10 +6220,19 @@ function findDocsPage(
   entry?: string,
 ): DocsMcpPage | null {
   const normalizedRequest = normalizeRequestedPath(requestedPath, entry);
+  const normalizedRequestWithoutLocale = normalizeRequestedPath(
+    removeDocsLocaleQuery(requestedPath),
+    entry,
+  );
 
   for (const page of pages) {
     const normalizedPageUrl = normalizeUrlPath(page.url);
-    if (normalizedPageUrl === normalizedRequest) return page;
+    if (
+      normalizedPageUrl === normalizedRequest ||
+      normalizedPageUrl === normalizedRequestWithoutLocale
+    ) {
+      return page;
+    }
   }
 
   const normalizedSlug = normalizePathSegment(requestedPath.replace(/^\//, ""));
@@ -6148,6 +6241,17 @@ function findDocsPage(
   }
 
   return null;
+}
+
+function removeDocsLocaleQuery(value: string): string {
+  try {
+    const absolute = /^[a-z][a-z\d+.-]*:/iu.test(value);
+    const url = new URL(value, "https://docs.local");
+    url.searchParams.delete("lang");
+    return absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return value;
+  }
 }
 
 function normalizeRequestedPath(requestedPath: string, entry?: string): string {

--- a/packages/docs/src/retrieval-digest.test.ts
+++ b/packages/docs/src/retrieval-digest.test.ts
@@ -1,0 +1,41 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { digestDocsRetrievalContent } from "./retrieval-digest.js";
+
+function expectedDigest(value: string): string {
+  const normalized = value
+    .replace(/\r\n?/gu, "\n")
+    .replace(/^\uFEFF/u, "")
+    .trimEnd();
+  return `sha256:${createHash("sha256").update(normalized, "utf8").digest("hex")}`;
+}
+
+describe("retrieval digest", () => {
+  it.each(["", "abc", "Café 配置 💡", "\uFEFFline one\r\nline two  \r\n"])(
+    "matches SHA-256 for normalized UTF-8 content: %j",
+    (value) => {
+      expect(digestDocsRetrievalContent(value)).toBe(expectedDigest(value));
+    },
+  );
+
+  it("normalizes line endings and trailing whitespace deterministically", () => {
+    expect(digestDocsRetrievalContent("one\r\ntwo\n\n")).toBe(
+      digestDocsRetrievalContent("one\ntwo"),
+    );
+  });
+
+  it.each([55, 56, 63, 64, 65, 129])(
+    "matches SHA-256 across the %i-byte block boundary",
+    (length) => {
+      const value = "a".repeat(length);
+      expect(digestDocsRetrievalContent(value)).toBe(expectedDigest(value));
+    },
+  );
+
+  it("matches the standard one-million-a multi-block vector", () => {
+    const value = "a".repeat(1_000_000);
+    expect(digestDocsRetrievalContent(value)).toBe(
+      "sha256:cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+    );
+  });
+});

--- a/packages/docs/src/retrieval-digest.ts
+++ b/packages/docs/src/retrieval-digest.ts
@@ -1,0 +1,128 @@
+const SHA256_INITIAL_STATE = [
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+] as const;
+
+const SHA256_ROUND_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+] as const;
+
+function rotateRight(value: number, bits: number): number {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+function normalizeDigestContent(value: string): string {
+  return value
+    .replace(/\r\n?/gu, "\n")
+    .replace(/^\uFEFF/u, "")
+    .trimEnd();
+}
+
+/** Validate the bounded HTTP(S) URL or root-relative URI reference used by provenance. */
+export function isDocsRetrievalCanonicalUrl(value: string): boolean {
+  const hasUnsafeCharacter =
+    value.includes("\\") ||
+    Array.from(value).some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    });
+  if (!value || value !== value.trim() || value.length > 4_096 || hasUnsafeCharacter) {
+    return false;
+  }
+  if (/^\/(?!\/)/u.test(value)) {
+    try {
+      new URL(value, "https://docs.local");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  try {
+    const url = new URL(value);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") && !url.username && !url.password
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hash a retrieval source projection with portable SHA-256.
+ *
+ * The projection is normalized by removing one leading BOM, converting CRLF/CR
+ * line endings to LF, and trimming trailing whitespace. The helper is exported so
+ * agents can independently verify provenance in Node, edge, and browser runtimes.
+ */
+export function digestDocsRetrievalContent(value: string): `sha256:${string}` {
+  const input = new TextEncoder().encode(normalizeDigestContent(value));
+  const paddedLength = Math.ceil((input.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(input);
+  padded[input.length] = 0x80;
+
+  const bitLength = input.length * 8;
+  const dataView = new DataView(padded.buffer);
+  dataView.setUint32(paddedLength - 8, Math.floor(bitLength / 0x1_0000_0000), false);
+  dataView.setUint32(paddedLength - 4, bitLength >>> 0, false);
+
+  const state = Uint32Array.from(SHA256_INITIAL_STATE);
+  const words = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      words[index] = dataView.getUint32(offset + index * 4, false);
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const previous15 = words[index - 15]!;
+      const previous2 = words[index - 2]!;
+      const sigma0 = rotateRight(previous15, 7) ^ rotateRight(previous15, 18) ^ (previous15 >>> 3);
+      const sigma1 = rotateRight(previous2, 17) ^ rotateRight(previous2, 19) ^ (previous2 >>> 10);
+      words[index] = (words[index - 16]! + sigma0 + words[index - 7]! + sigma1) >>> 0;
+    }
+
+    let a = state[0]!;
+    let b = state[1]!;
+    let c = state[2]!;
+    let d = state[3]!;
+    let e = state[4]!;
+    let f = state[5]!;
+    let g = state[6]!;
+    let h = state[7]!;
+
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const temporary1 = (h + sum1 + choice + SHA256_ROUND_CONSTANTS[index]! + words[index]!) >>> 0;
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temporary2 = (sum0 + majority) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temporary1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temporary1 + temporary2) >>> 0;
+    }
+
+    state[0] = (state[0]! + a) >>> 0;
+    state[1] = (state[1]! + b) >>> 0;
+    state[2] = (state[2]! + c) >>> 0;
+    state[3] = (state[3]! + d) >>> 0;
+    state[4] = (state[4]! + e) >>> 0;
+    state[5] = (state[5]! + f) >>> 0;
+    state[6] = (state[6]! + g) >>> 0;
+    state[7] = (state[7]! + h) >>> 0;
+  }
+
+  return `sha256:${Array.from(state, (word) => word.toString(16).padStart(8, "0")).join("")}`;
+}

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DocsSearchAdapterContext } from "./types.js";
+import type { DocsSearchAdapterContext, DocsSearchResult } from "./types.js";
 import {
   buildDocsAskAIContext,
+  buildDocsRetrievalDigestProjection,
   buildDocsSearchDocuments,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
   createMcpSearchAdapter,
   createTypesenseSearchAdapter,
+  enrichDocsSearchDocumentsWithProvenance,
   normalizeDocsSearchFilters,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -14,6 +16,7 @@ import {
   resolveDocsSearchRequest,
   resolveSearchRequestConfig,
 } from "./search.js";
+import { digestDocsRetrievalContent } from "./retrieval-digest.js";
 
 const pages = [
   {
@@ -40,6 +43,24 @@ describe("buildDocsSearchDocuments", () => {
     expect(documents.some((item) => item.section === "Quickstart")).toBe(true);
     expect(documents.find((item) => item.section === "Quickstart")?.url).toBe(
       "/docs/installation#quickstart",
+    );
+  });
+
+  it("uses the locale-qualified URL for page and section document identities", () => {
+    const documents = buildDocsSearchDocuments([
+      {
+        ...pages[0],
+        locale: "pt_BR",
+      },
+    ]);
+
+    expect(documents.map((document) => document.id)).toEqual([
+      "/docs/installation?lang=pt_BR#page",
+      "/docs/installation?lang=pt_BR#section-0",
+      "/docs/installation?lang=pt_BR#section-1",
+    ]);
+    expect(documents.find((document) => document.section === "Quickstart")?.url).toBe(
+      "/docs/installation?lang=pt_BR#quickstart",
     );
   });
 
@@ -669,6 +690,373 @@ describe("performDocsSearch", () => {
     }
   });
 
+  it("attaches canonical, scoped provenance to simple and structured search results", async () => {
+    const provenancePages = [
+      {
+        title: "Provenance install",
+        url: "/docs/provenance-install",
+        canonicalUrl: "/guides/provenance-install",
+        description: "Install the provenance-aware package.",
+        content: "Install the provenance-aware package with the cobalt marker.",
+        rawContent: `# Provenance install
+
+Install the provenance-aware package.
+
+## Quick start
+
+Run the cobalt provenance marker.
+`,
+        locale: "en-US",
+        framework: "Next.js",
+        version: "v16",
+        tags: ["Setup", "AUTH"],
+        lastModified: "2026-07-27T12:34:56.000Z",
+        agent: {
+          appliesTo: {
+            framework: "next",
+            version: "16",
+            package: "@FARMING-LABS/NEXT",
+          },
+        },
+      },
+    ];
+    const options = {
+      pages: provenancePages,
+      query: "cobalt provenance marker",
+      baseUrl: "https://docs.example.com/api/docs/search",
+    };
+
+    const legacy = await performDocsSearch(options);
+    const structured = await performDocsSearchWithMetadata(options);
+    const legacySection = legacy.find((result) => result.section === "Quick start");
+    const structuredSection = structured.results.find((result) => result.section === "Quick start");
+
+    expect(legacySection?.source).toMatchObject({
+      canonicalUrl: "https://docs.example.com/guides/provenance-install#quick-start",
+      scope: {
+        audience: "human",
+        locale: ["en-us"],
+        framework: ["nextjs"],
+        version: ["16"],
+        package: ["@farming-labs/next"],
+        tags: ["auth", "setup"],
+      },
+      lastModified: "2026-07-27T12:34:56.000Z",
+    });
+    expect(legacySection?.source?.digest).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(legacySection?.source?.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(structured.indexGeneration).toBe(legacySection?.source?.indexGeneration);
+    expect(structuredSection?.source).toEqual(legacySection?.source);
+  });
+
+  it("returns reproducible digests for human and explicit agent source projections", async () => {
+    const page = {
+      title: "Reproducible provenance",
+      url: "/docs/reproducible-provenance",
+      content: "Human vermilion retrieval marker.",
+      rawContent: "# Reproducible provenance\n\nHuman vermilion retrieval marker.",
+      agentContent: "Agent cerulean retrieval marker.",
+      agentRawContent: "# Reproducible provenance\n\nAgent cerulean retrieval marker.",
+      lastModified: "2026-07-20T10:00:00.000Z",
+      agentLastModified: "2026-07-19T09:00:00.000Z",
+      agent: {
+        task: "Verify the selected retrieval projection.",
+        outcome: "The projection digest matches.",
+      },
+    };
+    const [humanResult] = await performDocsSearch({
+      pages: [page],
+      query: "human vermilion",
+      audience: "human",
+    });
+    const [agentResult] = await performDocsSearch({
+      pages: [page],
+      query: "agent cerulean",
+      audience: "agent",
+    });
+
+    expect(humanResult?.source?.digest).toBe(
+      digestDocsRetrievalContent(buildDocsRetrievalDigestProjection(page, "human")),
+    );
+    expect(agentResult?.source?.digest).toBe(
+      digestDocsRetrievalContent(buildDocsRetrievalDigestProjection(page, "agent")),
+    );
+    expect(agentResult?.source?.digest).not.toBe(humanResult?.source?.digest);
+    expect(agentResult?.source?.lastModified).toBe("2026-07-20T10:00:00.000Z");
+  });
+
+  it("normalizes provenance locale scope without changing its addressable locale query", async () => {
+    const [result] = await performDocsSearch({
+      pages: [
+        {
+          title: "Localized provenance",
+          url: "/docs/localized-provenance",
+          content: "Localized provenance marker.",
+          locale: "pt_BR",
+        },
+      ],
+      query: "localized provenance marker",
+      baseUrl: "https://docs.example.com",
+    });
+
+    expect(result?.source).toMatchObject({
+      canonicalUrl: "https://docs.example.com/docs/localized-provenance?lang=pt_BR",
+      scope: { audience: "human", locale: ["pt-br"] },
+    });
+  });
+
+  it("keeps index generations stable across request noise and changes them with index semantics", async () => {
+    const alphaPage = {
+      title: "Alpha provenance",
+      url: "/docs/alpha-provenance",
+      content: "Alpha provenance marker.",
+      rawContent: "# Alpha provenance\n\nAlpha provenance marker.",
+      framework: "nextjs",
+    };
+    const betaPage = {
+      title: "Beta provenance",
+      url: "/docs/beta-provenance",
+      content: "Beta provenance marker.",
+      rawContent: "# Beta provenance\n\nBeta provenance marker.",
+      framework: "astro",
+    };
+    const baseline = await performDocsSearchWithMetadata({
+      pages: [alphaPage, betaPage],
+      query: "alpha",
+      baseUrl: "https://docs.example.com/api/docs/search",
+    });
+    const reordered = await performDocsSearchWithMetadata({
+      pages: [betaPage, alphaPage],
+      query: "beta",
+      baseUrl: "https://docs.example.com/api/docs/search",
+    });
+    const previewHost = await performDocsSearchWithMetadata({
+      pages: [alphaPage, betaPage],
+      query: "unmatched request text",
+      baseUrl: "https://preview.example.net/other/base",
+    });
+    const changedContent = await performDocsSearchWithMetadata({
+      pages: [
+        {
+          ...alphaPage,
+          content: "Alpha provenance marker with changed content.",
+          rawContent: "# Alpha provenance\n\nAlpha provenance marker with changed content.",
+        },
+        betaPage,
+      ],
+      query: "alpha",
+    });
+    const changedScope = await performDocsSearchWithMetadata({
+      pages: [{ ...alphaPage, framework: "nuxt" }, betaPage],
+      query: "alpha",
+    });
+    const changedFilesystemTime = await performDocsSearchWithMetadata({
+      pages: [{ ...alphaPage, lastModified: "2026-07-28T00:00:00.000Z" }, betaPage],
+      query: "alpha",
+    });
+    const changedAuthoredTime = await performDocsSearchWithMetadata({
+      pages: [{ ...alphaPage, lastmod: "2026-07-28" }, betaPage],
+      query: "alpha",
+    });
+    const changedAgentContract = await performDocsSearchWithMetadata({
+      pages: [
+        {
+          ...alphaPage,
+          agent: {
+            task: "Configure the contract-only retrieval marker.",
+            outcome: "The contract marker is indexed.",
+          },
+        },
+        betaPage,
+      ],
+      query: "alpha",
+    });
+    const agentAudience = await performDocsSearchWithMetadata({
+      pages: [alphaPage, betaPage],
+      query: "alpha",
+      audience: "agent",
+    });
+    const pageChunking = await performDocsSearchWithMetadata({
+      pages: [alphaPage, betaPage],
+      query: "alpha",
+      search: { provider: "simple", chunking: { strategy: "page" } },
+    });
+
+    expect(baseline.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(reordered.indexGeneration).toBe(baseline.indexGeneration);
+    expect(previewHost.indexGeneration).toBe(baseline.indexGeneration);
+    expect(changedContent.indexGeneration).not.toBe(baseline.indexGeneration);
+    expect(changedScope.indexGeneration).not.toBe(baseline.indexGeneration);
+    expect(changedFilesystemTime.indexGeneration).toBe(baseline.indexGeneration);
+    expect(changedAuthoredTime.indexGeneration).not.toBe(baseline.indexGeneration);
+    expect(changedAgentContract.indexGeneration).not.toBe(baseline.indexGeneration);
+    expect(agentAudience.indexGeneration).not.toBe(baseline.indexGeneration);
+    expect(pageChunking.indexGeneration).not.toBe(baseline.indexGeneration);
+  });
+
+  it("returns a structured generation for blank queries without invoking the provider", async () => {
+    const providerSearch = vi.fn(async () => {
+      throw new Error("Blank structured queries must not reach the provider.");
+    });
+
+    const structured = await performDocsSearchWithMetadata({
+      pages: [
+        {
+          title: "Blank query provenance",
+          url: "/docs/blank-query-provenance",
+          content: "Blank query provenance marker.",
+        },
+      ],
+      query: " \n ",
+      search: createCustomSearchAdapter({
+        name: "blank-query-provenance-provider",
+        search: providerSearch,
+      }),
+    });
+
+    expect(providerSearch).not.toHaveBeenCalled();
+    expect(structured).toMatchObject({
+      query: " \n ",
+      resultCount: 0,
+      results: [],
+    });
+    expect(structured.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/u);
+  });
+
+  it("drops malformed provenance returned by a custom provider", async () => {
+    const malformedResult = {
+      id: "malformed-provenance",
+      url: "https://remote.example/docs/install",
+      content: "Remote installation result",
+      type: "page",
+      source: {
+        canonicalUrl: "javascript:alert(1)",
+        scope: { audience: "human" },
+        digest: "sha256:aaaaaaaa",
+        indexGeneration: "sha256:bbbbbbbb",
+      },
+    } as unknown as DocsSearchResult;
+
+    const results = await performDocsSearch({
+      pages: [],
+      query: "installation",
+      baseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: createCustomSearchAdapter({
+        name: "malformed-provenance-provider",
+        async search() {
+          return [malformedResult];
+        },
+      }),
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it.each([
+    { framework: "nextjs" },
+    { tags: Array.from({ length: 17 }, (_, index) => `tag-${index}`) },
+    { locale: [123] },
+    { versionGroups: [["16"], "17"] },
+    { truncated: ["framework", "unknown"] },
+    { conflicts: ["framework", "version", "package", "tags", "framework"] },
+  ])("fails closed for malformed or oversized source scope %#", async (scope) => {
+    const results = await performDocsSearch({
+      pages: [],
+      query: "installation",
+      baseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: createCustomSearchAdapter({
+        name: "malformed-scope-provider",
+        async search() {
+          return [
+            {
+              id: "malformed-scope",
+              url: "https://remote.example/docs/install",
+              content: "Remote installation result",
+              type: "page",
+              source: {
+                canonicalUrl: "https://remote.example/docs/install",
+                scope: { audience: "human", ...scope },
+                digest: `sha256:${"a".repeat(64)}`,
+                indexGeneration: `sha256:${"b".repeat(64)}`,
+              },
+            } as DocsSearchResult,
+          ];
+        },
+      }),
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("rejects foreign results whose valid provenance targets another audience", async () => {
+    const source = {
+      canonicalUrl: "https://remote.example/docs/install",
+      scope: { audience: "agent" as const, framework: ["nextjs"] },
+      digest: `sha256:${"a".repeat(64)}`,
+      indexGeneration: `sha256:${"b".repeat(64)}`,
+    };
+    const results = await performDocsSearch({
+      pages: [],
+      query: "installation",
+      audience: "human",
+      baseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: createCustomSearchAdapter({
+        name: "cross-audience-provenance-provider",
+        async search() {
+          return [
+            {
+              id: "cross-audience-provenance",
+              url: source.canonicalUrl,
+              content: "Agent-only installation result",
+              type: "page",
+              source,
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("rejects filtered foreign results whose relevant provenance scope was truncated", async () => {
+    const results = await performDocsSearch({
+      pages: [],
+      query: "installation",
+      filters: { framework: "nextjs" },
+      baseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: createCustomSearchAdapter({
+        name: "truncated-scope-provider",
+        async search() {
+          return [
+            {
+              id: "truncated-scope",
+              url: "https://remote.example/docs/install",
+              content: "Remote installation result",
+              type: "page",
+              source: {
+                canonicalUrl: "https://remote.example/docs/install",
+                scope: {
+                  audience: "human",
+                  framework: ["nextjs"],
+                  truncated: ["framework"],
+                },
+                digest: `sha256:${"a".repeat(64)}`,
+                indexGeneration: `sha256:${"b".repeat(64)}`,
+              },
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(results).toEqual([]);
+  });
+
   it("reports and excludes unknown, missing, and conflicting scope metadata", async () => {
     const structured = await performDocsSearchWithMetadata({
       pages: [
@@ -1182,6 +1570,42 @@ Customize the loading UI.
         type: "page",
       },
     ]);
+  });
+
+  it("round-trips helper-generated relative provenance through a custom adapter", async () => {
+    const search = await performDocsSearch({
+      pages,
+      query: "install",
+      supplementExternalResults: false,
+      search: createCustomSearchAdapter({
+        name: "provenance-aware-custom",
+        async search(_query, context) {
+          const [document] = await enrichDocsSearchDocumentsWithProvenance({
+            documents: context.documents,
+            pages: context.pages,
+            audience: context.audience,
+            chunking: context.chunking,
+          });
+          if (!document) return [];
+          return [
+            {
+              id: document.id,
+              url: document.url,
+              content: document.title,
+              type: document.type,
+              source: document.source,
+            },
+          ];
+        },
+      }),
+    });
+
+    expect(search[0]?.source).toMatchObject({
+      canonicalUrl: "/docs/installation",
+      scope: { audience: "human" },
+      digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+      indexGeneration: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+    });
   });
 
   it("projects raw audience blocks before passing documents to custom adapters", async () => {
@@ -2176,11 +2600,18 @@ Nine built-in themes are available.
     expect(context.context).toContain(
       "URL: https://docs.example.com/docs/customize#available-themes",
     );
+    expect(context.context).toContain(
+      "Canonical URL: https://docs.example.com/docs/customize#available-themes",
+    );
+    expect(context.context).toMatch(/Source digest: sha256:[a-f0-9]{64}/u);
+    expect(context.context).toMatch(/Index generation: sha256:[a-f0-9]{64}/u);
   });
 });
 
 describe("remote search adapters", () => {
   const originalFetch = globalThis.fetch;
+  const sourceDigest = `sha256:${"a".repeat(64)}`;
+  const sourceGeneration = `sha256:${"b".repeat(64)}`;
 
   beforeEach(() => {
     globalThis.fetch = vi.fn() as typeof fetch;
@@ -2202,6 +2633,12 @@ describe("remote search adapters", () => {
               title: "Installation",
               section: "Quickstart",
               type: "heading",
+              source_canonical_url: "https://docs.example.com/docs/installation#quickstart",
+              source_scope_audience: "human",
+              source_scope_framework: ["nextjs"],
+              source_last_modified: "2026-07-27T12:34:56.000Z",
+              source_digest: sourceDigest,
+              source_index_generation: sourceGeneration,
               _snippetResult: {
                 content: {
                   value: "Install the docs framework in your app.",
@@ -2238,8 +2675,61 @@ describe("remote search adapters", () => {
         type: "heading",
         score: undefined,
         section: "Quickstart",
+        source: {
+          canonicalUrl: "https://docs.example.com/docs/installation#quickstart",
+          scope: { audience: "human", framework: ["nextjs"] },
+          lastModified: "2026-07-27T12:34:56.000Z",
+          digest: sourceDigest,
+          indexGeneration: sourceGeneration,
+        },
       },
     ]);
+  });
+
+  it("rejects hosted hits with malformed nested provenance despite valid flattened fields", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          hits: [
+            {
+              objectID: "alg-mixed-source",
+              url: "/docs/installation",
+              title: "Installation",
+              type: "page",
+              source: { canonicalUrl: "javascript:alert(1)" },
+              source_canonical_url: "https://docs.example.com/docs/installation",
+              source_scope_audience: "human",
+              source_digest: sourceDigest,
+              source_index_generation: sourceGeneration,
+            },
+            {
+              objectID: "alg-null-source",
+              url: "/docs/null-source",
+              title: "Null source",
+              type: "page",
+              source: null,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    const adapter = createAlgoliaSearchAdapter({
+      provider: "algolia",
+      appId: "app-id",
+      indexName: "docs",
+      searchApiKey: "search-key",
+    });
+
+    await expect(
+      adapter.search({ query: "install", limit: 5 }, {
+        pages: [],
+        documents: [],
+      } as DocsSearchAdapterContext),
+    ).resolves.toEqual([]);
   });
 
   it("filters Algolia before provider top-k using the locally scoped document ids", async () => {
@@ -2282,12 +2772,18 @@ describe("remote search adapters", () => {
     ) as Record<string, unknown>;
     expect(request).toMatchObject({
       hitsPerPage: 5,
+      restrictSearchableAttributes: ["title", "section", "content", "description"],
       filters: 'objectID:"/docs/next#page"',
     });
   });
 
   it("trims oversized Algolia records before syncing", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      if (String(input).endsWith("/batch")) {
+        return new Response(JSON.stringify({ taskID: 1 }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+    });
 
     const adapter = createAlgoliaSearchAdapter({
       provider: "algolia",
@@ -2333,6 +2829,608 @@ describe("remote search adapters", () => {
       package: ["@farming-labs/next"],
       tags: ["setup"],
     });
+    expect(String(call?.[0])).toBe("https://app-id.algolia.net/1/indexes/docs/batch");
+  });
+
+  it("owns Algolia records with scoped ids and avoids unsafe cross-generation pruning", async () => {
+    let indexedRecord: Record<string, unknown> | undefined;
+    const operations: string[] = [];
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/batch")) {
+        const payload = JSON.parse(String(init?.body)) as {
+          requests: Array<{ action: string; body: Record<string, unknown> }>;
+        };
+        const action = payload.requests[0]?.action;
+        operations.push(action ?? "empty");
+        if (action === "addObject") indexedRecord = payload.requests[0]?.body;
+        return new Response(JSON.stringify({ taskID: action === "addObject" ? 1 : 2 }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      if (url.endsWith("/query")) {
+        return new Response(JSON.stringify({ hits: [indexedRecord] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected Algolia request: ${url}`);
+    });
+
+    const adapter = createAlgoliaSearchAdapter({
+      provider: "algolia",
+      appId: "owned-app",
+      indexName: "owned-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncNamespace: "site-a",
+    });
+    const context = {
+      pages,
+      documents: buildDocsSearchDocuments(pages),
+      audience: "human" as const,
+      baseUrl: "https://docs.example.com",
+      indexBaseUrl: "https://docs.example.com",
+      chunking: { strategy: "section" as const },
+    };
+
+    await adapter.index?.(context);
+
+    expect(indexedRecord?.objectID).toMatch(/^docs_[a-f0-9]{64}$/u);
+    expect(indexedRecord).toMatchObject({
+      id: indexedRecord?.objectID,
+      source_document_id: "/docs/installation#page",
+      _tags: [indexedRecord?.source_corpus_id],
+    });
+    expect(indexedRecord?.source_corpus_id).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(operations).toEqual(["addObject"]);
+    expect(
+      vi.mocked(globalThis.fetch).mock.calls.some(([input]) => String(input).endsWith("/browse")),
+    ).toBe(false);
+
+    const results = await adapter.search({ query: "install", limit: 5 }, context);
+    const queryCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find(([input]) => String(input).endsWith("/query"));
+    const queryBody = JSON.parse(String(queryCall?.[1]?.body)) as {
+      filters?: string;
+    };
+    expect(queryBody.filters).toBe(`_tags:"${String(indexedRecord?.source_corpus_id)}"`);
+    expect(results[0]?.id).toBe("/docs/installation#page");
+  });
+
+  it("uses the current human hosted generation only as a ranking hint for agent output", async () => {
+    let pageRecord: Record<string, unknown> | undefined;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/batch")) {
+        const payload = JSON.parse(String(init?.body)) as {
+          requests: Array<{ action: string; body: Record<string, unknown> }>;
+        };
+        if (payload.requests[0]?.action === "addObject") {
+          pageRecord = payload.requests
+            .map((request) => request.body)
+            .find((record) => record.source_document_id === "/docs/audience-ranking#page");
+        }
+        return new Response(JSON.stringify({ taskID: 1 }), { status: 200 });
+      }
+      if (url.includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      if (url.endsWith("/browse")) {
+        return new Response(
+          JSON.stringify({
+            hits: pageRecord
+              ? [
+                  {
+                    objectID: pageRecord.objectID,
+                    source_corpus_id: pageRecord.source_corpus_id,
+                  },
+                ]
+              : [],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/query")) {
+        return new Response(
+          JSON.stringify({
+            hits: pageRecord
+              ? [
+                  {
+                    ...pageRecord,
+                    _snippetResult: {
+                      content: { value: "Human-only semantic cobalt explanation." },
+                    },
+                  },
+                ]
+              : [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected Algolia request: ${url}`);
+    });
+
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Audience ranking",
+          url: "/docs/audience-ranking",
+          content: "Human and agent guidance.",
+          rawContent: `# Audience ranking
+
+<Human>
+Human-only semantic cobalt explanation.
+</Human>
+
+<Agent>
+Agent-safe indigo procedure.
+</Agent>
+`,
+        },
+      ],
+      query: "semantic cobalt",
+      audience: "agent",
+      baseUrl: "https://docs.example.com",
+      syncBaseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: {
+        provider: "algolia",
+        appId: "agent-ranking-app",
+        indexName: "agent-ranking-index",
+        searchApiKey: "search-key",
+        adminApiKey: "admin-key",
+        syncNamespace: "agent-ranking-site",
+      },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: "/docs/audience-ranking#page",
+      url: "/docs/audience-ranking",
+      content: "Audience ranking",
+      source: {
+        scope: { audience: "agent" },
+      },
+    });
+    expect(results[0]?.description).toContain("Agent-safe indigo procedure");
+    expect(results[0]?.description).not.toContain("Human-only");
+  });
+
+  it("uses local scope when a known hosted result has bounded provenance values", async () => {
+    let indexedRecord: Record<string, unknown> | undefined;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/batch")) {
+        const payload = JSON.parse(String(init?.body)) as {
+          requests: Array<{ action: string; body: Record<string, unknown> }>;
+        };
+        if (payload.requests[0]?.action === "addObject") {
+          indexedRecord = payload.requests[0]?.body;
+        }
+        return Response.json({ taskID: 1 });
+      }
+      if (url.includes("/task/")) return Response.json({ status: "published" });
+      if (url.endsWith("/browse")) {
+        return Response.json({
+          hits: indexedRecord
+            ? [
+                {
+                  objectID: indexedRecord.objectID,
+                  source_corpus_id: indexedRecord.source_corpus_id,
+                },
+              ]
+            : [],
+        });
+      }
+      if (url.endsWith("/query")) {
+        return Response.json({ hits: indexedRecord ? [indexedRecord] : [] });
+      }
+      throw new Error(`Unexpected Algolia request: ${url}`);
+    });
+    const tags = Array.from({ length: 17 }, (_, index) => `tag-${String(index).padStart(2, "0")}`);
+
+    const results = await performDocsSearch({
+      pages: [
+        {
+          title: "Bounded provenance",
+          url: "/docs/bounded-provenance",
+          content: "Bounded provenance retrieval marker.",
+          tags,
+        },
+      ],
+      query: "bounded provenance",
+      filters: { tags: "tag-16" },
+      baseUrl: "https://docs.example.com",
+      syncBaseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: {
+        provider: "algolia",
+        appId: "bounded-scope-app",
+        indexName: "bounded-scope-index",
+        searchApiKey: "search-key",
+        adminApiKey: "admin-key",
+        syncNamespace: "bounded-scope-site",
+        chunking: { strategy: "page" },
+      },
+    });
+
+    expect(indexedRecord?.source_scope_tags).not.toContain("tag-16");
+    expect(indexedRecord?.source_scope_truncated).toContain("tags");
+    expect(results).toHaveLength(1);
+    expect(results[0]?.source?.scope.truncated).toContain("tags");
+  });
+
+  it("uses source-less legacy local hits only as ranking hints", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          hits: [
+            {
+              objectID: "/docs/installation#page",
+              url: "/docs/installation",
+              title: "Installation",
+              type: "page",
+            },
+            {
+              objectID: "partial-provenance",
+              url: "/docs/installation",
+              title: "Partial installation",
+              type: "page",
+              source_canonical_url: "/docs/installation",
+              source_scope_audience: "human",
+              source_digest: `sha256:${"a".repeat(64)}`,
+            },
+            {
+              objectID: "foreign-legacy",
+              url: "https://foreign.example/docs/install",
+              title: "Foreign installation",
+              type: "page",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const results = await performDocsSearch({
+      pages,
+      query: "install",
+      baseUrl: "https://docs.example.com",
+      syncBaseUrl: "https://docs.example.com",
+      supplementExternalResults: false,
+      search: {
+        provider: "algolia",
+        appId: "legacy-hint-app",
+        indexName: "legacy-hint-index",
+        searchApiKey: "search-key",
+        syncNamespace: "legacy-hint-site",
+      },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: "/docs/installation#page",
+      url: "/docs/installation",
+      source: { scope: { audience: "human" } },
+    });
+  });
+
+  it("does not prune an owned Algolia corpus when discovery is empty", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    const adapter = createAlgoliaSearchAdapter({
+      provider: "algolia",
+      appId: "empty-owned-app",
+      indexName: "empty-owned-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncNamespace: "empty-owned-site",
+    });
+
+    await adapter.index?.({
+      pages: [],
+      documents: [],
+      audience: "human",
+    } as DocsSearchAdapterContext);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-syncs Algolia only when the complete index generation changes", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      if (String(input).endsWith("/batch")) {
+        return new Response(JSON.stringify({ taskID: 1 }), { status: 200 });
+      }
+      if (String(input).includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const search = {
+      provider: "algolia" as const,
+      appId: "provenance-generation-app",
+      indexName: "provenance-generation-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncOnSearch: true,
+    };
+    const originalPages = [
+      {
+        title: "Generation sync",
+        url: "/docs/generation-sync",
+        content: "First generation provenance marker.",
+        rawContent: "# Generation sync\n\nFirst generation provenance marker.",
+      },
+    ];
+
+    await performDocsSearch({
+      pages: originalPages,
+      query: "generation provenance",
+      search,
+      baseUrl: "https://docs.example.com",
+    });
+    await performDocsSearch({
+      pages: originalPages,
+      query: "different request",
+      search,
+      baseUrl: "https://docs.example.com",
+    });
+    await performDocsSearch({
+      pages: [
+        {
+          ...originalPages[0],
+          content: "Second generation provenance marker.",
+          rawContent: "# Generation sync\n\nSecond generation provenance marker.",
+        },
+      ],
+      query: "generation provenance",
+      search,
+      baseUrl: "https://docs.example.com",
+    });
+
+    const batchCalls = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(([input]) => String(input).endsWith("/batch"));
+    const generations = batchCalls.map(([, init]) => {
+      const payload = JSON.parse(String(init?.body)) as {
+        requests: Array<{
+          body: { source_canonical_url?: string; source_index_generation?: string };
+        }>;
+      };
+      return payload.requests[0]?.body.source_index_generation;
+    });
+
+    expect(batchCalls).toHaveLength(2);
+    expect(generations.every((generation) => /^sha256:[a-f0-9]{64}$/u.test(generation ?? ""))).toBe(
+      true,
+    );
+    expect(new Set(generations).size).toBe(2);
+    const firstBatch = JSON.parse(String(batchCalls[0]?.[1]?.body)) as {
+      requests: Array<{ body: { source_canonical_url?: string } }>;
+    };
+    expect(firstBatch.requests[0]?.body.source_canonical_url).toBe(
+      "https://docs.example.com/docs/generation-sync",
+    );
+  });
+
+  it("keeps canonical hosted sync state isolated between sites in one process", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/batch")) {
+        return Response.json({ taskID: 1 });
+      }
+      if (url.includes("/task/")) {
+        return Response.json({ status: "published" });
+      }
+      return Response.json({ hits: [] });
+    });
+    const search = {
+      provider: "algolia" as const,
+      appId: "multi-site-sync-app",
+      indexName: "multi-site-sync-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncOnSearch: true,
+    };
+    const run = (baseUrl: string) =>
+      performDocsSearch({
+        pages,
+        query: "install",
+        search,
+        baseUrl,
+        syncBaseUrl: baseUrl,
+      });
+
+    await run("https://alpha.example.com");
+    await run("https://beta.example.com");
+    await run("https://alpha.example.com");
+
+    const addBatches = vi.mocked(globalThis.fetch).mock.calls.filter(([, init]) => {
+      if (!init?.body) return false;
+      const body = JSON.parse(String(init.body)) as {
+        requests?: Array<{ action?: string }>;
+      };
+      return body.requests?.[0]?.action === "addObject";
+    });
+    expect(addBatches).toHaveLength(2);
+  });
+
+  it("retries a failed generation sync instead of marking it complete", async () => {
+    let failBatch = true;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      if (String(input).endsWith("/batch")) {
+        if (failBatch) return new Response("sync failed", { status: 500 });
+        return new Response(JSON.stringify({ taskID: 1 }), { status: 200 });
+      }
+      if (String(input).includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const options = {
+      pages: [
+        {
+          title: "Retry generation sync",
+          url: "/docs/retry-generation-sync",
+          content: "Retry generation provenance marker.",
+          rawContent: "# Retry generation sync\n\nRetry generation provenance marker.",
+        },
+      ],
+      query: "retry generation",
+      failureMode: "throw" as const,
+      search: {
+        provider: "algolia" as const,
+        appId: "provenance-retry-app",
+        indexName: "provenance-retry-index",
+        searchApiKey: "search-key",
+        adminApiKey: "admin-key",
+        syncOnSearch: true,
+      },
+    };
+
+    await expect(performDocsSearch(options)).rejects.toThrow("Failed to sync documents to Algolia");
+    failBatch = false;
+    await expect(performDocsSearch(options)).resolves.not.toHaveLength(0);
+
+    expect(
+      vi.mocked(globalThis.fetch).mock.calls.filter(([input]) => String(input).endsWith("/batch")),
+    ).toHaveLength(2);
+  });
+
+  it("serializes concurrent syncs for different generations of one hosted index", async () => {
+    let releaseFirstSync: (() => void) | undefined;
+    const firstSyncGate = new Promise<void>((resolve) => {
+      releaseFirstSync = resolve;
+    });
+    let batchCalls = 0;
+    let activeBatches = 0;
+    let maxActiveBatches = 0;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      if (String(input).endsWith("/batch")) {
+        batchCalls += 1;
+        activeBatches += 1;
+        maxActiveBatches = Math.max(maxActiveBatches, activeBatches);
+        if (batchCalls === 1) await firstSyncGate;
+        activeBatches -= 1;
+        return new Response(JSON.stringify({ taskID: batchCalls }), { status: 200 });
+      }
+      if (String(input).includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const search = {
+      provider: "algolia" as const,
+      appId: "provenance-concurrent-app",
+      indexName: "provenance-concurrent-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncOnSearch: true,
+    };
+    const basePage = {
+      title: "Concurrent generation",
+      url: "/docs/concurrent-generation",
+      content: "First concurrent generation.",
+      rawContent: "# Concurrent generation\n\nFirst concurrent generation.",
+    };
+    const firstSearch = performDocsSearch({
+      pages: [basePage],
+      query: "concurrent generation",
+      search,
+    });
+    await vi.waitFor(() => expect(batchCalls).toBe(1));
+    const secondSearch = performDocsSearch({
+      pages: [
+        {
+          ...basePage,
+          content: "Second concurrent generation.",
+          rawContent: "# Concurrent generation\n\nSecond concurrent generation.",
+        },
+      ],
+      query: "concurrent generation",
+      search,
+    });
+    await Promise.resolve();
+
+    expect(batchCalls).toBe(1);
+    releaseFirstSync?.();
+    await Promise.all([firstSearch, secondSearch]);
+
+    expect(batchCalls).toBe(2);
+    expect(maxActiveBatches).toBe(1);
+  });
+
+  it("re-syncs A after an in-flight B generation would otherwise overwrite it", async () => {
+    let releaseGenerationB: (() => void) | undefined;
+    const generationBGate = new Promise<void>((resolve) => {
+      releaseGenerationB = resolve;
+    });
+    let batchCalls = 0;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      if (String(input).endsWith("/batch")) {
+        batchCalls += 1;
+        if (batchCalls === 2) await generationBGate;
+        return new Response(JSON.stringify({ taskID: batchCalls }), { status: 200 });
+      }
+      if (String(input).includes("/task/")) {
+        return new Response(JSON.stringify({ status: "published" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const search = {
+      provider: "algolia" as const,
+      appId: "provenance-aba-app",
+      indexName: "provenance-aba-index",
+      searchApiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncOnSearch: true,
+    };
+    const generationA = {
+      title: "A-B-A generation",
+      url: "/docs/aba-generation",
+      content: "Generation A.",
+      rawContent: "# A-B-A generation\n\nGeneration A.",
+    };
+    const generationB = {
+      ...generationA,
+      content: "Generation B.",
+      rawContent: "# A-B-A generation\n\nGeneration B.",
+    };
+
+    await performDocsSearch({ pages: [generationA], query: "generation", search });
+    const searchB = performDocsSearch({ pages: [generationB], query: "generation", search });
+    await vi.waitFor(() => expect(batchCalls).toBe(2));
+    const finalSearchA = performDocsSearch({
+      pages: [generationA],
+      query: "generation",
+      search,
+    });
+    await Promise.resolve();
+    expect(batchCalls).toBe(2);
+
+    releaseGenerationB?.();
+    await Promise.all([searchB, finalSearchA]);
+    expect(batchCalls).toBe(3);
   });
 
   it("maps Typesense hits into docs search results", async () => {
@@ -2349,6 +3447,11 @@ describe("remote search adapters", () => {
                 section: "Quickstart",
                 type: "heading",
                 description: "Install the docs framework in your app.",
+                source_canonical_url: "https://docs.example.com/docs/installation#quickstart",
+                source_scope_audience: "agent",
+                source_scope_package: ["@farming-labs/docs"],
+                source_digest: sourceDigest,
+                source_index_generation: sourceGeneration,
               },
               highlights: [
                 {
@@ -2387,6 +3490,12 @@ describe("remote search adapters", () => {
         type: "heading",
         score: 123,
         section: "Quickstart",
+        source: {
+          canonicalUrl: "https://docs.example.com/docs/installation#quickstart",
+          scope: { audience: "agent", package: ["@farming-labs/docs"] },
+          digest: sourceDigest,
+          indexGeneration: sourceGeneration,
+        },
       },
     ]);
   });
@@ -2442,10 +3551,20 @@ describe("remote search adapters", () => {
   });
 
   it("creates a Typesense collection without an invalid default sorting field", async () => {
-    vi.mocked(globalThis.fetch)
-      .mockResolvedValueOnce(new Response(null, { status: 404 }))
-      .mockResolvedValueOnce(new Response("{}", { status: 201 }))
-      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/collections/docs") && !init?.method) {
+        return new Response(null, { status: 404 });
+      }
+      if (url.endsWith("/collections") && init?.method === "POST") {
+        return new Response("{}", { status: 201 });
+      }
+      const count = String(init?.body).split("\n").filter(Boolean).length;
+      return new Response(
+        Array.from({ length: count }, () => JSON.stringify({ success: true })).join("\n"),
+        { status: 200 },
+      );
+    });
 
     const adapter = createTypesenseSearchAdapter({
       provider: "typesense",
@@ -2459,6 +3578,7 @@ describe("remote search adapters", () => {
     await adapter.index!({
       pages,
       documents: buildDocsSearchDocuments(pages),
+      baseUrl: "https://docs.example.com",
     } as DocsSearchAdapterContext);
 
     const createCall = vi.mocked(globalThis.fetch).mock.calls[1];
@@ -2473,6 +3593,272 @@ describe("remote search adapters", () => {
       type: "string[]",
       optional: true,
     });
+    expect(payload.fields).toContainEqual({
+      name: "source_digest",
+      type: "string",
+      optional: true,
+    });
+    const imported = JSON.parse(
+      String(vi.mocked(globalThis.fetch).mock.calls[2]?.[1]?.body).split("\n")[0],
+    ) as Record<string, unknown>;
+    expect(imported.source_canonical_url).toBe("https://docs.example.com/docs/installation");
+    expect(imported.source_scope_audience).toBe("human");
+    expect(imported.source_digest).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(imported.source_index_generation).toMatch(/^sha256:[a-f0-9]{64}$/u);
+  });
+
+  it("recovers when another sync creates the Typesense collection concurrently", async () => {
+    let inspectCount = 0;
+    let createdFields: Array<Record<string, unknown>> = [];
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/collections/docs") && !init?.method) {
+        inspectCount += 1;
+        return inspectCount === 1
+          ? new Response(null, { status: 404 })
+          : Response.json({ fields: createdFields });
+      }
+      if (url.endsWith("/collections") && init?.method === "POST") {
+        createdFields = (
+          JSON.parse(String(init.body)) as { fields: Array<Record<string, unknown>> }
+        ).fields;
+        return new Response("already exists", { status: 409 });
+      }
+      if (url.includes("/documents/import")) {
+        const count = String(init?.body).split("\n").filter(Boolean).length;
+        return new Response(
+          Array.from({ length: count }, () => JSON.stringify({ success: true })).join("\n"),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unexpected Typesense request: ${url}`);
+    });
+
+    const adapter = createTypesenseSearchAdapter({
+      provider: "typesense",
+      baseUrl: "https://typesense.example.com",
+      collection: "docs",
+      apiKey: "search-key",
+      adminApiKey: "admin-key",
+    });
+
+    await adapter.index!({
+      pages,
+      documents: buildDocsSearchDocuments(pages),
+      audience: "human",
+    } as DocsSearchAdapterContext);
+    expect(inspectCount).toBe(2);
+  });
+
+  it("recovers when another sync adds missing Typesense provenance fields concurrently", async () => {
+    let inspectCount = 0;
+    let alteredFields: Array<Record<string, unknown>> = [];
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/collections/docs") && !init?.method) {
+        inspectCount += 1;
+        return Response.json({ fields: inspectCount === 1 ? [] : alteredFields });
+      }
+      if (url.endsWith("/collections/docs") && init?.method === "PATCH") {
+        alteredFields = (
+          JSON.parse(String(init.body)) as { fields: Array<Record<string, unknown>> }
+        ).fields;
+        return new Response("fields already exist", { status: 409 });
+      }
+      if (url.includes("/documents/import")) {
+        const count = String(init?.body).split("\n").filter(Boolean).length;
+        return new Response(
+          Array.from({ length: count }, () => JSON.stringify({ success: true })).join("\n"),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unexpected Typesense request: ${url}`);
+    });
+    const adapter = createTypesenseSearchAdapter({
+      provider: "typesense",
+      baseUrl: "https://typesense.example.com",
+      collection: "docs",
+      apiKey: "search-key",
+      adminApiKey: "admin-key",
+    });
+
+    await adapter.index!({
+      pages,
+      documents: buildDocsSearchDocuments(pages),
+      audience: "human",
+    } as DocsSearchAdapterContext);
+
+    expect(inspectCount).toBe(2);
+    expect(alteredFields).toContainEqual({
+      name: "source_digest",
+      type: "string",
+      optional: true,
+    });
+  });
+
+  it("owns Typesense records with scoped ids and avoids unsafe cross-generation pruning", async () => {
+    let importedRecord: Record<string, unknown> | undefined;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/collections/owned-docs") && !init?.method) {
+        return new Response(null, { status: 404 });
+      }
+      if (url.pathname.endsWith("/collections") && init?.method === "POST") {
+        return new Response("{}", { status: 201 });
+      }
+      if (url.pathname.endsWith("/documents/import")) {
+        const records = String(init?.body)
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as Record<string, unknown>);
+        importedRecord = records[0];
+        return new Response(records.map(() => JSON.stringify({ success: true })).join("\n"), {
+          status: 200,
+        });
+      }
+      if (url.pathname.endsWith("/multi_search")) {
+        return new Response(
+          JSON.stringify({
+            results: [{ hits: [{ document: importedRecord, text_match: 123 }] }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected Typesense request: ${url.toString()}`);
+    });
+
+    const adapter = createTypesenseSearchAdapter({
+      provider: "typesense",
+      baseUrl: "https://typesense.example.com",
+      collection: "owned-docs",
+      apiKey: "search-key",
+      adminApiKey: "admin-key",
+      syncNamespace: "site-a",
+    });
+    const context = {
+      pages,
+      documents: buildDocsSearchDocuments(pages),
+      audience: "human" as const,
+      baseUrl: "https://docs.example.com",
+      indexBaseUrl: "https://docs.example.com",
+      chunking: { strategy: "section" as const },
+    };
+
+    await adapter.index?.(context);
+
+    expect(importedRecord).toMatchObject({
+      id: expect.stringMatching(/^docs_[a-f0-9]{64}$/u),
+      source_document_id: "/docs/installation#page",
+    });
+    expect(importedRecord?.source_corpus_id).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(
+      vi.mocked(globalThis.fetch).mock.calls.some(([input, init]) => {
+        const url = new URL(String(input));
+        return (
+          url.pathname.endsWith("/documents/export") ||
+          (url.pathname.endsWith("/documents") && init?.method === "DELETE")
+        );
+      }),
+    ).toBe(false);
+
+    const results = await adapter.search({ query: "install", limit: 5 }, context);
+    const searchCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find(([input]) => String(input).endsWith("/multi_search"));
+    const searchBody = JSON.parse(String(searchCall?.[1]?.body)) as {
+      searches: Array<{ filter_by?: string }>;
+    };
+    expect(searchBody.searches[0]?.filter_by).toBe(
+      `source_corpus_id:=\`${String(importedRecord?.source_corpus_id)}\``,
+    );
+    expect(results[0]?.id).toBe("/docs/installation#page");
+  });
+
+  it("rejects incompatible existing Typesense provenance field types", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          fields: [
+            {
+              name: "source_scope_locale",
+              type: "string",
+              optional: true,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const adapter = createTypesenseSearchAdapter({
+      provider: "typesense",
+      baseUrl: "https://typesense.example.com",
+      collection: "incompatible-provenance",
+      apiKey: "search-key",
+      adminApiKey: "admin-key",
+    });
+
+    await expect(
+      adapter.index?.({
+        pages,
+        documents: buildDocsSearchDocuments(pages),
+      } as DocsSearchAdapterContext),
+    ).rejects.toThrow(
+      "Typesense collection has incompatible provenance fields: source_scope_locale.",
+    );
+  });
+
+  it("rejects per-record Typesense import failures and retries the generation", async () => {
+    let importAttempts = 0;
+    vi.mocked(globalThis.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/documents/import?action=upsert")) {
+        importAttempts += 1;
+        const count = String(init?.body).split("\n").filter(Boolean).length;
+        return new Response(
+          Array.from({ length: count }, (_, index) =>
+            JSON.stringify(
+              importAttempts === 1 && index === 0
+                ? { success: false, error: "schema rejected the document" }
+                : { success: true },
+            ),
+          ).join("\n"),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/documents/search?")) {
+        return new Response(JSON.stringify({ hits: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (!init?.method) {
+        return new Response(JSON.stringify({ fields: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const options = {
+      pages,
+      query: "install",
+      failureMode: "throw" as const,
+      search: {
+        provider: "typesense" as const,
+        baseUrl: "https://typesense.example.com",
+        collection: "provenance-import-retry",
+        apiKey: "search-key",
+        adminApiKey: "admin-key",
+        syncOnSearch: true,
+      },
+    };
+
+    await expect(performDocsSearch(options)).rejects.toThrow(
+      "Typesense failed to import record 1: schema rejected the document",
+    );
+    await expect(performDocsSearch(options)).resolves.not.toHaveLength(0);
+    expect(importAttempts).toBe(2);
   });
 
   it("starts non-sync MCP I/O before agent projection without building the human corpus", async () => {
@@ -2540,7 +3926,7 @@ describe("remote search adapters", () => {
     expect(results[0]?.url).toBe("/docs/lazy-mcp-search");
   });
 
-  it("maps legacy MCP search_docs payloads into docs search results", async () => {
+  it("maps legacy MCP search_docs payloads and drops malformed provenance", async () => {
     vi.mocked(globalThis.fetch)
       .mockResolvedValueOnce(
         new Response(
@@ -2578,6 +3964,25 @@ describe("remote search adapters", () => {
                         url: "/docs/installation",
                         title: "Installation",
                         excerpt: "Install the docs framework in your app.",
+                      },
+                      {
+                        slug: "unsafe-installation",
+                        url: "/docs/unsafe-installation",
+                        title: "Unsafe installation",
+                        excerpt: "This malformed provenance result must be dropped.",
+                        source: {
+                          canonicalUrl: "data:text/html,unsafe",
+                          scope: { audience: "human" },
+                          digest: "invalid",
+                          indexGeneration: "invalid",
+                        },
+                      },
+                      {
+                        slug: "partial-installation",
+                        url: "/docs/partial-installation",
+                        title: "Partial installation",
+                        excerpt: "This partial provenance result must be dropped.",
+                        source: { lastModified: "2026-07-28" },
                       },
                     ],
                   }),

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -17,9 +17,12 @@ import type {
   DocsSearchSourcePage,
   DocsSearchWarning,
   DocsSearchChunkingConfig,
+  DocsRetrievalSourceProvenance,
+  DocsRetrievalSourceScope,
   McpDocsSearchConfig,
   TypesenseDocsSearchConfig,
 } from "./types.js";
+import { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 import {
   PAGE_AGENT_CONTRACT_END_MARKER,
   PAGE_AGENT_CONTRACT_START_MARKER,
@@ -30,6 +33,7 @@ import {
   agentVersionConstraintGroupsOverlap,
   agentVersionConstraintsOverlap,
   normalizeAgentFramework,
+  normalizeAgentLocale,
   normalizeAgentScopeValues,
   normalizeAgentVersion,
 } from "./agent-scope.js";
@@ -45,7 +49,8 @@ const DEFAULT_SEARCH_LIMIT = 10;
 const MAX_SEARCH_SNIPPET_CHARS = 160;
 const DEFAULT_MCP_PROTOCOL_VERSION = "2025-11-25";
 const MCP_SESSION_CLEANUP_TIMEOUT_MS = 1_000;
-const syncedIndexes = new Set<string>();
+const syncedIndexes = new Map<string, string>();
+const syncingIndexes = new Map<string, { fingerprint: string; promise: Promise<void> }>();
 const ALGOLIA_MAX_RECORD_BYTES = 9_500;
 const DEFAULT_ASK_AI_CONTEXT_CHARS = 24_000;
 const DEFAULT_ASK_AI_RESULT_CHARS = 6_000;
@@ -55,9 +60,13 @@ const MAX_SEARCH_FILTER_RAW_CHARS = 4_096;
 const MAX_SEARCH_FILTER_SEGMENTS = 64;
 const MAX_PROVIDER_SCOPE_FILTER_IDS = 1_000;
 const MAX_PROVIDER_SCOPE_FILTER_CHARS = 16_000;
+const ALGOLIA_BATCH_OPERATIONS = 1_000;
 const MAX_SEARCH_WARNINGS = 16;
 const MAX_SEARCH_WARNING_VALUES = 16;
 const MAX_SEARCH_WARNING_PAGE_URLS = 8;
+const RETRIEVAL_INDEX_FORMAT = "docs-retrieval-index.v1";
+const MAX_RETRIEVAL_SOURCE_URL_CHARS = 4_096;
+const MAX_RETRIEVAL_SOURCE_VALUE_CHARS = 256;
 const SEARCH_FILTER_FIELDS = ["framework", "version", "package", "tags"] as const;
 const SEARCH_AMBIGUITY_FIELDS = ["framework", "version", "package"] as const;
 const SEARCH_STOP_WORDS = new Set([
@@ -204,10 +213,20 @@ function hasDocsSearchFilters(filters: DocsSearchFilters): boolean {
 function resolveProviderScopeDocumentIds(
   query: DocsSearchQuery,
   context: DocsSearchAdapterContext,
+  corpusId?: string,
 ): string[] | undefined {
   if (!hasDocsSearchFilters(query.filters ?? {})) return undefined;
 
-  const ids = Array.from(new Set(context.documents.map((document) => document.id)));
+  const documents = corpusId
+    ? buildDocsSearchDocuments(context.pages, context.chunking ?? { strategy: "section" }, "human")
+    : context.documents;
+  const ids = Array.from(
+    new Set(
+      documents.map((document) =>
+        corpusId ? makeHostedProviderDocumentId(corpusId, document.id) : document.id,
+      ),
+    ),
+  );
   return ids.length <= MAX_PROVIDER_SCOPE_FILTER_IDS ? ids : [];
 }
 
@@ -457,12 +476,59 @@ function tokenizeSearchQuery(query: string): string[] {
   );
 }
 
-function normalizeUrlPathname(value: string): string {
+function normalizeUrlRouteKey(value: string): string {
   try {
-    return new URL(value, "https://docs.local").pathname.replace(/\/+$/, "") || "/";
+    const url = new URL(value, "https://docs.local");
+    return `${url.pathname || "/"}${url.search}`;
   } catch {
-    return value.split(/[?#]/)[0]?.replace(/\/+$/, "") || "/";
+    return value.split("#", 1)[0] || "/";
   }
+}
+
+function normalizeAuthoredUrlIdentity(value: string): string {
+  const trimmed = value.trim();
+  const explicitScheme = trimmed.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
+  if (explicitScheme && explicitScheme !== "http" && explicitScheme !== "https") {
+    return normalizeUrlRouteKey("/");
+  }
+
+  try {
+    const url = new URL(trimmed, "https://docs.local");
+    const route = `${url.pathname || "/"}${url.search}`;
+    if (explicitScheme) return `${url.origin}${route}`;
+    if (trimmed.startsWith("//")) return `//${url.host}${route}`;
+    return route;
+  } catch {
+    return normalizeUrlRouteKey(trimmed);
+  }
+}
+
+function appendDocsLocaleQuery(value: string, locale: string): string {
+  const hashIndex = value.indexOf("#");
+  const withoutHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+  const hash = hashIndex >= 0 ? value.slice(hashIndex) : "";
+  const queryIndex = withoutHash.indexOf("?");
+  const rawQuery = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : "";
+  if (new URLSearchParams(rawQuery).has("lang")) return value;
+  return `${withoutHash}${queryIndex >= 0 ? "&" : "?"}lang=${encodeURIComponent(locale)}${hash}`;
+}
+
+function localizeDocsSearchPage(
+  page: DocsSearchSourcePage,
+  localeFallback?: string,
+): DocsSearchSourcePage {
+  const rawLocale = (page.locale ?? localeFallback)?.trim();
+  if (!rawLocale) return page;
+  const locale = rawLocale;
+  const url = appendDocsLocaleQuery(page.url, locale);
+  if (url === page.url && page.locale === locale) {
+    return page;
+  }
+  return {
+    ...page,
+    url,
+    locale,
+  };
 }
 
 function safeDecodeUrlSegment(value: string): string {
@@ -681,16 +747,18 @@ function clampText(value: string, maxChars: number): string {
 }
 
 function findPageForSearchResult(
-  pages: DocsSearchSourcePage[],
+  pages: readonly DocsSearchSourcePage[],
   result: DocsSearchResult,
   baseUrl?: string,
-  strictExternalOrigins = false,
+  pagesByRoute?: ReadonlyMap<string, DocsSearchSourcePage>,
 ): DocsSearchSourcePage | undefined {
   const rawUrl = result.url.trim();
   const explicitlySchemed = /^[a-z][a-z\d+.-]*:/iu.test(rawUrl);
   const explicitlyHosted = explicitlySchemed || /^[\\/]{2}/u.test(rawUrl);
   if (explicitlySchemed && !/^https?:/iu.test(rawUrl)) return undefined;
-  if (explicitlyHosted && !baseUrl && strictExternalOrigins) return undefined;
+  // Without a trusted origin, a hosted result cannot safely inherit local provenance
+  // merely because its pathname matches a local page.
+  if (explicitlyHosted && !baseUrl) return undefined;
   if (explicitlyHosted && baseUrl) {
     try {
       if (new URL(result.url, baseUrl).origin !== new URL(baseUrl).origin) return undefined;
@@ -698,8 +766,11 @@ function findPageForSearchResult(
       return undefined;
     }
   }
-  const resultPath = normalizeUrlPathname(result.url);
-  return pages.find((page) => normalizeUrlPathname(page.url) === resultPath);
+  const resultPath = normalizeUrlRouteKey(result.url);
+  return (
+    pagesByRoute?.get(resultPath) ??
+    pages.find((page) => normalizeUrlRouteKey(page.url) === resultPath)
+  );
 }
 
 function inferResultTitle(result: DocsSearchResult, page?: DocsSearchSourcePage): string {
@@ -741,7 +812,7 @@ function formatAskAIContextResult(options: {
 function getSearchResultKey(result: DocsSearchResult): string {
   const anchor = getSearchResultAnchor(result.url);
   const sectionFallback = normalizeWhitespace(result.section ?? "").toLowerCase();
-  return `${normalizeUrlPathname(result.url)}#${anchor ?? sectionFallback}`;
+  return `${normalizeUrlRouteKey(result.url)}#${anchor ?? sectionFallback}`;
 }
 
 function getSearchResultAnchor(value: string): string | undefined {
@@ -767,7 +838,7 @@ function getAskAIResultPageKey(
   baseUrl?: string,
   strictExternalOrigins = false,
 ): string {
-  const path = normalizeUrlPathname(value);
+  const path = normalizeUrlRouteKey(value);
   const rawValue = value.trim();
   const explicitlyHosted = /^[a-z][a-z\d+.-]*:/iu.test(rawValue) || /^[\\/]{2}/u.test(rawValue);
   if (!explicitlyHosted || (!baseUrl && !strictExternalOrigins)) return path;
@@ -837,8 +908,8 @@ function sanitizeExternalAudienceSearchResults(
   results: DocsSearchResult[],
   localAudienceResults: DocsSearchResult[],
   baseUrl?: string,
-  strictExternalOrigins = false,
   preserveUnmatched?: (result: DocsSearchResult) => boolean,
+  fallbackSectionToLocalPage = false,
 ): DocsSearchResult[] {
   const localByKey = new Map(
     localAudienceResults.map((result) => [getSearchResultKey(result), result] as const),
@@ -846,7 +917,7 @@ function sanitizeExternalAudienceSearchResults(
   const localPageResults = new Map<string, DocsSearchResult>();
 
   for (const result of localAudienceResults) {
-    const pageUrl = normalizeUrlPathname(result.url);
+    const pageUrl = normalizeUrlRouteKey(result.url);
     const existing = localPageResults.get(pageUrl);
     if (!existing || result.type === "page") localPageResults.set(pageUrl, result);
   }
@@ -857,7 +928,7 @@ function sanitizeExternalAudienceSearchResults(
     const externallyHosted =
       (explicitlySchemed && /^https?:/iu.test(rawUrl)) || /^[\\/]{2}/u.test(rawUrl);
     const unsupportedScheme = explicitlySchemed && !/^https?:/iu.test(rawUrl);
-    let sameOriginOrUnknown = !externallyHosted || (!baseUrl && !strictExternalOrigins);
+    let sameOriginOrUnknown = !externallyHosted;
     if (unsupportedScheme) sameOriginOrUnknown = false;
     if (externallyHosted && baseUrl) {
       try {
@@ -869,7 +940,9 @@ function sanitizeExternalAudienceSearchResults(
     const hasSection = Boolean(getSearchResultAnchor(result.url) || result.section);
     const local = sameOriginOrUnknown
       ? (localByKey.get(getSearchResultKey(result)) ??
-        (hasSection ? undefined : localPageResults.get(normalizeUrlPathname(result.url))))
+        (hasSection && !fallbackSectionToLocalPage
+          ? undefined
+          : localPageResults.get(normalizeUrlRouteKey(result.url))))
       : undefined;
     if (!local) return preserveUnmatched?.(result) ? [result] : [];
 
@@ -889,14 +962,14 @@ function shouldPreserveUnmatchedExternalResult(options: {
   baseUrl?: string;
 }): boolean {
   const { result, localPagePaths, baseUrl } = options;
-  const path = normalizeUrlPathname(result.url);
+  const path = normalizeUrlRouteKey(result.url);
   const rawUrl = result.url.trim();
   const explicitScheme = rawUrl.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
   if (explicitScheme && explicitScheme !== "http" && explicitScheme !== "https") return false;
   const explicitlyHosted = /^[a-z][a-z\d+.-]*:/iu.test(rawUrl) || /^[\\/]{2}/u.test(rawUrl);
   const knownLocalPath = localPagePaths.has(path);
   if (!explicitlyHosted) return !knownLocalPath;
-  if (!baseUrl) return !knownLocalPath;
+  if (!baseUrl) return true;
   try {
     if (new URL(result.url, baseUrl).origin !== new URL(baseUrl).origin) return true;
   } catch {
@@ -905,21 +978,22 @@ function shouldPreserveUnmatchedExternalResult(options: {
   return !knownLocalPath;
 }
 
-function getPageAudienceRawContent(
-  page: DocsSearchSourcePage,
-  audience: DocsContentAudience,
-): string {
-  const source =
-    audience === "agent"
-      ? (page.agentRawContent ??
+function getPageAudienceSource(page: DocsSearchSourcePage, audience: DocsContentAudience): string {
+  return audience === "agent"
+    ? (page.agentRawContent ??
         page.agentFallbackRawContent ??
         page.agentContent ??
         page.agentFallbackContent ??
         page.rawContent ??
         page.content)
-      : (page.rawContent ?? page.content);
+    : (page.rawContent ?? page.content);
+}
 
-  return resolveDocsAudienceMdxContent(source, audience);
+function getPageAudienceRawContent(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string {
+  return resolveDocsAudienceMdxContent(getPageAudienceSource(page, audience), audience);
 }
 
 function getPageAudienceSectionContent(
@@ -930,6 +1004,20 @@ function getPageAudienceSectionContent(
   return audience === "agent" ? upsertPageAgentContractMarkdown(content, page.agent) : content;
 }
 
+/**
+ * Build the exact normalized-input projection represented by a retrieval source digest.
+ * This is public so consumers can independently reproduce `source.digest`.
+ */
+export function buildDocsRetrievalDigestProjection(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience = "human",
+): string {
+  const audienceContent = getPageAudienceRawContent(page, audience);
+  return audience === "agent"
+    ? upsertPageAgentContractMarkdown(audienceContent, page.agent)
+    : [audienceContent, renderPageAgentContractMarkdown(page.agent)].filter(Boolean).join("\n\n");
+}
+
 function getPageAudienceSearchText(
   page: DocsSearchSourcePage,
   audience: DocsContentAudience,
@@ -937,17 +1025,863 @@ function getPageAudienceSearchText(
   return stripMarkdownText(getPageAudienceRawContent(page, audience));
 }
 
-function isLocalProviderResult(
-  result: DocsSearchResult,
+function getPageAudienceIndexContent(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string {
+  return normalizeWhitespace(
+    [getPageAudienceSearchText(page, audience), getPageAgentContractSearchText(page)].join(" "),
+  );
+}
+
+function sortRetrievalSourceValues(values: readonly string[]): string[] | undefined {
+  const sorted = Array.from(new Set(values))
+    .sort(compareSearchMetadataValues)
+    .slice(0, MAX_SEARCH_FILTER_VALUES);
+  return sorted.length > 0 ? sorted : undefined;
+}
+
+function buildDocsRetrievalSourceScope(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+  localeFallback?: string,
+): DocsRetrievalSourceScope {
+  const resolved = resolveDocsSearchPageScope(page);
+  const rawLocale = (page.locale ?? localeFallback)?.trim();
+  const locale = rawLocale
+    ? normalizeAgentLocale(rawLocale).slice(0, MAX_SEARCH_FILTER_VALUE_CHARS)
+    : undefined;
+  const framework = sortRetrievalSourceValues(resolved.framework);
+  const version = sortRetrievalSourceValues(resolved.version);
+  const versionGroups = resolved.declarations.version
+    .map((group) => sortRetrievalSourceValues(group))
+    .filter((group): group is string[] => Boolean(group))
+    .slice(0, MAX_SEARCH_FILTER_VALUES);
+  const packageNames = sortRetrievalSourceValues(resolved.package);
+  const tags = sortRetrievalSourceValues(resolved.tags);
+  const truncated = SEARCH_FILTER_FIELDS.filter((field) => {
+    if (field === "version") {
+      return (
+        resolved.version.length > MAX_SEARCH_FILTER_VALUES ||
+        resolved.declarations.version.length > MAX_SEARCH_FILTER_VALUES ||
+        resolved.declarations.version.some((group) => group.length > MAX_SEARCH_FILTER_VALUES)
+      );
+    }
+    return resolved[field].length > MAX_SEARCH_FILTER_VALUES;
+  });
+
+  return {
+    audience,
+    ...(locale ? { locale: [locale] } : {}),
+    ...(framework ? { framework } : {}),
+    ...(version ? { version } : {}),
+    ...(versionGroups.length > 1 ? { versionGroups } : {}),
+    ...(packageNames ? { package: packageNames } : {}),
+    ...(tags ? { tags } : {}),
+    ...(truncated.length > 0 ? { truncated } : {}),
+    ...(resolved.conflicts.length > 0
+      ? {
+          conflicts: [...resolved.conflicts].sort(
+            (left, right) =>
+              SEARCH_FILTER_FIELDS.indexOf(left) - SEARCH_FILTER_FIELDS.indexOf(right),
+          ),
+        }
+      : {}),
+  };
+}
+
+function buildDocsRetrievalScopeIdentity(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+  localeFallback?: string,
+): string {
+  const resolved = resolveDocsSearchPageScope(page);
+  const sortValues = (values: readonly string[]) =>
+    Array.from(new Set(values)).sort(compareSearchMetadataValues);
+  const declarations = Object.fromEntries(
+    SEARCH_FILTER_FIELDS.map((field) => [
+      field,
+      resolved.declarations[field]
+        .map(sortValues)
+        .sort((left, right) =>
+          compareSearchMetadataValues(JSON.stringify(left), JSON.stringify(right)),
+        ),
+    ]),
+  );
+  return hashDocsRetrievalValue(
+    JSON.stringify({
+      audience,
+      locale: (page.locale ?? localeFallback)?.trim(),
+      declarations,
+      conflicts: [...resolved.conflicts].sort(
+        (left, right) => SEARCH_FILTER_FIELDS.indexOf(left) - SEARCH_FILTER_FIELDS.indexOf(right),
+      ),
+    }),
+  );
+}
+
+function getUrlHash(value: string): string {
+  const hashIndex = value.indexOf("#");
+  return hashIndex >= 0 ? value.slice(hashIndex) : "";
+}
+
+function resolveDocsRetrievalCanonicalUrl(
+  page: DocsSearchSourcePage,
+  resultUrl: string,
   baseUrl?: string,
-  strictExternalOrigins = false,
+): string {
+  const requestedCanonical = page.canonicalUrl?.trim();
+  const requested =
+    requestedCanonical && requestedCanonical.length <= MAX_RETRIEVAL_SOURCE_URL_CHARS
+      ? requestedCanonical
+      : page.url;
+  const explicitScheme = requested.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
+  const pageScheme = page.url.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
+  const safePageUrl =
+    pageScheme && pageScheme !== "http" && pageScheme !== "https" ? "/" : page.url;
+  const configured =
+    explicitScheme && explicitScheme !== "http" && explicitScheme !== "https"
+      ? safePageUrl
+      : requested;
+  let canonical = configured;
+
+  if (baseUrl) {
+    try {
+      canonical = new URL(configured, baseUrl).toString();
+    } catch {
+      canonical = configured;
+    }
+  } else if (configured.startsWith("//")) {
+    canonical = `https:${configured}`;
+  }
+
+  const withSection = `${canonical.split("#", 1)[0]}${getUrlHash(resultUrl)}`;
+  if (
+    withSection.length <= MAX_RETRIEVAL_SOURCE_URL_CHARS &&
+    isDocsRetrievalCanonicalUrl(withSection)
+  ) {
+    return withSection;
+  }
+
+  const fallback = (
+    baseUrl
+      ? (() => {
+          try {
+            return new URL(safePageUrl, baseUrl).toString();
+          } catch {
+            return safePageUrl;
+          }
+        })()
+      : safePageUrl
+  ).split("#", 1)[0];
+  if (fallback.length <= MAX_RETRIEVAL_SOURCE_URL_CHARS && isDocsRetrievalCanonicalUrl(fallback)) {
+    return fallback;
+  }
+
+  if (baseUrl) {
+    try {
+      const root = new URL("/", baseUrl).toString();
+      if (root.length <= MAX_RETRIEVAL_SOURCE_URL_CHARS && isDocsRetrievalCanonicalUrl(root)) {
+        return root;
+      }
+    } catch {
+      // Fall through to a bounded relative canonical URL.
+    }
+  }
+  return "/";
+}
+
+function hashDocsRetrievalValue(value: string): string {
+  return digestDocsRetrievalContent(value);
+}
+
+type DocsRetrievalDigestCache = Map<DocsSearchSourcePage, string>;
+interface DocsRetrievalDigestMemo {
+  source: string;
+  agentContractKey: string;
+  digest: string;
+}
+const docsRetrievalDigestMemo = new WeakMap<
+  DocsSearchSourcePage,
+  Partial<Record<DocsContentAudience, DocsRetrievalDigestMemo>>
+>();
+
+function getDocsRetrievalSourceDigest(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+  cache?: DocsRetrievalDigestCache,
+): string {
+  const cached = cache?.get(page);
+  if (cached) return cached;
+  const source = getPageAudienceSource(page, audience);
+  let agentContractKey = "";
+  let cacheable = true;
+  try {
+    agentContractKey = JSON.stringify(page.agent ?? null);
+  } catch {
+    // Cyclic custom metadata remains supported; it simply bypasses cross-request memoization.
+    cacheable = false;
+  }
+  const memo = docsRetrievalDigestMemo.get(page)?.[audience];
+  if (cacheable && memo && memo.source === source && memo.agentContractKey === agentContractKey) {
+    cache?.set(page, memo.digest);
+    return memo.digest;
+  }
+
+  const digest = hashDocsRetrievalValue(buildDocsRetrievalDigestProjection(page, audience));
+  if (cacheable) {
+    const pageMemo = docsRetrievalDigestMemo.get(page) ?? {};
+    pageMemo[audience] = { source, agentContractKey, digest };
+    docsRetrievalDigestMemo.set(page, pageMemo);
+  }
+  cache?.set(page, digest);
+  return digest;
+}
+
+export function resolveDocsRetrievalLastModified(
+  page: DocsSearchSourcePage,
+  audience: DocsContentAudience,
+): string | undefined {
+  const parseCandidate = (value: string | undefined) => {
+    const normalized = value?.trim();
+    if (!normalized) return undefined;
+    const timestamp = Date.parse(normalized);
+    return Number.isFinite(timestamp) ? { value: normalized, timestamp } : undefined;
+  };
+  // Authored lastmod is the explicit public freshness value; filesystem mtime is
+  // only a fallback when the page does not declare one.
+  const pageModified = parseCandidate(page.lastmod) ?? parseCandidate(page.lastModified);
+  const explicitAgentSource =
+    audience === "agent" && (page.agentRawContent !== undefined || page.agentContent !== undefined);
+  if (!explicitAgentSource) return pageModified?.value;
+
+  // An explicit agent source is the selected retrieval document, so report its
+  // freshness when available. Page freshness remains the fallback for generated
+  // agent projections and sources without an independently tracked timestamp.
+  const agentModified = parseCandidate(page.agentLastModified);
+  if (!renderPageAgentContractMarkdown(page.agent)) {
+    return agentModified?.value ?? pageModified?.value;
+  }
+  // Structured page metadata is inserted into an explicit agent source. When it
+  // contributes to the selected projection, freshness must cover both inputs.
+  if (!agentModified) return pageModified?.value;
+  if (!pageModified) return agentModified.value;
+  return agentModified.timestamp >= pageModified.timestamp
+    ? agentModified.value
+    : pageModified.value;
+}
+
+interface DocsSearchProvenanceOptions {
+  audience: DocsContentAudience;
+  chunking: DocsSearchChunkingConfig;
+  locale?: string;
+  baseUrl?: string;
+  indexGeneration: string;
+  digestCache?: DocsRetrievalDigestCache;
+}
+
+async function buildDocsSearchIndexGeneration(
+  pages: readonly DocsSearchSourcePage[],
+  options: Omit<DocsSearchProvenanceOptions, "indexGeneration">,
+): Promise<string> {
+  const sources = (
+    await Promise.all(
+      pages.map(async (rawPage) => {
+        const page = localizeDocsSearchPage(rawPage, options.locale);
+        const authoredLastModified = page.lastmod?.trim();
+        return {
+          canonicalIdentity: normalizeAuthoredUrlIdentity(page.canonicalUrl?.trim() || page.url),
+          url: normalizeAuthoredUrlIdentity(page.url),
+          indexedUrl: page.url,
+          title: page.title,
+          description: page.description,
+          type: page.type,
+          scope: buildDocsRetrievalSourceScope(page, options.audience, options.locale),
+          scopeIdentity: buildDocsRetrievalScopeIdentity(page, options.audience, options.locale),
+          // Filesystem mtimes differ between checkout/build/deployment for identical
+          // content. Only an authored timestamp participates in generation identity;
+          // the effective runtime modified time is still returned on each source.
+          lastModified:
+            authoredLastModified && Number.isFinite(Date.parse(authoredLastModified))
+              ? authoredLastModified
+              : undefined,
+          digest: getDocsRetrievalSourceDigest(rawPage, options.audience, options.digestCache),
+          agentContract: getPageAgentContractSearchText(rawPage),
+        };
+      }),
+    )
+  ).sort((left, right) => {
+    const canonical = compareSearchMetadataValues(left.canonicalIdentity, right.canonicalIdentity);
+    if (canonical !== 0) return canonical;
+    const url = compareSearchMetadataValues(left.url, right.url);
+    if (url !== 0) return url;
+    const digest = compareSearchMetadataValues(left.digest, right.digest);
+    if (digest !== 0) return digest;
+    const title = compareSearchMetadataValues(left.title, right.title);
+    return title !== 0
+      ? title
+      : compareSearchMetadataValues(JSON.stringify(left), JSON.stringify(right));
+  });
+
+  return hashDocsRetrievalValue(
+    JSON.stringify({
+      format: RETRIEVAL_INDEX_FORMAT,
+      audience: options.audience,
+      chunking: options.chunking.strategy ?? "section",
+      sources,
+    }),
+  );
+}
+
+async function buildDocsRetrievalSource(
+  rawPage: DocsSearchSourcePage,
+  resultUrl: string,
+  options: DocsSearchProvenanceOptions,
+): Promise<DocsRetrievalSourceProvenance> {
+  const page = localizeDocsSearchPage(rawPage, options.locale);
+  const lastModified = resolveDocsRetrievalLastModified(rawPage, options.audience);
+  return {
+    canonicalUrl: resolveDocsRetrievalCanonicalUrl(page, resultUrl, options.baseUrl),
+    scope: buildDocsRetrievalSourceScope(page, options.audience, options.locale),
+    ...(lastModified ? { lastModified } : {}),
+    digest: getDocsRetrievalSourceDigest(rawPage, options.audience, options.digestCache),
+    indexGeneration: options.indexGeneration,
+  };
+}
+
+function parseRetrievalSourceString(
+  value: unknown,
+  maxChars = MAX_RETRIEVAL_SOURCE_VALUE_CHARS,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxChars) return undefined;
+  const hasControlCharacter = Array.from(normalized).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+  if (hasControlCharacter) return undefined;
+  return normalized;
+}
+
+function parseRetrievalSourceValues(
+  field: DocsSearchFilterField | "locale",
+  value: unknown,
+): { valid: boolean; values?: string[] } {
+  if (!Array.isArray(value) || value.length > MAX_SEARCH_FILTER_VALUES) {
+    return { valid: false };
+  }
+  const parsed: string[] = [];
+  for (const item of value) {
+    const stringValue = parseRetrievalSourceString(item, MAX_SEARCH_FILTER_VALUE_CHARS);
+    if (!stringValue) return { valid: false };
+    if (field === "locale") {
+      const normalizedLocale = normalizeAgentLocale(stringValue);
+      if (!normalizedLocale) return { valid: false };
+      parsed.push(normalizedLocale);
+      continue;
+    }
+    const normalized = normalizeDocsSearchFilterValue(field, stringValue);
+    if (!normalized) return { valid: false };
+    parsed.push(normalized);
+  }
+  return { valid: true, values: sortRetrievalSourceValues(parsed) };
+}
+
+function parseRetrievalSourceVersionGroups(value: unknown): {
+  valid: boolean;
+  groups?: string[][];
+} {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_SEARCH_FILTER_VALUES) {
+    return { valid: false };
+  }
+  const groups = value.map((group) => parseRetrievalSourceValues("version", group));
+  if (groups.some((group) => !group.valid || !group.values || group.values.length === 0)) {
+    return { valid: false };
+  }
+  return {
+    valid: true,
+    groups: groups.map((group) => group.values!),
+  };
+}
+
+function parseDocsRetrievalSource(
+  value: unknown,
+  options: { allowRootRelativeCanonical?: boolean } = {},
+): DocsRetrievalSourceProvenance | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const canonicalUrl = parseRetrievalSourceString(
+    record.canonicalUrl,
+    MAX_RETRIEVAL_SOURCE_URL_CHARS,
+  );
+  const digest = parseRetrievalSourceString(record.digest);
+  const indexGeneration = parseRetrievalSourceString(record.indexGeneration);
+  if (!canonicalUrl || !digest || !indexGeneration) return undefined;
+  const digestPattern = /^sha256:[a-f\d]{64}$/iu;
+  if (!digestPattern.test(digest) || !digestPattern.test(indexGeneration)) return undefined;
+  if (
+    !isDocsRetrievalCanonicalUrl(canonicalUrl) ||
+    (/^\/(?!\/)/u.test(canonicalUrl) && !options.allowRootRelativeCanonical)
+  ) {
+    return undefined;
+  }
+
+  if (!record.scope || typeof record.scope !== "object" || Array.isArray(record.scope)) {
+    return undefined;
+  }
+  const rawScope = record.scope as Record<string, unknown>;
+  const audience =
+    rawScope.audience === "human" || rawScope.audience === "agent" ? rawScope.audience : undefined;
+  if (!audience) return undefined;
+  const parseScopeFields = (
+    value: unknown,
+  ): { valid: boolean; values?: DocsSearchFilterField[] } => {
+    if (
+      !Array.isArray(value) ||
+      value.length > SEARCH_FILTER_FIELDS.length ||
+      value.some(
+        (field) =>
+          typeof field !== "string" ||
+          !SEARCH_FILTER_FIELDS.includes(field as DocsSearchFilterField),
+      )
+    ) {
+      return { valid: false };
+    }
+    return {
+      valid: true,
+      values: Array.from(new Set(value as DocsSearchFilterField[])).sort(
+        (left, right) => SEARCH_FILTER_FIELDS.indexOf(left) - SEARCH_FILTER_FIELDS.indexOf(right),
+      ),
+    };
+  };
+  const parseOptionalValues = (
+    field: DocsSearchFilterField | "locale",
+    value: unknown,
+  ): { valid: boolean; values?: string[] } =>
+    value === undefined ? { valid: true } : parseRetrievalSourceValues(field, value);
+  const parseOptionalScopeFields = (
+    value: unknown,
+  ): { valid: boolean; values?: DocsSearchFilterField[] } =>
+    value === undefined ? { valid: true } : parseScopeFields(value);
+  const conflicts = parseOptionalScopeFields(rawScope.conflicts);
+  const truncated = parseOptionalScopeFields(rawScope.truncated);
+  const locale = parseOptionalValues("locale", rawScope.locale);
+  const framework = parseOptionalValues("framework", rawScope.framework);
+  const version = parseOptionalValues("version", rawScope.version);
+  const versionGroups =
+    rawScope.versionGroups === undefined
+      ? { valid: true, groups: undefined }
+      : parseRetrievalSourceVersionGroups(rawScope.versionGroups);
+  const packageNames = parseOptionalValues("package", rawScope.package);
+  const tags = parseOptionalValues("tags", rawScope.tags);
+  if (
+    !conflicts.valid ||
+    !truncated.valid ||
+    !locale.valid ||
+    !framework.valid ||
+    !version.valid ||
+    !versionGroups.valid ||
+    !packageNames.valid ||
+    !tags.valid
+  ) {
+    return undefined;
+  }
+  const scope: DocsRetrievalSourceScope = {
+    audience,
+    ...(locale.values ? { locale: locale.values } : {}),
+    ...(framework.values ? { framework: framework.values } : {}),
+    ...(version.values ? { version: version.values } : {}),
+    ...(versionGroups.groups ? { versionGroups: versionGroups.groups } : {}),
+    ...(packageNames.values ? { package: packageNames.values } : {}),
+    ...(tags.values ? { tags: tags.values } : {}),
+    ...(truncated.values && truncated.values.length > 0 ? { truncated: truncated.values } : {}),
+    ...(conflicts.values && conflicts.values.length > 0 ? { conflicts: conflicts.values } : {}),
+  };
+  const rawLastModified = parseRetrievalSourceString(record.lastModified);
+  if (
+    record.lastModified !== undefined &&
+    (!rawLastModified || !Number.isFinite(Date.parse(rawLastModified)))
+  ) {
+    return undefined;
+  }
+  const lastModified =
+    rawLastModified && Number.isFinite(Date.parse(rawLastModified)) ? rawLastModified : undefined;
+
+  return {
+    canonicalUrl,
+    scope,
+    ...(lastModified ? { lastModified } : {}),
+    digest,
+    indexGeneration,
+  };
+}
+
+function docsRetrievalSourceMatchesRequest(
+  source: DocsRetrievalSourceProvenance,
+  audience: DocsContentAudience,
+  filters?: DocsSearchFilters,
+  locale?: string,
 ): boolean {
+  if (source.scope.audience !== audience) return false;
+
+  for (const field of SEARCH_FILTER_FIELDS) {
+    const requested = filters?.[field];
+    if (!requested?.length) continue;
+    if (source.scope.conflicts?.includes(field)) return false;
+    if (source.scope.truncated?.includes(field)) return false;
+    if (field === "version" && source.scope.versionGroups?.length) {
+      if (!agentVersionConstraintGroupsOverlap([requested, ...source.scope.versionGroups])) {
+        return false;
+      }
+      continue;
+    }
+    const candidates = source.scope[field];
+    if (!candidates?.length) return false;
+    if (
+      !requested.some((requestedValue) =>
+        candidates.some((candidate) =>
+          docsSearchScopeValueMatches(field, requestedValue, candidate),
+        ),
+      )
+    ) {
+      return false;
+    }
+  }
+
+  const requestedLocale = locale ? normalizeAgentLocale(locale) : undefined;
+  if (
+    requestedLocale &&
+    (!source.scope.locale?.length ||
+      !source.scope.locale.some((candidate) => normalizeAgentLocale(candidate) === requestedLocale))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+const HOSTED_RETRIEVAL_SOURCE_FIELDS = [
+  "source_canonical_url",
+  "source_scope_audience",
+  "source_scope_locale",
+  "source_scope_framework",
+  "source_scope_version",
+  "source_scope_version_groups",
+  "source_scope_package",
+  "source_scope_tags",
+  "source_scope_truncated",
+  "source_scope_conflicts",
+  "source_last_modified",
+  "source_digest",
+  "source_index_generation",
+] as const;
+
+function readFlattenedHostedRetrievalSource(record: Record<string, unknown>) {
+  return parseDocsRetrievalSource(
+    {
+      canonicalUrl: record.source_canonical_url,
+      scope: {
+        audience: record.source_scope_audience,
+        locale: record.source_scope_locale,
+        framework: record.source_scope_framework,
+        version: record.source_scope_version,
+        versionGroups: (() => {
+          const value = record.source_scope_version_groups;
+          if (typeof value !== "string") return value;
+          try {
+            return JSON.parse(value) as unknown;
+          } catch {
+            return null;
+          }
+        })(),
+        package: record.source_scope_package,
+        tags: record.source_scope_tags,
+        truncated: record.source_scope_truncated,
+        conflicts: record.source_scope_conflicts,
+      },
+      lastModified: record.source_last_modified,
+      digest: record.source_digest,
+      indexGeneration: record.source_index_generation,
+    },
+    { allowRootRelativeCanonical: true },
+  );
+}
+
+function readHostedRetrievalSource(record: Record<string, unknown>) {
+  const hasNested = record.source !== undefined;
+  const hasFlattened = HOSTED_RETRIEVAL_SOURCE_FIELDS.some((key) => key in record);
+  if (hasNested) {
+    const nested = parseDocsRetrievalSource(record.source, {
+      allowRootRelativeCanonical: true,
+    });
+    if (!nested) return undefined;
+    if (!hasFlattened) return nested;
+
+    const flattened = readFlattenedHostedRetrievalSource(record);
+    return flattened && JSON.stringify(flattened) === JSON.stringify(nested) ? nested : undefined;
+  }
+
+  return readFlattenedHostedRetrievalSource(record);
+}
+
+function hasHostedRetrievalSource(record: Record<string, unknown>): boolean {
+  return (
+    record.source !== undefined ||
+    ["source_corpus_id", "source_document_id", ...HOSTED_RETRIEVAL_SOURCE_FIELDS].some(
+      (key) => key in record,
+    )
+  );
+}
+
+function serializeHostedRetrievalSource(
+  source: DocsRetrievalSourceProvenance | undefined,
+  corpusId?: string,
+  sourceDocumentId?: string,
+): Record<string, unknown> {
+  if (!source) return {};
+  return {
+    source_corpus_id: corpusId,
+    source_document_id: sourceDocumentId,
+    source_canonical_url: source.canonicalUrl,
+    source_scope_audience: source.scope.audience,
+    source_scope_locale: source.scope.locale,
+    source_scope_framework: source.scope.framework,
+    source_scope_version: source.scope.version,
+    source_scope_version_groups: source.scope.versionGroups
+      ? JSON.stringify(source.scope.versionGroups)
+      : undefined,
+    source_scope_package: source.scope.package,
+    source_scope_tags: source.scope.tags,
+    source_scope_truncated: source.scope.truncated,
+    source_scope_conflicts: source.scope.conflicts,
+    source_last_modified: source.lastModified,
+    source_digest: source.digest,
+    source_index_generation: source.indexGeneration,
+  };
+}
+
+function resolveHostedCorpusId(
+  syncNamespace: string | undefined,
+  context: Pick<DocsSearchAdapterContext, "audience" | "locale" | "baseUrl" | "indexBaseUrl">,
+): string | undefined {
+  const explicitNamespace = syncNamespace?.trim();
+  if (explicitNamespace && explicitNamespace.length > 1_024) {
+    throw new Error("Search syncNamespace must be 1024 characters or fewer.");
+  }
+  let canonicalIdentity: string | undefined;
+  const indexBaseUrl = context.indexBaseUrl;
+  if (!explicitNamespace && indexBaseUrl) {
+    try {
+      const url = new URL(indexBaseUrl);
+      if (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        !url.username &&
+        !url.password
+      ) {
+        canonicalIdentity = `${url.origin}${url.pathname.replace(/\/+$/u, "") || "/"}`;
+      }
+    } catch {
+      // Relative/request-derived origins do not establish safe hosted-record ownership.
+    }
+  }
+  const identity = explicitNamespace
+    ? `namespace:${explicitNamespace}`
+    : canonicalIdentity
+      ? `canonical:${canonicalIdentity}`
+      : undefined;
+  if (!identity) return undefined;
+
+  return hashDocsRetrievalValue(
+    JSON.stringify({
+      format: "docs-hosted-corpus.v1",
+      identity,
+      audience: resolveDocsSearchAudience(context.audience),
+      locale: context.locale ? normalizeAgentLocale(context.locale) : "__all__",
+    }),
+  );
+}
+
+function resolveHostedHumanCorpusId(
+  syncNamespace: string | undefined,
+  context: DocsSearchAdapterContext,
+): string | undefined {
+  return resolveHostedCorpusId(syncNamespace, {
+    audience: "human",
+    locale: context.locale,
+    baseUrl: context.baseUrl,
+    indexBaseUrl: context.indexBaseUrl,
+  });
+}
+
+function makeHostedProviderDocumentId(corpusId: string, sourceDocumentId: string): string {
+  const digest = hashDocsRetrievalValue(
+    JSON.stringify({
+      format: "docs-hosted-document.v1",
+      corpusId,
+      sourceDocumentId,
+    }),
+  );
+  return `docs_${digest.slice("sha256:".length)}`;
+}
+
+function readHostedSourceDocumentId(record: Record<string, unknown>): string | undefined {
+  return parseRetrievalSourceString(record.source_document_id, MAX_RETRIEVAL_SOURCE_URL_CHARS);
+}
+
+function hostedRecordMatchesCorpus(
+  record: Record<string, unknown>,
+  corpusId: string | undefined,
+): boolean {
+  if (!corpusId) return true;
+  if (record.source_corpus_id === corpusId) return true;
+  return record.source_corpus_id === undefined && !hasHostedRetrievalSource(record);
+}
+
+async function enrichDocsSearchResultsWithSources(options: {
+  results: readonly DocsSearchResult[];
+  pages: readonly DocsSearchSourcePage[];
+  generationPages?: readonly DocsSearchSourcePage[];
+  audience: DocsContentAudience;
+  chunking: DocsSearchChunkingConfig;
+  baseUrl?: string;
+  indexGeneration?: string;
+  strictExternalOrigins?: boolean;
+  filters?: DocsSearchFilters;
+  locale?: string;
+  requireCurrentIndexGeneration?: boolean;
+}): Promise<DocsSearchResult[]> {
+  const digestCache = new Map<DocsSearchSourcePage, string>();
+  const localizedPages = options.pages.map((page) => localizeDocsSearchPage(page, options.locale));
+  const pagesByRoute = new Map<string, DocsSearchSourcePage>();
+  for (const page of localizedPages) {
+    const route = normalizeUrlRouteKey(page.url);
+    if (!pagesByRoute.has(route)) pagesByRoute.set(route, page);
+  }
+  let resolvedIndexGeneration: Promise<string> | undefined;
+  const getIndexGeneration = () => {
+    resolvedIndexGeneration ??= options.indexGeneration
+      ? Promise.resolve(options.indexGeneration)
+      : buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+          audience: options.audience,
+          chunking: options.chunking,
+          locale: options.locale,
+          baseUrl: options.baseUrl,
+          digestCache,
+        });
+    return resolvedIndexGeneration;
+  };
+
+  const results = await Promise.all(
+    options.results.map(async (result) => {
+      const { source: rawSource, ...resultWithoutSource } = result;
+      const page = findPageForSearchResult(localizedPages, result, options.baseUrl, pagesByRoute);
+      if (page) {
+        return {
+          ...resultWithoutSource,
+          source: await buildDocsRetrievalSource(page, result.url, {
+            audience: options.audience,
+            chunking: options.chunking,
+            locale: options.locale,
+            baseUrl: options.baseUrl,
+            indexGeneration: await getIndexGeneration(),
+            digestCache,
+          }),
+        };
+      }
+
+      if (rawSource === undefined) return resultWithoutSource;
+      const source = parseDocsRetrievalSource(rawSource, {
+        allowRootRelativeCanonical: options.requireCurrentIndexGeneration,
+      });
+      if (!source) return null;
+      if (
+        !docsRetrievalSourceMatchesRequest(
+          source,
+          options.audience,
+          options.filters,
+          options.locale,
+        )
+      ) {
+        return null;
+      }
+      if (
+        options.requireCurrentIndexGeneration &&
+        source.indexGeneration !== (await getIndexGeneration())
+      ) {
+        return null;
+      }
+      return { ...resultWithoutSource, source };
+    }),
+  );
+  return results.filter((result): result is DocsSearchResult => Boolean(result));
+}
+
+async function enrichDocsSearchDocumentsWithSources(options: {
+  documents: readonly DocsSearchDocument[];
+  pages: readonly DocsSearchSourcePage[];
+  audience: DocsContentAudience;
+  chunking: DocsSearchChunkingConfig;
+  locale?: string;
+  baseUrl?: string;
+  indexGeneration?: string;
+}): Promise<DocsSearchDocument[]> {
+  const results = await enrichDocsSearchResultsWithSources({
+    results: options.documents.map((document) => ({
+      id: document.id,
+      url: document.url,
+      content: document.title,
+      description: document.description,
+      type: document.type,
+      section: document.section,
+      source: document.source,
+    })),
+    pages: options.pages,
+    audience: options.audience,
+    chunking: options.chunking,
+    locale: options.locale,
+    baseUrl: options.baseUrl,
+    indexGeneration: options.indexGeneration,
+  });
+  const sources = new Map(results.map((result) => [result.id, result.source] as const));
+
+  return options.documents.map((document) => {
+    const source = sources.get(document.id);
+    return source ? { ...document, source } : document;
+  });
+}
+
+export interface EnrichDocsSearchDocumentsWithProvenanceOptions {
+  documents: readonly DocsSearchDocument[];
+  pages: readonly DocsSearchSourcePage[];
+  audience?: DocsContentAudience;
+  chunking?: DocsSearchChunkingConfig;
+  locale?: string;
+  baseUrl?: string;
+  indexGeneration?: string;
+}
+
+/**
+ * Attach the same canonical provenance used by built-in search providers.
+ * Custom adapters can call this before persisting their own hosted records.
+ */
+export function enrichDocsSearchDocumentsWithProvenance(
+  options: EnrichDocsSearchDocumentsWithProvenanceOptions,
+): Promise<DocsSearchDocument[]> {
+  return enrichDocsSearchDocumentsWithSources({
+    ...options,
+    audience: resolveDocsSearchAudience(options.audience),
+    chunking: options.chunking ?? { strategy: "section" },
+  });
+}
+
+function isLocalProviderResult(result: DocsSearchResult, baseUrl?: string): boolean {
   const rawUrl = result.url.trim();
   const explicitScheme = rawUrl.match(/^([a-z][a-z\d+.-]*):/iu)?.[1]?.toLowerCase();
   if (explicitScheme && explicitScheme !== "http" && explicitScheme !== "https") return false;
   const explicitlyHosted = /^[a-z][a-z\d+.-]*:/iu.test(rawUrl) || /^[\\/]{2}/u.test(rawUrl);
   if (!explicitlyHosted) return true;
-  if (!baseUrl) return !strictExternalOrigins;
+  if (!baseUrl) return false;
 
   try {
     return new URL(result.url, baseUrl).origin === new URL(baseUrl).origin;
@@ -962,13 +1896,12 @@ function hasOppositeAudienceEvidence(options: {
   query: string;
   audience: DocsContentAudience;
   baseUrl?: string;
-  strictExternalOrigins?: boolean;
 }): boolean {
-  const { result, pages, query, audience, baseUrl, strictExternalOrigins } = options;
-  if (!isLocalProviderResult(result, baseUrl, strictExternalOrigins)) return false;
+  const { result, pages, query, audience, baseUrl } = options;
+  if (!isLocalProviderResult(result, baseUrl)) return false;
 
-  const pagePath = normalizeUrlPathname(result.url);
-  const page = pages.find((candidate) => normalizeUrlPathname(candidate.url) === pagePath);
+  const pagePath = normalizeUrlRouteKey(result.url);
+  const page = pages.find((candidate) => normalizeUrlRouteKey(candidate.url) === pagePath);
   if (!page) return false;
   if (scoreDocument(query, pageToSearchDocument(page, audience)) > 0) return false;
 
@@ -996,17 +1929,16 @@ function hasOppositeAudienceEvidence(options: {
 }
 
 function pageToSearchDocument(
-  page: DocsSearchSourcePage,
+  rawPage: DocsSearchSourcePage,
   audience: DocsContentAudience = "human",
 ): DocsSearchDocument {
+  const page = localizeDocsSearchPage(rawPage, rawPage.locale);
   const scope = resolveDocsSearchPageScope(page);
   return {
     id: makeDocumentId(page.url, "page"),
     url: page.url,
     title: page.title,
-    content: normalizeWhitespace(
-      [getPageAudienceSearchText(page, audience), getPageAgentContractSearchText(page)].join(" "),
-    ),
+    content: getPageAudienceIndexContent(page, audience),
     description: page.description,
     type: "page",
     locale: page.locale,
@@ -1097,6 +2029,25 @@ function buildAskAIContextBlock(result: DocsAskAIContextResult): string {
   const lines = [`## ${result.title}`, `URL: ${result.url}`];
   if (result.section) lines.push(`Section: ${result.section}`);
   if (result.description) lines.push(`Search snippet: ${result.description}`);
+  if (result.source) {
+    const scope = result.source.scope;
+    const scopeEntries = [
+      `audience=${scope.audience}`,
+      scope.locale?.length ? `locale=${scope.locale.join(",")}` : undefined,
+      scope.framework?.length ? `framework=${scope.framework.join(",")}` : undefined,
+      scope.version?.length ? `version=${scope.version.join(",")}` : undefined,
+      scope.package?.length ? `package=${scope.package.join(",")}` : undefined,
+      scope.tags?.length ? `tags=${scope.tags.join(",")}` : undefined,
+      scope.conflicts?.length ? `conflicts=${scope.conflicts.join(",")}` : undefined,
+    ].filter((value): value is string => Boolean(value));
+    lines.push(`Canonical URL: ${result.source.canonicalUrl}`);
+    lines.push(`Source scope: ${scopeEntries.join("; ")}`);
+    if (result.source.lastModified) {
+      lines.push(`Source modified: ${result.source.lastModified}`);
+    }
+    lines.push(`Source digest: ${result.source.digest}`);
+    lines.push(`Index generation: ${result.source.indexGeneration}`);
+  }
   lines.push("", result.contextContent);
   return lines.join("\n").trim();
 }
@@ -1157,7 +2108,8 @@ export function buildDocsSearchDocuments(
 ): DocsSearchDocument[] {
   const strategy = chunking.strategy ?? "section";
 
-  return pages.flatMap((page) => {
+  return pages.flatMap((rawPage) => {
+    const page = localizeDocsSearchPage(rawPage, rawPage.locale);
     const base = pageToSearchDocument(page, audience);
 
     if (strategy === "page") return [base];
@@ -1321,45 +2273,26 @@ function cleanSearchResultText(value?: string): string | undefined {
   return cleaned || undefined;
 }
 
-function trimTextToBytes(value: string, maxBytes: number): string {
-  if (maxBytes <= 0) return "";
-
-  const encoder = new TextEncoder();
-  if (encoder.encode(value).length <= maxBytes) return value;
-
-  let low = 0;
-  let high = value.length;
-  let best = "";
-
-  while (low <= high) {
-    const mid = Math.floor((low + high) / 2);
-    const next = `${value.slice(0, mid).trimEnd()}...`;
-    if (encoder.encode(next).length <= maxBytes) {
-      best = next;
-      low = mid + 1;
-    } else {
-      high = mid - 1;
-    }
-  }
-
-  return best;
-}
-
-function buildAlgoliaRecord(document: DocsSearchDocument) {
+function buildAlgoliaRecord(document: DocsSearchDocument, corpusId?: string) {
+  const providerDocumentId = corpusId
+    ? makeHostedProviderDocumentId(corpusId, document.id)
+    : document.id;
   const record: Record<string, unknown> = {
-    objectID: document.id,
-    id: document.id,
+    objectID: providerDocumentId,
+    id: providerDocumentId,
     url: document.url,
     title: document.title,
     section: document.section,
     content: document.content,
     description: document.description,
     type: document.type,
-    locale: document.locale,
+    locale: document.locale ?? document.source?.scope.locale?.[0],
     framework: document.framework,
     version: document.version,
     package: document.package,
     tags: document.tags,
+    _tags: corpusId ? [corpusId] : undefined,
+    ...serializeHostedRetrievalSource(document.source, corpusId, document.id),
   };
 
   const encoder = new TextEncoder();
@@ -1369,10 +2302,46 @@ function buildAlgoliaRecord(document: DocsSearchDocument) {
   delete record.description;
   if (sizeOf(record) <= ALGOLIA_MAX_RECORD_BYTES) return record;
 
-  const baseRecord = { ...record, content: "" };
-  const fixedBytes = sizeOf(baseRecord);
-  const remainingBytes = Math.max(ALGOLIA_MAX_RECORD_BYTES - fixedBytes - 32, 0);
-  record.content = trimTextToBytes(document.content, remainingBytes);
+  record.content = "";
+  for (const field of ["package", "tags", "framework", "version"]) {
+    if (sizeOf(record) <= ALGOLIA_MAX_RECORD_BYTES) break;
+    delete record[field];
+  }
+
+  const trimFieldToFit = (field: "section" | "title" | "content", value: string) => {
+    let low = 0;
+    let high = value.length;
+    let best = "";
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const candidate = middle < value.length ? `${value.slice(0, middle).trimEnd()}...` : value;
+      record[field] = candidate;
+      if (sizeOf(record) <= ALGOLIA_MAX_RECORD_BYTES) {
+        best = candidate;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+    record[field] = best;
+  };
+
+  if (sizeOf(record) > ALGOLIA_MAX_RECORD_BYTES && typeof record.section === "string") {
+    trimFieldToFit("section", record.section);
+  }
+  if (sizeOf(record) > ALGOLIA_MAX_RECORD_BYTES && typeof record.title === "string") {
+    trimFieldToFit("title", record.title);
+  }
+  if (sizeOf(record) > ALGOLIA_MAX_RECORD_BYTES) {
+    throw new Error(
+      `Algolia record ${document.id} exceeds the record limit with required provenance.`,
+    );
+  }
+
+  trimFieldToFit("content", document.content);
+  if (sizeOf(record) > ALGOLIA_MAX_RECORD_BYTES) {
+    throw new Error(`Algolia record ${document.id} still exceeds the record limit after trimming.`);
+  }
 
   return record;
 }
@@ -1382,8 +2351,7 @@ export function createSimpleSearchAdapter(): DocsSearchAdapter {
     name: "simple",
     async search(query, context) {
       const limit = query.limit ?? DEFAULT_SEARCH_LIMIT;
-
-      return context.documents
+      const results = context.documents
         .map((document) => ({
           document,
           score: scoreDocument(query.query, document),
@@ -1407,7 +2375,20 @@ export function createSimpleSearchAdapter(): DocsSearchAdapter {
           type: document.type,
           score,
           section: document.section,
+          source: document.source,
         }));
+
+      if (context.deferSourceProvenance) return results;
+      return enrichDocsSearchResultsWithSources({
+        results,
+        pages: context.pages,
+        audience: resolveDocsSearchAudience(context.audience),
+        chunking: context.chunking ?? { strategy: "section" },
+        locale: query.locale ?? context.locale,
+        baseUrl: context.baseUrl,
+        indexGeneration: context.indexGeneration,
+        filters: query.filters,
+      });
     },
   };
 }
@@ -1491,7 +2472,7 @@ function isDocsSearchResultType(value: unknown): value is DocsSearchResult["type
   return value === "page" || value === "heading" || value === "text";
 }
 
-function mapMcpSearchResult(value: unknown): DocsSearchResult | null {
+function mapMcpSearchResult(value: unknown, sourceBaseUrl?: string): DocsSearchResult | null {
   if (!value || typeof value !== "object") return null;
 
   const item = value as Record<string, unknown>;
@@ -1508,6 +2489,32 @@ function mapMcpSearchResult(value: unknown): DocsSearchResult | null {
   const url = typeof item.url === "string" ? item.url : undefined;
 
   if (!content || !url) return null;
+  const hasSource = item.source !== undefined;
+  let sourceValue = item.source;
+  if (
+    hasSource &&
+    sourceBaseUrl &&
+    sourceValue &&
+    typeof sourceValue === "object" &&
+    !Array.isArray(sourceValue)
+  ) {
+    const sourceRecord = sourceValue as Record<string, unknown>;
+    if (
+      typeof sourceRecord.canonicalUrl === "string" &&
+      /^\/(?!\/)/u.test(sourceRecord.canonicalUrl)
+    ) {
+      try {
+        sourceValue = {
+          ...sourceRecord,
+          canonicalUrl: new URL(sourceRecord.canonicalUrl, sourceBaseUrl).toString(),
+        };
+      } catch {
+        // The strict parser below will reject the unresolved relative source.
+      }
+    }
+  }
+  const source = hasSource ? parseDocsRetrievalSource(sourceValue) : undefined;
+  if (hasSource && !source) return null;
 
   return {
     id: typeof item.id === "string" ? item.id : typeof item.slug === "string" ? item.slug : url,
@@ -1524,6 +2531,7 @@ function mapMcpSearchResult(value: unknown): DocsSearchResult | null {
     type: isDocsSearchResultType(item.type) ? item.type : section ? "heading" : "page",
     score: typeof item.score === "number" ? item.score : undefined,
     section,
+    ...(source ? { source } : {}),
   };
 }
 
@@ -1602,10 +2610,30 @@ function quoteTypesenseFilterValue(value: string): string {
   return `\`${value.replace(/\\/gu, "\\\\").replace(/`/gu, "\\`")}\``;
 }
 
+const TYPESENSE_RETRIEVAL_SOURCE_FIELDS: Array<Record<string, unknown>> = [
+  { name: "source_corpus_id", type: "string", optional: true },
+  { name: "source_document_id", type: "string", optional: true },
+  { name: "source_canonical_url", type: "string", optional: true },
+  { name: "source_scope_audience", type: "string", optional: true },
+  { name: "source_scope_locale", type: "string[]", optional: true },
+  { name: "source_scope_framework", type: "string[]", optional: true },
+  { name: "source_scope_version", type: "string[]", optional: true },
+  { name: "source_scope_version_groups", type: "string", optional: true },
+  { name: "source_scope_package", type: "string[]", optional: true },
+  { name: "source_scope_tags", type: "string[]", optional: true },
+  { name: "source_scope_truncated", type: "string[]", optional: true },
+  { name: "source_scope_conflicts", type: "string[]", optional: true },
+  { name: "source_last_modified", type: "string", optional: true },
+  { name: "source_digest", type: "string", optional: true },
+  { name: "source_index_generation", type: "string", optional: true },
+];
+
 async function ensureTypesenseCollection(
   config: TypesenseDocsSearchConfig,
   dimensions?: number,
   signal?: AbortSignal,
+  retryAfterCreateConflict = true,
+  retryAfterAlterFailure = true,
 ) {
   const baseUrl = getTypesenseSearchBase(config);
   const headers = {
@@ -1618,7 +2646,84 @@ async function ensureTypesenseCollection(
     signal,
   });
 
-  if (existing.ok) return;
+  if (existing.ok) {
+    const existingPayload = (await readResponseJson(existing)) as {
+      fields?: Array<{ name?: unknown; type?: unknown; optional?: unknown; num_dim?: unknown }>;
+    } | null;
+    if (!Array.isArray(existingPayload?.fields)) {
+      throw new Error("Typesense collection response did not include a fields array.");
+    }
+    const existingFields = new Map(
+      existingPayload.fields.flatMap((field) =>
+        typeof field.name === "string" ? [[field.name, field] as const] : [],
+      ),
+    );
+    const incompatibleFields = TYPESENSE_RETRIEVAL_SOURCE_FIELDS.flatMap((expected) => {
+      const name = typeof expected.name === "string" ? expected.name : undefined;
+      const existingField = name ? existingFields.get(name) : undefined;
+      if (!name || !existingField) return [];
+      return existingField.type === expected.type && existingField.optional === true ? [] : [name];
+    });
+    if (incompatibleFields.length > 0) {
+      throw new Error(
+        `Typesense collection has incompatible provenance fields: ${incompatibleFields.join(", ")}.`,
+      );
+    }
+    const missingFields = TYPESENSE_RETRIEVAL_SOURCE_FIELDS.filter(
+      (field) => typeof field.name === "string" && !existingFields.has(field.name),
+    );
+    const embeddingField = existingPayload.fields.find((field) => field.name === "embedding");
+    const expectedEmbeddingField =
+      config.embeddings && dimensions
+        ? {
+            name: "embedding",
+            type: "float[]",
+            num_dim: dimensions,
+            optional: true,
+          }
+        : undefined;
+    const replaceEmbedding = Boolean(
+      expectedEmbeddingField &&
+      embeddingField &&
+      (embeddingField.type !== "float[]" || embeddingField.num_dim !== dimensions),
+    );
+
+    if (replaceEmbedding) {
+      const dropped = await fetch(
+        `${baseUrl}/collections/${encodeURIComponent(config.collection)}`,
+        {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ fields: [{ name: "embedding", drop: true }] }),
+          signal,
+        },
+      );
+      ensureOk(dropped, "Failed to replace an incompatible Typesense embedding field");
+    }
+
+    const fieldsToAdd = [
+      ...missingFields,
+      ...(expectedEmbeddingField && (!embeddingField || replaceEmbedding)
+        ? [expectedEmbeddingField]
+        : []),
+    ];
+    if (fieldsToAdd.length === 0) return;
+
+    const altered = await fetch(`${baseUrl}/collections/${encodeURIComponent(config.collection)}`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ fields: fieldsToAdd }),
+      signal,
+    });
+    if (!altered.ok && retryAfterAlterFailure) {
+      // Another instance may have added the same fields after our inspection.
+      // Re-read and validate the complete schema before accepting that race.
+      await ensureTypesenseCollection(config, dimensions, signal, retryAfterCreateConflict, false);
+      return;
+    }
+    ensureOk(altered, "Failed to update the Typesense search schema");
+    return;
+  }
   if (existing.status !== 404) {
     ensureOk(existing, "Failed to inspect Typesense collection");
   }
@@ -1636,6 +2741,7 @@ async function ensureTypesenseCollection(
     { name: "version", type: "string", optional: true },
     { name: "package", type: "string[]", optional: true },
     { name: "tags", type: "string[]", optional: true },
+    ...TYPESENSE_RETRIEVAL_SOURCE_FIELDS,
   ];
 
   if (config.embeddings && dimensions) {
@@ -1657,7 +2763,38 @@ async function ensureTypesenseCollection(
     signal,
   });
 
+  if (response.status === 409 && retryAfterCreateConflict) {
+    await ensureTypesenseCollection(config, dimensions, signal, false, retryAfterAlterFailure);
+    return;
+  }
   ensureOk(response, "Failed to create Typesense collection");
+}
+
+async function ensureTypesenseImportSucceeded(
+  response: Response,
+  expectedRecords: number,
+): Promise<void> {
+  ensureOk(response, "Failed to sync documents to Typesense");
+  const payload = await response.text();
+  const lines = payload.split(/\r?\n/u).filter((line) => line.trim());
+  if (lines.length !== expectedRecords) {
+    throw new Error(
+      `Typesense acknowledged ${lines.length} of ${expectedRecords} imported records.`,
+    );
+  }
+
+  for (const [index, line] of lines.entries()) {
+    let result: { success?: unknown; error?: unknown };
+    try {
+      result = JSON.parse(line) as { success?: unknown; error?: unknown };
+    } catch {
+      throw new Error(`Typesense import returned invalid JSON on record ${index + 1}.`);
+    }
+    if (result.success !== true) {
+      const detail = typeof result.error === "string" ? `: ${result.error}` : "";
+      throw new Error(`Typesense failed to import record ${index + 1}${detail}`);
+    }
+  }
 }
 
 export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig): DocsSearchAdapter {
@@ -1665,21 +2802,35 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
     name: "typesense",
     async index(context) {
       const adminApiKey = config.adminApiKey ?? config.apiKey;
+      const corpusId = resolveHostedHumanCorpusId(config.syncNamespace, context);
+      const documents = await enrichDocsSearchDocumentsWithSources({
+        documents: context.documents,
+        pages: context.pages,
+        audience: resolveDocsSearchAudience(context.audience),
+        chunking: context.chunking ?? { strategy: "section" },
+        locale: context.locale,
+        baseUrl: context.baseUrl,
+        indexGeneration: context.indexGeneration,
+      });
       const docsForImport = await Promise.all(
-        context.documents.map(async (document) => {
+        documents.map(async (document) => {
+          const providerDocumentId = corpusId
+            ? makeHostedProviderDocumentId(corpusId, document.id)
+            : document.id;
           const next: Record<string, unknown> = {
-            id: document.id,
+            id: providerDocumentId,
             url: document.url,
             title: document.title,
             section: document.section,
             content: document.content,
             description: document.description,
             type: document.type,
-            locale: document.locale,
+            locale: document.locale ?? document.source?.scope.locale?.[0],
             framework: document.framework,
             version: document.version,
             package: document.package,
             tags: document.tags,
+            ...serializeHostedRetrievalSource(document.source, corpusId, document.id),
           };
 
           if (config.mode === "hybrid" && config.embeddings) {
@@ -1694,31 +2845,30 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
         }),
       );
 
-      if (docsForImport.length === 0) return;
-
       const embeddingDimensions = Array.isArray(docsForImport[0]?.embedding)
         ? (docsForImport[0].embedding as number[]).length
         : undefined;
 
       await ensureTypesenseCollection(config, embeddingDimensions, context.signal);
-
-      const response = await fetch(
-        `${getTypesenseSearchBase(config)}/collections/${encodeURIComponent(config.collection)}/documents/import?action=upsert`,
-        {
-          method: "POST",
-          headers: {
-            "X-TYPESENSE-API-KEY": adminApiKey,
-            "Content-Type": "text/plain",
+      if (docsForImport.length > 0) {
+        const response = await fetch(
+          `${getTypesenseSearchBase(config)}/collections/${encodeURIComponent(config.collection)}/documents/import?action=upsert`,
+          {
+            method: "POST",
+            headers: {
+              "X-TYPESENSE-API-KEY": adminApiKey,
+              "Content-Type": "text/plain",
+            },
+            body: docsForImport.map((document) => JSON.stringify(document)).join("\n"),
+            signal: context.signal,
           },
-          body: docsForImport.map((document) => JSON.stringify(document)).join("\n"),
-          signal: context.signal,
-        },
-      );
-
-      ensureOk(response, "Failed to sync documents to Typesense");
+        );
+        await ensureTypesenseImportSucceeded(response, docsForImport.length);
+      }
     },
     async search(query, context) {
-      const scopedDocumentIds = resolveProviderScopeDocumentIds(query, context);
+      const corpusId = resolveHostedHumanCorpusId(config.syncNamespace, context);
+      const scopedDocumentIds = resolveProviderScopeDocumentIds(query, context, corpusId);
       if (scopedDocumentIds?.length === 0) return [];
 
       const params = new URLSearchParams({
@@ -1738,9 +2888,13 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
         );
       }
 
-      const filterBy = scopedDocumentIds
-        ? `id:=[${scopedDocumentIds.map(quoteTypesenseFilterValue).join(",")}]`
-        : undefined;
+      const filterClauses = [
+        corpusId ? `source_corpus_id:=${quoteTypesenseFilterValue(corpusId)}` : undefined,
+        scopedDocumentIds
+          ? `id:=[${scopedDocumentIds.map(quoteTypesenseFilterValue).join(",")}]`
+          : undefined,
+      ].filter((value): value is string => Boolean(value));
+      const filterBy = filterClauses.length > 0 ? filterClauses.join(" && ") : undefined;
       if (filterBy && filterBy.length > MAX_PROVIDER_SCOPE_FILTER_CHARS) return [];
 
       const response = filterBy
@@ -1788,8 +2942,9 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
       };
       const payload = filterBy ? (rawPayload.results?.[0] ?? {}) : rawPayload;
 
-      return (payload.hits ?? []).map((hit) => {
+      return (payload.hits ?? []).flatMap((hit): DocsSearchResult[] => {
         const document = hit.document ?? {};
+        if (!hostedRecordMatchesCorpus(document, corpusId)) return [];
         const section = typeof document.section === "string" ? document.section : undefined;
         const content =
           typeof document.title === "string"
@@ -1803,21 +2958,29 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
           hit.highlights?.find((item) => item.field === "content")?.snippet ??
           hit.highlights?.find((item) => item.field === "description")?.snippet ??
           (typeof document.description === "string" ? document.description : undefined);
+        const source = readHostedRetrievalSource(document);
+        if (hasHostedRetrievalSource(document) && !source) return [];
 
-        return {
-          id: typeof document.id === "string" ? document.id : String(document.url ?? content),
-          url: typeof document.url === "string" ? document.url : "/docs",
-          content: cleanSearchResultText(content) ?? content,
-          description: cleanSearchResultText(description),
-          type:
-            typeof document.type === "string" && ["page", "heading", "text"].includes(document.type)
-              ? (document.type as DocsSearchResult["type"])
-              : section
-                ? "heading"
-                : "page",
-          score: hit.text_match,
-          section,
-        } satisfies DocsSearchResult;
+        return [
+          {
+            id:
+              readHostedSourceDocumentId(document) ??
+              (typeof document.id === "string" ? document.id : String(document.url ?? content)),
+            url: typeof document.url === "string" ? document.url : "/docs",
+            content: cleanSearchResultText(content) ?? content,
+            description: cleanSearchResultText(description),
+            type:
+              typeof document.type === "string" &&
+              ["page", "heading", "text"].includes(document.type)
+                ? (document.type as DocsSearchResult["type"])
+                : section
+                  ? "heading"
+                  : "page",
+            score: hit.text_match,
+            section,
+            ...(source ? { source } : {}),
+          } satisfies DocsSearchResult,
+        ];
       });
     },
   };
@@ -1997,7 +3160,7 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
               : [];
 
         return rawResults
-          .map(mapMcpSearchResult)
+          .map((result) => mapMcpSearchResult(result, endpoint))
           .filter((result): result is DocsSearchResult => Boolean(result));
       } finally {
         if (sessionId) {
@@ -2027,8 +3190,93 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
   };
 }
 
-function getAlgoliaBase(config: AlgoliaDocsSearchConfig): string {
+function getAlgoliaSearchBase(config: AlgoliaDocsSearchConfig): string {
   return `https://${config.appId}-dsn.algolia.net`;
+}
+
+function getAlgoliaAdminBase(config: AlgoliaDocsSearchConfig): string {
+  return `https://${config.appId}.algolia.net`;
+}
+
+function getAlgoliaAdminHeaders(config: AlgoliaDocsSearchConfig): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "X-Algolia-Application-Id": config.appId,
+    "X-Algolia-API-Key": config.adminApiKey ?? config.searchApiKey,
+  };
+}
+
+async function waitForAlgoliaTask(
+  config: AlgoliaDocsSearchConfig,
+  taskId: string | number,
+  signal?: AbortSignal,
+): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  for (let attempt = 0; Date.now() < deadline; attempt += 1) {
+    const response = await fetch(
+      `${getAlgoliaAdminBase(config)}/1/indexes/${encodeURIComponent(config.indexName)}/task/${encodeURIComponent(String(taskId))}`,
+      {
+        headers: getAlgoliaAdminHeaders(config),
+        signal,
+      },
+    );
+    ensureOk(response, "Failed to inspect Algolia sync task");
+    const payload = (await readResponseJson(response)) as { status?: unknown } | null;
+    if (payload?.status === "published") return;
+    if (payload?.status !== "notPublished") {
+      throw new Error("Algolia sync task returned an unknown status.");
+    }
+    const delay = Math.min(100 * 2 ** Math.min(attempt, 4), 2_000);
+    await new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout>;
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(signal?.reason ?? new Error("Algolia sync was aborted."));
+      };
+      timer = setTimeout(
+        () => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        Math.min(delay, Math.max(1, deadline - Date.now())),
+      );
+      if (signal?.aborted) onAbort();
+      else signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  throw new Error("Timed out waiting for Algolia to publish the synced index.");
+}
+
+interface AlgoliaBatchRequest {
+  action: "addObject";
+  body: Record<string, unknown>;
+}
+
+async function executeAlgoliaBatch(
+  config: AlgoliaDocsSearchConfig,
+  requests: readonly AlgoliaBatchRequest[],
+  message: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  for (let offset = 0; offset < requests.length; offset += ALGOLIA_BATCH_OPERATIONS) {
+    const batch = requests.slice(offset, offset + ALGOLIA_BATCH_OPERATIONS);
+    const response = await fetch(
+      `${getAlgoliaAdminBase(config)}/1/indexes/${encodeURIComponent(config.indexName)}/batch`,
+      {
+        method: "POST",
+        headers: getAlgoliaAdminHeaders(config),
+        body: JSON.stringify({ requests: batch }),
+        signal,
+      },
+    );
+    ensureOk(response, message);
+    const payload = (await readResponseJson(response)) as { taskID?: unknown } | null;
+    if (typeof payload?.taskID !== "string" && typeof payload?.taskID !== "number") {
+      throw new Error("Algolia sync response did not include a task ID.");
+    }
+    await waitForAlgoliaTask(config, payload.taskID, signal);
+  }
 }
 
 function quoteAlgoliaFilterValue(value: string): string {
@@ -2040,38 +3288,43 @@ export function createAlgoliaSearchAdapter(config: AlgoliaDocsSearchConfig): Doc
     name: "algolia",
     async index(context) {
       if (!config.adminApiKey) return;
-
-      const response = await fetch(
-        `${getAlgoliaBase(config)}/1/indexes/${encodeURIComponent(config.indexName)}/batch`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Algolia-Application-Id": config.appId,
-            "X-Algolia-API-Key": config.adminApiKey,
-          },
-          body: JSON.stringify({
-            requests: context.documents.map((document) => ({
-              action: "addObject",
-              body: buildAlgoliaRecord(document),
-            })),
-          }),
-          signal: context.signal,
-        },
+      const corpusId = resolveHostedHumanCorpusId(config.syncNamespace, context);
+      const documents = await enrichDocsSearchDocumentsWithSources({
+        documents: context.documents,
+        pages: context.pages,
+        audience: resolveDocsSearchAudience(context.audience),
+        chunking: context.chunking ?? { strategy: "section" },
+        locale: context.locale,
+        baseUrl: context.baseUrl,
+        indexGeneration: context.indexGeneration,
+      });
+      const requests = documents.map((document) => ({
+        action: "addObject" as const,
+        body: buildAlgoliaRecord(document, corpusId),
+      }));
+      await executeAlgoliaBatch(
+        config,
+        requests,
+        "Failed to sync documents to Algolia",
+        context.signal,
       );
-
-      ensureOk(response, "Failed to sync documents to Algolia");
     },
     async search(query, context) {
-      const scopedDocumentIds = resolveProviderScopeDocumentIds(query, context);
+      const corpusId = resolveHostedHumanCorpusId(config.syncNamespace, context);
+      const scopedDocumentIds = resolveProviderScopeDocumentIds(query, context, corpusId);
       if (scopedDocumentIds?.length === 0) return [];
-      const filters = scopedDocumentIds
+      const scopedIdsFilter = scopedDocumentIds
         ?.map((id) => `objectID:${quoteAlgoliaFilterValue(id)}`)
         .join(" OR ");
+      const filterClauses = [
+        corpusId ? `_tags:${quoteAlgoliaFilterValue(corpusId)}` : undefined,
+        scopedIdsFilter ? (corpusId ? `(${scopedIdsFilter})` : scopedIdsFilter) : undefined,
+      ].filter((value): value is string => Boolean(value));
+      const filters = filterClauses.length > 0 ? filterClauses.join(" AND ") : undefined;
       if (filters && filters.length > MAX_PROVIDER_SCOPE_FILTER_CHARS) return [];
 
       const response = await fetch(
-        `${getAlgoliaBase(config)}/1/indexes/${encodeURIComponent(config.indexName)}/query`,
+        `${getAlgoliaSearchBase(config)}/1/indexes/${encodeURIComponent(config.indexName)}/query`,
         {
           method: "POST",
           headers: {
@@ -2082,6 +3335,7 @@ export function createAlgoliaSearchAdapter(config: AlgoliaDocsSearchConfig): Doc
           body: JSON.stringify({
             query: query.query,
             hitsPerPage: query.limit ?? config.maxResults ?? DEFAULT_SEARCH_LIMIT,
+            restrictSearchableAttributes: ["title", "section", "content", "description"],
             attributesToSnippet: ["content:20"],
             ...(filters ? { filters } : {}),
           }),
@@ -2103,27 +3357,33 @@ export function createAlgoliaSearchAdapter(config: AlgoliaDocsSearchConfig): Doc
         >;
       };
 
-      return (payload.hits ?? []).map((hit) => {
+      return (payload.hits ?? []).flatMap((hit): DocsSearchResult[] => {
+        if (!hostedRecordMatchesCorpus(hit, corpusId)) return [];
         const title = typeof hit.title === "string" ? hit.title : "Untitled result";
         const section = typeof hit.section === "string" ? hit.section : undefined;
-        return {
-          id: hit.objectID ?? String(hit.url ?? title),
-          url: typeof hit.url === "string" ? hit.url : "/docs",
-          content: cleanSearchResultText(section ? `${title} — ${section}` : title) ?? title,
-          description: cleanSearchResultText(
-            hit._snippetResult?.content?.value ??
-              hit._snippetResult?.description?.value ??
-              (typeof hit.description === "string" ? hit.description : undefined),
-          ),
-          type:
-            typeof hit.type === "string" && ["page", "heading", "text"].includes(hit.type)
-              ? (hit.type as DocsSearchResult["type"])
-              : section
-                ? "heading"
-                : "page",
-          score: hit._rankingInfo?.nbTypos != null ? 100 - hit._rankingInfo.nbTypos : undefined,
-          section,
-        } satisfies DocsSearchResult;
+        const source = readHostedRetrievalSource(hit);
+        if (hasHostedRetrievalSource(hit) && !source) return [];
+        return [
+          {
+            id: readHostedSourceDocumentId(hit) ?? hit.objectID ?? String(hit.url ?? title),
+            url: typeof hit.url === "string" ? hit.url : "/docs",
+            content: cleanSearchResultText(section ? `${title} — ${section}` : title) ?? title,
+            description: cleanSearchResultText(
+              hit._snippetResult?.content?.value ??
+                hit._snippetResult?.description?.value ??
+                (typeof hit.description === "string" ? hit.description : undefined),
+            ),
+            type:
+              typeof hit.type === "string" && ["page", "heading", "text"].includes(hit.type)
+                ? (hit.type as DocsSearchResult["type"])
+                : section
+                  ? "heading"
+                  : "page",
+            score: hit._rankingInfo?.nbTypos != null ? 100 - hit._rankingInfo.nbTypos : undefined,
+            section,
+            ...(source ? { source } : {}),
+          } satisfies DocsSearchResult,
+        ];
       });
     },
   };
@@ -2175,11 +3435,13 @@ function getSyncKey(search: ResolvedDocsSearchConfig, context: DocsSearchAdapter
   const raw = search.raw;
 
   if (search.provider === "algolia" && raw?.provider === "algolia") {
-    return `algolia:${raw.appId}:${raw.indexName}:${context.locale ?? "__default__"}`;
+    const corpusId = resolveHostedHumanCorpusId(raw.syncNamespace, context) ?? "__unowned__";
+    return `algolia:${raw.appId}:${raw.indexName}:${corpusId}:${context.locale ?? "__default__"}`;
   }
 
   if (search.provider === "typesense" && raw?.provider === "typesense") {
-    return `typesense:${raw.baseUrl}:${raw.collection}:${context.locale ?? "__default__"}`;
+    const corpusId = resolveHostedHumanCorpusId(raw.syncNamespace, context) ?? "__unowned__";
+    return `typesense:${raw.baseUrl}:${raw.collection}:${corpusId}:${context.locale ?? "__default__"}`;
   }
 
   if (search.provider === "mcp" && raw?.provider === "mcp") {
@@ -2187,6 +3449,42 @@ function getSyncKey(search: ResolvedDocsSearchConfig, context: DocsSearchAdapter
   }
 
   return `${search.provider}:${context.locale ?? "__default__"}`;
+}
+
+function getSearchSyncFingerprint(
+  search: ResolvedDocsSearchConfig,
+  context: DocsSearchAdapterContext,
+  indexGeneration: string,
+): string {
+  const raw = search.raw;
+  const providerConfig =
+    search.provider === "typesense" && raw?.provider === "typesense"
+      ? {
+          syncNamespace: raw.syncNamespace?.trim() || undefined,
+          mode: raw.mode ?? "keyword",
+          embeddings: raw.embeddings
+            ? {
+                provider: raw.embeddings.provider,
+                model: raw.embeddings.model,
+                baseUrl: raw.embeddings.baseUrl,
+              }
+            : undefined,
+        }
+      : search.provider === "algolia" && raw?.provider === "algolia"
+        ? {
+            syncNamespace: raw.syncNamespace?.trim() || undefined,
+          }
+        : undefined;
+
+  return hashDocsRetrievalValue(
+    JSON.stringify({
+      format: "docs-search-sync.v1",
+      indexGeneration,
+      canonicalBaseUrl: context.baseUrl,
+      provider: search.provider,
+      providerConfig,
+    }),
+  );
 }
 
 async function maybeSyncSearchIndex(
@@ -2197,14 +3495,48 @@ async function maybeSyncSearchIndex(
   if (!shouldSyncOnSearch(search) || typeof adapter.index !== "function") return;
 
   const syncKey = getSyncKey(search, context);
-  if (syncedIndexes.has(syncKey)) return;
+  const indexGeneration =
+    context.indexGeneration ??
+    (await buildDocsSearchIndexGeneration(context.pages, {
+      audience: resolveDocsSearchAudience(context.audience),
+      chunking: context.chunking ?? search.chunking,
+      locale: context.locale,
+      baseUrl: context.baseUrl,
+    }));
+  context.indexGeneration = indexGeneration;
+  const syncFingerprint = getSearchSyncFingerprint(search, context, indexGeneration);
+  while (true) {
+    const inFlight = syncingIndexes.get(syncKey);
+    if (inFlight) {
+      try {
+        await inFlight.promise;
+      } catch (error) {
+        if (inFlight.fingerprint === syncFingerprint) throw error;
+      }
+      continue;
+    }
+    if (syncedIndexes.get(syncKey) === syncFingerprint) return;
 
-  await adapter.index(context);
-  syncedIndexes.add(syncKey);
+    const sync = adapter.index(context).then(() => {
+      syncedIndexes.set(syncKey, syncFingerprint);
+    });
+    syncingIndexes.set(syncKey, { fingerprint: syncFingerprint, promise: sync });
+    try {
+      await sync;
+    } finally {
+      if (syncingIndexes.get(syncKey)?.promise === sync) {
+        syncingIndexes.delete(syncKey);
+      }
+    }
+  }
 }
 
 export interface PerformDocsSearchOptions {
   pages: DocsSearchSourcePage[];
+  /** @internal Complete corpus used for generation when `pages` is pre-scoped by a caller. */
+  generationPages?: DocsSearchSourcePage[];
+  /** @internal Precomputed complete-corpus generation for structured callers. */
+  indexGeneration?: string;
   query: string;
   search?: boolean | DocsSearchConfig;
   /** Selects which audience projection is searchable. Public site search defaults to human. */
@@ -2214,6 +3546,12 @@ export interface PerformDocsSearchOptions {
   siteTitle?: string;
   /** Canonical docs URL used to distinguish same-site absolute hits from foreign MCP results. */
   baseUrl?: string;
+  /**
+   * Canonical origin safe to persist in a hosted index. Pass `null` when `baseUrl`
+   * came from the current request rather than trusted configuration.
+   * @internal
+   */
+  syncBaseUrl?: string | null;
   limit?: number;
   /** Optional framework, version, package, and tag constraints. */
   filters?: DocsSearchFilterInput;
@@ -2228,7 +3566,7 @@ export interface PerformDocsSearchOptions {
    * Runtime search defaults to true; provider diagnostics can disable supplementation.
    */
   supplementExternalResults?: boolean;
-  /** Fail closed on absolute provider hits when no canonical docs origin is available. */
+  /** Keep absolute provider origins distinct when no canonical docs origin is available. */
   strictExternalOrigins?: boolean;
   /** Optional cancellation signal forwarded to adapters and their managed requests. */
   signal?: AbortSignal;
@@ -2243,11 +3581,14 @@ export async function performDocsSearch(
   const audience = resolveDocsSearchAudience(options.audience);
   const filters = normalizeDocsSearchFilters(options.filters);
   const hasFilters = hasDocsSearchFilters(filters);
+  const corpusPages = options.pages.map((page) => localizeDocsSearchPage(page, options.locale));
+  const indexBaseUrl =
+    options.syncBaseUrl === null ? undefined : (options.syncBaseUrl ?? options.baseUrl);
   const scopedPages = hasFilters
-    ? options.pages.filter((page) =>
+    ? corpusPages.filter((page) =>
         docsSearchPageMatchesFilters(resolveDocsSearchPageScope(page), filters),
       )
-    : options.pages;
+    : corpusPages;
   let resolvedDocuments: DocsSearchDocument[] | undefined;
   const getDocuments = (): DocsSearchDocument[] => {
     if (!resolvedDocuments) {
@@ -2269,6 +3610,10 @@ export async function performDocsSearch(
     locale: options.locale,
     pathname: options.pathname,
     siteTitle: options.siteTitle,
+    baseUrl: options.baseUrl,
+    indexBaseUrl,
+    chunking: search.chunking,
+    deferSourceProvenance: true,
     signal: options.signal,
   };
 
@@ -2280,22 +3625,51 @@ export async function performDocsSearch(
     audience,
     ...(hasFilters ? { filters } : {}),
   };
+  let currentIndexGeneration: Promise<string> | undefined;
+  const getCurrentIndexGeneration = () => {
+    currentIndexGeneration ??= options.indexGeneration
+      ? Promise.resolve(options.indexGeneration)
+      : buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+          audience,
+          chunking: search.chunking,
+          locale: options.locale,
+          baseUrl: options.baseUrl,
+        });
+    return currentIndexGeneration;
+  };
+  const requireCurrentIndexGeneration =
+    search.provider === "algolia" || search.provider === "typesense";
+  const finalizeResults = async (results: readonly DocsSearchResult[]) =>
+    enrichDocsSearchResultsWithSources({
+      results,
+      pages: scopedPages,
+      generationPages: options.generationPages ?? options.pages,
+      audience,
+      chunking: search.chunking,
+      locale: options.locale,
+      baseUrl: options.baseUrl,
+      indexGeneration: options.indexGeneration,
+      strictExternalOrigins: options.strictExternalOrigins,
+      filters,
+      requireCurrentIndexGeneration,
+    });
 
   try {
     const adapter = await resolveSearchAdapter(search, context);
     if (shouldSyncOnSearch(search) && typeof adapter.index === "function") {
-      const syncContext: DocsSearchAdapterContext =
-        audience === "agent" || hasFilters
-          ? {
-              pages: options.pages,
-              documents: buildDocsSearchDocuments(options.pages, search.chunking, "human"),
-              audience: "human",
-              locale: options.locale,
-              pathname: options.pathname,
-              siteTitle: options.siteTitle,
-              signal: options.signal,
-            }
-          : context;
+      const syncPages = audience === "agent" || hasFilters ? corpusPages : scopedPages;
+      const syncContext: DocsSearchAdapterContext = {
+        pages: syncPages,
+        documents: buildDocsSearchDocuments(syncPages, search.chunking, "human"),
+        audience: "human",
+        locale: options.locale,
+        pathname: options.pathname,
+        siteTitle: options.siteTitle,
+        baseUrl: indexBaseUrl,
+        indexBaseUrl,
+        chunking: search.chunking,
+        signal: options.signal,
+      };
       await maybeSyncSearchIndex(adapter, search, syncContext);
     }
 
@@ -2313,16 +3687,16 @@ export async function performDocsSearch(
       throw error;
     }
     const results = await adapterSearch;
-    if (search.provider === "simple") return results;
+    if (search.provider === "simple") return finalizeResults(results);
 
     const localAudienceProjectionResults = buildAudienceProjectionSearchResults(
       documents,
       options.query,
     );
-    const localPagePaths = new Set(scopedPages.map((page) => normalizeUrlPathname(page.url)));
+    const localPagePaths = new Set(scopedPages.map((page) => normalizeUrlRouteKey(page.url)));
     const allLocalPagePaths =
       hasFilters && search.provider === "mcp"
-        ? new Set(options.pages.map((page) => normalizeUrlPathname(page.url)))
+        ? new Set(options.pages.map((page) => normalizeUrlRouteKey(page.url)))
         : localPagePaths;
     // External indexes can be stale or built for a different audience. Replace
     // every local-page hit with the selected local projection before returning it.
@@ -2338,30 +3712,70 @@ export async function performDocsSearch(
               baseUrl: options.baseUrl,
             })
         : undefined;
+    const isKnownLocalProviderResult = (result: DocsSearchResult) =>
+      isLocalProviderResult(result, options.baseUrl) &&
+      localPagePaths.has(normalizeUrlRouteKey(result.url));
+    const expectedProviderGeneration = requireCurrentIndexGeneration
+      ? audience === "human"
+        ? await getCurrentIndexGeneration()
+        : await buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+            audience: "human",
+            chunking: search.chunking,
+            locale: options.locale,
+            baseUrl: indexBaseUrl,
+          })
+      : undefined;
+    const providerAudience: DocsContentAudience = requireCurrentIndexGeneration
+      ? "human"
+      : audience;
+    // Validate provenance before replacing a hosted hit with the local projection.
+    // Otherwise a stale hit could inherit a fresh digest and generation after ranking.
+    const provenanceSafeProviderResults = results.filter((result) => {
+      if (result.source === undefined) {
+        return !requireCurrentIndexGeneration || isKnownLocalProviderResult(result);
+      }
+      const source = parseDocsRetrievalSource(result.source, {
+        allowRootRelativeCanonical:
+          requireCurrentIndexGeneration || isKnownLocalProviderResult(result),
+      });
+      const knownLocal = isKnownLocalProviderResult(result);
+      return Boolean(
+        source &&
+        docsRetrievalSourceMatchesRequest(
+          source,
+          providerAudience,
+          knownLocal ? undefined : filters,
+          options.locale,
+        ) &&
+        (!expectedProviderGeneration || source.indexGeneration === expectedProviderGeneration),
+      );
+    });
     // Provider ranking may be semantic, so lexical query overlap is not required.
     // Fail closed only when a local snippet contains distinctive evidence from
     // the opposite projection and none from the selected one.
-    const audienceSafeAdapterResults = results.filter(
+    const audienceSafeAdapterResults = provenanceSafeProviderResults.filter(
       (result) =>
+        (requireCurrentIndexGeneration && isKnownLocalProviderResult(result)) ||
         !hasOppositeAudienceEvidence({
           result,
           pages: scopedPages,
           query: options.query,
           audience,
           baseUrl: options.baseUrl,
-          strictExternalOrigins: options.strictExternalOrigins,
         }),
     );
     const safeAdapterResults = sanitizeExternalAudienceSearchResults(
       audienceSafeAdapterResults,
       localAudienceProjectionResults,
       options.baseUrl,
-      options.strictExternalOrigins,
       preserveUnmatched,
+      requireCurrentIndexGeneration && audience === "agent",
     );
 
     if (options.supplementExternalResults === false) {
-      return safeAdapterResults.slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT);
+      return finalizeResults(
+        safeAdapterResults.slice(0, query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT),
+      );
     }
     const shouldSupplementWithLocalSearch =
       audience === "agent" || results.length === 0 || safeAdapterResults.length < results.length;
@@ -2378,13 +3792,15 @@ export async function performDocsSearch(
         ? (result) => getAskAIResultKey(result, options.baseUrl, options.strictExternalOrigins)
         : undefined,
     );
-    return prioritizeLiteralInsideResults(options.query, combinedResults).slice(
-      0,
-      query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT,
+    return finalizeResults(
+      prioritizeLiteralInsideResults(options.query, combinedResults).slice(
+        0,
+        query.limit ?? search.maxResults ?? DEFAULT_SEARCH_LIMIT,
+      ),
     );
   } catch (error) {
     if (options.failureMode === "throw") throw error;
-    return createSimpleSearchAdapter().search(query, context);
+    return finalizeResults(await createSimpleSearchAdapter().search(query, context));
   }
 }
 
@@ -2414,12 +3830,12 @@ function findSearchResultPages(
   results: readonly DocsSearchResult[],
   baseUrl?: string,
 ): DocsSearchSourcePage[] {
-  const pagesByPath = new Map(pages.map((page) => [normalizeUrlPathname(page.url), page] as const));
+  const pagesByPath = new Map(pages.map((page) => [normalizeUrlRouteKey(page.url), page] as const));
   const found = new Map<string, DocsSearchSourcePage>();
 
   for (const result of results) {
-    if (!isLocalProviderResult(result, baseUrl, true)) continue;
-    const page = pagesByPath.get(normalizeUrlPathname(result.url));
+    if (!isLocalProviderResult(result, baseUrl)) continue;
+    const page = pagesByPath.get(normalizeUrlRouteKey(result.url));
     if (page) found.set(page.url, page);
   }
 
@@ -2547,17 +3963,30 @@ export async function performDocsSearchWithMetadata(
 ): Promise<DocsSearchResponse> {
   const audience = resolveDocsSearchAudience(options.audience);
   const filters = normalizeDocsSearchFilters(options.filters);
-  const results = await performDocsSearch({
-    ...options,
-    audience,
-    filters,
-  });
+  const search = normalizeDocsSearchConfig(options.search);
+  const indexGeneration =
+    options.indexGeneration ??
+    (await buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+      audience,
+      chunking: search.chunking,
+      locale: options.locale,
+      baseUrl: options.baseUrl,
+    }));
+  const results = options.query.trim()
+    ? await performDocsSearch({
+        ...options,
+        audience,
+        filters,
+        indexGeneration,
+      })
+    : [];
 
   return {
     format: "docs-search.v1",
     query: options.query,
     audience,
     filters,
+    indexGeneration,
     resultCount: results.length,
     results,
     warnings: buildDocsSearchWarnings({
@@ -2579,6 +4008,8 @@ export async function buildDocsAskAIContext(options: {
   pathname?: string;
   siteTitle?: string;
   baseUrl?: string;
+  /** See `performDocsSearch.syncBaseUrl`. */
+  syncBaseUrl?: string | null;
   limit?: number;
   filters?: DocsSearchFilterInput;
   maxContextChars?: number;
@@ -2604,6 +4035,7 @@ export async function buildDocsAskAIContext(options: {
     pathname: options.pathname,
     siteTitle: options.siteTitle,
     baseUrl: options.baseUrl,
+    syncBaseUrl: options.syncBaseUrl,
     limit: searchLimit,
     filters: options.filters,
     failureMode: options.searchFailureMode,
@@ -2615,12 +4047,7 @@ export async function buildDocsAskAIContext(options: {
   const maxResultChars = options.maxResultChars ?? DEFAULT_ASK_AI_RESULT_CHARS;
   const rankedResults = searchResults
     .map((result, index) => {
-      const page = findPageForSearchResult(
-        options.pages,
-        result,
-        options.baseUrl,
-        options.strictExternalOrigins,
-      );
+      const page = findPageForSearchResult(options.pages, result, options.baseUrl);
       const formatted = formatAskAIContextResult({
         result,
         page,

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -70,12 +70,14 @@ export type {
 export type { DocsCloudAskAIConfig, DocsCloudAskAIResponseOptions } from "./cloud-ask-ai.js";
 export {
   buildDocsSearchDocuments,
+  buildDocsRetrievalDigestProjection,
   buildDocsAskAIContext,
   createAlgoliaSearchAdapter,
   createCustomSearchAdapter,
   createMcpSearchAdapter,
   createSimpleSearchAdapter,
   createTypesenseSearchAdapter,
+  enrichDocsSearchDocumentsWithProvenance,
   formatDocsAskAIPackageHints,
   inferDocsAskAIPackageHints,
   normalizeDocsSearchFilters,
@@ -84,10 +86,14 @@ export {
   resolveDocsSearchAudience,
   resolveDocsSearchFilters,
   resolveDocsSearchRequest,
+  resolveDocsRetrievalLastModified,
   resolveAskAISearchRequestConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
-export type { PerformDocsSearchOptions } from "./search.js";
+export type {
+  EnrichDocsSearchDocumentsWithProvenanceOptions,
+  PerformDocsSearchOptions,
+} from "./search.js";
 export { runDocsGoldenTasks } from "./agent-evals.js";
 export {
   resolveConfiguredAgentSkills,
@@ -204,6 +210,8 @@ export type {
   DocsSearchFilters,
   DocsSearchQuery,
   DocsSearchRequest,
+  DocsRetrievalSourceProvenance,
+  DocsRetrievalSourceScope,
   DocsSearchResult,
   DocsSearchResponse,
   DocsSearchSourcePage,
@@ -224,6 +232,8 @@ export type {
   DocsAgentTraceEventType,
   DocsAgentTraceStatus,
 } from "./types.js";
+
+export { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 export type {
   DocsAgentTraceContext,
   ResolvedDocsAnalyticsConfig,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1508,6 +1508,8 @@ export type DocsSearchResultType = "page" | "heading" | "text";
 export interface DocsSearchSourcePage {
   title: string;
   url: string;
+  /** Canonical public URL override. Relative values are resolved against the request base URL. */
+  canonicalUrl?: string;
   content: string;
   description?: string;
   related?: ResolvedDocsRelatedLink[];
@@ -1518,6 +1520,8 @@ export interface DocsSearchSourcePage {
   rawContent?: string;
   agentContent?: string;
   agentRawContent?: string;
+  /** Modified time for an explicit agent-source override such as agent.md. */
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
   type?: "page" | "api" | "code" | "changelog";
@@ -1525,6 +1529,39 @@ export interface DocsSearchSourcePage {
   framework?: string;
   version?: string;
   tags?: string[];
+}
+
+/** Normalized applicability metadata attached to a retrieved source. */
+export interface DocsRetrievalSourceScope {
+  audience: "human" | "agent";
+  locale?: string[];
+  framework?: string[];
+  version?: string[];
+  /**
+   * Version declarations remain grouped so consumers can enforce their intersection
+   * (for example, top-level `>=1` together with an agent contract `<2`).
+   */
+  versionGroups?: string[][];
+  package?: string[];
+  tags?: string[];
+  /** Scope fields with additional authored values omitted from this bounded payload. */
+  truncated?: DocsSearchFilterField[];
+  /** Conflicting declarations that prevent the affected scope fields from being trusted. */
+  conflicts?: DocsSearchFilterField[];
+}
+
+/**
+ * Verifiable metadata for the canonical source behind a retrieval result.
+ *
+ * Digests and generations are algorithm-prefixed. The digest identifies the selected
+ * audience projection of one page; the generation identifies the complete index snapshot.
+ */
+export interface DocsRetrievalSourceProvenance {
+  canonicalUrl: string;
+  scope: DocsRetrievalSourceScope;
+  lastModified?: string;
+  digest: string;
+  indexGeneration: string;
 }
 
 export interface DocsSearchDocument {
@@ -1540,6 +1577,8 @@ export interface DocsSearchDocument {
   version?: string;
   package?: string[];
   tags?: string[];
+  /** Source metadata persisted with hosted search records. */
+  source?: DocsRetrievalSourceProvenance;
 }
 
 export interface DocsSearchResult {
@@ -1550,6 +1589,8 @@ export interface DocsSearchResult {
   type: DocsSearchResultType;
   score?: number;
   section?: string;
+  /** Canonical, scope-aware provenance when supplied or recoverable locally. */
+  source?: DocsRetrievalSourceProvenance;
 }
 
 export type DocsSearchFilterField = "framework" | "version" | "package" | "tags";
@@ -1592,6 +1633,12 @@ export interface DocsSearchResponse {
   query: string;
   audience: "human" | "agent";
   filters: DocsSearchFilters;
+  /**
+   * Generation of the complete local index snapshot used for this retrieval.
+   * Built-in search endpoints always emit it; optionality preserves source compatibility
+   * for callers that construct the versioned response object themselves.
+   */
+  indexGeneration?: string;
   resultCount: number;
   results: DocsSearchResult[];
   warnings: DocsSearchWarning[];
@@ -1621,6 +1668,16 @@ export interface DocsSearchAdapterContext {
   locale?: string;
   pathname?: string;
   siteTitle?: string;
+  /** Canonical docs origin used to make result provenance URLs absolute. */
+  baseUrl?: string;
+  /** @internal Trusted canonical origin used to identify hosted-index ownership. */
+  indexBaseUrl?: string;
+  /** Complete index generation represented by this adapter context. */
+  indexGeneration?: string;
+  /** Chunking policy represented by this adapter context. */
+  chunking?: DocsSearchChunkingConfig;
+  /** @internal Let the shared search pipeline attach provenance once after provider merging. */
+  deferSourceProvenance?: boolean;
   /** Optional cancellation signal, including diagnostic timeouts. */
   signal?: AbortSignal;
 }
@@ -1675,6 +1732,8 @@ export interface AlgoliaDocsSearchConfig {
   adminApiKey?: string;
   maxResults?: number;
   syncOnSearch?: boolean;
+  /** Stable namespace used to identify this docs corpus in a shared index. */
+  syncNamespace?: string;
   chunking?: DocsSearchChunkingConfig;
 }
 
@@ -1687,6 +1746,8 @@ export interface TypesenseDocsSearchConfig {
   adminApiKey?: string;
   maxResults?: number;
   syncOnSearch?: boolean;
+  /** Stable namespace used to identify this docs corpus in a shared collection. */
+  syncNamespace?: string;
   queryBy?: string[];
   mode?: "keyword" | "hybrid";
   embeddings?: DocsSearchEmbeddingsConfig;

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -567,6 +567,50 @@ Welcome to the docs.
     ]);
   });
 
+  it("does not invoke configured providers for blank structured search metadata", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-blank-structured-search-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+
+    process.chdir(rootDir);
+    const search = vi.fn(async () => {
+      throw new Error("blank structured search must not invoke its provider");
+    });
+    const { GET } = createDocsAPI({
+      entry: "docs",
+      search: {
+        provider: "custom",
+        adapter: { name: "must-not-run", search },
+      },
+    });
+
+    const response = await GET(
+      new Request("https://docs.example.com/api/docs?query=%20&response=structured"),
+    );
+    const payload = await response.json();
+
+    expect(search).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      format: "docs-search.v1",
+      query: "",
+      resultCount: 0,
+      results: [],
+    });
+    expect(payload.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
   it("uses built-in simple search when no search config is provided", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-default-search-route-"));
     tempDirs.push(rootDir);
@@ -693,8 +737,16 @@ Scoped adapter token without metadata.
     const structuredPayload = (await structuredResponse.json()) as {
       format: string;
       filters: Record<string, string[]>;
+      indexGeneration: string;
       resultCount: number;
-      results: Array<{ url: string }>;
+      results: Array<{
+        url: string;
+        source?: {
+          canonicalUrl: string;
+          digest: string;
+          indexGeneration: string;
+        };
+      }>;
       warnings: Array<{ code: string; field: string }>;
     };
     expect(structuredPayload).toMatchObject({
@@ -707,8 +759,17 @@ Scoped adapter token without metadata.
       },
     });
     expect(structuredPayload.resultCount).toBe(structuredPayload.results.length);
+    expect(structuredPayload.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(
       structuredPayload.results.every((result) => result.url.split("#", 1)[0] === "/docs/next"),
+    ).toBe(true);
+    expect(
+      structuredPayload.results.every(
+        (result) =>
+          result.source?.canonicalUrl.startsWith("http://localhost/docs/next") &&
+          result.source.digest.match(/^sha256:[a-f0-9]{64}$/) &&
+          result.source.indexGeneration === structuredPayload.indexGeneration,
+      ),
     ).toBe(true);
     expect(
       structuredPayload.warnings.some(
@@ -742,7 +803,11 @@ Scoped adapter token without metadata.
 
     requestUrl.searchParams.set("response", "structured");
     const blankStructuredResponse = await GET(new Request(requestUrl));
-    await expect(blankStructuredResponse.json()).resolves.toEqual({
+    const blankStructuredPayload = (await blankStructuredResponse.json()) as {
+      indexGeneration: string;
+      warnings: Array<{ code: string; field: string }>;
+    };
+    expect(blankStructuredPayload).toMatchObject({
       format: "docs-search.v1",
       query: "",
       audience: "agent",
@@ -751,8 +816,16 @@ Scoped adapter token without metadata.
       },
       resultCount: 0,
       results: [],
-      warnings: [],
     });
+    expect(blankStructuredPayload.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(blankStructuredPayload.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "unknown_filter_value",
+          field: "framework",
+        }),
+      ]),
+    );
   });
 
   it("omits hidden folder index pages from search and markdown lookups", async () => {
@@ -2062,6 +2135,7 @@ Search should not return this hidden agent-only zebra token.
       `---
 title: "Quickstart"
 description: "Start fast"
+lastmod: 2026-07-17
 related:
   - /docs/overview
   - /docs/configuration
@@ -2115,13 +2189,16 @@ This embedded agent block should be ignored because agent.md overrides the page.
 </Agent>
 `,
     );
+    const overviewAgentPath = join(rootDir, "app", "docs", "overview", "agent.md");
     writeFileSync(
-      join(rootDir, "app", "docs", "overview", "agent.md"),
+      overviewAgentPath,
       `<Human>Open the overview dashboard.</Human>
 
 <Audience only="agent">Use this page as the implementation map.</Audience>
 `,
     );
+    const overviewAgentLastModified = new Date("2026-07-19T09:30:00.000Z");
+    utimesSync(overviewAgentPath, overviewAgentLastModified, overviewAgentLastModified);
     writeFileSync(
       join(rootDir, "app", "docs", "configuration", "page.mdx"),
       `---
@@ -2150,7 +2227,7 @@ Config content.
     expect(fallbackResponse.headers.get("link")).toBe(
       '<http://localhost/docs/getting-started/quickstart>; rel="canonical"',
     );
-    expect(fallbackResponse.headers.get("last-modified")).toBe("Sat, 18 Jul 2026 14:23:45 GMT");
+    expect(fallbackResponse.headers.get("last-modified")).toBe("Fri, 17 Jul 2026 00:00:00 GMT");
     expect(fallbackResponse.headers.get("vary")).toBeNull();
     const fallbackDocument = await fallbackResponse.text();
     expect(fallbackDocument).toMatch(/^---\ntitle: "Quickstart"/);
@@ -2211,7 +2288,7 @@ Config content.
       new Request("http://localhost/api/docs?format=markdown&path=overview"),
     );
     expect(agentResponse.status).toBe(200);
-    expect(agentResponse.headers.get("last-modified")).toBeNull();
+    expect(agentResponse.headers.get("last-modified")).toBe("Sun, 19 Jul 2026 09:30:00 GMT");
     const agentDocument = await agentResponse.text();
     expect(agentDocument).toMatch(/^---\ntitle: "Overview"/);
     expect(agentDocument).toContain('description: "Human overview"');
@@ -2220,6 +2297,18 @@ Config content.
     expect(agentDocument).toContain("Use this page as the implementation map.");
     expect(agentDocument).not.toContain("Open the overview dashboard.");
     expect(agentDocument).toContain("## Sitemap");
+
+    const agentSearchResponse = await GET(
+      new Request(
+        "http://localhost/api/docs?query=implementation%20map&audience=agent&response=structured",
+      ),
+    );
+    const agentSearchPayload = (await agentSearchResponse.json()) as {
+      results: Array<{ source?: { lastModified?: string } }>;
+    };
+    expect(agentSearchPayload.results[0]?.source?.lastModified).toBe(
+      overviewAgentLastModified.toISOString(),
+    );
 
     const rewrittenFallbackResponse = await GET(
       new Request("http://localhost/docs/getting-started/quickstart.md"),
@@ -2234,7 +2323,7 @@ Config content.
     );
     expect(rewrittenFallbackResponse.headers.get("etag")).toMatch(/^W\/"/);
     expect(rewrittenFallbackResponse.headers.get("last-modified")).toBe(
-      "Sat, 18 Jul 2026 14:23:45 GMT",
+      "Fri, 17 Jul 2026 00:00:00 GMT",
     );
     expect(rewrittenFallbackResponse.headers.get("vary")).toBeNull();
     expect(await rewrittenFallbackResponse.text()).toContain(
@@ -2250,7 +2339,7 @@ Config content.
 
     const dateConditionalResponse = await GET(
       new Request("http://localhost/docs/getting-started/quickstart.md", {
-        headers: { "If-Modified-Since": "Sat, 18 Jul 2026 14:23:45 GMT" },
+        headers: { "If-Modified-Since": "Fri, 17 Jul 2026 00:00:00 GMT" },
       }),
     );
     expect(dateConditionalResponse.status).toBe(304);
@@ -4525,8 +4614,9 @@ description: "Start here"
 Welcome to the docs.
 `,
     );
+    const changelogPagePath = join(rootDir, "app", "docs", "changelog", "2026-04-15", "page.mdx");
     writeFileSync(
-      join(rootDir, "app", "docs", "changelog", "2026-04-15", "page.mdx"),
+      changelogPagePath,
       `---
 title: "OpenAPI mode is now default"
 description: "A changelog entry"
@@ -4537,6 +4627,8 @@ description: "A changelog entry"
 The changelog now has its own dedicated route.
 `,
     );
+    const changelogModified = new Date("2026-04-15T12:00:00.000Z");
+    utimesSync(changelogPagePath, changelogModified, changelogModified);
 
     process.chdir(rootDir);
 
@@ -4559,6 +4651,17 @@ The changelog now has its own dedicated route.
 
     expect(payload.some((result) => result.url === "/docs/changelogs/2026-04-15")).toBe(true);
     expect(payload.some((result) => result.url.startsWith("/docs/changelog/"))).toBe(false);
+
+    const structuredResponse = await GET(
+      new Request("http://localhost/api/docs?query=OpenAPI&response=structured"),
+    );
+    const structuredPayload = (await structuredResponse.json()) as {
+      results: Array<{ url: string; source?: { lastModified?: string } }>;
+    };
+    expect(
+      structuredPayload.results.find((result) => result.url === "/docs/changelogs/2026-04-15")
+        ?.source?.lastModified,
+    ).toBe(changelogModified.toISOString());
   });
 
   it("serves changelog markdown with the public docsPath in lookups and canonical links", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -66,6 +66,7 @@ import {
   resolveDocsLlmsTxtSections,
   resolveDocsLocale,
   resolveDocsRequestApiRoute,
+  resolveDocsRetrievalLastModified,
   resolveDocsStandardsDiscoveryRequest,
   resolveDocsPublishedAgentSkill,
   resolveDocsAgentContractMcpTools,
@@ -218,6 +219,8 @@ interface DocsMCPAPIOptions {
   rootDir?: string;
   entry?: string;
   contentDir?: string;
+  /** Canonical public docs origin used in retrieval provenance. */
+  baseUrl?: string;
   nav?: { title?: unknown };
   ordering?: "alphabetical" | "numeric" | OrderingItem[];
   mcp?: boolean | DocsMcpConfig;
@@ -1542,10 +1545,18 @@ function readAudienceAgentDoc(dir: string) {
     return {
       agentContent: stripMdx(agentRawContent),
       agentRawContent,
+      agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
     };
   } catch {
     return undefined;
   }
+}
+
+function normalizeFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  return value instanceof Date && Number.isFinite(value.getTime())
+    ? value.toISOString()
+    : undefined;
 }
 
 function scanDocsDir(
@@ -1609,6 +1620,7 @@ function scanDocsDir(
             agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
             url,
             sourcePath: pageSource.replace(/\\/g, "/"),
+            lastmod: normalizeFrontmatterLastmod(data.lastmod),
             lastModified: fs.statSync(pageSource).mtime.toISOString(),
             locale,
             framework,
@@ -1704,6 +1716,9 @@ function scanChangelogDir(
         rawContent,
         agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
         url,
+        sourcePath: pagePath.replace(/\\/g, "/"),
+        lastmod: normalizeFrontmatterLastmod(data.lastmod),
+        lastModified: fs.statSync(pagePath).mtime.toISOString(),
         locale,
         type: "changelog",
         version: typeof data.version === "string" ? data.version : undefined,
@@ -2723,7 +2738,7 @@ async function handleAskAI(
   search: boolean | DocsSearchConfig | undefined,
   analytics?: boolean | DocsAnalyticsConfig,
   observability?: boolean | DocsObservabilityConfig,
-  analyticsContext: { locale?: string } = {},
+  analyticsContext: { locale?: string; syncBaseUrl?: string | null } = {},
 ): Promise<Response> {
   const url = new URL(request.url);
   const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
@@ -3222,7 +3237,8 @@ async function handleAskAI(
     locale: analyticsContext.locale,
     pathname: url.searchParams.get("pathname") ?? undefined,
     siteTitle: "Documentation",
-    baseUrl: url.origin,
+    baseUrl: analyticsContext.syncBaseUrl || url.origin,
+    syncBaseUrl: analyticsContext.syncBaseUrl,
     limit: maxResults,
   });
   const scored = retrieval.results;
@@ -4100,7 +4116,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             origin,
             sitemap: sitemapConfig,
           }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         };
       }
     }
@@ -4116,8 +4132,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           origin,
           sitemap: sitemapConfig,
         }),
-        lastModified:
-          fallbackPage.agentRawContent === undefined ? fallbackPage.lastModified : undefined,
+        lastModified: resolveDocsRetrievalLastModified(fallbackPage, "agent"),
       };
     }
 
@@ -4131,7 +4146,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             origin,
             sitemap: sitemapConfig,
           }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         };
       }
     }
@@ -4670,27 +4685,14 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
       const filters = resolveDocsSearchFilters(url.searchParams);
       const structured = url.searchParams.get("response") === "structured";
-      if (!query) {
-        const searchResponse = structured
-          ? {
-              format: "docs-search.v1",
-              query: "",
-              audience,
-              filters,
-              resultCount: 0,
-              results: [],
-              warnings: [],
-            }
-          : [];
-        return new Response(JSON.stringify(searchResponse), {
+      if (!query && !structured) {
+        return new Response("[]", {
           headers: { "Content-Type": "application/json" },
         });
       }
-
-      const searchStartedAt = Date.now();
       const searchOptions = {
         pages: getIndexes(ctx),
-        query,
+        query: query ?? "",
         search: resolveSearchRequestConfig(searchConfig, request.url),
         audience,
         filters,
@@ -4698,7 +4700,16 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         pathname: url.searchParams.get("pathname") ?? undefined,
         siteTitle: llmsConfig.siteTitle ?? "Documentation",
         baseUrl: markdownMetadataBaseUrl || url.origin,
+        syncBaseUrl: markdownMetadataBaseUrl ?? null,
       };
+      if (!query) {
+        const searchResponse = structured ? await performDocsSearchWithMetadata(searchOptions) : [];
+        return new Response(JSON.stringify(searchResponse), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const searchStartedAt = Date.now();
       const searchResponse = structured
         ? await performDocsSearchWithMetadata(searchOptions)
         : await performDocsSearch(searchOptions);
@@ -4858,6 +4869,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         observability,
         {
           locale: ctx.locale,
+          syncBaseUrl: markdownMetadataBaseUrl ?? null,
         },
       );
     },
@@ -4910,6 +4922,8 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
     entry,
     contentDir,
     siteTitle: navTitle,
+    baseUrl:
+      options.baseUrl?.trim() || resolveDocsMetadataBaseUrl(options as DocsConfig) || undefined,
     ordering: options.ordering,
   });
   const source = {

--- a/packages/nuxt/src/content.ts
+++ b/packages/nuxt/src/content.ts
@@ -53,6 +53,7 @@ export interface ContentPage {
   agent?: PageAgentFrontmatter;
   icon?: string;
   sourcePath?: string;
+  lastmod?: string;
   lastModified?: string;
   locale?: string;
   framework?: string;
@@ -62,8 +63,15 @@ export interface ContentPage {
   rawContent: string;
   agentContent?: string;
   agentRawContent?: string;
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
+}
+
+export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  return undefined;
 }
 
 /**
@@ -120,6 +128,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         agent: normalizePageAgentFrontmatter(data.agent),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
+        lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
         lastModified: stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
@@ -154,6 +163,7 @@ function readAgentDoc(dir: string) {
   return {
     agentContent: stripMarkdown(agentRawContent),
     agentRawContent,
+    agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
   };
 }
 

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -72,6 +72,7 @@ import {
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
+  resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
   resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
@@ -97,7 +98,12 @@ import {
   serializeOpenDocsProviders,
 } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
-import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
+import {
+  loadDocsNavTree,
+  loadDocsContent,
+  flattenNavTree,
+  normalizeDocsFrontmatterLastmod,
+} from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { defineApiReferenceHandler } from "./api-reference.js";
@@ -484,6 +490,8 @@ function searchIndexFromMap(
   contentMap: ContentFileMap,
   dirPrefix: string,
   entry: string,
+  locale?: string,
+  sitemapManifest?: ReturnType<typeof readDocsSitemapManifestFromContentMap>,
 ): ContentPage[] {
   const pages: ContentPage[] = [];
 
@@ -498,6 +506,13 @@ function searchIndexFromMap(
     const isIdx = base === "page" || base === "index" || base === "+page";
     const slug = isIdx ? segments.join("/") : [...segments, base].join("/");
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
+    const manifestLastmod =
+      (locale
+        ? resolveDocsSitemapPageLastmod(
+            sitemapManifest,
+            `${url}?lang=${encodeURIComponent(locale)}`,
+          )
+        : undefined) ?? resolveDocsSitemapPageLastmod(sitemapManifest, url);
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
@@ -515,6 +530,7 @@ function searchIndexFromMap(
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
       icon: data.icon as string | undefined,
+      lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
       framework: typeof data.framework === "string" ? data.framework : undefined,
       version: typeof data.version === "string" ? data.version : undefined,
@@ -523,6 +539,7 @@ function searchIndexFromMap(
         : undefined,
       content: stripMarkdownText(humanRawContent),
       rawContent: humanRawContent,
+      ...(manifestLastmod ? { lastModified: `${manifestLastmod}T00:00:00.000Z` } : {}),
       ...(pageAgentRawContent !== humanRawContent
         ? {
             agentFallbackContent: stripMarkdownText(pageAgentRawContent),
@@ -856,7 +873,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const cached = searchIndexByEntry.get(key);
     if (cached) return cached;
     const index = preloaded
-      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry)
+      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry, ctx.locale, preloadedSitemapManifest)
       : loadDocsContent(ctx.contentDirAbs, entry);
     searchIndexByEntry.set(key, index);
     return index;
@@ -982,7 +999,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return page
       ? {
           document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
   }
@@ -1322,27 +1339,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const filters = resolveDocsSearchFilters(url.searchParams);
     const structured = url.searchParams.get("response") === "structured";
-    if (!query) {
-      const searchResponse = structured
-        ? {
-            format: "docs-search.v1",
-            query: "",
-            audience,
-            filters,
-            resultCount: 0,
-            results: [],
-            warnings: [],
-          }
-        : [];
-      return new Response(JSON.stringify(searchResponse), {
+    if (!query && !structured) {
+      return new Response("[]", {
         headers: { "Content-Type": "application/json" },
       });
     }
-
-    const searchStartedAt = Date.now();
     const searchOptions = {
       pages: getSearchIndex(ctx),
-      query,
+      query: query ?? "",
       search: resolveSearchRequestConfig(config.search, context.request.url),
       audience,
       filters,
@@ -1350,7 +1354,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
       baseUrl: markdownMetadataBaseUrl || url.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
     };
+    if (!query) {
+      const searchResponse = structured ? await performDocsSearchWithMetadata(searchOptions) : [];
+      return new Response(JSON.stringify(searchResponse), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const searchStartedAt = Date.now();
     const searchResponse = structured
       ? await performDocsSearchWithMetadata(searchOptions)
       : await performDocsSearch(searchOptions);
@@ -1673,7 +1686,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
-      baseUrl: requestUrl.origin,
+      baseUrl: markdownMetadataBaseUrl || requestUrl.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
       limit: maxResults,
     });
     const scored = retrieval.results;
@@ -1973,6 +1987,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     source: {
       entry,
       siteTitle: mcpSiteTitle,
+      baseUrl: markdownMetadataBaseUrl || undefined,
+      resolveLocale: resolveLocaleForMcp,
       getPages(locale) {
         const ctx = resolveContextFromPath(`/${entry}`, resolveLocaleForMcp(locale));
         return getSearchIndex(ctx);

--- a/packages/nuxt/test/content.test.ts
+++ b/packages/nuxt/test/content.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadDocsContent } from "../src/content.js";
+
+describe("loadDocsContent", () => {
+  it("tracks the explicit agent.md modified time separately from the page source", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "farming-labs-nuxt-content-"));
+
+    try {
+      const pageDir = join(rootDir, "guide");
+      const pagePath = join(pageDir, "page.mdx");
+      const agentPath = join(pageDir, "agent.md");
+      mkdirSync(pageDir, { recursive: true });
+      writeFileSync(
+        pagePath,
+        "---\ntitle: Guide\nlastmod: 2026-07-17\n---\n\n# Guide\n\nHuman source.\n",
+      );
+      writeFileSync(agentPath, "# Guide\n\nAgent source.\n");
+
+      const pageModified = new Date("2026-07-18T08:00:00.000Z");
+      const agentModified = new Date("2026-07-19T09:30:00.000Z");
+      utimesSync(pagePath, pageModified, pageModified);
+      utimesSync(agentPath, agentModified, agentModified);
+
+      expect(loadDocsContent(rootDir)).toEqual([
+        expect.objectContaining({
+          url: "/docs/guide",
+          lastmod: "2026-07-17T00:00:00.000Z",
+          lastModified: pageModified.toISOString(),
+          agentLastModified: agentModified.toISOString(),
+          agentRawContent: "# Guide\n\nAgent source.\n",
+        }),
+      ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/nuxt/test/server-search.test.ts
+++ b/packages/nuxt/test/server-search.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { createDocsServer } from "../src/server.js";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const sitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Nuxt provenance",
+      lastmod: "2026-07-27",
+    },
+  ],
+});
+const source = `---
+title: "Nuxt provenance"
+framework: "Nuxt"
+version: "4"
+lastmod: 2026-07-26
+tags:
+  - retrieval
+---
+
+# Nuxt provenance
+
+Unique retrieval provenance needle.
+`;
+const localizedSource = source.replace("lastmod: 2026-07-26\n", "");
+const localizedSitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Nuxt fallback provenance",
+      lastmod: "2026-07-20",
+    },
+    {
+      url: "/docs?lang=fr",
+      markdownUrl: "/docs.md?lang=fr",
+      title: "Nuxt localized provenance",
+      lastmod: "2026-07-21",
+    },
+    {
+      url: "/docs/fallback",
+      markdownUrl: "/docs/fallback.md",
+      title: "Nuxt fallback freshness",
+      lastmod: "2026-07-22",
+    },
+  ],
+});
+const fallbackSource = `---
+title: "Nuxt fallback freshness"
+framework: "Nuxt"
+---
+
+# Nuxt fallback freshness
+
+Unique fallback freshness needle.
+`;
+
+describe("createDocsServer structured search provenance", () => {
+  it("uses the shared metadata pipeline without changing legacy response envelopes", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/page.md": source,
+        "/.farming-labs/sitemap-manifest.json": sitemapManifest,
+      },
+    });
+
+    const legacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance"),
+    });
+    expect(await legacy.json()).toEqual(expect.any(Array));
+
+    const structured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance&response=structured"),
+    });
+    const payload = await structured.json();
+
+    expect(payload.indexGeneration).toMatch(digestPattern);
+    expect(payload.results.length).toBeGreaterThan(0);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringMatching(/^https:\/\/docs\.example\.com\/docs(?:#|$)/),
+            scope: expect.objectContaining({ audience: "human", framework: ["nuxt"] }),
+            lastModified: "2026-07-26T00:00:00.000Z",
+            digest: expect.stringMatching(digestPattern),
+            indexGeneration: payload.indexGeneration,
+          }),
+        }),
+      ]),
+    );
+
+    const blankLegacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20"),
+    });
+    await expect(blankLegacy.json()).resolves.toEqual([]);
+
+    const blankStructured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20&response=structured"),
+    });
+    const blankPayload = await blankStructured.json();
+    expect(blankPayload).toMatchObject({
+      format: "docs-search.v1",
+      query: "",
+      resultCount: 0,
+      results: [],
+    });
+    expect(blankPayload.indexGeneration).toMatch(digestPattern);
+  });
+
+  it("prefers locale-qualified manifest freshness and falls back to the base page URL", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/fr/page.md": localizedSource,
+        "/docs/fr/fallback.md": fallbackSource,
+        "/.farming-labs/sitemap-manifest.json": localizedSitemapManifest,
+      },
+    });
+
+    const localized = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=provenance&response=structured&lang=fr",
+      ),
+    });
+    const localizedPayload = await localized.json();
+    expect(localizedPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-21T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+
+    const fallback = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=fallback&response=structured&lang=fr",
+      ),
+    });
+    const fallbackPayload = await fallback.json();
+    expect(fallbackPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs/fallback?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-22T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/svelte/src/content.ts
+++ b/packages/svelte/src/content.ts
@@ -53,6 +53,7 @@ export interface ContentPage {
   agent?: PageAgentFrontmatter;
   icon?: string;
   sourcePath?: string;
+  lastmod?: string;
   lastModified?: string;
   locale?: string;
   framework?: string;
@@ -62,8 +63,15 @@ export interface ContentPage {
   rawContent: string;
   agentContent?: string;
   agentRawContent?: string;
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
+}
+
+export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  return undefined;
 }
 
 /**
@@ -120,6 +128,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         agent: normalizePageAgentFrontmatter(data.agent),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
+        lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
         lastModified: stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
@@ -154,6 +163,7 @@ function readAgentDoc(dir: string) {
   return {
     agentContent: stripMarkdown(agentRawContent),
     agentRawContent,
+    agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
   };
 }
 

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -82,6 +82,7 @@ import {
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
+  resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
   resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
@@ -109,7 +110,12 @@ import {
   serializeOpenDocsProviders,
 } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
-import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
+import {
+  loadDocsNavTree,
+  loadDocsContent,
+  flattenNavTree,
+  normalizeDocsFrontmatterLastmod,
+} from "./content.js";
 import { renderMarkdown } from "./markdown.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createSvelteApiReference } from "./api-reference.js";
@@ -509,6 +515,8 @@ function searchIndexFromMap(
   contentMap: ContentFileMap,
   dirPrefix: string,
   entry: string,
+  locale?: string,
+  sitemapManifest?: ReturnType<typeof readDocsSitemapManifestFromContentMap>,
 ): ContentPage[] {
   const pages: ContentPage[] = [];
 
@@ -523,6 +531,13 @@ function searchIndexFromMap(
     const isIdx = base === "page" || base === "index" || base === "+page";
     const slug = isIdx ? segments.join("/") : [...segments, base].join("/");
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
+    const manifestLastmod =
+      (locale
+        ? resolveDocsSitemapPageLastmod(
+            sitemapManifest,
+            `${url}?lang=${encodeURIComponent(locale)}`,
+          )
+        : undefined) ?? resolveDocsSitemapPageLastmod(sitemapManifest, url);
 
     const { data, content } = matter(raw);
     const humanRawContent = resolveDocsAudienceMdxContent(content, "human");
@@ -540,6 +555,7 @@ function searchIndexFromMap(
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
       icon: data.icon as string | undefined,
+      lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
       framework: typeof data.framework === "string" ? data.framework : undefined,
       version: typeof data.version === "string" ? data.version : undefined,
@@ -548,6 +564,7 @@ function searchIndexFromMap(
         : undefined,
       content: stripMarkdownText(humanRawContent),
       rawContent: humanRawContent,
+      ...(manifestLastmod ? { lastModified: `${manifestLastmod}T00:00:00.000Z` } : {}),
       ...(pageAgentRawContent !== humanRawContent
         ? {
             agentFallbackContent: stripMarkdownText(pageAgentRawContent),
@@ -879,7 +896,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const cached = searchIndexByEntry.get(key);
     if (cached) return cached;
     const index = preloaded
-      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry)
+      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry, ctx.locale, preloadedSitemapManifest)
       : loadDocsContent(ctx.contentDirAbs, entry);
     searchIndexByEntry.set(key, index);
     return index;
@@ -1005,7 +1022,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     return page
       ? {
           document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
   }
@@ -1344,27 +1361,14 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const audience = resolveDocsSearchAudience(event.url.searchParams.get("audience"));
     const filters = resolveDocsSearchFilters(event.url.searchParams);
     const structured = event.url.searchParams.get("response") === "structured";
-    if (!query) {
-      const searchResponse = structured
-        ? {
-            format: "docs-search.v1",
-            query: "",
-            audience,
-            filters,
-            resultCount: 0,
-            results: [],
-            warnings: [],
-          }
-        : [];
-      return new Response(JSON.stringify(searchResponse), {
+    if (!query && !structured) {
+      return new Response("[]", {
         headers: { "Content-Type": "application/json" },
       });
     }
-
-    const searchStartedAt = Date.now();
     const searchOptions = {
       pages: getSearchIndex(ctx),
-      query,
+      query: query ?? "",
       search: resolveSearchRequestConfig(config.search, event.request.url),
       audience,
       filters,
@@ -1372,7 +1376,16 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       pathname: event.url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
       baseUrl: markdownMetadataBaseUrl || event.url.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
     };
+    if (!query) {
+      const searchResponse = structured ? await performDocsSearchWithMetadata(searchOptions) : [];
+      return new Response(JSON.stringify(searchResponse), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const searchStartedAt = Date.now();
     const searchResponse = structured
       ? await performDocsSearchWithMetadata(searchOptions)
       : await performDocsSearch(searchOptions);
@@ -1711,7 +1724,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
-      baseUrl: requestUrl.origin,
+      baseUrl: markdownMetadataBaseUrl || requestUrl.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
       limit: maxResults,
     });
     const scored = retrieval.results;
@@ -2011,6 +2025,8 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     source: {
       entry,
       siteTitle: mcpSiteTitle,
+      baseUrl: markdownMetadataBaseUrl || undefined,
+      resolveLocale: resolveLocaleForMcp,
       getPages(locale) {
         const ctx = resolveContextFromPath(`/${entry}`, resolveLocaleForMcp(locale));
         return getSearchIndex(ctx);

--- a/packages/svelte/test/content.test.ts
+++ b/packages/svelte/test/content.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadDocsContent } from "../src/content.js";
+
+describe("loadDocsContent", () => {
+  it("tracks the explicit agent.md modified time separately from the page source", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "farming-labs-svelte-content-"));
+
+    try {
+      const pageDir = join(rootDir, "guide");
+      const pagePath = join(pageDir, "page.mdx");
+      const agentPath = join(pageDir, "agent.md");
+      mkdirSync(pageDir, { recursive: true });
+      writeFileSync(
+        pagePath,
+        "---\ntitle: Guide\nlastmod: 2026-07-17\n---\n\n# Guide\n\nHuman source.\n",
+      );
+      writeFileSync(agentPath, "# Guide\n\nAgent source.\n");
+
+      const pageModified = new Date("2026-07-18T08:00:00.000Z");
+      const agentModified = new Date("2026-07-19T09:30:00.000Z");
+      utimesSync(pagePath, pageModified, pageModified);
+      utimesSync(agentPath, agentModified, agentModified);
+
+      expect(loadDocsContent(rootDir)).toEqual([
+        expect.objectContaining({
+          url: "/docs/guide",
+          lastmod: "2026-07-17T00:00:00.000Z",
+          lastModified: pageModified.toISOString(),
+          agentLastModified: agentModified.toISOString(),
+          agentRawContent: "# Guide\n\nAgent source.\n",
+        }),
+      ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/svelte/test/server-search.test.ts
+++ b/packages/svelte/test/server-search.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { createDocsServer } from "../src/server.js";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const sitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Svelte provenance",
+      lastmod: "2026-07-27",
+    },
+  ],
+});
+const source = `---
+title: "Svelte provenance"
+framework: "SvelteKit"
+version: "2"
+lastmod: 2026-07-26
+tags:
+  - retrieval
+---
+
+# Svelte provenance
+
+Unique retrieval provenance needle.
+`;
+const localizedSource = source.replace("lastmod: 2026-07-26\n", "");
+const localizedSitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "Svelte fallback provenance",
+      lastmod: "2026-07-20",
+    },
+    {
+      url: "/docs?lang=fr",
+      markdownUrl: "/docs.md?lang=fr",
+      title: "Svelte localized provenance",
+      lastmod: "2026-07-21",
+    },
+    {
+      url: "/docs/fallback",
+      markdownUrl: "/docs/fallback.md",
+      title: "Svelte fallback freshness",
+      lastmod: "2026-07-22",
+    },
+  ],
+});
+const fallbackSource = `---
+title: "Svelte fallback freshness"
+framework: "SvelteKit"
+---
+
+# Svelte fallback freshness
+
+Unique fallback freshness needle.
+`;
+
+function event(url: string) {
+  const request = new Request(url);
+  return { request, url: new URL(url) };
+}
+
+describe("createDocsServer structured search provenance", () => {
+  it("uses the shared metadata pipeline without changing legacy response envelopes", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/page.md": source,
+        "/.farming-labs/sitemap-manifest.json": sitemapManifest,
+      },
+    });
+
+    const legacy = await server.GET(event("https://preview.example/api/docs?query=provenance"));
+    expect(await legacy.json()).toEqual(expect.any(Array));
+
+    const structured = await server.GET(
+      event("https://preview.example/api/docs?query=provenance&response=structured"),
+    );
+    const payload = await structured.json();
+
+    expect(payload.indexGeneration).toMatch(digestPattern);
+    expect(payload.results.length).toBeGreaterThan(0);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringMatching(/^https:\/\/docs\.example\.com\/docs(?:#|$)/),
+            scope: expect.objectContaining({ audience: "human", framework: ["sveltekit"] }),
+            lastModified: "2026-07-26T00:00:00.000Z",
+            digest: expect.stringMatching(digestPattern),
+            indexGeneration: payload.indexGeneration,
+          }),
+        }),
+      ]),
+    );
+
+    const blankLegacy = await server.GET(event("https://preview.example/api/docs?query=%20"));
+    await expect(blankLegacy.json()).resolves.toEqual([]);
+
+    const blankStructured = await server.GET(
+      event("https://preview.example/api/docs?query=%20&response=structured"),
+    );
+    const blankPayload = await blankStructured.json();
+    expect(blankPayload).toMatchObject({
+      format: "docs-search.v1",
+      query: "",
+      resultCount: 0,
+      results: [],
+    });
+    expect(blankPayload.indexGeneration).toMatch(digestPattern);
+  });
+
+  it("prefers locale-qualified manifest freshness and falls back to the base page URL", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/fr/page.md": localizedSource,
+        "/docs/fr/fallback.md": fallbackSource,
+        "/.farming-labs/sitemap-manifest.json": localizedSitemapManifest,
+      },
+    });
+
+    const localized = await server.GET(
+      event("https://preview.example/api/docs?query=provenance&response=structured&lang=fr"),
+    );
+    const localizedPayload = await localized.json();
+    expect(localizedPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-21T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+
+    const fallback = await server.GET(
+      event("https://preview.example/api/docs?query=fallback&response=structured&lang=fr"),
+    );
+    const fallbackPayload = await fallback.json();
+    expect(fallbackPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs/fallback?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-22T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/tanstack-start/src/content.ts
+++ b/packages/tanstack-start/src/content.ts
@@ -53,6 +53,7 @@ export interface ContentPage {
   agent?: PageAgentFrontmatter;
   icon?: string;
   sourcePath?: string;
+  lastmod?: string;
   lastModified?: string;
   locale?: string;
   framework?: string;
@@ -62,8 +63,15 @@ export interface ContentPage {
   rawContent: string;
   agentContent?: string;
   agentRawContent?: string;
+  agentLastModified?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
+}
+
+export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+  return undefined;
 }
 
 export function loadDocsContent(contentDir: string, entry: string = "docs"): ContentPage[] {
@@ -112,6 +120,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         agent: normalizePageAgentFrontmatter(data.agent),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
+        lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
         lastModified: stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
@@ -146,6 +155,7 @@ function readAgentDoc(dir: string) {
   return {
     agentContent: stripMarkdown(agentRawContent),
     agentRawContent,
+    agentLastModified: fs.statSync(agentPath).mtime.toISOString(),
   };
 }
 

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -52,6 +52,7 @@ import {
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
   resolveDocsRequestApiRoute,
+  resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
   resolveDocsStandardsDiscoveryRequest,
   resolveDocsPath,
@@ -75,7 +76,12 @@ import {
   resolveConfiguredAgentSkills,
 } from "@farming-labs/docs/server";
 import type { DocsMcpHttpHandlers } from "@farming-labs/docs/server";
-import { loadDocsNavTree, loadDocsContent, flattenNavTree } from "./content.js";
+import {
+  loadDocsNavTree,
+  loadDocsContent,
+  flattenNavTree,
+  normalizeDocsFrontmatterLastmod,
+} from "./content.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 export { createTanstackApiReference } from "./api-reference.js";
 
@@ -436,6 +442,8 @@ function searchIndexFromMap(
   contentMap: ContentFileMap,
   dirPrefix: string,
   entry: string,
+  locale?: string,
+  sitemapManifest?: ReturnType<typeof readDocsSitemapManifestFromContentMap>,
 ): ContentPage[] {
   const pages: ContentPage[] = [];
 
@@ -456,6 +464,13 @@ function searchIndexFromMap(
     const related = normalizeDocsRelated(data.related);
     const slug = isIdx ? segments.join("/") : [...segments, base].join("/");
     const url = slug ? `/${entry}/${slug}` : `/${entry}`;
+    const manifestLastmod =
+      (locale
+        ? resolveDocsSitemapPageLastmod(
+            sitemapManifest,
+            `${url}?lang=${encodeURIComponent(locale)}`,
+          )
+        : undefined) ?? resolveDocsSitemapPageLastmod(sitemapManifest, url);
     const agentDoc = isIdx ? readAgentDocFromMap(contentMap, dirPrefix, slug) : undefined;
     const fallbackTitle = isIdx
       ? segments.length > 0
@@ -473,6 +488,7 @@ function searchIndexFromMap(
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
       icon: data.icon as string | undefined,
+      lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
       framework: typeof data.framework === "string" ? data.framework : undefined,
       version: typeof data.version === "string" ? data.version : undefined,
@@ -481,6 +497,7 @@ function searchIndexFromMap(
         : undefined,
       content: stripMarkdownText(humanRawContent),
       rawContent: humanRawContent,
+      ...(manifestLastmod ? { lastModified: `${manifestLastmod}T00:00:00.000Z` } : {}),
       ...(pageAgentRawContent !== humanRawContent
         ? {
             agentFallbackContent: stripMarkdownText(pageAgentRawContent),
@@ -836,7 +853,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const cached = searchIndexByEntry.get(key);
     if (cached) return cached;
     const index = preloaded
-      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry)
+      ? searchIndexFromMap(preloaded, ctx.dirPrefix, entry, ctx.locale, preloadedSitemapManifest)
       : loadDocsContent(ctx.contentDirAbs, entry);
     searchIndexByEntry.set(key, index);
     return index;
@@ -953,7 +970,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     return page
       ? {
           document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
-          lastModified: page.agentRawContent === undefined ? page.lastModified : undefined,
+          lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
   }
@@ -1292,27 +1309,14 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const audience = resolveDocsSearchAudience(url.searchParams.get("audience"));
     const filters = resolveDocsSearchFilters(url.searchParams);
     const structured = url.searchParams.get("response") === "structured";
-    if (!query) {
-      const searchResponse = structured
-        ? {
-            format: "docs-search.v1",
-            query: "",
-            audience,
-            filters,
-            resultCount: 0,
-            results: [],
-            warnings: [],
-          }
-        : [];
-      return new Response(JSON.stringify(searchResponse), {
+    if (!query && !structured) {
+      return new Response("[]", {
         headers: { "Content-Type": "application/json" },
       });
     }
-
-    const searchStartedAt = Date.now();
     const searchOptions = {
       pages: getSearchIndex(ctx),
-      query,
+      query: query ?? "",
       search: resolveSearchRequestConfig(config.search, event.request.url),
       audience,
       filters,
@@ -1320,7 +1324,16 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       pathname: url.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
       baseUrl: markdownMetadataBaseUrl || url.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
     };
+    if (!query) {
+      const searchResponse = structured ? await performDocsSearchWithMetadata(searchOptions) : [];
+      return new Response(JSON.stringify(searchResponse), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const searchStartedAt = Date.now();
     const searchResponse = structured
       ? await performDocsSearchWithMetadata(searchOptions)
       : await performDocsSearch(searchOptions);
@@ -1639,7 +1652,8 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       locale: ctx.locale,
       pathname: requestUrl.searchParams.get("pathname") ?? undefined,
       siteTitle: llmsTitle,
-      baseUrl: requestUrl.origin,
+      baseUrl: markdownMetadataBaseUrl || requestUrl.origin,
+      syncBaseUrl: markdownMetadataBaseUrl ?? null,
       limit: maxResults,
     });
     const scored = retrieval.results;
@@ -1935,6 +1949,8 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     source: {
       entry,
       siteTitle: mcpSiteTitle,
+      baseUrl: markdownMetadataBaseUrl || undefined,
+      resolveLocale: resolveLocaleForMcp,
       getPages(locale) {
         const ctx = resolveContextFromPath(`/${entry}`, resolveLocaleForMcp(locale));
         return getSearchIndex(ctx);

--- a/packages/tanstack-start/test/content.test.ts
+++ b/packages/tanstack-start/test/content.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadDocsContent } from "../src/content.js";
+
+describe("loadDocsContent", () => {
+  it("tracks the explicit agent.md modified time separately from the page source", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "farming-labs-tanstack-content-"));
+
+    try {
+      const pageDir = join(rootDir, "guide");
+      const pagePath = join(pageDir, "page.mdx");
+      const agentPath = join(pageDir, "agent.md");
+      mkdirSync(pageDir, { recursive: true });
+      writeFileSync(
+        pagePath,
+        "---\ntitle: Guide\nlastmod: 2026-07-17\n---\n\n# Guide\n\nHuman source.\n",
+      );
+      writeFileSync(agentPath, "# Guide\n\nAgent source.\n");
+
+      const pageModified = new Date("2026-07-18T08:00:00.000Z");
+      const agentModified = new Date("2026-07-19T09:30:00.000Z");
+      utimesSync(pagePath, pageModified, pageModified);
+      utimesSync(agentPath, agentModified, agentModified);
+
+      expect(loadDocsContent(rootDir)).toEqual([
+        expect.objectContaining({
+          url: "/docs/guide",
+          lastmod: "2026-07-17T00:00:00.000Z",
+          lastModified: pageModified.toISOString(),
+          agentLastModified: agentModified.toISOString(),
+          agentRawContent: "# Guide\n\nAgent source.\n",
+        }),
+      ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/tanstack-start/test/server-search.test.ts
+++ b/packages/tanstack-start/test/server-search.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { createDocsServer } from "../src/server.js";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const sitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "TanStack provenance",
+      lastmod: "2026-07-27",
+    },
+  ],
+});
+const source = `---
+title: "TanStack provenance"
+framework: "TanStack Start"
+version: "1"
+lastmod: 2026-07-26
+tags:
+  - retrieval
+---
+
+# TanStack provenance
+
+Unique retrieval provenance needle.
+`;
+const localizedSource = source.replace("lastmod: 2026-07-26\n", "");
+const localizedSitemapManifest = JSON.stringify({
+  version: 1,
+  generatedAt: "2026-07-28T00:00:00.000Z",
+  entry: "docs",
+  pages: [
+    {
+      url: "/docs",
+      markdownUrl: "/docs.md",
+      title: "TanStack fallback provenance",
+      lastmod: "2026-07-20",
+    },
+    {
+      url: "/docs?lang=fr",
+      markdownUrl: "/docs.md?lang=fr",
+      title: "TanStack localized provenance",
+      lastmod: "2026-07-21",
+    },
+    {
+      url: "/docs/fallback",
+      markdownUrl: "/docs/fallback.md",
+      title: "TanStack fallback freshness",
+      lastmod: "2026-07-22",
+    },
+  ],
+});
+const fallbackSource = `---
+title: "TanStack fallback freshness"
+framework: "TanStack Start"
+---
+
+# TanStack fallback freshness
+
+Unique fallback freshness needle.
+`;
+
+describe("createDocsServer structured search provenance", () => {
+  it("uses the shared metadata pipeline without changing legacy response envelopes", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/page.md": source,
+        "/.farming-labs/sitemap-manifest.json": sitemapManifest,
+      },
+    });
+
+    const legacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance"),
+    });
+    expect(await legacy.json()).toEqual(expect.any(Array));
+
+    const structured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=provenance&response=structured"),
+    });
+    const payload = await structured.json();
+
+    expect(payload.indexGeneration).toMatch(digestPattern);
+    expect(payload.results.length).toBeGreaterThan(0);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringMatching(/^https:\/\/docs\.example\.com\/docs(?:#|$)/),
+            scope: expect.objectContaining({
+              audience: "human",
+              framework: ["tanstackstart"],
+            }),
+            lastModified: "2026-07-26T00:00:00.000Z",
+            digest: expect.stringMatching(digestPattern),
+            indexGeneration: payload.indexGeneration,
+          }),
+        }),
+      ]),
+    );
+
+    const blankLegacy = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20"),
+    });
+    await expect(blankLegacy.json()).resolves.toEqual([]);
+
+    const blankStructured = await server.GET({
+      request: new Request("https://preview.example/api/docs?query=%20&response=structured"),
+    });
+    const blankPayload = await blankStructured.json();
+    expect(blankPayload).toMatchObject({
+      format: "docs-search.v1",
+      query: "",
+      resultCount: 0,
+      results: [],
+    });
+    expect(blankPayload.indexGeneration).toMatch(digestPattern);
+  });
+
+  it("prefers locale-qualified manifest freshness and falls back to the base page URL", async () => {
+    const server = createDocsServer({
+      entry: "docs",
+      i18n: { locales: ["en", "fr"], defaultLocale: "en" },
+      sitemap: { baseUrl: "https://docs.example.com" },
+      _preloadedContent: {
+        "/docs/fr/page.md": localizedSource,
+        "/docs/fr/fallback.md": fallbackSource,
+        "/.farming-labs/sitemap-manifest.json": localizedSitemapManifest,
+      },
+    });
+
+    const localized = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=provenance&response=structured&lang=fr",
+      ),
+    });
+    const localizedPayload = await localized.json();
+    expect(localizedPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-21T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+
+    const fallback = await server.GET({
+      request: new Request(
+        "https://preview.example/api/docs?query=fallback&response=structured&lang=fr",
+      ),
+    });
+    const fallbackPayload = await fallback.json();
+    expect(fallbackPayload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({
+            canonicalUrl: expect.stringContaining("/docs/fallback?lang=fr"),
+            scope: expect.objectContaining({ locale: ["fr"] }),
+            lastModified: "2026-07-22T00:00:00.000Z",
+          }),
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- return canonical URL, normalized audience/scope, modified time, SHA-256 digest, and index generation on search, Ask AI, MCP, and golden-evaluation retrieval results
- make digest projection reproducible and keep generation stable across request noise while changing for content, scope, contract, audience, and chunking changes
- persist and validate provenance in Algolia and Typesense with isolated corpus ownership, strict malformed-data handling, and concurrency-safe schema setup
- preserve authored and filesystem freshness across Next/Fumadocs, Astro, Nuxt, SvelteKit, and TanStack Start, including localized preloaded indexes and unquoted YAML dates
- add trusted-origin boundaries for hosted sync and prevent request-controlled MCP origins/locales from creating hosted-index ownership
- extend CLI search sync with canonical site URL and explicit sync namespaces

## Why

Retrieval results previously discarded the metadata agents need to verify where content came from, whether it applies to their framework/version/package, whether it is fresh, and whether multiple results belong to the same index snapshot.

## Compatibility and safety

- existing array search responses remain supported; structured responses add `indexGeneration`
- public source fields are optional for callers that construct legacy result objects
- remote provenance is parsed fail-closed, including truncated/conflicting scopes and mixed representations
- stale hosted generations are rejected at retrieval; automatic cross-generation pruning is intentionally avoided because it is unsafe during rolling deployments

## Validation

- `pnpm --filter @farming-labs/docs test` — 1,211 tests
- `pnpm --filter @farming-labs/theme test` — 163 tests
- Astro — 11 tests
- Nuxt — 34 tests
- SvelteKit — 11 tests
- TanStack Start — 4 tests
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` — 0 errors (existing repository warnings only)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retrieval source provenance to search, MCP, and eval results so citations are verifiable and stable. Results now include canonical URLs, normalized scope, freshness, SHA-256 digests, and an index generation id.

- New Features
  - Add canonical URL, scope (framework/version/package/tags/locale/audience), modified time, SHA‑256 content digest, and indexGeneration to retrieval results.
  - Deterministic digests and generations: stable across request noise; change only with content, scope, contract, audience, or chunking updates.
  - Persist and validate provenance in Algolia and Typesense with isolated corpus ownership, strict malformed-data handling, and concurrency-safe schema setup.
  - Track page lastmod (frontmatter and filesystem) plus separate agent.md modified time; handle unquoted YAML dates, localized indexes, sitemap manifests, and locale-aware URLs.
  - Enforce trusted-origin boundaries for hosted sync; block request-controlled MCP origins/locales from acquiring hosted-index ownership.
  - CLI search sync: add canonical `siteUrl` and explicit `syncNamespace` (env: `DOCS_SEARCH_SYNC_NAMESPACE`); uses configured base URL; blank structured search short-circuits provider calls.

- Migration
  - Structured search responses now include indexGeneration; legacy array responses still work.
  - Provenance fields are optional for custom callers; remote provenance is parsed fail-closed.
  - Set a canonical base URL (`baseUrl`/`siteUrl`) and a stable `syncNamespace` for hosted corpora to get correct canonical URLs and ownership.
  - Stale hosted generations are rejected at retrieval; cross-generation pruning is not automatic.

<sup>Written for commit d414025902818a3376334b115c93389145f1accd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

