### PR TITLE
fix: avoid same-server MCP search loopback

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -1378,7 +1378,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const searchOptions = {
       pages: getSearchIndex(ctx),
       query: query ?? "",
-      search: resolveSearchRequestConfig(config.search, context.request.url),
+      search: resolveSearchRequestConfig(config.search, context.request.url, {
+        localMcp: config.mcp,
+      }),
       audience,
       filters,
       locale: ctx.locale,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -368,12 +368,16 @@ export {
   resolveDocsSearchRequest,
   resolveDocsRetrievalLastModified,
   resolveAskAISearchRequestConfig,
+  resolveLocalDocsMcpSearchConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
 export { DocsPaginationCursorError } from "./pagination.js";
 export type {
   BuildDocsContentSnapshotOptions,
   BuildDocsSearchFacetsOptions,
+  DocsLocalMcpSearchRuntimeConfig,
+  DocsLocalMcpSearchRuntimeInput,
+  DocsSearchRequestResolutionOptions,
   EnrichDocsSearchDocumentsWithProvenanceOptions,
   PerformDocsSearchOptions,
 } from "./search.js";

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -5067,7 +5067,38 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
     expect(wrongFacet.result?.content?.[0]?.text).toContain("Invalid or stale pagination cursor");
   });
 
-  it("falls back to simple search for self-referential MCP search configs", async () => {
+  it.each([
+    {
+      label: "canonical route",
+      endpoint: "/api/docs/mcp",
+      route: "/api/docs/mcp",
+      requestUrl: "http://localhost/api/docs/mcp",
+    },
+    {
+      label: "public alias",
+      endpoint: "/mcp",
+      route: "/api/docs/mcp",
+      requestUrl: "http://localhost/mcp",
+    },
+    {
+      label: "well-known alias",
+      endpoint: "/.well-known/mcp",
+      route: "/api/docs/mcp",
+      requestUrl: "http://localhost/.well-known/mcp",
+    },
+    {
+      label: "custom route",
+      endpoint: "/internal/docs/mcp",
+      route: "/internal/docs/mcp",
+      requestUrl: "http://localhost/internal/docs/mcp",
+    },
+    {
+      label: "absolute same-origin alias",
+      endpoint: "http://localhost/mcp",
+      route: "/api/docs/mcp",
+      requestUrl: "http://localhost/api/docs/mcp",
+    },
+  ])("uses direct simple search for a self-referential MCP $label", async (scenario) => {
     const rootDir = createTempDocsProject();
     const source = createFilesystemDocsMcpSource({
       rootDir,
@@ -5075,13 +5106,16 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
       contentDir: "docs",
       siteTitle: "Example Docs",
     });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("Unexpected loopback MCP request"));
 
     const handlers = createDocsMcpHttpHandler({
       source,
-      mcp: { enabled: true, name: "Example Docs", route: "/api/docs/mcp" },
+      mcp: { enabled: true, name: "Example Docs", route: scenario.route },
       search: {
         provider: "mcp",
-        endpoint: "/api/docs/mcp",
+        endpoint: scenario.endpoint,
         chunking: {
           strategy: "page",
         },
@@ -5089,7 +5123,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
     });
 
     const initializeResponse = await handlers.POST({
-      request: new Request("http://localhost/api/docs/mcp", {
+      request: new Request(scenario.requestUrl, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -5116,7 +5150,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
     expect(sessionId).toBeNull();
 
     const searchResponse = await handlers.POST({
-      request: new Request("http://localhost/api/docs/mcp", {
+      request: new Request(scenario.requestUrl, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -5144,6 +5178,7 @@ ${'export const value = "你好🙂";\n'.repeat(40)}
 
     expect(searchPayload.result?.content?.[0]?.text).toContain("/docs/installation");
     expect(searchPayload.result?.content?.[0]?.text).not.toContain("#quickstart");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("returns JSON-RPC 404 responses when MCP is disabled", async () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -55,6 +55,7 @@ import {
   normalizeDocsSearchFilters,
   performDocsSearch,
   performDocsSearchWithMetadata,
+  resolveLocalDocsMcpSearchConfig,
 } from "./search.js";
 import { isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 import { findDocsMarkdownSection, parseDocsMarkdownSections } from "./markdown-sections.js";
@@ -105,7 +106,6 @@ import type {
   DocsSearchSourcePage,
   DocsTelemetryConfig,
   DocsTelemetryFramework,
-  McpDocsSearchConfig,
   OrderingItem,
   PageAgentFrontmatter,
 } from "./types.js";
@@ -3417,7 +3417,11 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
     defaultName: options.defaultName ?? options.source.siteTitle ?? DEFAULT_MCP_NAME,
     defaultVersion: options.defaultVersion,
   });
-  const toolSearchConfig = resolveMcpToolSearchConfig(options.search, resolved.route);
+  const toolSearchConfig = resolveLocalDocsMcpSearchConfig(
+    options.search,
+    options.mcp,
+    options.requestContext?.request?.url,
+  );
   const protocolScope = stableDocsMcpPaginationScope({
     name: resolved.name,
     version: resolved.version,
@@ -6564,32 +6568,6 @@ function normalizeConfigSchemaToken(value: string): string {
     .replace(/^docs\.config\.?/, "")
     .replace(/[`'"]/g, "")
     .replace(/[_\-\s]+/g, "");
-}
-
-function isSelfMcpSearchEndpoint(search?: boolean | DocsSearchConfig, route?: string): boolean {
-  if (!search || search === true || typeof search !== "object" || search.provider !== "mcp") {
-    return false;
-  }
-
-  const endpoint = (search as McpDocsSearchConfig).endpoint.trim();
-  if (!endpoint.startsWith("/")) return false;
-
-  return normalizeDocsMcpRoute(endpoint) === normalizeDocsMcpRoute(route);
-}
-
-function resolveMcpToolSearchConfig(
-  search: boolean | DocsSearchConfig | undefined,
-  route: string,
-): boolean | DocsSearchConfig | undefined {
-  if (!isSelfMcpSearchEndpoint(search, route)) return search;
-
-  const config = search as McpDocsSearchConfig;
-  return {
-    provider: "simple",
-    enabled: config.enabled,
-    maxResults: config.maxResults,
-    chunking: config.chunking,
-  };
 }
 
 function toAgentContractSummary(value: unknown): DocsMcpAgentContractSummary {

--- a/packages/docs/src/search.test.ts
+++ b/packages/docs/src/search.test.ts
@@ -21,6 +21,7 @@ import {
   performDocsSearchWithMetadata,
   resolveDocsSearchAudience,
   resolveDocsSearchRequest,
+  resolveLocalDocsMcpSearchConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
 import { digestDocsRetrievalContent } from "./retrieval-digest.js";
@@ -1880,6 +1881,79 @@ Run the cobalt provenance marker.
         "https://docs.example.com/api/docs",
       ),
     ).toMatchObject({ forwardAudience: false });
+  });
+
+  it.each([
+    ["/api/docs/mcp", undefined],
+    ["/mcp", undefined],
+    ["/mcp", null],
+    ["/.well-known/mcp", undefined],
+    ["https://docs.example.com/api/docs/mcp", undefined],
+    ["/internal/docs/mcp", { route: "/internal/docs/mcp" }],
+    ["/mcp", { route: "/internal/docs/mcp" }],
+    ["/.well-known/mcp", { route: "/internal/docs/mcp" }],
+  ])("resolves the local MCP search endpoint %s to direct simple search", (endpoint, localMcp) => {
+    const search = {
+      provider: "mcp" as const,
+      endpoint,
+      maxResults: 7,
+      chunking: { strategy: "page" as const },
+    };
+
+    expect(
+      resolveLocalDocsMcpSearchConfig(
+        search,
+        localMcp,
+        "https://docs.example.com/api/docs?query=install",
+      ),
+    ).toEqual({
+      provider: "simple",
+      enabled: undefined,
+      maxResults: 7,
+      chunking: { strategy: "page" },
+    });
+    expect(
+      resolveSearchRequestConfig(search, "https://docs.example.com/api/docs?query=install", {
+        localMcp,
+      }),
+    ).toEqual({
+      provider: "simple",
+      enabled: undefined,
+      maxResults: 7,
+      chunking: { strategy: "page" },
+    });
+  });
+
+  it("preserves remote, disabled, and custom-tool MCP search providers", () => {
+    const requestUrl = "https://docs.example.com/api/docs?query=install";
+    const remote = {
+      provider: "mcp" as const,
+      endpoint: "https://search.example.com/mcp",
+    };
+    const customTool = {
+      provider: "mcp" as const,
+      endpoint: "/mcp",
+      toolName: "custom_search",
+    };
+
+    expect(resolveSearchRequestConfig(remote, requestUrl, { localMcp: undefined })).toMatchObject({
+      endpoint: "https://search.example.com/mcp",
+      forwardAudience: false,
+    });
+    expect(
+      resolveSearchRequestConfig(customTool, requestUrl, { localMcp: undefined }),
+    ).toMatchObject({
+      endpoint: "https://docs.example.com/mcp",
+      toolName: "custom_search",
+      forwardAudience: false,
+    });
+    expect(
+      resolveSearchRequestConfig({ provider: "mcp", endpoint: "/mcp" }, requestUrl, {
+        localMcp: false,
+      }),
+    ).toMatchObject({
+      endpoint: "https://docs.example.com/mcp",
+    });
   });
 
   it("keeps public search human-only while allowing explicit agent retrieval", async () => {

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -54,6 +54,7 @@ import {
   parseDocsMarkdownSections,
   stripDocsGeneratedAgentContractMarkers,
 } from "./markdown-sections.js";
+import { isDocsMcpResourcePath } from "./mcp-auth.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;
 const MAX_STRUCTURED_SEARCH_LIMIT = 25;
@@ -3294,9 +3295,15 @@ export function createTypesenseSearchAdapter(config: TypesenseDocsSearchConfig):
 export function resolveSearchRequestConfig(
   search: boolean | DocsSearchConfig | undefined,
   requestUrl?: string,
+  options?: DocsSearchRequestResolutionOptions,
 ): boolean | DocsSearchConfig | undefined {
   if (!search || search === true || typeof search !== "object" || search.provider !== "mcp") {
     return search;
+  }
+
+  if (options) {
+    const localSearch = resolveLocalDocsMcpSearchConfig(search, options.localMcp, requestUrl);
+    if (localSearch !== search) return localSearch;
   }
 
   if (!requestUrl) return search;
@@ -3309,6 +3316,96 @@ export function resolveSearchRequestConfig(
     ...search,
     endpoint: resolvedEndpoint.toString(),
     forwardAudience: search.forwardAudience ?? (usesDefaultSearchTool && isSameOrigin),
+  };
+}
+
+export interface DocsLocalMcpSearchRuntimeConfig {
+  enabled?: boolean;
+  route?: string;
+  tools?: {
+    searchDocs?: boolean;
+  };
+}
+
+export type DocsLocalMcpSearchRuntimeInput =
+  | boolean
+  | DocsLocalMcpSearchRuntimeConfig
+  | null
+  | undefined;
+
+export interface DocsSearchRequestResolutionOptions {
+  /**
+   * The built-in MCP server colocated with this search handler. When the configured
+   * provider points at one of its local aliases, search runs directly instead of
+   * performing a loopback MCP handshake.
+   */
+  localMcp?: DocsLocalMcpSearchRuntimeInput;
+}
+
+function isLocalDocsMcpSearchEndpoint(
+  search: McpDocsSearchConfig,
+  localMcp: DocsLocalMcpSearchRuntimeInput,
+  requestUrl?: string,
+): boolean {
+  if (
+    localMcp === false ||
+    (localMcp !== null &&
+      typeof localMcp === "object" &&
+      (localMcp.enabled === false || localMcp.tools?.searchDocs === false)) ||
+    (search.toolName ?? "search_docs") !== "search_docs"
+  ) {
+    return false;
+  }
+
+  const endpoint = search.endpoint.trim();
+  if (!endpoint) return false;
+
+  const route = localMcp !== null && typeof localMcp === "object" ? localMcp.route : undefined;
+  let endpointPath: string;
+
+  try {
+    if (endpoint.startsWith("/") && !endpoint.startsWith("//")) {
+      endpointPath = new URL(endpoint, "https://local.docs.invalid").pathname;
+    } else {
+      if (!requestUrl) return false;
+      const request = new URL(requestUrl);
+      const resolvedEndpoint = new URL(endpoint, request);
+      if (
+        resolvedEndpoint.origin !== request.origin ||
+        resolvedEndpoint.username ||
+        resolvedEndpoint.password
+      ) {
+        return false;
+      }
+      endpointPath = resolvedEndpoint.pathname;
+    }
+  } catch {
+    return false;
+  }
+
+  return isDocsMcpResourcePath(endpointPath, route);
+}
+
+export function resolveLocalDocsMcpSearchConfig(
+  search: boolean | DocsSearchConfig | undefined,
+  localMcp: DocsLocalMcpSearchRuntimeInput,
+  requestUrl?: string,
+): boolean | DocsSearchConfig | undefined {
+  if (
+    !search ||
+    search === true ||
+    typeof search !== "object" ||
+    search.provider !== "mcp" ||
+    !isLocalDocsMcpSearchEndpoint(search, localMcp, requestUrl)
+  ) {
+    return search;
+  }
+
+  return {
+    provider: "simple",
+    enabled: search.enabled,
+    maxResults: search.maxResults,
+    chunking: search.chunking,
   };
 }
 

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -94,11 +94,15 @@ export {
   resolveDocsSearchRequest,
   resolveDocsRetrievalLastModified,
   resolveAskAISearchRequestConfig,
+  resolveLocalDocsMcpSearchConfig,
   resolveSearchRequestConfig,
 } from "./search.js";
 export { DocsPaginationCursorError } from "./pagination.js";
 export type {
   BuildDocsContentSnapshotOptions,
+  DocsLocalMcpSearchRuntimeConfig,
+  DocsLocalMcpSearchRuntimeInput,
+  DocsSearchRequestResolutionOptions,
   EnrichDocsSearchDocumentsWithProvenanceOptions,
   PerformDocsSearchOptions,
 } from "./search.js";

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -5287,7 +5287,7 @@ Search from process cwd docs files.
     expect(payload.some((result) => result.content.includes("Overview"))).toBe(true);
   });
 
-  it("routes GET search through an MCP search provider with a relative endpoint", async () => {
+  it("routes GET search through a non-local MCP search provider with a relative endpoint", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-mcp-search-route-"));
     tempDirs.push(rootDir);
 
@@ -5370,7 +5370,7 @@ Welcome to the docs.
         entry: "docs",
         search: {
           provider: "mcp",
-          endpoint: "/api/docs/mcp",
+          endpoint: "/external/search/mcp",
         },
       });
 
@@ -5395,8 +5395,12 @@ Welcome to the docs.
         },
       ]);
 
-      expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe("http://localhost/api/docs/mcp");
-      expect(vi.mocked(globalThis.fetch).mock.calls[2]?.[0]).toBe("http://localhost/api/docs/mcp");
+      expect(vi.mocked(globalThis.fetch).mock.calls[0]?.[0]).toBe(
+        "http://localhost/external/search/mcp",
+      );
+      expect(vi.mocked(globalThis.fetch).mock.calls[2]?.[0]).toBe(
+        "http://localhost/external/search/mcp",
+      );
       expect(
         JSON.parse(String(vi.mocked(globalThis.fetch).mock.calls[2]?.[1]?.body)),
       ).toMatchObject({
@@ -5407,6 +5411,66 @@ Welcome to the docs.
       vi.restoreAllMocks();
     }
   });
+
+  it.each([
+    { endpoint: "/api/docs/mcp", mcp: undefined },
+    { endpoint: "/mcp", mcp: undefined },
+    { endpoint: "/.well-known/mcp", mcp: undefined },
+    { endpoint: "/internal/docs/mcp", mcp: { route: "/internal/docs/mcp" } },
+  ])(
+    "keeps GET search in-process for the local MCP endpoint $endpoint",
+    async ({ endpoint, mcp }) => {
+      const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-local-mcp-search-route-"));
+      tempDirs.push(rootDir);
+
+      mkdirSync(join(rootDir, "app", "docs", "installation"), { recursive: true });
+      writeFileSync(
+        join(rootDir, "app", "docs", "installation", "page.mdx"),
+        `---
+title: "Installation"
+---
+
+# Installation
+
+Install the framework with the local MCP search alias.
+`,
+      );
+
+      process.chdir(rootDir);
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("Unexpected loopback MCP request"));
+
+      try {
+        const { GET } = createDocsAPI({
+          entry: "docs",
+          mcp,
+          search: {
+            provider: "mcp",
+            endpoint,
+          },
+        });
+
+        const response = await GET(new Request("http://localhost/api/docs?query=framework"));
+        const payload = (await response.json()) as Array<{
+          url: string;
+          content: string;
+        }>;
+
+        expect(payload).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              url: expect.stringContaining("/docs/installation"),
+              content: expect.stringContaining("Installation"),
+            }),
+          ]),
+        );
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.restoreAllMocks();
+      }
+    },
+  );
 
   it.each([
     {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -4781,7 +4781,9 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       const searchOptions = {
         pages: getIndexes(ctx),
         query: query ?? "",
-        search: resolveSearchRequestConfig(searchConfig, request.url),
+        search: resolveSearchRequestConfig(searchConfig, request.url, {
+          localMcp: rawMcpConfig,
+        }),
         audience,
         filters,
         locale: ctx.locale,

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -1368,7 +1368,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const searchOptions = {
       pages: getSearchIndex(ctx),
       query: query ?? "",
-      search: resolveSearchRequestConfig(config.search, context.request.url),
+      search: resolveSearchRequestConfig(config.search, context.request.url, {
+        localMcp: config.mcp,
+      }),
       audience,
       filters,
       locale: ctx.locale,

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -1390,7 +1390,9 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const searchOptions = {
       pages: getSearchIndex(ctx),
       query: query ?? "",
-      search: resolveSearchRequestConfig(config.search, event.request.url),
+      search: resolveSearchRequestConfig(config.search, event.request.url, {
+        localMcp: config.mcp,
+      }),
       audience,
       filters,
       locale: ctx.locale,

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -1338,7 +1338,9 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const searchOptions = {
       pages: getSearchIndex(ctx),
       query: query ?? "",
-      search: resolveSearchRequestConfig(config.search, event.request.url),
+      search: resolveSearchRequestConfig(config.search, event.request.url, {
+        localMcp: config.mcp,
+      }),
       audience,
       filters,
       locale: ctx.locale,


### PR DESCRIPTION
## What changed

- recognize `/api/docs/mcp`, `/mcp`, and `/.well-known/mcp` as aliases for the same colocated MCP server
- recognize configured custom MCP routes and absolute same-origin aliases
- run the built-in `search_docs` implementation directly for local MCP search instead of performing an HTTP MCP initialize/call/cleanup loop
- apply the same resolution across Next/Fumadocs, TanStack Start, SvelteKit, Astro, and Nuxt
- preserve normal HTTP behavior for remote MCP providers and custom MCP tool names

## Root cause

Public search resolved a relative local MCP endpoint into an absolute same-origin URL before invoking the MCP adapter. That caused a full loopback MCP handshake and another serverless invocation even though the MCP `search_docs` tool ultimately used the same in-process docs index. The MCP-side guard also compared only one exact route, so it did not model the public and well-known aliases as one server.

## Impact

Default local MCP-backed search no longer pays the nested HTTP and cold-start cost. Human and agent search keep their existing audience projections and result shapes, while remote MCP search remains unchanged.

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run src/search.test.ts src/mcp.test.ts` — 212 passed
- `pnpm --filter @farming-labs/theme exec vitest run src/docs-api.test.ts` — 76 passed
- `pnpm --filter @farming-labs/docs test` — 1,288 passed
- Next — 119 passed
- Nuxt — 34 passed
- Astro — 12 passed
- SvelteKit — 11 passed
- TanStack Start — 4 passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` — 0 errors (43 existing warnings)
- `pnpm test:smoke-agent-surfaces` — 24 passed, 1 intentionally skipped


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents same-origin MCP search from looping back through HTTP. Local MCP endpoints now run in-process search, cutting latency and cold starts while leaving remote MCP behavior unchanged.

- **Bug Fixes**
  - Detect and treat `/api/docs/mcp`, `/mcp`, `/.well-known/mcp`, custom routes, and absolute same-origin URLs as local MCP aliases.
  - For local MCP endpoints, bypass MCP handshake and use the simple in-process search path; remote providers and custom MCP tool names are preserved.
  - Apply the fix across Astro, SvelteKit, Nuxt, TanStack Start, and `@farming-labs/fumadocs` by passing `localMcp` into `resolveSearchRequestConfig`; add `resolveLocalDocsMcpSearchConfig` and tests.

<sup>Written for commit c43708cc96b64ec0fc7233f9cb7529478498f8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

