### PR TITLE
feat: add agent content change feed

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -38,6 +38,8 @@ import {
   buildDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -54,6 +56,7 @@ import {
   getDocsAgentManifestLinkHeader,
   getDocsDiscoveryLinkHeader,
   isDocsAgentDiscoveryRequest,
+  isDocsContentChangesRequest,
   isDocsAgentsRequest,
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
@@ -83,6 +86,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
+  resolveDocsContentChangesConfig,
   resolveDocsRequestApiRoute,
   resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
@@ -904,6 +908,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
   const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
+  const contentChangesConfig = resolveDocsContentChangesConfig(config.agent?.contentChanges, {
+    staticExport: config.staticExport === true,
+  });
+  const contentChangeFeed = createDocsContentChangeFeed(config.agent?.contentChanges);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1011,6 +1019,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       apiCatalog: apiCatalogEnabled,
       i18n,
       search: config.search,
+      contentChanges: contentChangesConfig.enabled,
       mcp: mcpConfig,
       feedback: agentFeedbackDiscovery,
       llms: {
@@ -1133,6 +1142,23 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isDocsContentChangesRequest(url)) {
+      if (!contentChangesConfig.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8", "X-Robots-Tag": "noindex" },
+        });
+      }
+      return createDocsContentChangesHttpResponse({
+        request: context.request,
+        feed: contentChangeFeed,
+        pages: getSearchIndex(ctx),
+        search: config.search,
+        locale: ctx.locale,
+        baseUrl: markdownMetadataBaseUrl || url.origin,
+      });
     }
 
     if (isApiReferenceOpenApiRequest(url)) {

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -104,11 +104,83 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       url: discoveryUrl,
     });
     await expect(discoveryResponse.json()).resolves.toMatchObject({
+      capabilities: {
+        contentChanges: true,
+      },
+      contentChanges: {
+        enabled: true,
+        endpoint: "/api/docs?audience=agent&response=changes",
+        format: "docs-content-changes.v1",
+        bodyFree: true,
+        etag: true,
+      },
       markdown: {
         enabled: true,
         acceptHeader: "text/markdown",
       },
     });
+
+    const changesUrl = new URL(
+      "/api/docs?audience=agent&response=changes",
+      "https://docs.example.com",
+    );
+    const changesResponse = await server.GET({
+      request: new Request(changesUrl),
+      url: changesUrl,
+    });
+    const changesEtag = changesResponse.headers.get("etag");
+    const changes = (await changesResponse.json()) as {
+      format: string;
+      indexGeneration: string;
+      mode: string;
+      resetRequired: boolean;
+      documentCount: number;
+      added: Array<{ canonicalUrl: string; digest: string; content?: string }>;
+    };
+    expect(changesResponse.status).toBe(200);
+    expect(changesEtag).toMatch(/^"sha256:[a-f0-9]{64}"$/);
+    expect(changes).toMatchObject({
+      format: "docs-content-changes.v1",
+      mode: "snapshot",
+      resetRequired: false,
+      documentCount: 1,
+      added: [
+        {
+          canonicalUrl: "https://docs.example.com/docs?lang=en",
+          digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+      ],
+    });
+    expect(changes.added[0]).not.toHaveProperty("content");
+
+    const deltaUrl = new URL(changesUrl);
+    deltaUrl.searchParams.set("since", changes.indexGeneration);
+    const deltaResponse = await server.GET({
+      request: new Request(deltaUrl),
+      url: deltaUrl,
+    });
+    await expect(deltaResponse.json()).resolves.toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 0, changed: 0, deleted: 0 },
+    });
+
+    const changesHead = await server.HEAD({
+      request: new Request(changesUrl, { method: "HEAD" }),
+      url: changesUrl,
+    });
+    expect(changesHead.status).toBe(200);
+    expect(changesHead.headers.get("x-docs-index-generation")).toBe(changes.indexGeneration);
+    expect(await changesHead.text()).toBe("");
+
+    const notModified = await server.GET({
+      request: new Request(changesUrl, {
+        headers: { "If-None-Match": changesEtag! },
+      }),
+      url: changesUrl,
+    });
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe("");
 
     const indexUrl = new URL("/.well-known/agent-skills/index.json", "https://docs.example.com");
     const indexResponse = await server.GET({
@@ -297,6 +369,40 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
     expect(headResponse.status).toBe(200);
     expect(Object.fromEntries(headResponse.headers)).toEqual(getHeaders);
     expect(await headResponse.text()).toBe("");
+  });
+
+  it("does not advertise or serve the runtime feed from static exports", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
+    const server = createDocsServer({
+      entry: "docs",
+      staticExport: true,
+      _preloadedContent: {
+        "/docs/page.md": "# Home\n",
+      },
+    });
+    const discoveryUrl = new URL("/.well-known/agent.json", "https://docs.example.com");
+    const discoveryResponse = await server.GET({
+      request: new Request(discoveryUrl),
+      url: discoveryUrl,
+    });
+    const discovery = (await discoveryResponse.json()) as {
+      capabilities: { contentChanges: boolean };
+      api: Record<string, string>;
+      contentChanges: { enabled: boolean; endpoint: string | null };
+    };
+    expect(discovery.capabilities.contentChanges).toBe(false);
+    expect(discovery.api).not.toHaveProperty("contentChanges");
+    expect(discovery.contentChanges).toMatchObject({ enabled: false, endpoint: null });
+
+    const changesUrl = new URL(
+      "/api/docs?audience=agent&response=changes",
+      "https://docs.example.com",
+    );
+    const changesResponse = await server.GET({
+      request: new Request(changesUrl),
+      url: changesUrl,
+    });
+    expect(changesResponse.status).toBe(404);
   });
 
   it("keeps discovery HEAD requests metadata-only", async () => {

--- a/packages/docs/src/agent-manifest-schema.test.ts
+++ b/packages/docs/src/agent-manifest-schema.test.ts
@@ -290,6 +290,59 @@ describe("Farming Labs agent manifest schema", () => {
     expect(validate({ ...manifest, search: detachedPagination })).toBe(false);
   });
 
+  it("advertises the body-free content synchronization contract", () => {
+    const manifest = buildManifest();
+
+    expect(manifest.capabilities.contentChanges).toBe(true);
+    expect(manifest.api.contentChanges).toBe("/api/docs?audience=agent&response=changes");
+    expect(manifest.contentChanges).toEqual({
+      enabled: true,
+      endpoint: "/api/docs?audience=agent&response=changes",
+      method: "GET",
+      audienceParam: "audience",
+      defaultAudience: "agent",
+      supportedAudiences: ["human", "agent"],
+      responseParam: "response",
+      responseValue: "changes",
+      sinceParam: "since",
+      format: "docs-content-changes.v1",
+      generationField: "indexGeneration",
+      resetRequiredField: "resetRequired",
+      modes: ["snapshot", "delta", "reset"],
+      bodyFree: true,
+      etag: true,
+    });
+    expectValid(manifest);
+
+    expect(
+      validate({
+        ...manifest,
+        contentChanges: {
+          ...manifest.contentChanges,
+          format: "docs-content-changes.v2",
+        },
+      }),
+    ).toBe(false);
+
+    const disabled = buildManifest({ contentChanges: false });
+    expect(disabled.capabilities.contentChanges).toBe(false);
+    expect(disabled.api).not.toHaveProperty("contentChanges");
+    expect(disabled.contentChanges).toMatchObject({ enabled: false, endpoint: null });
+    expectValid(disabled);
+
+    const legacyCapabilities: Record<string, boolean> = { ...manifest.capabilities };
+    const legacyApi: Record<string, string> = { ...manifest.api };
+    const preChangeFeed: Record<string, unknown> = {
+      ...manifest,
+      capabilities: legacyCapabilities,
+      api: legacyApi,
+    };
+    delete preChangeFeed.contentChanges;
+    delete legacyCapabilities.contentChanges;
+    delete legacyApi.contentChanges;
+    expectValid(preChangeFeed);
+  });
+
   it("keeps Markdown section-discovery declarations synchronized", () => {
     const enabledManifest = buildManifest();
     const disabledManifest = buildManifest({

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -378,6 +378,7 @@ describe("agent route helpers", () => {
         agentSkillsArtifact: "/.well-known/agent-skills/{name}/SKILL.md",
         search: null,
         agentSearch: null,
+        contentChanges: null,
         askAi: null,
         llmsTxt: null,
         robots: null,
@@ -416,6 +417,12 @@ describe("agent route helpers", () => {
           nextCursorField: "nextCursor",
           hasMoreField: "hasMore",
           totalField: "total",
+        },
+        contentChanges: {
+          status: "disabled",
+          reason: "Runtime content-change feeds are unavailable in static exports.",
+          route: null,
+          format: "docs-content-changes.v1",
         },
         ai: {
           status: "disabled",
@@ -495,6 +502,7 @@ describe("agent route helpers", () => {
       skill: "/api/internal/docs?format=skill",
       search: "/api/internal/docs?query={query}",
       agentSearch: "/api/internal/docs?query={query}&audience=agent",
+      contentChanges: "/api/internal/docs?audience=agent&response=changes",
       askAi: "/api/internal/docs",
       openapi: "/api/internal/docs?format=openapi",
     });
@@ -528,6 +536,15 @@ describe("agent route helpers", () => {
         nextCursorField: "nextCursor",
         hasMoreField: "hasMore",
         totalField: "total",
+      },
+      contentChanges: {
+        status: "enabled",
+        route: "/api/internal/docs?audience=agent&response=changes",
+        format: "docs-content-changes.v1",
+        defaultAudience: "agent",
+        sinceParam: "since",
+        generationField: "indexGeneration",
+        resetRequiredField: "resetRequired",
       },
       ai: { route: "/api/internal/docs" },
       apiReference: { routes: { openapi: "/api/internal/docs?format=openapi" } },
@@ -3004,6 +3021,7 @@ After`;
     expect(spec.api.apiCatalogQuery).toBe("/api/docs?format=api-catalog");
     expect(spec.api.agentSkillsIndex).toBe("/.well-known/agent-skills/index.json");
     expect(spec.api.openapi).toBe("/api/docs?format=openapi");
+    expect(spec.api.contentChanges).toBe("/api/docs?audience=agent&response=changes");
     expect(spec.config).toMatchObject({
       format: "docs-config-map.v1",
       endpoint: "/api/docs?format=config",
@@ -3056,6 +3074,23 @@ After`;
       nextCursorField: "nextCursor",
       hasMoreField: "hasMore",
       totalField: "total",
+    });
+    expect(spec.contentChanges).toEqual({
+      enabled: true,
+      endpoint: "/api/docs?audience=agent&response=changes",
+      method: "GET",
+      audienceParam: "audience",
+      defaultAudience: "agent",
+      supportedAudiences: ["human", "agent"],
+      responseParam: "response",
+      responseValue: "changes",
+      sinceParam: "since",
+      format: "docs-content-changes.v1",
+      generationField: "indexGeneration",
+      resetRequiredField: "resetRequired",
+      modes: ["snapshot", "delta", "reset"],
+      bodyFree: true,
+      etag: true,
     });
     expect(spec.agents).toEqual({
       enabled: true,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1,5 +1,6 @@
 import type {
   DocsConfig,
+  DocsAgentContentChangesConfig,
   DocsRobotsConfig,
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
@@ -29,6 +30,11 @@ import {
 } from "./agent-contract.js";
 import { renderDocsRelatedMarkdownLines } from "./related.js";
 import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
+import {
+  DOCS_CONTENT_CHANGES_FORMAT,
+  DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
+  resolveDocsContentChangesConfig,
+} from "./content-changes.js";
 import {
   DEFAULT_SITEMAP_MD_DOCS_ROUTE,
   DEFAULT_SITEMAP_MD_ROUTE,
@@ -464,6 +470,10 @@ export interface DocsDiagnosticsFeature {
   };
   responseFormat?: "docs-search.v1";
   facetsResponseFormat?: "docs-search-facets.v1";
+  format?: string;
+  sinceParam?: string;
+  generationField?: string;
+  resetRequiredField?: string;
   warningsField?: "warnings";
   /** Facet field selected for facet-value continuation. */
   facetParam?: "facet";
@@ -503,6 +513,7 @@ export interface DocsDiagnostics {
     skill: string;
     search: string | null;
     agentSearch: string | null;
+    contentChanges: string | null;
     askAi: string | null;
     mcp: string | null;
     llmsTxt: string | null;
@@ -519,6 +530,7 @@ export interface DocsDiagnostics {
     diagnostics: DocsDiagnosticsFeature;
     apiCatalog: DocsDiagnosticsFeature;
     search: DocsDiagnosticsFeature;
+    contentChanges: DocsDiagnosticsFeature;
     ai: DocsDiagnosticsFeature;
     mcp: DocsDiagnosticsFeature;
     feedback: DocsDiagnosticsFeature;
@@ -652,6 +664,8 @@ export interface DocsAgentDiscoverySpecOptions extends DocsDiscoveryApiRouteOpti
   apiCatalog?: boolean;
   i18n?: ResolvedDocsI18n | null;
   search?: boolean | DocsSearchConfig;
+  /** Runtime metadata-only document synchronization feed. Defaults to enabled. */
+  contentChanges?: boolean | DocsAgentContentChangesConfig;
   mcp: DocsMcpResolvedConfig;
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
@@ -678,6 +692,8 @@ export interface DocsSkillDocumentOptions extends DocsDiscoveryApiRouteOptions {
   /** Whether this deployment actually serves the RFC 9727 API catalog. Defaults to true. */
   apiCatalog?: boolean;
   search?: boolean | DocsSearchConfig;
+  /** Runtime metadata-only document synchronization feed. Defaults to enabled. */
+  contentChanges?: boolean | DocsAgentContentChangesConfig;
   mcp: DocsMcpResolvedConfig;
   feedback?: DocsAgentFeedbackDiscoveryConfig;
   llms?: DocsLlmsDiscoveryConfig;
@@ -929,6 +945,11 @@ export function buildDocsDiagnostics(
   const i18n = options.i18n ?? null;
   const localesEnabled = Boolean(i18n?.locales.length);
   const search = resolveDocsDiagnosticsSearch(input.search, staticExport);
+  const agent = isPlainObject(input.agent) ? input.agent : undefined;
+  const contentChanges = resolveDocsContentChangesConfig(
+    agent?.contentChanges as boolean | DocsAgentContentChangesConfig | undefined,
+    { staticExport },
+  );
   const ai = resolveDocsDiagnosticsAi(input.ai, staticExport);
   const llms = resolveDocsDiagnosticsLlms(input.llmsTxt);
   const apiCatalog = resolveDocsDiagnosticsApiCatalog(
@@ -1024,6 +1045,9 @@ export function buildDocsDiagnostics(
       skill: apiQueryRoute("format=skill"),
       search: search.enabled ? apiQueryRoute("query={query}") : null,
       agentSearch: search.enabled ? apiQueryRoute("query={query}&audience=agent") : null,
+      contentChanges: contentChanges.enabled
+        ? apiQueryRoute(`audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`)
+        : null,
       askAi: ai.enabled ? apiRoute : null,
       mcp: mcp.enabled ? mcp.route : null,
       llmsTxt: llms.enabled ? DEFAULT_LLMS_TXT_ROUTE : null,
@@ -1093,6 +1117,25 @@ export function buildDocsDiagnostics(
         totalField: "total",
         provider: search.provider,
         transport: "GET",
+      },
+      contentChanges: {
+        status: contentChanges.enabled ? "enabled" : "disabled",
+        reason: staticExport
+          ? "Runtime content-change feeds are unavailable in static exports."
+          : contentChanges.enabled
+            ? undefined
+            : "configured-disabled",
+        route: contentChanges.enabled
+          ? apiQueryRoute(`audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`)
+          : null,
+        transport: "GET",
+        format: DOCS_CONTENT_CHANGES_FORMAT,
+        audienceParam: "audience",
+        defaultAudience: "agent",
+        supportedAudiences: ["human", "agent"],
+        sinceParam: "since",
+        generationField: "indexGeneration",
+        resetRequiredField: "resetRequired",
       },
       ai: {
         status: ai.enabled ? "enabled" : "disabled",
@@ -3742,6 +3785,7 @@ interface DocsAgentDocumentContext {
   siteDescription?: string;
   llmsEnabled: boolean;
   searchEnabled: boolean;
+  contentChangesEnabled: boolean;
   mcpEnabled: boolean;
   feedbackEnabled: boolean;
   sitemapConfig: ReturnType<typeof resolveDocsSitemapConfig>;
@@ -3763,6 +3807,7 @@ function resolveDocsAgentDocumentContext({
   apiRoute,
   apiCatalog: explicitApiCatalog,
   search,
+  contentChanges,
   mcp,
   feedback,
   llms,
@@ -3782,6 +3827,7 @@ function resolveDocsAgentDocumentContext({
     siteDescription: llms?.siteDescription ? compactSkillText(llms.siteDescription) : undefined,
     llmsEnabled: llms?.enabled ?? true,
     searchEnabled: isSearchEnabled(search),
+    contentChangesEnabled: resolveDocsContentChangesConfig(contentChanges).enabled,
     mcpEnabled: mcp.enabled,
     feedbackEnabled: feedback?.enabled ?? false,
     sitemapConfig: resolveDocsSitemapConfig(sitemap),
@@ -3834,6 +3880,16 @@ function appendDocsSearchStartLine(
     variant === "skill"
       ? `- Search with ${context.apiRoute}?query={query}&audience=agent&response=structured when you do not know the page; optionally repeat framework, version, package, or tags filters.`
       : `- Search with ${context.apiRoute}?query={query}&audience=agent&response=structured when the route is unknown; optionally repeat framework, version, package, or tags filters.`,
+  );
+}
+
+function appendDocsContentChangesStartLine(
+  lines: string[],
+  context: DocsAgentDocumentContext,
+): void {
+  if (!context.contentChangesEnabled) return;
+  lines.push(
+    `- Synchronize changed documents with ${context.apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}; pass the returned indexGeneration as since on the next request and clear stale state when resetRequired is true.`,
   );
 }
 
@@ -3985,6 +4041,7 @@ function appendDocsAgentStartHereLines(
   if (variant === "skill") {
     appendDocsMarkdownNegotiationStartLines(lines, context, variant);
     appendDocsSearchStartLine(lines, context, variant);
+    appendDocsContentChangesStartLine(lines, context);
     appendDocsOpenApiStartLine(lines, context, variant);
     appendDocsLlmsStartLines(lines, context, variant);
     appendDocsSitemapStartLines(lines, context, variant);
@@ -3998,6 +4055,7 @@ function appendDocsAgentStartHereLines(
   appendDocsSitemapStartLines(lines, context, variant);
   appendDocsRobotsStartLine(lines, context, variant);
   appendDocsSearchStartLine(lines, context, variant);
+  appendDocsContentChangesStartLine(lines, context);
   appendDocsOpenApiStartLine(lines, context, variant);
   appendDocsMcpStartLine(lines, context, variant);
   appendDocsFeedbackStartLine(lines, context, variant);
@@ -4084,6 +4142,11 @@ function appendDocsAgentPublicRouteLines(
     appendDocsOpenApiRouteLines(lines, context);
     appendDocsSitemapRouteLines(lines, context);
     appendDocsMcpRouteLines(lines, context);
+    if (context.contentChangesEnabled) {
+      lines.push(
+        `- Content changes: ${context.apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`,
+      );
+    }
     return;
   }
 
@@ -4121,6 +4184,11 @@ function appendDocsAgentPublicRouteLines(
   appendDocsSitemapRouteLines(lines, context);
   appendDocsOpenApiRouteLines(lines, context);
   appendDocsMcpRouteLines(lines, context);
+  if (context.contentChangesEnabled) {
+    lines.push(
+      `- Content changes: ${context.apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`,
+    );
+  }
 }
 
 export function renderDocsMarkdownDocument(
@@ -4274,6 +4342,7 @@ export function buildDocsAgentDiscoverySpec({
   apiCatalog: explicitApiCatalog,
   i18n = null,
   search,
+  contentChanges,
   mcp,
   feedback,
   llms,
@@ -4289,6 +4358,7 @@ export function buildDocsAgentDiscoverySpec({
   const apiQueryRoute = (query: string) => `${resolvedApiRoute}?${query}`;
   const localesEnabled = i18n !== null;
   const searchEnabled = isSearchEnabled(search);
+  const contentChangesEnabled = resolveDocsContentChangesConfig(contentChanges).enabled;
   const feedbackRoute = feedback?.route ?? DEFAULT_AGENT_FEEDBACK_ROUTE;
   const feedbackSchemaRoute = feedback?.schemaRoute ?? `${feedbackRoute}/schema`;
   const llmsEnabled = llms?.enabled ?? true;
@@ -4339,6 +4409,7 @@ export function buildDocsAgentDiscoverySpec({
       agentSkillsDiscovery: true,
       mcp: mcp.enabled,
       search: searchEnabled,
+      contentChanges: contentChangesEnabled,
       sitemap: sitemapConfig.enabled,
       robots: robotsEnabled,
       structuredData: true,
@@ -4371,6 +4442,13 @@ export function buildDocsAgentDiscoverySpec({
       legacySkillsIndex: DEFAULT_LEGACY_SKILLS_INDEX_ROUTE,
       ...(agentCard ? { agentCard: DEFAULT_A2A_AGENT_CARD_ROUTE } : {}),
       openapi: defaultOpenapiRoute,
+      ...(contentChangesEnabled
+        ? {
+            contentChanges: apiQueryRoute(
+              `audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`,
+            ),
+          }
+        : {}),
     },
     apiCatalog: {
       enabled: apiCatalogEnabled,
@@ -4510,6 +4588,25 @@ export function buildDocsAgentDiscoverySpec({
       nextCursorField: "nextCursor",
       hasMoreField: "hasMore",
       totalField: "total",
+    },
+    contentChanges: {
+      enabled: contentChangesEnabled,
+      endpoint: contentChangesEnabled
+        ? apiQueryRoute(`audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`)
+        : null,
+      method: "GET",
+      audienceParam: "audience",
+      defaultAudience: "agent",
+      supportedAudiences: ["human", "agent"],
+      responseParam: "response",
+      responseValue: DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
+      sinceParam: "since",
+      format: DOCS_CONTENT_CHANGES_FORMAT,
+      generationField: "indexGeneration",
+      resetRequiredField: "resetRequired",
+      modes: ["snapshot", "delta", "reset"],
+      bodyFree: true,
+      etag: true,
     },
     agents: {
       enabled: true,

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -177,6 +177,9 @@ pnpm add example
     expect(discovery.staticBundle.manifest).toBe("/.well-known/agent-bundle.json");
     expect(discovery.capabilities.mcp).toBe(false);
     expect(discovery.capabilities.search).toBe(false);
+    expect(discovery.capabilities.contentChanges).toBe(false);
+    expect(discovery.contentChanges).toMatchObject({ enabled: false, endpoint: null });
+    expect(discovery.api).not.toHaveProperty("contentChanges");
     expect(discovery.capabilities.apiCatalog).toBe(false);
     expect(discovery.capabilities.markdownSectionDiscovery).toBe(false);
     expect(discovery.markdown.sectionDiscovery).toEqual({ enabled: false });

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -1152,6 +1152,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
     // `agent export` publishes files only. Never advertise runtime endpoints that the bundle does
     // not contain, even when the application's server-rendered config enables them.
     search: false,
+    contentChanges: false,
     mcp,
     feedback,
     llms,

--- a/packages/docs/src/content-changes.test.ts
+++ b/packages/docs/src/content-changes.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DocsContentSnapshot, DocsSearchSourcePage } from "./types.js";
+import {
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
+  resolveDocsContentChangesConfig,
+  resolveDocsContentChangesRequest,
+} from "./content-changes.js";
+import { buildDocsContentSnapshot, performDocsSearchWithMetadata } from "./search.js";
+
+const digestPattern = /^sha256:[a-f\d]{64}$/u;
+const baseUrl = "https://docs.example.com";
+
+function pages(version = 1): DocsSearchSourcePage[] {
+  if (version === 1) {
+    return [
+      {
+        title: "Install",
+        url: "/docs/install",
+        content: "Install version one.",
+        rawContent: "# Install\n\nInstall version one.",
+        lastmod: "2026-07-01",
+      },
+      {
+        title: "Removed",
+        url: "/docs/removed",
+        content: "This page will be removed.",
+        rawContent: "# Removed\n\nThis page will be removed.",
+        lastmod: "2026-07-02",
+      },
+    ];
+  }
+  return [
+    {
+      title: "Install",
+      url: "/docs/install",
+      content: "Install version two.",
+      rawContent: "# Install\n\nInstall version two.",
+      lastmod: "2026-07-03",
+    },
+    {
+      title: "Added",
+      url: "/docs/added",
+      content: "This page was added.",
+      rawContent: "# Added\n\nThis page was added.",
+      lastmod: "2026-07-04",
+    },
+  ];
+}
+
+describe("agent content change feed", () => {
+  it("uses the structured-search generation for the same content projection", async () => {
+    const snapshot = await buildDocsContentSnapshot({
+      pages: pages(),
+      audience: "agent",
+      baseUrl,
+      search: { provider: "simple", chunking: { strategy: "page" } },
+    });
+    const search = await performDocsSearchWithMetadata({
+      pages: pages(),
+      query: "install",
+      audience: "agent",
+      baseUrl,
+      search: { provider: "simple", chunking: { strategy: "page" } },
+    });
+
+    expect(snapshot.indexGeneration).toBe(search.indexGeneration);
+    expect(snapshot.documents).toEqual([
+      {
+        url: "/docs/install",
+        canonicalUrl: "https://docs.example.com/docs/install",
+        digest: expect.stringMatching(digestPattern),
+        lastModified: "2026-07-01",
+      },
+      {
+        url: "/docs/removed",
+        canonicalUrl: "https://docs.example.com/docs/removed",
+        digest: expect.stringMatching(digestPattern),
+        lastModified: "2026-07-02",
+      },
+    ]);
+    expect(JSON.stringify(snapshot)).not.toContain("Install version one");
+  });
+
+  it("returns a snapshot, exact deltas, current-generation no-ops, and honest resets", async () => {
+    const feed = createDocsContentChangeFeed();
+    const first = await feed.resolve({
+      pages: pages(1),
+      audience: "agent",
+      baseUrl,
+    });
+    expect(first).toMatchObject({
+      format: "docs-content-changes.v1",
+      audience: "agent",
+      since: null,
+      mode: "snapshot",
+      resetRequired: false,
+      documentCount: 2,
+      counts: { added: 2, changed: 0, deleted: 0 },
+    });
+
+    const unchanged = await feed.resolve({
+      pages: pages(1),
+      audience: "agent",
+      baseUrl,
+      since: first.indexGeneration,
+    });
+    expect(unchanged).toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 0, changed: 0, deleted: 0 },
+      added: [],
+      changed: [],
+      deleted: [],
+    });
+
+    const changed = await feed.resolve({
+      pages: pages(2),
+      audience: "agent",
+      baseUrl,
+      since: first.indexGeneration,
+    });
+    expect(changed).toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      documentCount: 2,
+      counts: { added: 1, changed: 1, deleted: 1 },
+      added: [
+        {
+          canonicalUrl: "https://docs.example.com/docs/added",
+          digest: expect.stringMatching(digestPattern),
+          lastModified: "2026-07-04",
+        },
+      ],
+      changed: [
+        {
+          canonicalUrl: "https://docs.example.com/docs/install",
+          digest: expect.stringMatching(digestPattern),
+          previousDigest: first.added[0]?.digest,
+          lastModified: "2026-07-03",
+          previousLastModified: "2026-07-01",
+        },
+      ],
+      deleted: [
+        {
+          canonicalUrl: "https://docs.example.com/docs/removed",
+          digest: first.added[1]?.digest,
+          lastModified: "2026-07-02",
+        },
+      ],
+    });
+
+    const reset = await feed.resolve({
+      pages: pages(2),
+      audience: "agent",
+      baseUrl,
+      since: `sha256:${"f".repeat(64)}`,
+    });
+    expect(reset).toMatchObject({
+      mode: "reset",
+      resetRequired: true,
+      counts: { added: 2, changed: 0, deleted: 0 },
+    });
+
+    const metadataOnly = pages(2);
+    metadataOnly[0] = { ...metadataOnly[0]!, title: "Install renamed" };
+    const metadataChanged = await feed.resolve({
+      pages: metadataOnly,
+      audience: "agent",
+      baseUrl,
+      since: changed.indexGeneration,
+    });
+    expect(metadataChanged).toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 0, changed: 1, deleted: 0 },
+      changed: [{ canonicalUrl: "https://docs.example.com/docs/install" }],
+    });
+  });
+
+  it("loads and saves snapshots for exact cross-deployment deltas", async () => {
+    const snapshots = new Map<string, DocsContentSnapshot>();
+    const saveSnapshot = vi.fn((snapshot: DocsContentSnapshot) => {
+      snapshots.set(snapshot.indexGeneration, structuredClone(snapshot));
+    });
+    const firstFeed = createDocsContentChangeFeed({ saveSnapshot });
+    const first = await firstFeed.resolve({
+      pages: pages(1),
+      audience: "agent",
+      baseUrl,
+    });
+    expect(saveSnapshot).toHaveBeenCalledTimes(1);
+
+    const loadSnapshot = vi.fn((generation: string) => snapshots.get(generation));
+    const nextFeed = createDocsContentChangeFeed({ loadSnapshot, saveSnapshot });
+    const next = await nextFeed.resolve({
+      pages: pages(2),
+      audience: "agent",
+      baseUrl,
+      since: first.indexGeneration,
+    });
+    expect(loadSnapshot).toHaveBeenCalledWith(
+      first.indexGeneration,
+      expect.objectContaining({ audience: "agent", baseUrl }),
+    );
+    expect(next).toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 1, changed: 1, deleted: 1 },
+    });
+  });
+
+  it("validates configuration and request parameters", () => {
+    expect(resolveDocsContentChangesConfig()).toMatchObject({
+      enabled: true,
+      maxSnapshots: 8,
+    });
+    expect(resolveDocsContentChangesConfig(false).enabled).toBe(false);
+    expect(resolveDocsContentChangesConfig(true, { staticExport: true }).enabled).toBe(false);
+    expect(resolveDocsContentChangesConfig({ maxSnapshots: 100 }).maxSnapshots).toBe(8);
+    expect(
+      resolveDocsContentChangesRequest(
+        new URL(
+          `https://docs.example.com/api/docs?response=changes&audience=human&since=sha256:${"a".repeat(64)}`,
+        ),
+      ),
+    ).toEqual({
+      audience: "human",
+      since: `sha256:${"a".repeat(64)}`,
+    });
+    expect(() =>
+      resolveDocsContentChangesRequest(
+        new URL("https://docs.example.com/api/docs?response=changes&audience=robot"),
+      ),
+    ).toThrow("audience must be");
+    expect(() =>
+      resolveDocsContentChangesRequest(
+        new URL("https://docs.example.com/api/docs?response=changes&since=latest"),
+      ),
+    ).toThrow("must be a SHA-256");
+  });
+
+  it("serves cache-aware HTTP responses without document bodies", async () => {
+    const feed = createDocsContentChangeFeed();
+    const request = new Request(
+      "https://docs.example.com/api/docs?response=changes&audience=agent",
+    );
+    const response = await createDocsContentChangesHttpResponse({
+      request,
+      feed,
+      pages: pages(),
+      baseUrl,
+    });
+    const etag = response.headers.get("etag");
+    expect(response.status).toBe(200);
+    expect(etag).toMatch(/^"sha256:[a-f\d]{64}"$/u);
+    expect(response.headers.get("x-docs-index-generation")).toMatch(digestPattern);
+    expect(response.headers.get("cache-control")).toContain("stale-while-revalidate=300");
+    expect(await response.text()).not.toContain("Install version one");
+
+    const notModified = await createDocsContentChangesHttpResponse({
+      request: new Request(request, { headers: { "if-none-match": etag! } }),
+      feed,
+      pages: pages(),
+      baseUrl,
+    });
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe("");
+
+    const head = await createDocsContentChangesHttpResponse({
+      request: new Request(request, { method: "HEAD" }),
+      feed,
+      pages: pages(),
+      baseUrl,
+    });
+    expect(head.status).toBe(200);
+    expect(head.headers.get("x-docs-index-generation")).toBe(
+      response.headers.get("x-docs-index-generation"),
+    );
+    expect(await head.text()).toBe("");
+  });
+});

--- a/packages/docs/src/content-changes.ts
+++ b/packages/docs/src/content-changes.ts
@@ -1,0 +1,360 @@
+import type {
+  DocsAgentContentChangesConfig,
+  DocsContentChangeDocument,
+  DocsContentChangesResponse,
+  DocsContentChangeSnapshotContext,
+  DocsContentChangedDocument,
+  DocsContentSnapshot,
+  DocsContentSnapshotDocument,
+  DocsSearchConfig,
+  DocsSearchSourcePage,
+} from "./types.js";
+import { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
+import { buildDocsContentSnapshot, type BuildDocsContentSnapshotOptions } from "./search.js";
+
+export const DOCS_CONTENT_CHANGES_FORMAT = "docs-content-changes.v1";
+export const DOCS_CONTENT_SNAPSHOT_FORMAT = "docs-content-snapshot.v1";
+export const DOCS_CONTENT_CHANGES_RESPONSE_VALUE = "changes";
+export const DEFAULT_DOCS_CONTENT_CHANGE_SNAPSHOTS = 8;
+const MAX_DOCS_CONTENT_CHANGE_SNAPSHOTS = 64;
+const DOCS_RETRIEVAL_DIGEST_PATTERN = /^sha256:[a-f\d]{64}$/u;
+
+export interface DocsContentChangesRequest {
+  audience: "human" | "agent";
+  since?: string;
+}
+
+export interface DocsResolvedContentChangesConfig {
+  enabled: boolean;
+  maxSnapshots: number;
+  loadSnapshot?: DocsAgentContentChangesConfig["loadSnapshot"];
+  saveSnapshot?: DocsAgentContentChangesConfig["saveSnapshot"];
+}
+
+export interface ResolveDocsContentChangesOptions extends Omit<
+  BuildDocsContentSnapshotOptions,
+  "pages"
+> {
+  pages: readonly DocsSearchSourcePage[];
+  since?: string;
+  request?: Request;
+}
+
+export interface DocsContentChangeFeed {
+  resolve(options: ResolveDocsContentChangesOptions): Promise<DocsContentChangesResponse>;
+}
+
+export class DocsContentChangesRequestError extends Error {
+  readonly code = "invalid_content_changes_request";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DocsContentChangesRequestError";
+  }
+}
+
+export function resolveDocsContentChangesConfig(
+  input?: boolean | DocsAgentContentChangesConfig,
+  options: { staticExport?: boolean } = {},
+): DocsResolvedContentChangesConfig {
+  const configured = input && typeof input === "object" ? input : undefined;
+  const enabled = !options.staticExport && input !== false && configured?.enabled !== false;
+  const requestedMax = configured?.maxSnapshots ?? DEFAULT_DOCS_CONTENT_CHANGE_SNAPSHOTS;
+  const maxSnapshots =
+    Number.isSafeInteger(requestedMax) &&
+    requestedMax >= 1 &&
+    requestedMax <= MAX_DOCS_CONTENT_CHANGE_SNAPSHOTS
+      ? requestedMax
+      : DEFAULT_DOCS_CONTENT_CHANGE_SNAPSHOTS;
+  return {
+    enabled,
+    maxSnapshots,
+    ...(configured?.loadSnapshot ? { loadSnapshot: configured.loadSnapshot } : {}),
+    ...(configured?.saveSnapshot ? { saveSnapshot: configured.saveSnapshot } : {}),
+  };
+}
+
+export function isDocsContentChangesRequest(url: URL): boolean {
+  return url.searchParams.get("response") === DOCS_CONTENT_CHANGES_RESPONSE_VALUE;
+}
+
+export function resolveDocsContentChangesRequest(url: URL): DocsContentChangesRequest {
+  if (!isDocsContentChangesRequest(url)) {
+    throw new DocsContentChangesRequestError("Content changes require `response=changes`.");
+  }
+  const rawAudience = url.searchParams.get("audience");
+  if (rawAudience !== null && rawAudience !== "human" && rawAudience !== "agent") {
+    throw new DocsContentChangesRequestError("Content-change audience must be `human` or `agent`.");
+  }
+  const since = url.searchParams.get("since") ?? undefined;
+  if (since !== undefined && !DOCS_RETRIEVAL_DIGEST_PATTERN.test(since)) {
+    throw new DocsContentChangesRequestError(
+      "Content-change `since` must be a SHA-256 index generation.",
+    );
+  }
+  return {
+    audience: rawAudience ?? "agent",
+    ...(since ? { since } : {}),
+  };
+}
+
+function snapshotScope(snapshot: DocsContentSnapshot): string {
+  return JSON.stringify({
+    audience: snapshot.audience,
+    locale: snapshot.locale,
+    baseUrl: snapshot.baseUrl,
+  });
+}
+
+function snapshotKey(snapshot: DocsContentSnapshot): string {
+  return `${snapshotScope(snapshot)}\0${snapshot.indexGeneration}`;
+}
+
+function snapshotContext(
+  snapshot: DocsContentSnapshot,
+  request?: Request,
+): DocsContentChangeSnapshotContext {
+  return {
+    audience: snapshot.audience,
+    ...(snapshot.locale ? { locale: snapshot.locale } : {}),
+    ...(snapshot.baseUrl ? { baseUrl: snapshot.baseUrl } : {}),
+    ...(request ? { request } : {}),
+  };
+}
+
+function isSnapshotDocument(value: unknown): value is DocsContentSnapshotDocument {
+  if (!value || typeof value !== "object") return false;
+  const document = value as Partial<DocsContentSnapshotDocument>;
+  return (
+    typeof document.url === "string" &&
+    document.url.length > 0 &&
+    typeof document.canonicalUrl === "string" &&
+    isDocsRetrievalCanonicalUrl(document.canonicalUrl) &&
+    typeof document.digest === "string" &&
+    DOCS_RETRIEVAL_DIGEST_PATTERN.test(document.digest) &&
+    (document.lastModified === undefined ||
+      (typeof document.lastModified === "string" &&
+        Number.isFinite(Date.parse(document.lastModified))))
+  );
+}
+
+function validateLoadedSnapshot(
+  value: DocsContentSnapshot,
+  generation: string,
+  current: DocsContentSnapshot,
+): DocsContentSnapshot {
+  if (
+    value.format !== DOCS_CONTENT_SNAPSHOT_FORMAT ||
+    value.indexGeneration !== generation ||
+    !DOCS_RETRIEVAL_DIGEST_PATTERN.test(value.indexGeneration) ||
+    snapshotScope(value) !== snapshotScope(current) ||
+    !Array.isArray(value.documents) ||
+    !value.documents.every(isSnapshotDocument)
+  ) {
+    throw new TypeError("Content-change snapshot storage returned an invalid snapshot.");
+  }
+  const documents = value.documents.map((document) => ({ ...document }));
+  documents.sort((left, right) =>
+    left.canonicalUrl === right.canonicalUrl
+      ? left.url.localeCompare(right.url)
+      : left.canonicalUrl.localeCompare(right.canonicalUrl),
+  );
+  if (
+    documents.some(
+      (document, index) =>
+        index > 0 && documents[index - 1]?.canonicalUrl === document.canonicalUrl,
+    )
+  ) {
+    throw new TypeError("Content-change snapshot storage returned duplicate canonical URLs.");
+  }
+  return { ...value, documents };
+}
+
+function asChangeDocument(document: DocsContentSnapshotDocument): DocsContentChangeDocument {
+  return { ...document };
+}
+
+function buildDelta(
+  current: DocsContentSnapshot,
+  previous: DocsContentSnapshot | undefined,
+  since: string | undefined,
+): DocsContentChangesResponse {
+  const currentByUrl = new Map(
+    current.documents.map((document) => [document.canonicalUrl, document]),
+  );
+  const previousByUrl = new Map(
+    previous?.documents.map((document) => [document.canonicalUrl, document]) ?? [],
+  );
+  const added: DocsContentChangeDocument[] = [];
+  const changed: DocsContentChangedDocument[] = [];
+  const deleted: DocsContentChangeDocument[] = [];
+
+  if (!since || !previous) {
+    added.push(...current.documents.map(asChangeDocument));
+  } else {
+    for (const document of current.documents) {
+      const old = previousByUrl.get(document.canonicalUrl);
+      if (!old) {
+        added.push(asChangeDocument(document));
+      } else if (
+        old.digest !== document.digest ||
+        old.lastModified !== document.lastModified ||
+        old.url !== document.url
+      ) {
+        changed.push({
+          ...asChangeDocument(document),
+          previousDigest: old.digest,
+          ...(old.lastModified ? { previousLastModified: old.lastModified } : {}),
+        });
+      }
+    }
+    for (const document of previous.documents) {
+      if (!currentByUrl.has(document.canonicalUrl)) {
+        deleted.push(asChangeDocument(document));
+      }
+    }
+  }
+
+  const mode = !since ? "snapshot" : previous ? "delta" : "reset";
+  return {
+    format: DOCS_CONTENT_CHANGES_FORMAT,
+    audience: current.audience,
+    ...(current.locale ? { locale: current.locale } : {}),
+    since: since ?? null,
+    indexGeneration: current.indexGeneration,
+    mode,
+    resetRequired: mode === "reset",
+    documentCount: current.documents.length,
+    counts: {
+      added: added.length,
+      changed: changed.length,
+      deleted: deleted.length,
+    },
+    added,
+    changed,
+    deleted,
+  };
+}
+
+export function createDocsContentChangeFeed(
+  input?: boolean | DocsAgentContentChangesConfig,
+): DocsContentChangeFeed {
+  const config = resolveDocsContentChangesConfig(input);
+  const snapshots = new Map<string, DocsContentSnapshot>();
+  const saved = new Set<string>();
+
+  const remember = (snapshot: DocsContentSnapshot) => {
+    const key = snapshotKey(snapshot);
+    snapshots.delete(key);
+    snapshots.set(key, snapshot);
+    while (snapshots.size > config.maxSnapshots) {
+      const oldest = snapshots.keys().next().value as string | undefined;
+      if (!oldest) break;
+      snapshots.delete(oldest);
+      saved.delete(oldest);
+    }
+  };
+
+  return {
+    async resolve(options) {
+      if (!config.enabled) {
+        throw new DocsContentChangesRequestError("Content changes are disabled.");
+      }
+      const current = await buildDocsContentSnapshot(options);
+      const currentKey = snapshotKey(current);
+      let previous: DocsContentSnapshot | undefined;
+
+      if (options.since === current.indexGeneration) {
+        previous = current;
+      } else if (options.since) {
+        const scopedKey = `${snapshotScope(current)}\0${options.since}`;
+        previous = snapshots.get(scopedKey);
+        if (!previous && config.loadSnapshot) {
+          const loaded = await config.loadSnapshot(
+            options.since,
+            snapshotContext(current, options.request),
+          );
+          if (loaded) {
+            previous = validateLoadedSnapshot(loaded, options.since, current);
+            remember(previous);
+          }
+        }
+      }
+
+      remember(current);
+      if (config.saveSnapshot && !saved.has(currentKey)) {
+        await config.saveSnapshot(
+          {
+            ...current,
+            documents: current.documents.map((document) => ({ ...document })),
+          },
+          snapshotContext(current, options.request),
+        );
+        saved.add(currentKey);
+      }
+      return buildDelta(current, previous, options.since);
+    },
+  };
+}
+
+function contentChangesEtag(response: DocsContentChangesResponse): string {
+  return `"${digestDocsRetrievalContent(
+    JSON.stringify([
+      response.format,
+      response.audience,
+      response.locale ?? null,
+      response.since,
+      response.indexGeneration,
+      response.mode,
+    ]),
+  )}"`;
+}
+
+function requestMatchesEtag(request: Request, etag: string): boolean {
+  const header = request.headers.get("if-none-match");
+  if (!header) return false;
+  return header
+    .split(",")
+    .map((value) => value.trim().replace(/^W\//u, ""))
+    .some((value) => value === "*" || value === etag);
+}
+
+export async function createDocsContentChangesHttpResponse(options: {
+  request: Request;
+  feed: DocsContentChangeFeed;
+  pages: readonly DocsSearchSourcePage[];
+  search?: boolean | DocsSearchConfig;
+  locale?: string;
+  baseUrl?: string;
+}): Promise<Response> {
+  let resolved: DocsContentChangesRequest;
+  try {
+    resolved = resolveDocsContentChangesRequest(new URL(options.request.url));
+  } catch (error) {
+    if (!(error instanceof DocsContentChangesRequestError)) throw error;
+    return Response.json({ error: { code: error.code, message: error.message } }, { status: 400 });
+  }
+  const response = await options.feed.resolve({
+    pages: options.pages,
+    search: options.search,
+    audience: resolved.audience,
+    locale: options.locale,
+    baseUrl: options.baseUrl,
+    since: resolved.since,
+    request: options.request,
+  });
+  const etag = contentChangesEtag(response);
+  const headers = {
+    "Cache-Control": "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+    ETag: etag,
+    "X-Docs-Index-Generation": response.indexGeneration,
+    "X-Robots-Tag": "noindex",
+  };
+  if (requestMatchesEtag(options.request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+  if (options.request.method.toUpperCase() === "HEAD") {
+    return new Response(null, { headers });
+  }
+  return Response.json(response, { headers });
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -345,6 +345,7 @@ export type {
   DocsRobotsRenderOptions,
 } from "./robots.js";
 export {
+  buildDocsContentSnapshot,
   buildDocsSearchDocuments,
   buildDocsSearchFacets,
   buildDocsRetrievalDigestProjection,
@@ -371,10 +372,28 @@ export {
 } from "./search.js";
 export { DocsPaginationCursorError } from "./pagination.js";
 export type {
+  BuildDocsContentSnapshotOptions,
   BuildDocsSearchFacetsOptions,
   EnrichDocsSearchDocumentsWithProvenanceOptions,
   PerformDocsSearchOptions,
 } from "./search.js";
+export {
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
+  DOCS_CONTENT_CHANGES_FORMAT,
+  DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
+  DOCS_CONTENT_SNAPSHOT_FORMAT,
+  isDocsContentChangesRequest,
+  resolveDocsContentChangesConfig,
+  resolveDocsContentChangesRequest,
+  DocsContentChangesRequestError,
+} from "./content-changes.js";
+export type {
+  DocsContentChangeFeed,
+  DocsContentChangesRequest,
+  DocsResolvedContentChangesConfig,
+  ResolveDocsContentChangesOptions,
+} from "./content-changes.js";
 export type { GeneratedAgentProvenance, GeneratedAgentSourceKind } from "./agent-provenance.js";
 export type {
   DocsConfig,
@@ -402,6 +421,7 @@ export type {
   DocsMcpSecurityConfig,
   DocsMcpToolsConfig,
   DocsAgentConfig,
+  DocsAgentContentChangesConfig,
   DocsAgentA2AApiKeySecurityScheme,
   DocsAgentA2ACapabilities,
   DocsAgentA2AConfig,
@@ -518,6 +538,14 @@ export type {
   DocsSearchQuery,
   DocsSearchRequest,
   DocsPaginatedSearchResponse,
+  DocsContentChangeDocument,
+  DocsContentChangedDocument,
+  DocsContentChangesResponse,
+  DocsContentChangeSnapshotContext,
+  DocsContentChangeSnapshotLoader,
+  DocsContentChangeSnapshotSaver,
+  DocsContentSnapshot,
+  DocsContentSnapshotDocument,
   DocsRetrievalSourceProvenance,
   DocsRetrievalSourceScope,
   DocsSearchResult,

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -683,9 +683,49 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
     path: "agent",
     name: "agent",
     type: "DocsAgentConfig",
-    description: "Agent compaction defaults and offline-by-default usefulness evaluations.",
+    description:
+      "Agent synchronization, reusable skills, compaction defaults, and offline-by-default usefulness evaluations.",
     docs: "/docs/getting-started/agent-ready-docs",
     children: [
+      {
+        path: "agent.contentChanges",
+        name: "contentChanges",
+        type: "boolean | DocsAgentContentChangesConfig",
+        default: true,
+        description:
+          "Body-free runtime document synchronization feed. Disable it with false, or configure bounded and durable snapshot history.",
+        children: [
+          {
+            path: "agent.contentChanges.enabled",
+            name: "enabled",
+            type: "boolean",
+            default: true,
+            description: "Whether runtime adapters serve response=changes.",
+          },
+          {
+            path: "agent.contentChanges.maxSnapshots",
+            name: "maxSnapshots",
+            type: "number",
+            default: 8,
+            description:
+              "Metadata-only snapshots retained in this server process; accepted range is 1 through 64.",
+          },
+          {
+            path: "agent.contentChanges.loadSnapshot",
+            name: "loadSnapshot",
+            type: "DocsContentChangeSnapshotLoader",
+            description:
+              "Optional callback that loads a prior generation from durable storage for exact cross-deployment deltas.",
+          },
+          {
+            path: "agent.contentChanges.saveSnapshot",
+            name: "saveSnapshot",
+            type: "DocsContentChangeSnapshotSaver",
+            description:
+              "Optional callback that persists each current metadata snapshot to durable storage.",
+          },
+        ],
+      },
       {
         path: "agent.skills",
         name: "skills",

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -20,6 +20,7 @@ import type {
   DocsSearchSourcePage,
   DocsSearchWarning,
   DocsSearchChunkingConfig,
+  DocsContentSnapshot,
   DocsRetrievalSourceProvenance,
   DocsRetrievalSourceScope,
   McpDocsSearchConfig,
@@ -1418,6 +1419,93 @@ async function buildDocsSearchIndexGeneration(
       sources,
     }),
   );
+}
+
+export interface BuildDocsContentSnapshotOptions {
+  pages: readonly DocsSearchSourcePage[];
+  search?: boolean | DocsSearchConfig;
+  audience?: DocsContentAudience;
+  locale?: string;
+  baseUrl?: string;
+  /** @internal Precomputed complete-corpus generation for composed callers. */
+  indexGeneration?: string;
+}
+
+/**
+ * Build a deterministic, body-free inventory for content-change synchronization.
+ *
+ * Its generation is identical to structured search for the same pages, audience,
+ * locale, base URL, and chunking policy.
+ */
+export async function buildDocsContentSnapshot(
+  options: BuildDocsContentSnapshotOptions,
+): Promise<DocsContentSnapshot> {
+  const audience = resolveDocsSearchAudience(options.audience);
+  const search = normalizeDocsSearchConfig(options.search);
+  const digestCache = new Map<DocsSearchSourcePage, string>();
+  const indexGeneration =
+    options.indexGeneration ??
+    (await buildDocsSearchIndexGeneration(options.pages, {
+      audience,
+      chunking: search.chunking,
+      locale: options.locale,
+      baseUrl: options.baseUrl,
+      digestCache,
+    }));
+  const documents = await Promise.all(
+    options.pages.map(async (page) => {
+      const localizedPage = localizeDocsSearchPage(page, options.locale);
+      const source = await buildDocsRetrievalSource(page, localizedPage.url, {
+        audience,
+        chunking: search.chunking,
+        locale: options.locale,
+        baseUrl: options.baseUrl,
+        indexGeneration,
+        digestCache,
+      });
+      const canonicalUrl = source.canonicalUrl.split("#", 1)[0]!;
+      return {
+        url: localizedPage.url,
+        canonicalUrl,
+        // Cover every page-level input that can change a fetched document.
+        // source.digest remains the independently verifiable body projection.
+        digest: hashDocsRetrievalValue(
+          JSON.stringify({
+            format: "docs-content-document.v1",
+            url: localizedPage.url,
+            canonicalUrl,
+            title: localizedPage.title,
+            description: localizedPage.description,
+            type: localizedPage.type,
+            scope: source.scope,
+            lastModified: source.lastModified,
+            sourceDigest: source.digest,
+          }),
+        ),
+        ...(source.lastModified ? { lastModified: source.lastModified } : {}),
+      };
+    }),
+  );
+  documents.sort((left, right) => {
+    const canonical = compareSearchMetadataValues(left.canonicalUrl, right.canonicalUrl);
+    return canonical !== 0 ? canonical : compareSearchMetadataValues(left.url, right.url);
+  });
+  for (let index = 1; index < documents.length; index += 1) {
+    if (documents[index - 1]?.canonicalUrl === documents[index]?.canonicalUrl) {
+      throw new DocsSearchRequestError(
+        `Content-change snapshots require unique canonical URLs; duplicate: ${documents[index]!.canonicalUrl}`,
+      );
+    }
+  }
+
+  return {
+    format: "docs-content-snapshot.v1",
+    audience,
+    ...(options.locale ? { locale: normalizeAgentLocale(options.locale) } : {}),
+    ...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
+    indexGeneration,
+    documents,
+  };
 }
 
 async function buildDocsRetrievalSource(

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -69,6 +69,7 @@ export type {
 } from "./docs-cloud-server.js";
 export type { DocsCloudAskAIConfig, DocsCloudAskAIResponseOptions } from "./cloud-ask-ai.js";
 export {
+  buildDocsContentSnapshot,
   buildDocsSearchDocuments,
   buildDocsRetrievalDigestProjection,
   buildDocsAskAIContext,
@@ -94,9 +95,27 @@ export {
 } from "./search.js";
 export { DocsPaginationCursorError } from "./pagination.js";
 export type {
+  BuildDocsContentSnapshotOptions,
   EnrichDocsSearchDocumentsWithProvenanceOptions,
   PerformDocsSearchOptions,
 } from "./search.js";
+export {
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
+  DOCS_CONTENT_CHANGES_FORMAT,
+  DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
+  DOCS_CONTENT_SNAPSHOT_FORMAT,
+  isDocsContentChangesRequest,
+  resolveDocsContentChangesConfig,
+  resolveDocsContentChangesRequest,
+  DocsContentChangesRequestError,
+} from "./content-changes.js";
+export type {
+  DocsContentChangeFeed,
+  DocsContentChangesRequest,
+  DocsResolvedContentChangesConfig,
+  ResolveDocsContentChangesOptions,
+} from "./content-changes.js";
 export { runDocsGoldenTasks } from "./agent-evals.js";
 export {
   resolveConfiguredAgentSkills,
@@ -219,6 +238,15 @@ export type {
   DocsSearchQuery,
   DocsSearchRequest,
   DocsPaginatedSearchResponse,
+  DocsContentChangeDocument,
+  DocsAgentContentChangesConfig,
+  DocsContentChangedDocument,
+  DocsContentChangesResponse,
+  DocsContentChangeSnapshotContext,
+  DocsContentChangeSnapshotLoader,
+  DocsContentChangeSnapshotSaver,
+  DocsContentSnapshot,
+  DocsContentSnapshotDocument,
   DocsRetrievalSourceProvenance,
   DocsRetrievalSourceScope,
   DocsSearchResult,

--- a/packages/docs/src/telemetry.test.ts
+++ b/packages/docs/src/telemetry.test.ts
@@ -337,6 +337,7 @@ describe("telemetry", () => {
       }),
     ).toMatchObject({
       search: true,
+      contentChanges: false,
       ai: true,
       mcp: true,
       pageActions: true,
@@ -348,6 +349,13 @@ describe("telemetry", () => {
   });
 
   it("classifies agent-facing request surfaces", () => {
+    expect(
+      inferDocsTelemetryAgentSurface(
+        new Request("https://example.com/api/docs?audience=agent&response=changes"),
+        { entry: "docs" },
+      ),
+    ).toBe("content_changes");
+
     expect(
       inferDocsTelemetryAgentSurface(new Request("https://example.com/api/docs?format=skill"), {
         entry: "docs",

--- a/packages/docs/src/telemetry.ts
+++ b/packages/docs/src/telemetry.ts
@@ -9,6 +9,7 @@ import {
   resolveDocsMarkdownRequest,
   resolveDocsSkillFormat,
 } from "./agent.js";
+import { isDocsContentChangesRequest, resolveDocsContentChangesConfig } from "./content-changes.js";
 import type {
   DocsConfig,
   DocsTelemetryAgentSurface,
@@ -312,6 +313,9 @@ export function getDocsTelemetryFeatures(config: Partial<DocsConfig>): DocsTelem
 
   return {
     search: isObjectConfigEnabled(config.search, true),
+    contentChanges: resolveDocsContentChangesConfig(config.agent?.contentChanges, {
+      staticExport: config.staticExport === true,
+    }).enabled,
     ai: isObjectConfigEnabled(config.ai, false),
     mcp: isObjectConfigEnabled(config.mcp, true),
     llmsTxt: isObjectConfigEnabled(config.llmsTxt, true),
@@ -553,6 +557,10 @@ export function inferDocsTelemetryAgentSurface(
   }
 
   if (method === "GET" || method === "HEAD") {
+    if (isDocsContentChangesRequest(url)) {
+      return "content_changes";
+    }
+
     if (isDocsAgentsRequest(url) || resolveDocsAgentsFormat(url) === "agents") {
       return "agents";
     }

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -976,6 +976,7 @@ export type DocsTelemetryAgentSurface =
   | "llms"
   | "agent_feedback_schema"
   | "agent_feedback_submit"
+  | "content_changes"
   | "ask_ai"
   | "mcp";
 
@@ -999,6 +1000,7 @@ export interface DocsTelemetryConfig {
 
 export interface DocsTelemetryFeatures {
   search: boolean;
+  contentChanges: boolean;
   ai: boolean;
   mcp: boolean;
   llmsTxt: boolean;
@@ -1573,6 +1575,81 @@ export interface DocsRetrievalSourceProvenance {
   digest: string;
   indexGeneration: string;
 }
+
+/** One canonical document in a content-change snapshot. */
+export interface DocsContentSnapshotDocument {
+  /** Framework route that produced this canonical document. */
+  url: string;
+  canonicalUrl: string;
+  /** SHA-256 of the body digest plus fetch-relevant page metadata. */
+  digest: string;
+  lastModified?: string;
+}
+
+/**
+ * Serializable content inventory stored by the optional durable change-feed callbacks.
+ *
+ * The snapshot contains metadata only, never document bodies.
+ */
+export interface DocsContentSnapshot {
+  format: "docs-content-snapshot.v1";
+  audience: "human" | "agent";
+  locale?: string;
+  baseUrl?: string;
+  indexGeneration: string;
+  documents: DocsContentSnapshotDocument[];
+}
+
+/** Added or removed document metadata in a content-change response. */
+export type DocsContentChangeDocument = DocsContentSnapshotDocument;
+
+/** Changed document metadata, including the immediately compared prior digest. */
+export interface DocsContentChangedDocument extends DocsContentChangeDocument {
+  previousDigest: string;
+  previousLastModified?: string;
+}
+
+/**
+ * Body-free synchronization response for documentation agents.
+ *
+ * `resetRequired` is explicit because a bare SHA-256 generation cannot reconstruct
+ * history that was never retained by this process or a configured durable store.
+ */
+export interface DocsContentChangesResponse {
+  format: "docs-content-changes.v1";
+  audience: "human" | "agent";
+  locale?: string;
+  since: string | null;
+  indexGeneration: string;
+  mode: "snapshot" | "delta" | "reset";
+  resetRequired: boolean;
+  documentCount: number;
+  counts: {
+    added: number;
+    changed: number;
+    deleted: number;
+  };
+  added: DocsContentChangeDocument[];
+  changed: DocsContentChangedDocument[];
+  deleted: DocsContentChangeDocument[];
+}
+
+export interface DocsContentChangeSnapshotContext {
+  audience: "human" | "agent";
+  locale?: string;
+  baseUrl?: string;
+  request?: Request;
+}
+
+export type DocsContentChangeSnapshotLoader = (
+  generation: string,
+  context: DocsContentChangeSnapshotContext,
+) => DocsContentSnapshot | null | undefined | Promise<DocsContentSnapshot | null | undefined>;
+
+export type DocsContentChangeSnapshotSaver = (
+  snapshot: DocsContentSnapshot,
+  context: DocsContentChangeSnapshotContext,
+) => void | Promise<void>;
 
 export interface DocsSearchDocument {
   id: string;
@@ -3336,8 +3413,25 @@ export interface DocsAgentConfig {
   evaluations?: boolean | DocsAgentEvaluationsConfig;
   /** Publish reusable Agent Skills through standards discovery, static exports, and MCP. */
   skills?: DocsAgentSkillsInput;
+  /**
+   * Body-free document synchronization feed. Enabled for runtime adapters by default.
+   *
+   * Configure snapshot callbacks when exact deltas must survive server restarts or deployments.
+   */
+  contentChanges?: boolean | DocsAgentContentChangesConfig;
   /** Opt in to an A2A Agent Card for a separately implemented A2A service. */
   a2a?: DocsAgentA2AConfig;
+}
+
+export interface DocsAgentContentChangesConfig {
+  /** Disable the runtime content-change endpoint. @default true */
+  enabled?: boolean;
+  /** Number of metadata-only snapshots retained in this server process. @default 8 */
+  maxSnapshots?: number;
+  /** Load an older snapshot from a durable store for exact cross-deployment deltas. */
+  loadSnapshot?: DocsContentChangeSnapshotLoader;
+  /** Persist the current snapshot to a durable store. */
+  saveSnapshot?: DocsContentChangeSnapshotSaver;
 }
 
 export type DocsReviewSeverity = "off" | "suggestion" | "warn" | "error";

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -724,6 +724,85 @@ Welcome to the docs.
     expect(payload.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
 
+  it("serves a body-free content change feed with generations and HTTP validators", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-content-changes-route-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      join(rootDir, "app", "docs", "page.mdx"),
+      `---
+title: "Introduction"
+---
+
+# Introduction
+
+Welcome to the docs.
+`,
+    );
+
+    process.chdir(rootDir);
+    const { GET, HEAD } = createDocsAPI({ entry: "docs" });
+    const url = "https://docs.example.com/api/docs?audience=agent&response=changes";
+    const firstResponse = await GET(new Request(url));
+    const first = (await firstResponse.json()) as {
+      format: string;
+      mode: string;
+      resetRequired: boolean;
+      indexGeneration: string;
+      documentCount: number;
+      added: Array<{ canonicalUrl: string; digest: string; content?: string }>;
+    };
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.headers.get("etag")).toMatch(/^"sha256:[a-f0-9]{64}"$/);
+    expect(first).toMatchObject({
+      format: "docs-content-changes.v1",
+      mode: "snapshot",
+      resetRequired: false,
+      documentCount: 1,
+      added: [
+        {
+          canonicalUrl: "https://docs.example.com/docs",
+          digest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+      ],
+    });
+    expect(first.indexGeneration).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(first.added[0]).not.toHaveProperty("content");
+
+    const nextResponse = await GET(new Request(`${url}&since=${first.indexGeneration}`));
+    await expect(nextResponse.json()).resolves.toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 0, changed: 0, deleted: 0 },
+    });
+
+    const headResponse = await HEAD(new Request(url, { method: "HEAD" }));
+    expect(headResponse.status).toBe(200);
+    expect(await headResponse.text()).toBe("");
+    expect(headResponse.headers.get("x-docs-index-generation")).toBe(first.indexGeneration);
+
+    const notModified = await GET(
+      new Request(url, {
+        headers: { "If-None-Match": firstResponse.headers.get("etag")! },
+      }),
+    );
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe("");
+
+    const staticHandlers = createDocsAPI({ entry: "docs", staticExport: true });
+    const disabled = await staticHandlers.GET(new Request(url));
+    expect(disabled.status).toBe(404);
+    const staticDiscovery = await staticHandlers.GET(
+      new Request("https://docs.example.com/.well-known/agent.json"),
+    );
+    await expect(staticDiscovery.json()).resolves.toMatchObject({
+      capabilities: { contentChanges: false },
+      contentChanges: { enabled: false, endpoint: null },
+    });
+  });
+
   it("uses built-in simple search when no search config is provided", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-default-search-route-"));
     tempDirs.push(rootDir);
@@ -3595,6 +3674,7 @@ description: "Start building quickly"
         queryParam: string;
         localeParam: string;
       };
+      contentChanges: Record<string, unknown>;
       robots: { enabled: boolean; route: string; defaultRoute: string };
       structuredData: Record<string, unknown>;
       skills: {
@@ -3657,6 +3737,7 @@ description: "Start building quickly"
       agentSkillsDiscovery: true,
       mcp: true,
       search: true,
+      contentChanges: true,
       sitemap: true,
       robots: true,
       structuredData: true,
@@ -3680,6 +3761,7 @@ description: "Start building quickly"
       apiCatalogQuery: "/api/docs?format=api-catalog",
       agentSkillsIndex: "/.well-known/agent-skills/index.json",
       openapi: "/api/docs?format=openapi",
+      contentChanges: "/api/docs?audience=agent&response=changes",
     });
     expect(spec.apiCatalog).toEqual({
       enabled: true,
@@ -3691,6 +3773,16 @@ description: "Start building quickly"
     expect(spec.config).toMatchObject({
       format: "docs-config-map.v1",
       endpoint: "/api/docs?format=config",
+    });
+    expect(spec.contentChanges).toMatchObject({
+      enabled: true,
+      endpoint: "/api/docs?audience=agent&response=changes",
+      format: "docs-content-changes.v1",
+      sinceParam: "since",
+      generationField: "indexGeneration",
+      resetRequiredField: "resetRequired",
+      bodyFree: true,
+      etag: true,
     });
     expect(spec.agentContract).toMatchObject({
       enabled: true,
@@ -4168,6 +4260,7 @@ description: "Start building quickly"
       agentSkillsDiscovery: true,
       mcp: false,
       search: false,
+      contentChanges: true,
       sitemap: true,
       robots: true,
       structuredData: true,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -35,6 +35,8 @@ import {
   DOCS_AGENT_MANIFEST_FORMAT,
   DOCS_AGENT_MANIFEST_SCHEMA_URI,
   DOCS_AGENT_MANIFEST_VERSION,
+  DOCS_CONTENT_CHANGES_FORMAT,
+  DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
   getDocsMcpProtectedResourceMetadataRoutes,
   acceptsDocsMarkdown,
   normalizeDocsRelated,
@@ -44,6 +46,8 @@ import {
   resolveChangelogConfig,
   createDocsAgentTraceContext,
   createDocsAgentTraceId,
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsRobotsResponse,
   createDocsMarkdownResponse,
@@ -76,7 +80,9 @@ import {
   DEFAULT_SITEMAP_MD_DOCS_ROUTE,
   resolveDocsSitemapConfig,
   isDocsConfigRequest,
+  isDocsContentChangesRequest,
   isDocsDiagnosticsRequest,
+  resolveDocsContentChangesConfig,
   stripGeneratedAgentProvenance,
 } from "@farming-labs/docs";
 import type {
@@ -323,6 +329,7 @@ interface AgentSpecOptions {
   apiCatalog: boolean;
   i18n: ReturnType<typeof resolveDocsI18n>;
   search?: boolean | DocsSearchConfig;
+  contentChanges?: boolean;
   mcp: ReturnType<typeof resolveDocsMcpConfig>;
   feedback: ResolvedAgentFeedbackConfig;
   llms: LlmsTxtOptions & { enabled: boolean };
@@ -493,6 +500,7 @@ function buildAgentSpec({
   apiCatalog,
   i18n,
   search,
+  contentChanges,
   mcp,
   feedback,
   llms,
@@ -505,6 +513,7 @@ function buildAgentSpec({
   const normalizedEntry = normalizePathSegment(entry) || "docs";
   const localesEnabled = i18n !== null;
   const searchEnabled = isSearchEnabled(search);
+  const contentChangesEnabled = resolveDocsContentChangesConfig(contentChanges).enabled;
   const sitemapConfig = resolveDocsSitemapConfig(sitemap, { baseUrl: llms.baseUrl });
   const robotsEnabled = isRobotsDiscoveryEnabled(robots);
   const llmsSections = resolveDocsLlmsTxtSections(llms);
@@ -547,6 +556,7 @@ function buildAgentSpec({
       skills: true,
       mcp: mcp.enabled,
       search: searchEnabled,
+      contentChanges: contentChangesEnabled,
       sitemap: sitemapConfig.enabled,
       robots: robotsEnabled,
       structuredData: true,
@@ -569,6 +579,11 @@ function buildAgentSpec({
       agentSpecQuery: `${apiRoute}?agent=spec`,
       agents: `${apiRoute}?format=agents`,
       openapi: `${apiRoute}?format=openapi`,
+      ...(contentChangesEnabled
+        ? {
+            contentChanges: `${apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`,
+          }
+        : {}),
       ...(apiCatalog
         ? {
             apiCatalog: DEFAULT_API_CATALOG_ROUTE,
@@ -727,6 +742,25 @@ function buildAgentSpec({
       totalField: "total",
       defaultAudience: "human",
       supportedAudiences: ["human", "agent"],
+    },
+    contentChanges: {
+      enabled: contentChangesEnabled,
+      endpoint: contentChangesEnabled
+        ? `${apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}`
+        : null,
+      method: "GET",
+      audienceParam: "audience",
+      defaultAudience: "agent",
+      supportedAudiences: ["human", "agent"],
+      responseParam: "response",
+      responseValue: DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
+      sinceParam: "since",
+      format: DOCS_CONTENT_CHANGES_FORMAT,
+      generationField: "indexGeneration",
+      resetRequiredField: "resetRequired",
+      modes: ["snapshot", "delta", "reset"],
+      bodyFree: true,
+      etag: true,
     },
     agents: {
       enabled: true,
@@ -2059,6 +2093,7 @@ function renderSkillDocument({
   apiRoute,
   apiCatalog,
   search,
+  contentChanges,
   mcp,
   feedback,
   llms,
@@ -2122,6 +2157,12 @@ function renderSkillDocument({
     lines.push(
       `- Discover valid search filters with ${apiRoute}?audience=agent&response=facets before choosing framework, version, package, or tag values; continue a large field with facet={field}, limit={limit}, and its nextCursor.`,
       `- Search with ${apiRoute}?query={query}&audience=agent&response=structured when you do not know the page; add framework, version, package, or repeated tags filters when scope matters.`,
+    );
+  }
+
+  if (resolveDocsContentChangesConfig(contentChanges).enabled) {
+    lines.push(
+      `- Synchronize changed documents with ${apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}; pass indexGeneration as since on the next request and clear stale state when resetRequired is true.`,
     );
   }
 
@@ -2251,6 +2292,7 @@ function renderAgentsDocument({
   apiRoute,
   apiCatalog,
   search,
+  contentChanges,
   mcp,
   feedback,
   llms,
@@ -2321,6 +2363,12 @@ function renderAgentsDocument({
     lines.push(
       `- Discover valid search filters with ${apiRoute}?audience=agent&response=facets before choosing framework, version, package, or tag values; continue a large field with facet={field}, limit={limit}, and its nextCursor.`,
       `- Search with ${apiRoute}?query={query}&audience=agent&response=structured when the route is unknown; add framework, version, package, or repeated tags filters when scope matters.`,
+    );
+  }
+
+  if (resolveDocsContentChangesConfig(contentChanges).enabled) {
+    lines.push(
+      `- Synchronize changed documents with ${apiRoute}?audience=agent&response=${DOCS_CONTENT_CHANGES_RESPONSE_VALUE}; pass indexGeneration as since on the next request and clear stale state when resetRequired is true.`,
     );
   }
 
@@ -3842,6 +3890,10 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       ? { ...cloudConfig, apiRoute: configuredApiRoute }
       : cloudConfig;
   const searchConfig = options?.search;
+  const contentChangesConfig = resolveDocsContentChangesConfig(options?.agent?.contentChanges, {
+    staticExport: options?.staticExport === true,
+  });
+  const contentChangeFeed = createDocsContentChangeFeed(options?.agent?.contentChanges);
 
   // Read llms.txt config
   const llmsConfig = resolveLlmsTxtConfig(options?.llmsTxt, readLlmsTxtConfig(root));
@@ -3878,6 +3930,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     contentDir,
     telemetry: options?.telemetry,
     search: searchConfig,
+    agent: options?.agent,
     ai: aiConfig as DocsConfig["ai"],
     cloud: effectiveCloudConfig,
     i18n: i18nConfig ?? undefined,
@@ -3909,6 +3962,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   setConfigMapFallback("entry", entry);
   setConfigMapFallback("ai", Object.keys(aiConfig).length > 0 ? aiConfig : undefined);
   setConfigMapFallback("search", searchConfig);
+  setConfigMapFallback("agent", options?.agent);
   setConfigMapFallback("i18n", i18nConfig ?? undefined);
   setConfigMapFallback("mcp", rawMcpConfig);
   setConfigMapFallback("apiReference", apiReferenceConfig);
@@ -4187,6 +4241,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           apiCatalog: apiCatalogEnabled,
           i18n,
           search: searchConfig,
+          contentChanges: contentChangesConfig.enabled,
           mcp: mcpConfig,
           feedback: agentFeedbackConfig,
           llms: llmsConfig,
@@ -4209,6 +4264,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       apiRoute,
       i18n,
       search: searchConfig,
+      contentChanges: contentChangesConfig.enabled,
       mcp: mcpConfig,
       feedback: agentFeedbackConfig,
       llms: llmsConfig,
@@ -4297,6 +4353,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             apiCatalog: apiCatalogEnabled,
             i18n,
             search: searchConfig,
+            contentChanges: contentChangesConfig.enabled,
             mcp: mcpConfig,
             feedback: agentFeedbackConfig,
             llms: llmsConfig,
@@ -4313,6 +4370,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
                   apiCatalog: apiCatalogEnabled,
                   i18n,
                   search: searchConfig,
+                  contentChanges: contentChangesConfig.enabled,
                   mcp: mcpConfig,
                   feedback: agentFeedbackConfig,
                   llms: llmsConfig,
@@ -4333,6 +4391,26 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             },
           },
         );
+      }
+
+      if (isDocsContentChangesRequest(url)) {
+        if (!contentChangesConfig.enabled) {
+          return new Response("Not Found", {
+            status: 404,
+            headers: {
+              "Content-Type": "text/plain; charset=utf-8",
+              "X-Robots-Tag": "noindex",
+            },
+          });
+        }
+        return createDocsContentChangesHttpResponse({
+          request,
+          feed: contentChangeFeed,
+          pages: getIndexes(ctx),
+          search: searchConfig,
+          locale: ctx.locale,
+          baseUrl: markdownMetadataBaseUrl || url.origin,
+        });
       }
 
       if (isApiReferenceOpenApiRequest(url)) {
@@ -4431,6 +4509,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
                   apiRoute: requestApiRoute,
                   apiCatalog: apiCatalogEnabled,
                   search: searchConfig,
+                  contentChanges: contentChangesConfig.enabled,
                   mcp: mcpConfig,
                   feedback: agentFeedbackConfig,
                   llms: llmsConfig,
@@ -4472,6 +4551,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
                   apiCatalog: apiCatalogEnabled,
                   i18n,
                   search: searchConfig,
+                  contentChanges: contentChangesConfig.enabled,
                   mcp: mcpConfig,
                   feedback: agentFeedbackConfig,
                   llms: llmsConfig,

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -25,6 +25,8 @@ import {
   buildDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -41,6 +43,7 @@ import {
   getDocsAgentManifestLinkHeader,
   getDocsDiscoveryLinkHeader,
   isDocsAgentDiscoveryRequest,
+  isDocsContentChangesRequest,
   isDocsConfigRequest,
   isDocsLlmsTxtPublicRequest,
   isDocsMcpRequest,
@@ -73,6 +76,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
+  resolveDocsContentChangesConfig,
   resolveDocsRequestApiRoute,
   resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
@@ -894,6 +898,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
   const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
+  const contentChangesConfig = resolveDocsContentChangesConfig(config.agent?.contentChanges, {
+    staticExport: config.staticExport === true,
+  });
+  const contentChangeFeed = createDocsContentChangeFeed(config.agent?.contentChanges);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1001,6 +1009,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       apiCatalog: apiCatalogEnabled,
       i18n,
       search: config.search,
+      contentChanges: contentChangesConfig.enabled,
       mcp: mcpConfig,
       feedback: agentFeedbackDiscovery,
       llms: {
@@ -1123,6 +1132,23 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isDocsContentChangesRequest(url)) {
+      if (!contentChangesConfig.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8", "X-Robots-Tag": "noindex" },
+        });
+      }
+      return createDocsContentChangesHttpResponse({
+        request: context.request,
+        feed: contentChangeFeed,
+        pages: getSearchIndex(ctx),
+        search: config.search,
+        locale: ctx.locale,
+        baseUrl: markdownMetadataBaseUrl || url.origin,
+      });
     }
 
     if (isApiReferenceOpenApiRequest(url)) {

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -38,6 +38,8 @@ import {
   buildDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -54,6 +56,7 @@ import {
   getDocsAgentManifestLinkHeader,
   getDocsDiscoveryLinkHeader,
   isDocsAgentDiscoveryRequest,
+  isDocsContentChangesRequest,
   isDocsAgentsRequest,
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
@@ -83,6 +86,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
+  resolveDocsContentChangesConfig,
   resolveDocsRequestApiRoute,
   resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
@@ -917,6 +921,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
   const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
+  const contentChangesConfig = resolveDocsContentChangesConfig(config.agent?.contentChanges, {
+    staticExport: config.staticExport === true,
+  });
+  const contentChangeFeed = createDocsContentChangeFeed(config.agent?.contentChanges);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -1024,6 +1032,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       apiCatalog: apiCatalogEnabled,
       i18n,
       search: config.search,
+      contentChanges: contentChangesConfig.enabled,
       mcp: mcpConfig,
       feedback: agentFeedbackDiscovery,
       llms: {
@@ -1145,6 +1154,23 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
           },
         },
       );
+    }
+
+    if (isDocsContentChangesRequest(event.url)) {
+      if (!contentChangesConfig.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8", "X-Robots-Tag": "noindex" },
+        });
+      }
+      return createDocsContentChangesHttpResponse({
+        request: event.request,
+        feed: contentChangeFeed,
+        pages: getSearchIndex(ctx),
+        search: config.search,
+        locale: ctx.locale,
+        baseUrl: markdownMetadataBaseUrl || event.url.origin,
+      });
     }
 
     if (isApiReferenceOpenApiRequest(event.url)) {

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -8,6 +8,8 @@ import {
   buildDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
+  createDocsContentChangeFeed,
+  createDocsContentChangesHttpResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -24,6 +26,7 @@ import {
   getDocsAgentManifestLinkHeader,
   getDocsDiscoveryLinkHeader,
   isDocsAgentDiscoveryRequest,
+  isDocsContentChangesRequest,
   isDocsAgentsRequest,
   isDocsConfigRequest,
   isDocsDiagnosticsRequest,
@@ -53,6 +56,7 @@ import {
   resolveDocsLocale,
   resolveDocsMarkdownRequest,
   resolveDocsMetadataBaseUrl,
+  resolveDocsContentChangesConfig,
   resolveDocsRequestApiRoute,
   resolveDocsRetrievalLastModified,
   resolveDocsPublishedAgentSkill,
@@ -872,6 +876,10 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
   const llmsBaseUrl = typeof llmsTxtConfig === "object" ? (llmsTxtConfig.baseUrl ?? "") : "";
   const markdownMetadataBaseUrl = resolveDocsMetadataBaseUrl(config as any);
+  const contentChangesConfig = resolveDocsContentChangesConfig(config.agent?.contentChanges, {
+    staticExport: config.staticExport === true,
+  });
+  const contentChangeFeed = createDocsContentChangeFeed(config.agent?.contentChanges);
   const llmsTitle =
     typeof llmsTxtConfig === "object" ? (llmsTxtConfig.siteTitle ?? llmsSiteTitle) : llmsSiteTitle;
   const llmsDesc = typeof llmsTxtConfig === "object" ? llmsTxtConfig.siteDescription : undefined;
@@ -972,6 +980,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       apiCatalog: apiCatalogEnabled,
       i18n,
       search: config.search,
+      contentChanges: contentChangesConfig.enabled,
       mcp: mcpConfig,
       feedback: agentFeedbackDiscovery,
       llms: {
@@ -1093,6 +1102,23 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
           },
         },
       );
+    }
+
+    if (isDocsContentChangesRequest(url)) {
+      if (!contentChangesConfig.enabled) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: { "Content-Type": "text/plain; charset=utf-8", "X-Robots-Tag": "noindex" },
+        });
+      }
+      return createDocsContentChangesHttpResponse({
+        request: event.request,
+        feed: contentChangeFeed,
+        pages: getSearchIndex(ctx),
+        search: config.search,
+        locale: ctx.locale,
+        baseUrl: markdownMetadataBaseUrl || url.origin,
+      });
     }
 
     if (isApiReferenceOpenApiRequest(url)) {

--- a/website/public/schema/agent-manifest.v2.json
+++ b/website/public/schema/agent-manifest.v2.json
@@ -206,6 +206,9 @@
         "search": {
           "type": "boolean"
         },
+        "contentChanges": {
+          "type": "boolean"
+        },
         "sitemap": {
           "type": "boolean"
         },
@@ -299,6 +302,9 @@
           "$ref": "#/$defs/route"
         },
         "openapi": {
+          "$ref": "#/$defs/route"
+        },
+        "contentChanges": {
           "$ref": "#/$defs/route"
         }
       },
@@ -976,6 +982,81 @@
         "audienceParam",
         "defaultAudience",
         "supportedAudiences"
+      ]
+    },
+    "contentChanges": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "method": {
+          "const": "GET"
+        },
+        "audienceParam": {
+          "const": "audience"
+        },
+        "defaultAudience": {
+          "const": "agent"
+        },
+        "supportedAudiences": {
+          "const": [
+            "human",
+            "agent"
+          ]
+        },
+        "responseParam": {
+          "const": "response"
+        },
+        "responseValue": {
+          "const": "changes"
+        },
+        "sinceParam": {
+          "const": "since"
+        },
+        "format": {
+          "const": "docs-content-changes.v1"
+        },
+        "generationField": {
+          "const": "indexGeneration"
+        },
+        "resetRequiredField": {
+          "const": "resetRequired"
+        },
+        "modes": {
+          "const": [
+            "snapshot",
+            "delta",
+            "reset"
+          ]
+        },
+        "bodyFree": {
+          "const": true
+        },
+        "etag": {
+          "const": true
+        }
+      },
+      "required": [
+        "enabled",
+        "endpoint",
+        "method",
+        "audienceParam",
+        "defaultAudience",
+        "supportedAudiences",
+        "responseParam",
+        "responseValue",
+        "sinceParam",
+        "format",
+        "generationField",
+        "resetRequiredField",
+        "modes",
+        "bodyFree",
+        "etag"
       ]
     },
     "agents": {


### PR DESCRIPTION
## Summary

- add a metadata-only `response=changes` feed so agents can synchronize added, changed, and deleted docs by `indexGeneration`
- return exact deltas when retained history exists and an explicit `resetRequired` snapshot when it does not
- support bounded in-memory history plus optional `loadSnapshot` / `saveSnapshot` callbacks for durable cross-deployment deltas
- expose the feed consistently across Next, TanStack Start, SvelteKit, Astro, and Nuxt discovery, diagnostics, generated agent instructions, config schema, and telemetry
- keep the runtime feed enabled by default, allow `agent.contentChanges: false`, and avoid advertising or serving it in static exports
- add ETag, conditional GET, HEAD parity, body-free digests, manifest schema coverage, and adapter conformance tests

## Validation

- `pnpm test` — 1,272 tests passed
- `pnpm --filter "./packages/*" --if-present run test` — all workspace package tests passed
- `pnpm typecheck` — all package typechecks passed
- `pnpm format:check`
- `pnpm lint` — passes with existing repository warnings only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata-only agent content change feed (`response=changes`) so agents can sync added, changed, and deleted docs using stable generations and cache-friendly responses. Enabled by default at runtime across `@farming-labs/docs` adapters and `@farming-labs/fumadocs`, and not advertised or served in static exports.

- New Features
  - New GET `/api/docs?audience=agent&response=changes` returning `docs-content-changes.v1` with modes: `snapshot`, `delta`, and `reset`.
  - Body-free responses with counts and document metadata (canonicalUrl, digest, lastModified); no content bodies.
  - Uses the same `indexGeneration` as structured search for the same projection; pass `since` to receive precise deltas.
  - HTTP caching: strong ETag, conditional GET (304), HEAD parity, `X-Docs-Index-Generation` header.
  - Config: `agent.contentChanges` (default true); `maxSnapshots` (1–64, default 8); optional `loadSnapshot`/`saveSnapshot` for durable cross-deployment deltas.
  - Discovery and docs: manifest adds `capabilities.contentChanges` and a `contentChanges` block; diagnostics, generated agent instructions, and telemetry updated.
  - Adapter coverage across Astro, SvelteKit, TanStack Start, Nuxt, and Next via `@farming-labs/fumadocs`; conformance, schema, and telemetry tests included.

- Migration
  - No breaking changes. To disable, set `agent.contentChanges: false`.
  - For exact deltas across restarts/deployments, implement `agent.contentChanges.loadSnapshot` and `saveSnapshot`.
  - Static exports remain unchanged: the feed is not advertised and returns 404.

<sup>Written for commit 2cf955901a23b2d1d6eb947daaa3cd6c536f8c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

