### PR TITLE
feat: expose MCP page section discovery

### DIFF
--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -579,6 +579,7 @@ describe("agent route helpers", () => {
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: true,
         readTask: true,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -227,6 +227,7 @@ export const DEFAULT_AGENT_FEEDBACK_PAYLOAD_SCHEMA: Record<string, unknown> = {
 const DEFAULT_DOCS_DIAGNOSTICS_MCP_TOOLS = {
   listDocs: true,
   listPages: true,
+  listPageSections: true,
   readPage: true,
   listTasks: true,
   readTask: true,
@@ -1505,6 +1506,7 @@ function resolveDocsDiagnosticsMcp(mcp: unknown): DocsMcpResolvedConfig {
       ...DEFAULT_DOCS_DIAGNOSTICS_MCP_TOOLS,
       listDocs: tools.listDocs !== false,
       listPages: tools.listPages !== false,
+      listPageSections: tools.listPageSections !== false,
       readPage: tools.readPage !== false,
       listTasks: tools.listTasks !== false,
       readTask: tools.readTask !== false,

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -1419,6 +1419,7 @@ Use MCP and markdown routes.
                 tools: {
                   listDocs: true,
                   listPages: true,
+                  listPageSections: true,
                   listTasks: false,
                   readTask: false,
                   getNavigation: true,
@@ -1645,6 +1646,7 @@ Use MCP and markdown routes.
               tools: [
                 { name: "list_docs" },
                 { name: "list_pages" },
+                { name: "list_page_sections" },
                 { name: "get_navigation" },
                 { name: "search_docs" },
                 { name: "read_page" },

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -2327,6 +2327,7 @@ function hostedMcpRoutes(discoveryBody: unknown): string[] {
 const MCP_DISCOVERY_TOOL_NAMES = [
   ["listDocs", "list_docs"],
   ["listPages", "list_pages"],
+  ["listPageSections", "list_page_sections"],
   ["listTasks", "list_tasks"],
   ["readTask", "read_task"],
   ["getNavigation", "get_navigation"],

--- a/packages/docs/src/cli/mcp.test.ts
+++ b/packages/docs/src/cli/mcp.test.ts
@@ -82,6 +82,7 @@ describe("readMcpConfig", () => {
         mcp: {
           enabled: true,
           tools: {
+            listPageSections: false,
             listTasks: false,
             readTask: false,
             getContext: false,
@@ -93,6 +94,7 @@ describe("readMcpConfig", () => {
     expect(config).toMatchObject({
       enabled: true,
       tools: {
+        listPageSections: false,
         listTasks: false,
         readTask: false,
         getContext: false,

--- a/packages/docs/src/cli/mcp.ts
+++ b/packages/docs/src/cli/mcp.ts
@@ -237,6 +237,7 @@ export function readMcpConfig(content: string): boolean | DocsMcpConfig | undefi
     tools: {
       listDocs: readBooleanProperty(block, "listDocs"),
       listPages: readBooleanProperty(block, "listPages"),
+      listPageSections: readBooleanProperty(block, "listPageSections"),
       listTasks: readBooleanProperty(block, "listTasks"),
       readTask: readBooleanProperty(block, "readTask"),
       readPage: readBooleanProperty(block, "readPage"),

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -156,6 +156,7 @@ describe("resolveDocsMcpConfig", () => {
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: true,
         readTask: true,
@@ -184,6 +185,7 @@ describe("resolveDocsMcpConfig", () => {
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: true,
         readTask: true,
@@ -216,6 +218,7 @@ describe("resolveDocsMcpConfig", () => {
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: true,
         readTask: true,
@@ -232,6 +235,21 @@ describe("resolveDocsMcpConfig", () => {
         maxBodyBytes: 1_048_576,
         cors: DEFAULT_RESOLVED_MCP_CORS,
       },
+    });
+  });
+
+  it("publishes the list_page_sections tool toggle in the config schema", () => {
+    expect(getDocsConfigSchema({ option: "mcp.tools.listPageSections" })).toMatchObject({
+      resultCount: 1,
+      options: [
+        {
+          path: "mcp.tools.listPageSections",
+          name: "listPageSections",
+          type: "boolean",
+          default: true,
+          description: expect.stringContaining("list_page_sections"),
+        },
+      ],
     });
   });
 
@@ -1455,6 +1473,7 @@ sidebar:
       expect.arrayContaining([
         "list_docs",
         "list_pages",
+        "list_page_sections",
         "list_tasks",
         "read_task",
         "get_navigation",
@@ -1470,6 +1489,7 @@ sidebar:
         [
           "list_docs",
           "list_pages",
+          "list_page_sections",
           "list_tasks",
           "read_task",
           "get_navigation",
@@ -2555,6 +2575,230 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
     });
   });
 
+  it("discovers canonical page sections without returning the document body", async () => {
+    const resolvedLocaleInputs: Array<string | undefined> = [];
+    const servedLocales: Array<string | undefined> = [];
+    const rawContent = [
+      "# Install",
+      "",
+      "PRIVATE_PAGE_BODY",
+      "",
+      "## Café 配置",
+      "",
+      "PRIVATE_FIRST_SECTION",
+      "",
+      "### Verify",
+      "",
+      "PRIVATE_NESTED_SECTION",
+      "",
+      "## Café 配置",
+      "",
+      "PRIVATE_SECOND_SECTION",
+    ].join("\n");
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        baseUrl: "https://canonical.docs.example",
+        resolveLocale: (locale) => {
+          resolvedLocaleInputs.push(locale);
+          if (locale === "fr") return "fr-CA";
+          if (locale === "fr-CA") return "resolved-twice";
+          return locale;
+        },
+        getPages: (locale) => {
+          servedLocales.push(locale);
+          return [
+            {
+              slug: "international-v1",
+              url: "/docs/international?source=other",
+              title: "Wrong international version",
+              content: "# Wrong\n\nWRONG_VERSION_BODY",
+              rawContent: "# Wrong\n\nWRONG_VERSION_BODY",
+            },
+            {
+              slug: "international",
+              url: "/docs/international?source=page",
+              title: "International",
+              content: rawContent,
+              rawContent,
+            },
+          ];
+        },
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+    const payload = await parseMcpPayload<{
+      result?: {
+        content?: Array<{ text?: string }>;
+        structuredContent?: {
+          schemaVersion?: number;
+          format?: string;
+          canonicalUrl?: string;
+          markdownUrl?: string;
+          sectionIndexUrl?: string;
+          lineNumbering?: string;
+          sectionCount?: number;
+          estimatedTokens?: number;
+          utf8Bytes?: number;
+          fetchBudget?: { tokenBudget?: number; byteBudget?: number };
+          sections?: Array<{
+            id?: string;
+            heading?: string;
+            level?: number;
+            parentId?: string;
+            startLine?: number;
+            endLine?: number;
+            estimatedTokens?: number;
+            utf8Bytes?: number;
+            canonicalUrl?: string;
+            markdownUrl?: string;
+            content?: string;
+            document?: string;
+          }>;
+        };
+        isError?: boolean;
+      };
+    }>(
+      await callMcpTool(
+        handlers,
+        "list_page_sections",
+        {
+          path: "/docs/international?source=page",
+          locale: "fr",
+          tokenBudget: 80,
+          byteBudget: 256,
+        },
+        "https://untrusted-preview.example/api/docs/mcp",
+      ),
+    );
+
+    expectSuccessfulStructuredTextResult(payload);
+    const result = payload.result?.structuredContent;
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      format: "docs-markdown-sections.v2",
+      lineNumbering: "body",
+      sectionCount: 4,
+      fetchBudget: { tokenBudget: 80, byteBudget: 256 },
+      sections: [
+        expect.objectContaining({ id: "install", heading: "Install", level: 1 }),
+        expect.objectContaining({
+          id: "café-配置",
+          heading: "Café 配置",
+          level: 2,
+          parentId: "install",
+        }),
+        expect.objectContaining({
+          id: "verify",
+          heading: "Verify",
+          level: 3,
+          parentId: "café-配置",
+        }),
+        expect.objectContaining({
+          id: "café-配置-1",
+          heading: "Café 配置",
+          level: 2,
+          parentId: "install",
+        }),
+      ],
+    });
+    expect(result?.estimatedTokens).toBeGreaterThan(0);
+    expect(result?.utf8Bytes).toBeGreaterThan(0);
+    expect(result?.sections?.every((section) => (section.startLine ?? 0) > 0)).toBe(true);
+    expect(
+      result?.sections?.every(
+        (section) =>
+          (section.endLine ?? 0) >= (section.startLine ?? 0) &&
+          (section.estimatedTokens ?? 0) > 0 &&
+          (section.utf8Bytes ?? 0) > 0,
+      ),
+    ).toBe(true);
+
+    for (const value of [
+      result?.canonicalUrl,
+      result?.markdownUrl,
+      result?.sectionIndexUrl,
+      ...((result?.sections ?? []).flatMap((section) => [
+        section.canonicalUrl,
+        section.markdownUrl,
+      ]) as Array<string | undefined>),
+    ]) {
+      expect(value).toBeTruthy();
+      expect(new URL(value!).origin).toBe("https://canonical.docs.example");
+      expect(new URL(value!).searchParams.get("lang")).toBe("fr-CA");
+    }
+    expect(new URL(result?.sectionIndexUrl ?? "").searchParams.has("sections")).toBe(true);
+    const secondFetchUrl = new URL(result?.sections?.[3]?.markdownUrl ?? "");
+    expect(secondFetchUrl.searchParams.get("section")).toBe("café-配置-1");
+    expect(secondFetchUrl.searchParams.get("tokenBudget")).toBe("80");
+    expect(secondFetchUrl.searchParams.get("byteBudget")).toBe("256");
+    expect(
+      decodeURIComponent(new URL(result?.sections?.[3]?.canonicalUrl ?? "").hash.slice(1)),
+    ).toBe("café-配置-1");
+
+    const serialized = JSON.stringify(payload.result);
+    expect(serialized).not.toContain("PRIVATE_PAGE_BODY");
+    expect(serialized).not.toContain("PRIVATE_FIRST_SECTION");
+    expect(serialized).not.toContain("PRIVATE_NESTED_SECTION");
+    expect(serialized).not.toContain("PRIVATE_SECOND_SECTION");
+    expect(serialized).not.toContain("WRONG_VERSION_BODY");
+    expect(result?.sections?.every((section) => !("content" in section))).toBe(true);
+    expect(result?.sections?.every((section) => !("document" in section))).toBe(true);
+    expect(resolvedLocaleInputs).toContain("fr");
+    expect(resolvedLocaleInputs).not.toContain("fr-CA");
+    expect(servedLocales).toContain("fr-CA");
+    expect(servedLocales).not.toContain("resolved-twice");
+  });
+
+  it("returns an empty body-free index for heading-less pages and an error for missing pages", async () => {
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        entry: "docs",
+        getPages: () => [
+          {
+            slug: "heading-less",
+            url: "/docs/heading-less?source=page",
+            title: "Synthetic title must stay absent",
+            content: "PRIVATE_HEADING_LESS_BODY",
+            rawContent: "PRIVATE_HEADING_LESS_BODY",
+          },
+        ],
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+
+    const emptyPayload = await parseMcpPayload<{
+      result?: {
+        content?: Array<{ text?: string }>;
+        structuredContent?: { sectionCount?: number; sections?: unknown[] };
+      };
+    }>(
+      await callMcpTool(handlers, "list_page_sections", {
+        path: "/docs/heading-less",
+      }),
+    );
+    expectSuccessfulStructuredTextResult(emptyPayload);
+    expect(emptyPayload.result?.structuredContent).toMatchObject({
+      sectionCount: 0,
+      sections: [],
+    });
+    expect(JSON.stringify(emptyPayload.result)).not.toContain("PRIVATE_HEADING_LESS_BODY");
+    expect(JSON.stringify(emptyPayload.result)).not.toContain("Synthetic title must stay absent");
+
+    const missingPayload = await parseMcpPayload<{
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    }>(
+      await callMcpTool(handlers, "list_page_sections", {
+        path: "/docs/missing",
+      }),
+    );
+    expect(missingPayload.result?.isError).toBe(true);
+    expect(JSON.parse(missingPayload.result?.content?.[0]?.text ?? "{}")).toEqual({
+      error: 'No docs page matched "/docs/missing".',
+    });
+    expect(JSON.stringify(missingPayload.result)).not.toContain("PRIVATE_HEADING_LESS_BODY");
+  });
+
   it("caps section-not-found errors and includes only headings that fit", async () => {
     const rawContent = Array.from(
       { length: 20 },
@@ -3475,6 +3719,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
       expect.arrayContaining([
         "list_docs",
         "list_pages",
+        "list_page_sections",
         "get_navigation",
         "search_docs",
         "read_page",
@@ -3510,6 +3755,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
       expect.arrayContaining([
         "list_docs",
         "list_pages",
+        "list_page_sections",
         "get_navigation",
         "search_docs",
         "read_page",
@@ -3969,6 +4215,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
           listTasks: false,
           readTask: false,
           searchDocs: false,
+          listPageSections: false,
           readPage: false,
           getConfigSchema: false,
           getContext: false,
@@ -4034,6 +4281,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
         "list_tasks",
         "read_task",
         "search_docs",
+        "list_page_sections",
         "read_page",
         "get_config_schema",
         "get_context",

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -14,6 +14,12 @@ import {
   upsertPageAgentContractMarkdown,
 } from "./agent-contract.js";
 import {
+  DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
+  buildDocsMarkdownSectionIndex,
+  toDocsMarkdownUrl,
+  type DocsMarkdownSectionIndex,
+} from "./agent.js";
+import {
   agentVersionConstraintMatches,
   agentVersionConstraintsOverlap,
   normalizeAgentFramework,
@@ -93,6 +99,9 @@ export interface DocsMcpPage {
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
 }
+
+/** Body-free section discovery metadata returned by the `list_page_sections` MCP tool. */
+export type DocsMcpPageSectionIndex = DocsMarkdownSectionIndex;
 
 export interface DocsMcpCodeExample {
   id: string;
@@ -344,6 +353,8 @@ export interface DocsMcpResolvedConfig {
   tools: {
     listDocs: boolean;
     listPages: boolean;
+    /** Optional so manually constructed resolved configs from older releases remain assignable. */
+    listPageSections?: boolean;
     readPage: boolean;
     listTasks?: boolean;
     readTask?: boolean;
@@ -1936,6 +1947,14 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
             description: "Expose the list_pages tool.",
           },
           {
+            path: "mcp.tools.listPageSections",
+            name: "listPageSections",
+            type: "boolean",
+            default: true,
+            description:
+              "Expose the body-free list_page_sections discovery tool for page headings, anchors, hierarchy, sizes, and follow-up fetch URLs.",
+          },
+          {
             path: "mcp.tools.listTasks",
             name: "listTasks",
             type: "boolean",
@@ -2183,6 +2202,13 @@ const readPageInputSchema = z.object({
   locale: z.string().trim().min(1).max(128).optional(),
   section: z.string().trim().min(1).optional(),
   maxChars: z.number().int().min(256).max(1_000_000).optional(),
+});
+
+const listPageSectionsInputSchema = z.object({
+  path: z.string().min(1),
+  locale: z.string().trim().min(1).max(128).optional(),
+  tokenBudget: z.number().int().min(1).max(1_000_000).optional(),
+  byteBudget: z.number().int().min(1).max(1_000_000).optional(),
 });
 
 const listTasksInputSchema = z.object({
@@ -2516,6 +2542,36 @@ const readPageOutputSchema = z.object({
   totalChars: z.number().int().nonnegative(),
   truncated: z.boolean(),
 });
+const pageSectionMetadataOutputSchema = z.object({
+  id: z.string(),
+  heading: z.string(),
+  level: z.number().int().positive(),
+  parentId: z.string().optional(),
+  startLine: z.number().int().positive(),
+  endLine: z.number().int().positive(),
+  estimatedTokens: z.number().int().nonnegative(),
+  utf8Bytes: z.number().int().nonnegative(),
+  canonicalUrl: z.string(),
+  markdownUrl: z.string(),
+});
+const pageSectionIndexOutputSchema = z.object({
+  schemaVersion: z.literal(2),
+  format: z.literal(DOCS_MARKDOWN_SECTION_INDEX_FORMAT),
+  canonicalUrl: z.string(),
+  markdownUrl: z.string(),
+  sectionIndexUrl: z.string(),
+  lineNumbering: z.literal("body"),
+  sectionCount: z.number().int().nonnegative(),
+  estimatedTokens: z.number().int().nonnegative(),
+  utf8Bytes: z.number().int().nonnegative(),
+  fetchBudget: z
+    .object({
+      tokenBudget: z.number().int().positive().optional(),
+      byteBudget: z.number().int().positive().optional(),
+    })
+    .optional(),
+  sections: z.array(pageSectionMetadataOutputSchema),
+});
 const contextSourceOutputSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -2582,6 +2638,7 @@ export function resolveDocsMcpConfig(
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: true,
         readTask: true,
@@ -2605,6 +2662,7 @@ export function resolveDocsMcpConfig(
     tools: {
       listDocs: config.tools?.listDocs ?? true,
       listPages: config.tools?.listPages ?? true,
+      listPageSections: config.tools?.listPageSections ?? true,
       readPage: config.tools?.readPage ?? true,
       listTasks: config.tools?.listTasks ?? true,
       readTask: config.tools?.readTask ?? true,
@@ -3882,6 +3940,187 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             locale,
             outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
             metadata: { tool: "get_context" },
+          });
+          throw error;
+        }
+      },
+    );
+  }
+
+  if (resolved.tools.listPageSections !== false) {
+    server.registerTool(
+      "list_page_sections",
+      {
+        title: "List sections in a docs page",
+        description:
+          "Discover a page's canonical headings, anchors, hierarchy, line ranges, size estimates, and budget-aware fetch URLs without returning the page body.",
+        inputSchema: listPageSectionsInputSchema,
+        outputSchema: pageSectionIndexOutputSchema,
+        annotations: { readOnlyHint: true },
+      },
+      async ({ path: requestedPath, locale, tokenBudget, byteBudget }) => {
+        const startedAt = nowMs();
+        const resolvedLocale = resolveSourceLocale(locale);
+        const trace = createDocsAgentTraceContext("mcp.tool.list_page_sections");
+        const callSpanId = createDocsAgentTraceId("span");
+        await emitDocsAgentTraceEvent(options.observability, {
+          type: "tool.call",
+          source: "mcp",
+          traceId: trace.traceId,
+          spanId: callSpanId,
+          name: "list_page_sections",
+          startedAt: trace.startedAt,
+          status: "started",
+          locale: resolvedLocale,
+          inputPreview: {
+            path: requestedPath,
+            locale,
+            resolvedLocale,
+            tokenBudget,
+            byteBudget,
+          },
+          metadata: { tool: "list_page_sections" },
+        });
+
+        try {
+          const pages = dedupePages(
+            await options.source.getPages(resolvedLocale, options.requestContext),
+          );
+          const page = findDocsPage(pages, requestedPath, options.source.entry);
+
+          if (!page) {
+            const elapsed = durationMs(startedAt);
+            await emitDocsAnalyticsEvent(options.analytics, {
+              type: "mcp_tool",
+              source: "mcp",
+              locale: resolvedLocale,
+              properties: {
+                tool: "list_page_sections",
+                requestedPath,
+                found: false,
+                durationMs: elapsed,
+              },
+            });
+            trackMcpTool("list_page_sections", {
+              locale: resolvedLocale,
+              resultCount: 0,
+            });
+            await emitDocsAgentTraceEvent(options.observability, {
+              type: "tool.error",
+              source: "mcp",
+              traceId: trace.traceId,
+              parentSpanId: callSpanId,
+              name: "list_page_sections",
+              startedAt: trace.startedAt,
+              endedAt: new Date().toISOString(),
+              durationMs: elapsed,
+              status: "error",
+              locale: resolvedLocale,
+              outputPreview: { found: false, path: requestedPath },
+              metadata: { tool: "list_page_sections", reason: "not_found" },
+            });
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      error: `No docs page matched "${requestedPath}".`,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const document = upsertPageAgentContractMarkdown(
+            getDocsMcpSourceMarkdown(page),
+            page.agent,
+          );
+          const publicBaseUrl =
+            options.source.baseUrl ??
+            (options.requestContext?.request
+              ? new URL(options.requestContext.request.url).origin
+              : undefined);
+          const canonicalUrl = resolveDocsMcpPublicUrl(
+            withDocsMcpUrlLocale(page.url, resolvedLocale),
+            publicBaseUrl,
+          );
+          const markdownUrl = resolveDocsMcpPublicUrl(
+            toDocsMcpPageMarkdownUrl(page.url, resolvedLocale),
+            publicBaseUrl,
+          );
+          const sectionIndex: DocsMcpPageSectionIndex = buildDocsMarkdownSectionIndex(document, {
+            canonicalUrl,
+            markdownUrl,
+            tokenBudget,
+            byteBudget,
+          });
+          const elapsed = durationMs(startedAt);
+
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "mcp_tool",
+            source: "mcp",
+            locale: resolvedLocale,
+            path: page.url,
+            properties: {
+              tool: "list_page_sections",
+              requestedPath,
+              slug: page.slug,
+              found: true,
+              sectionCount: sectionIndex.sectionCount,
+              estimatedTokens: sectionIndex.estimatedTokens,
+              utf8Bytes: sectionIndex.utf8Bytes,
+              tokenBudget,
+              byteBudget,
+              durationMs: elapsed,
+            },
+          });
+          trackMcpTool("list_page_sections", {
+            locale: resolvedLocale,
+            resultCount: sectionIndex.sectionCount,
+          });
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.result",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "list_page_sections",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "success",
+            locale: resolvedLocale,
+            path: page.url,
+            outputPreview: {
+              found: true,
+              slug: page.slug,
+              sectionCount: sectionIndex.sectionCount,
+              estimatedTokens: sectionIndex.estimatedTokens,
+              utf8Bytes: sectionIndex.utf8Bytes,
+            },
+            metadata: { tool: "list_page_sections" },
+          });
+
+          return createStructuredTextResult(sectionIndex);
+        } catch (error) {
+          const elapsed = durationMs(startedAt);
+          await emitDocsAgentTraceEvent(options.observability, {
+            type: "tool.error",
+            source: "mcp",
+            traceId: trace.traceId,
+            parentSpanId: callSpanId,
+            name: "list_page_sections",
+            startedAt: trace.startedAt,
+            endedAt: new Date().toISOString(),
+            durationMs: elapsed,
+            status: "error",
+            locale: resolvedLocale,
+            outputPreview: { message: error instanceof Error ? error.message : "Unknown error" },
+            metadata: { tool: "list_page_sections" },
           });
           throw error;
         }
@@ -5899,6 +6138,41 @@ function toStructuredDocsMcpPage(page: DocsMcpPage) {
   };
 }
 
+function withDocsMcpUrlLocale(value: string, locale?: string): string {
+  if (!locale) return value;
+  const absolute = /^[a-z][a-z\d+.-]*:/iu.test(value);
+
+  try {
+    const url = new URL(value, "https://docs.invalid");
+    if (!url.searchParams.has("lang")) url.searchParams.set("lang", locale);
+    return absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return value;
+  }
+}
+
+function toDocsMcpPageMarkdownUrl(value: string, locale?: string): string {
+  const absolute = /^[a-z][a-z\d+.-]*:/iu.test(value);
+
+  try {
+    const url = new URL(value, "https://docs.invalid");
+    const markdownPath = toDocsMarkdownUrl(`${url.pathname}${url.search}${url.hash}`, { locale });
+    return absolute ? new URL(markdownPath, url.origin).toString() : markdownPath;
+  } catch {
+    return toDocsMarkdownUrl(value, { locale });
+  }
+}
+
+function resolveDocsMcpPublicUrl(value: string, baseUrl?: string): string {
+  if (!baseUrl || /^[a-z][a-z\d+.-]*:/iu.test(value)) return value;
+
+  try {
+    return new URL(value, `${baseUrl.replace(/\/+$/u, "")}/`).toString();
+  } catch {
+    return value;
+  }
+}
+
 function getDocsMcpSourceMarkdown(page: DocsMcpPage): string {
   return (
     page.agentRawContent ??
@@ -6219,38 +6493,42 @@ function findDocsPage(
   requestedPath: string,
   entry?: string,
 ): DocsMcpPage | null {
-  const normalizedRequest = normalizeRequestedPath(requestedPath, entry);
-  const normalizedRequestWithoutLocale = normalizeRequestedPath(
-    removeDocsLocaleQuery(requestedPath),
-    entry,
+  const normalizedRequest = normalizeDocsMcpPageIdentity(requestedPath, entry, true);
+
+  for (const page of pages) {
+    if (normalizeDocsMcpPageIdentity(page.url, entry, true) === normalizedRequest) return page;
+  }
+
+  const normalizedRequestPath = normalizeDocsMcpPageIdentity(requestedPath, entry, false);
+  const pathMatches = pages.filter(
+    (page) => normalizeDocsMcpPageIdentity(page.url, entry, false) === normalizedRequestPath,
   );
+  if (pathMatches.length === 1) return pathMatches[0]!;
+  if (pathMatches.length > 1) return null;
 
-  for (const page of pages) {
-    const normalizedPageUrl = normalizeUrlPath(page.url);
-    if (
-      normalizedPageUrl === normalizedRequest ||
-      normalizedPageUrl === normalizedRequestWithoutLocale
-    ) {
-      return page;
-    }
-  }
+  const normalizedSlug = normalizePathSegment(
+    normalizeDocsMcpPageIdentity(requestedPath, undefined, false).replace(/^\//u, ""),
+  );
+  const slugMatches = pages.filter((page) => normalizePathSegment(page.slug) === normalizedSlug);
 
-  const normalizedSlug = normalizePathSegment(requestedPath.replace(/^\//, ""));
-  for (const page of pages) {
-    if (normalizePathSegment(page.slug) === normalizedSlug) return page;
-  }
-
-  return null;
+  return slugMatches.length === 1 ? slugMatches[0]! : null;
 }
 
-function removeDocsLocaleQuery(value: string): string {
+function normalizeDocsMcpPageIdentity(
+  value: string,
+  entry: string | undefined,
+  includeSearch: boolean,
+): string {
   try {
-    const absolute = /^[a-z][a-z\d+.-]*:/iu.test(value);
     const url = new URL(value, "https://docs.local");
-    url.searchParams.delete("lang");
-    return absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+    if (includeSearch) url.searchParams.sort();
+    const pathname = normalizeRequestedPath(url.pathname, entry);
+    return `${pathname}${includeSearch ? url.search : ""}`;
   } catch {
-    return value;
+    const [pathname = value, search = ""] = value.split("?", 2);
+    return `${normalizeRequestedPath(pathname, entry)}${
+      includeSearch && search ? `?${search}` : ""
+    }`;
   }
 }
 

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -174,6 +174,7 @@ export type {
   DocsMcpNavigationNode,
   DocsMcpNavigationTree,
   DocsMcpPage,
+  DocsMcpPageSectionIndex,
   DocsMcpRequestContext,
   DocsMcpResolvedCorsConfig,
   DocsMcpResolvedConfig,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1360,6 +1360,11 @@ export interface DocsMcpToolsConfig {
   listDocs?: boolean;
   /** Expose a `list_pages` tool that returns the known docs pages. */
   listPages?: boolean;
+  /**
+   * Expose a `list_page_sections` tool that returns body-free section discovery metadata
+   * for a page.
+   */
+  listPageSections?: boolean;
   /** Expose a `read_page` tool that returns a page by slug or URL path. */
   readPage?: boolean;
   /** Expose a `list_tasks` tool for pages with actionable agent contracts. */

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -405,6 +405,7 @@ title: "Introduction"
   mcp: {
     enabled: true,
     tools: {
+      listPageSections: false,
       listTasks: false,
       readTask: false,
       getContext: false,
@@ -439,7 +440,7 @@ title: "Introduction"
     expect(response.status).toBe(200);
     expect(toolNames).toContain("list_pages");
     expect(toolNames).not.toEqual(
-      expect.arrayContaining(["list_tasks", "read_task", "get_context"]),
+      expect.arrayContaining(["list_page_sections", "list_tasks", "read_task", "get_context"]),
     );
   });
 
@@ -3615,6 +3616,7 @@ description: "Start building quickly"
       tools: {
         listDocs: true,
         listPages: true,
+        listPageSections: true,
         readPage: true,
         listTasks: false,
         readTask: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -1202,6 +1202,7 @@ function readMcpConfig(
         tools: {
           listDocs: readBooleanFromBlock(block, "listDocs"),
           listPages: readBooleanFromBlock(block, "listPages"),
+          listPageSections: readBooleanFromBlock(block, "listPageSections"),
           listTasks: readBooleanFromBlock(block, "listTasks"),
           readTask: readBooleanFromBlock(block, "readTask"),
           readPage: readBooleanFromBlock(block, "readPage"),


### PR DESCRIPTION
## Summary

- add a default-on `list_page_sections` MCP tool with an explicit `mcp.tools.listPageSections` opt-out
- return the existing `docs-markdown-sections.v2` metadata contract: canonical anchors, hierarchy, line ranges, token/byte estimates, and budget-aware follow-up URLs
- reuse the same agent-projected Markdown and canonical section builder as `read_page`, without returning page or section bodies
- keep locale resolution, configured canonical origins, diagnostics, config parsing, discovery manifests, and deployed doctor checks aligned
- prefer exact query-qualified pages before an unambiguous pathname fallback so versioned/query-scoped pages cannot resolve to the wrong document

## Why

MCP clients currently need to retrieve page content before they can learn which sections are available. This gives agents a compact discovery step so they can select one canonical section and spend context only on the content they need.

## Validation

- `@farming-labs/docs` typecheck
- `@farming-labs/theme` typecheck
- `@farming-labs/docs` production build
- 1,215 core tests across 65 files
- 69 Fumadocs tests
- formatting and `git diff --check`
- two independent implementation reviews


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a default-on MCP tool to list a page’s sections with metadata, without returning the body. Also tightens page resolution to prefer exact path+query so versioned or query-scoped pages don’t resolve to the wrong document.

- **New Features**
  - Added list_page_sections (opt-out via `mcp.tools.listPageSections`) returning docs-markdown-sections.v2: canonical anchors, hierarchy, line ranges, size estimates, and budget-aware follow-up URLs.
  - Reuses read_page’s canonical section builder; updated config schema, CLI parsing, discovery manifests, and doctor output; exports `DocsMcpPageSectionIndex`.

- **Refactors**
  - Page matching now prefers exact path+query; only falls back to unambiguous pathname or slug; prevents wrong-document resolution.
  - Public and markdown URLs include resolved locale and canonical origin; added analytics/trace for the new tool and tests in `@farming-labs/docs` and `@farming-labs/fumadocs`.

<sup>Written for commit 30f783be60ca45cd6fe5cef28bbd8f6b566e7694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

