### PR TITLE
feat: hydrate MCP content changes

### DIFF
--- a/packages/docs/src/content-change-hydration.test.ts
+++ b/packages/docs/src/content-change-hydration.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+import { createDocsContentChangeFeed } from "./content-changes.js";
+import {
+  DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+  hydrateDocsContentChanges,
+} from "./content-change-hydration.js";
+import type { DocsContentChangeHydrationResponse } from "./content-change-hydration.js";
+import type { DocsSearchSourcePage } from "./types.js";
+
+const baseUrl = "https://docs.example.com";
+const digestPattern = /^sha256:[a-f\d]{64}$/u;
+
+function initialPages(): DocsSearchSourcePage[] {
+  return [
+    {
+      title: "Stable",
+      url: "/docs/stable",
+      content: "Stable content.",
+      rawContent: "# Stable\n\nStable content.",
+    },
+    {
+      title: "Install",
+      url: "/docs/install",
+      content: "Old install content.",
+      rawContent: "# Install\n\nOld install content.",
+      lastmod: "2026-07-01",
+    },
+    {
+      title: "Removed",
+      url: "/docs/removed",
+      content: "Removed content.",
+      rawContent: "# Removed\n\nRemoved content.",
+      lastmod: "2026-07-02",
+    },
+  ];
+}
+
+function currentPages(): DocsSearchSourcePage[] {
+  return [
+    initialPages()[0]!,
+    {
+      title: "Install",
+      url: "/docs/install",
+      content: "Updated install content.",
+      rawContent: [
+        "# Install",
+        "",
+        "Run the updated installer with the recommended package manager and verify every file.",
+        "",
+        "## Verify",
+        "",
+        "Check that the generated configuration exists and the development server starts.",
+      ].join("\n"),
+      lastmod: "2026-07-03",
+    },
+    {
+      title: "Added",
+      url: "/docs/added",
+      content: "Newly added content.",
+      rawContent: "# Added\n\nNewly added content for agents.",
+      lastmod: "2026-07-04",
+    },
+  ];
+}
+
+async function buildDelta() {
+  const feed = createDocsContentChangeFeed();
+  const first = await feed.resolve({
+    pages: initialPages(),
+    audience: "agent",
+    baseUrl,
+  });
+  const changes = await feed.resolve({
+    pages: currentPages(),
+    audience: "agent",
+    baseUrl,
+    since: first.indexGeneration,
+  });
+  return { feed, first, changes };
+}
+
+describe("content-change hydration", () => {
+  it("returns only changed section content and deletion tombstones under a cursor budget", async () => {
+    const { first, changes } = await buildDelta();
+    const responses: DocsContentChangeHydrationResponse[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const response = hydrateDocsContentChanges({
+        changes,
+        pages: currentPages(),
+        since: first.indexGeneration,
+        tokenBudget: 64,
+        cursor,
+        cursorScope: "test-server",
+      });
+      responses.push(response);
+      cursor = response.nextCursor;
+    } while (cursor);
+
+    expect(responses.length).toBeGreaterThan(1);
+    expect(responses[0]).toMatchObject({
+      format: DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+      audience: "agent",
+      since: first.indexGeneration,
+      indexGeneration: changes.indexGeneration,
+      mode: "delta",
+      resetRequired: false,
+      counts: { added: 1, changed: 1, deleted: 1 },
+      budget: {
+        requestedTokens: 64,
+        strategy: "utf8-bytes",
+        maxUtf8Bytes: 64,
+      },
+    });
+    expect(responses.every((response) => response.budget.usedUtf8Bytes <= 64)).toBe(true);
+    expect(responses.at(-1)?.hasMore).toBe(false);
+    expect(responses.at(-1)?.nextCursor).toBeUndefined();
+
+    const content = responses.flatMap((response) => response.content);
+    const tombstones = responses.flatMap((response) => response.tombstones);
+    expect(content.length + tombstones.length).toBe(responses[0]?.total);
+    expect(new Set(content.map((item) => item.canonicalUrl))).toEqual(
+      new Set(["https://docs.example.com/docs/added", "https://docs.example.com/docs/install"]),
+    );
+    expect(content.some((item) => item.canonicalUrl.endsWith("/stable"))).toBe(false);
+    expect(content.map((item) => item.section.id)).toEqual(
+      expect.arrayContaining(["install", "verify", "added"]),
+    );
+    expect(
+      content.every(
+        (item) =>
+          digestPattern.test(item.digest) &&
+          digestPattern.test(item.sectionDigest) &&
+          digestPattern.test(item.chunkDigest) &&
+          item.utf8Bytes <= 64,
+      ),
+    ).toBe(true);
+    expect(
+      content
+        .filter((item) => item.canonicalUrl.endsWith("/install"))
+        .every(
+          (item) => item.change === "changed" && digestPattern.test(item.previousDigest ?? ""),
+        ),
+    ).toBe(true);
+    expect(tombstones).toEqual([
+      expect.objectContaining({
+        type: "tombstone",
+        change: "deleted",
+        canonicalUrl: "https://docs.example.com/docs/removed",
+        digest: expect.stringMatching(digestPattern),
+      }),
+    ]);
+  });
+
+  it("binds cursors to the prior generation, current generation, locale, and budget", async () => {
+    const { first, changes } = await buildDelta();
+    const page = hydrateDocsContentChanges({
+      changes,
+      pages: currentPages(),
+      since: first.indexGeneration,
+      tokenBudget: 64,
+      cursorScope: "test-server",
+    });
+    expect(page.nextCursor).toBeDefined();
+
+    expect(() =>
+      hydrateDocsContentChanges({
+        changes,
+        pages: currentPages(),
+        since: first.indexGeneration,
+        tokenBudget: 65,
+        cursor: page.nextCursor,
+        cursorScope: "test-server",
+      }),
+    ).toThrow("Invalid or stale pagination cursor");
+    expect(() =>
+      hydrateDocsContentChanges({
+        changes: { ...changes, indexGeneration: `sha256:${"f".repeat(64)}` },
+        pages: currentPages(),
+        since: first.indexGeneration,
+        tokenBudget: 64,
+        cursor: page.nextCursor,
+        cursorScope: "test-server",
+      }),
+    ).toThrow("Invalid or stale pagination cursor");
+    expect(() =>
+      hydrateDocsContentChanges({
+        changes: {
+          ...changes,
+          mode: "reset",
+          resetRequired: true,
+          added: [...changes.added, ...changes.changed],
+          changed: [],
+          deleted: [],
+        },
+        pages: currentPages(),
+        since: first.indexGeneration,
+        tokenBudget: 64,
+        cursor: page.nextCursor,
+        cursorScope: "test-server",
+      }),
+    ).toThrow("Invalid or stale pagination cursor");
+  });
+
+  it("returns empty no-op hydration and marks stale generations as resets", async () => {
+    const { feed, changes } = await buildDelta();
+    const unchanged = await feed.resolve({
+      pages: currentPages(),
+      audience: "agent",
+      baseUrl,
+      since: changes.indexGeneration,
+    });
+    expect(
+      hydrateDocsContentChanges({
+        changes: unchanged,
+        pages: currentPages(),
+        since: changes.indexGeneration,
+        tokenBudget: 500,
+        cursorScope: "test-server",
+      }),
+    ).toMatchObject({
+      mode: "delta",
+      resetRequired: false,
+      resultCount: 0,
+      total: 0,
+      hasMore: false,
+      content: [],
+      tombstones: [],
+    });
+
+    const missingGeneration = `sha256:${"e".repeat(64)}`;
+    const reset = await feed.resolve({
+      pages: currentPages(),
+      audience: "agent",
+      baseUrl,
+      since: missingGeneration,
+    });
+    const hydratedReset = hydrateDocsContentChanges({
+      changes: reset,
+      pages: currentPages(),
+      since: missingGeneration,
+      tokenBudget: 500,
+      cursorScope: "test-server",
+    });
+    expect(hydratedReset).toMatchObject({
+      mode: "reset",
+      resetRequired: true,
+      counts: { added: 3, changed: 0, deleted: 0 },
+      tombstones: [],
+    });
+    expect(hydratedReset.content.length).toBeGreaterThan(0);
+  });
+
+  it("continues safely across multi-byte content without losing chunk boundaries", async () => {
+    const since = `sha256:${"d".repeat(64)}`;
+    const unicodePages: DocsSearchSourcePage[] = [
+      {
+        title: "Emoji",
+        url: "/docs/emoji",
+        content: "🙂🙂",
+        rawContent: "# Emoji\n\n🙂🙂",
+      },
+    ];
+    const changes = await createDocsContentChangeFeed().resolve({
+      pages: unicodePages,
+      audience: "agent",
+      baseUrl,
+      since,
+    });
+    const chunks: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = hydrateDocsContentChanges({
+        changes,
+        pages: unicodePages,
+        since,
+        tokenBudget: 4,
+        cursor,
+        cursorScope: "test-server",
+      });
+      chunks.push(...response.content.map((item) => item.content));
+      cursor = response.nextCursor;
+    } while (cursor);
+
+    expect(chunks.join("")).toBe("# Emoji\n\n🙂🙂");
+  });
+});

--- a/packages/docs/src/content-change-hydration.ts
+++ b/packages/docs/src/content-change-hydration.ts
@@ -1,0 +1,395 @@
+import matter from "gray-matter";
+import { parseDocsMarkdownSections } from "./markdown-sections.js";
+import {
+  createDocsPaginationCursor,
+  DocsPaginationCursorError,
+  resolveDocsPaginationOffset,
+} from "./pagination.js";
+import { digestDocsRetrievalContent } from "./retrieval-digest.js";
+import { buildDocsRetrievalDigestProjection } from "./search.js";
+import type {
+  DocsContentChangeDocument,
+  DocsContentChangedDocument,
+  DocsContentChangesResponse,
+  DocsSearchSourcePage,
+} from "./types.js";
+
+export const DOCS_CONTENT_CHANGE_HYDRATION_FORMAT = "docs-content-change-hydration.v1";
+export const DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET = 5_000;
+export const MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET = 4;
+export const MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET = 32_000;
+const DOCS_CONTENT_CHANGE_HYDRATION_PAGE_SIZE = 25;
+const DOCS_CONTENT_CHANGE_HYDRATION_CURSOR_KIND = "mcp.tool/hydrate_content_changes";
+
+export interface DocsContentChangeHydrationSection {
+  id: string;
+  heading: string;
+  level: number;
+}
+
+export interface DocsContentChangeHydrationContent {
+  type: "content";
+  change: "added" | "changed";
+  url: string;
+  canonicalUrl: string;
+  /** Digest from the body-free document change feed. */
+  digest: string;
+  previousDigest?: string;
+  lastModified?: string;
+  previousLastModified?: string;
+  section: DocsContentChangeHydrationSection;
+  /** Digest of the complete, non-overlapping section before chunking. */
+  sectionDigest: string;
+  /** Digest of the content bytes returned in this chunk. */
+  chunkDigest: string;
+  chunk: {
+    index: number;
+    count: number;
+  };
+  content: string;
+  utf8Bytes: number;
+}
+
+export interface DocsContentChangeHydrationTombstone {
+  type: "tombstone";
+  change: "deleted";
+  url: string;
+  canonicalUrl: string;
+  /** Last known digest for the deleted document. */
+  digest: string;
+  lastModified?: string;
+}
+
+export interface DocsContentChangeHydrationBudget {
+  requestedTokens: number;
+  strategy: "utf8-bytes";
+  maxUtf8Bytes: number;
+  usedUtf8Bytes: number;
+  conservativeTokenUpperBound: number;
+  remainingUtf8Bytes: number;
+}
+
+export interface DocsContentChangeHydrationResponse {
+  format: typeof DOCS_CONTENT_CHANGE_HYDRATION_FORMAT;
+  audience: "agent";
+  locale?: string;
+  since: string;
+  indexGeneration: string;
+  mode: DocsContentChangesResponse["mode"];
+  resetRequired: boolean;
+  documentCount: number;
+  counts: DocsContentChangesResponse["counts"];
+  budget: DocsContentChangeHydrationBudget;
+  resultCount: number;
+  total: number;
+  hasMore: boolean;
+  nextCursor?: string;
+  content: DocsContentChangeHydrationContent[];
+  tombstones: DocsContentChangeHydrationTombstone[];
+}
+
+export interface HydrateDocsContentChangesOptions {
+  changes: DocsContentChangesResponse;
+  pages: readonly DocsSearchSourcePage[];
+  since: string;
+  tokenBudget?: number;
+  cursor?: string;
+  /** Stable MCP server identity mixed into opaque continuation cursors. */
+  cursorScope: string;
+}
+
+type HydrationUnit = DocsContentChangeHydrationContent | DocsContentChangeHydrationTombstone;
+
+interface HydrationSection {
+  id: string;
+  heading: string;
+  level: number;
+  content: string;
+}
+
+function docsHydrationUtf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function appendDocsHydrationLocale(url: string, locale: string | undefined): string {
+  if (!locale) return url;
+  const hashIndex = url.indexOf("#");
+  const withoutHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : "";
+  const queryIndex = withoutHash.indexOf("?");
+  const rawQuery = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : "";
+  if (new URLSearchParams(rawQuery).has("lang")) return url;
+  return `${withoutHash}${queryIndex >= 0 ? "&" : "?"}lang=${encodeURIComponent(locale)}${hash}`;
+}
+
+function splitDocsHydrationChunk(value: string, maxUtf8Bytes: number): [string, string] {
+  if (docsHydrationUtf8Bytes(value) <= maxUtf8Bytes) return [value, ""];
+
+  const encoder = new TextEncoder();
+  let usedUtf8Bytes = 0;
+  let endOffset = 0;
+  let paragraphOffset = -1;
+  let lineOffset = -1;
+  for (const character of value) {
+    const characterUtf8Bytes = encoder.encode(character).byteLength;
+    if (usedUtf8Bytes + characterUtf8Bytes > maxUtf8Bytes) break;
+    usedUtf8Bytes += characterUtf8Bytes;
+    endOffset += character.length;
+    if (value.slice(Math.max(0, endOffset - 2), endOffset) === "\n\n") {
+      paragraphOffset = endOffset;
+    } else if (character === "\n") {
+      lineOffset = endOffset;
+    }
+  }
+
+  const minimumUsefulBoundary = Math.floor(endOffset * 0.5);
+  const boundary =
+    paragraphOffset >= minimumUsefulBoundary
+      ? paragraphOffset
+      : lineOffset >= minimumUsefulBoundary
+        ? lineOffset
+        : endOffset;
+  return [value.slice(0, boundary), value.slice(boundary)];
+}
+
+function splitDocsHydrationContent(value: string, maxUtf8Bytes: number): string[] {
+  if (!value) return [""];
+  const chunks: string[] = [];
+  let remaining = value;
+  while (remaining) {
+    const [chunk, next] = splitDocsHydrationChunk(remaining, maxUtf8Bytes);
+    if (!chunk && next === remaining) {
+      throw new TypeError("Unable to split changed content within the requested token budget.");
+    }
+    chunks.push(chunk);
+    remaining = next;
+  }
+  return chunks;
+}
+
+function partitionDocsHydrationSections(
+  document: string,
+  page: DocsSearchSourcePage,
+): HydrationSection[] {
+  const body = matter(document).content.trim();
+  const parsed = parseDocsMarkdownSections(body);
+  if (parsed.length === 0) {
+    return [{ id: "document", heading: page.title, level: 1, content: body }];
+  }
+
+  const lines = body.split(/\r?\n/u);
+  return parsed.map((section, index) => {
+    const startLine = index === 0 ? 0 : Math.max(0, section.startLine - 1);
+    const nextStartLine = parsed[index + 1]?.startLine;
+    const endLine = nextStartLine ? Math.max(startLine, nextStartLine - 1) : lines.length;
+    return {
+      id: section.anchor,
+      heading: section.title,
+      level: section.level,
+      content: lines.slice(startLine, endLine).join("\n").trim(),
+    };
+  });
+}
+
+function toHydrationContentUnits(
+  change: DocsContentChangeDocument | DocsContentChangedDocument,
+  kind: "added" | "changed",
+  page: DocsSearchSourcePage,
+  maxUtf8Bytes: number,
+): DocsContentChangeHydrationContent[] {
+  const document = buildDocsRetrievalDigestProjection(page, "agent");
+  return partitionDocsHydrationSections(document, page).flatMap((section) => {
+    const sectionDigest = digestDocsRetrievalContent(section.content);
+    const chunks = splitDocsHydrationContent(section.content, maxUtf8Bytes);
+    return chunks.map((content, index) => ({
+      type: "content" as const,
+      change: kind,
+      url: change.url,
+      canonicalUrl: change.canonicalUrl,
+      digest: change.digest,
+      ...("previousDigest" in change ? { previousDigest: change.previousDigest } : {}),
+      ...(change.lastModified ? { lastModified: change.lastModified } : {}),
+      ...("previousLastModified" in change && change.previousLastModified
+        ? { previousLastModified: change.previousLastModified }
+        : {}),
+      section: {
+        id: section.id,
+        heading: section.heading,
+        level: section.level,
+      },
+      sectionDigest,
+      chunkDigest: digestDocsRetrievalContent(content),
+      chunk: {
+        index,
+        count: chunks.length,
+      },
+      content,
+      utf8Bytes: docsHydrationUtf8Bytes(content),
+    }));
+  });
+}
+
+function buildDocsHydrationUnits(
+  changes: DocsContentChangesResponse,
+  pages: readonly DocsSearchSourcePage[],
+  maxUtf8Bytes: number,
+): HydrationUnit[] {
+  const pagesByUrl = new Map<string, DocsSearchSourcePage>();
+  for (const page of pages) {
+    pagesByUrl.set(page.url, page);
+    pagesByUrl.set(appendDocsHydrationLocale(page.url, changes.locale), page);
+  }
+
+  const currentUnits = (
+    [
+      ...changes.added.map((change) => [change, "added"] as const),
+      ...changes.changed.map((change) => [change, "changed"] as const),
+    ] satisfies ReadonlyArray<
+      readonly [DocsContentChangeDocument | DocsContentChangedDocument, "added" | "changed"]
+    >
+  ).flatMap(([change, kind]) => {
+    const page = pagesByUrl.get(change.url);
+    if (!page) {
+      throw new TypeError(`Unable to hydrate changed documentation content for ${change.url}.`);
+    }
+    return toHydrationContentUnits(change, kind, page, maxUtf8Bytes);
+  });
+  const tombstones = changes.deleted.map(
+    (change): DocsContentChangeHydrationTombstone => ({
+      type: "tombstone",
+      change: "deleted",
+      url: change.url,
+      canonicalUrl: change.canonicalUrl,
+      digest: change.digest,
+      ...(change.lastModified ? { lastModified: change.lastModified } : {}),
+    }),
+  );
+  return [...currentUnits, ...tombstones];
+}
+
+function resolveDocsHydrationTokenBudget(value: number | undefined): number {
+  const tokenBudget = value ?? DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET;
+  if (
+    !Number.isSafeInteger(tokenBudget) ||
+    tokenBudget < MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET ||
+    tokenBudget > MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET
+  ) {
+    throw new TypeError(
+      `Content-change hydration tokenBudget must be between ${MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET} and ${MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET}.`,
+    );
+  }
+  return tokenBudget;
+}
+
+/**
+ * Hydrate only the current bodies named by a content-change delta.
+ *
+ * The conservative budget treats one UTF-8 byte as at most one token. Cursors are
+ * bound to the requested generation, current generation, locale, and budget.
+ */
+export function hydrateDocsContentChanges(
+  options: HydrateDocsContentChangesOptions,
+): DocsContentChangeHydrationResponse {
+  if (options.changes.audience !== "agent") {
+    throw new TypeError("MCP content-change hydration requires the agent audience.");
+  }
+  if (options.changes.since !== options.since) {
+    throw new TypeError("Content-change hydration must use the resolved delta generation.");
+  }
+
+  const tokenBudget = resolveDocsHydrationTokenBudget(options.tokenBudget);
+  const units = buildDocsHydrationUnits(options.changes, options.pages, tokenBudget);
+  const hydrationSnapshot = digestDocsRetrievalContent(
+    JSON.stringify({
+      format: DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+      since: options.since,
+      indexGeneration: options.changes.indexGeneration,
+      mode: options.changes.mode,
+      resetRequired: options.changes.resetRequired,
+      units: units.map((unit) =>
+        unit.type === "content"
+          ? {
+              type: unit.type,
+              change: unit.change,
+              canonicalUrl: unit.canonicalUrl,
+              digest: unit.digest,
+              section: unit.section.id,
+              sectionDigest: unit.sectionDigest,
+              chunk: unit.chunk.index,
+              chunkDigest: unit.chunkDigest,
+            }
+          : {
+              type: unit.type,
+              canonicalUrl: unit.canonicalUrl,
+              digest: unit.digest,
+            },
+      ),
+    }),
+  );
+  const paginationOptions = {
+    kind: DOCS_CONTENT_CHANGE_HYDRATION_CURSOR_KIND,
+    scope: JSON.stringify({
+      server: options.cursorScope,
+      since: options.since,
+      locale: options.changes.locale ?? null,
+      tokenBudget,
+    }),
+    snapshot: hydrationSnapshot,
+  };
+  const offset = resolveDocsPaginationOffset(options.cursor, paginationOptions);
+  if (options.cursor !== undefined && offset >= units.length) {
+    throw new DocsPaginationCursorError();
+  }
+
+  const selected: HydrationUnit[] = [];
+  let usedUtf8Bytes = 0;
+  for (
+    let index = offset;
+    index < units.length && selected.length < DOCS_CONTENT_CHANGE_HYDRATION_PAGE_SIZE;
+    index += 1
+  ) {
+    const unit = units[index]!;
+    const unitUtf8Bytes = unit.type === "content" ? unit.utf8Bytes : 0;
+    if (unitUtf8Bytes > 0 && usedUtf8Bytes + unitUtf8Bytes > tokenBudget) break;
+    selected.push(unit);
+    usedUtf8Bytes += unitUtf8Bytes;
+  }
+
+  const nextOffset = offset + selected.length;
+  const hasMore = nextOffset < units.length;
+  const nextCursor = hasMore
+    ? createDocsPaginationCursor(nextOffset, paginationOptions)
+    : undefined;
+  const content = selected.filter(
+    (unit): unit is DocsContentChangeHydrationContent => unit.type === "content",
+  );
+  const tombstones = selected.filter(
+    (unit): unit is DocsContentChangeHydrationTombstone => unit.type === "tombstone",
+  );
+
+  return {
+    format: DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+    audience: "agent",
+    ...(options.changes.locale ? { locale: options.changes.locale } : {}),
+    since: options.since,
+    indexGeneration: options.changes.indexGeneration,
+    mode: options.changes.mode,
+    resetRequired: options.changes.resetRequired,
+    documentCount: options.changes.documentCount,
+    counts: { ...options.changes.counts },
+    budget: {
+      requestedTokens: tokenBudget,
+      strategy: "utf8-bytes",
+      maxUtf8Bytes: tokenBudget,
+      usedUtf8Bytes,
+      conservativeTokenUpperBound: usedUtf8Bytes,
+      remainingUtf8Bytes: Math.max(0, tokenBudget - usedUtf8Bytes),
+    },
+    resultCount: selected.length,
+    total: units.length,
+    hasMore,
+    ...(nextCursor ? { nextCursor } : {}),
+    content,
+    tombstones,
+  };
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -399,6 +399,21 @@ export type {
   DocsResolvedContentChangesConfig,
   ResolveDocsContentChangesOptions,
 } from "./content-changes.js";
+export {
+  DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+  hydrateDocsContentChanges,
+  MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+} from "./content-change-hydration.js";
+export type {
+  DocsContentChangeHydrationBudget,
+  DocsContentChangeHydrationContent,
+  DocsContentChangeHydrationResponse,
+  DocsContentChangeHydrationSection,
+  DocsContentChangeHydrationTombstone,
+  HydrateDocsContentChangesOptions,
+} from "./content-change-hydration.js";
 export type { GeneratedAgentProvenance, GeneratedAgentSourceKind } from "./agent-provenance.js";
 export type {
   DocsConfig,

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -174,6 +174,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         searchFacets: true,
         listContentChanges: true,
+        hydrateContentChanges: true,
         getNavigation: true,
         getCodeExamples: true,
         getConfigSchema: true,
@@ -205,6 +206,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         searchFacets: true,
         listContentChanges: true,
+        hydrateContentChanges: true,
         getNavigation: true,
         getCodeExamples: true,
         getConfigSchema: true,
@@ -240,6 +242,7 @@ describe("resolveDocsMcpConfig", () => {
         searchDocs: true,
         searchFacets: true,
         listContentChanges: true,
+        hydrateContentChanges: true,
         getNavigation: true,
         getCodeExamples: true,
         getConfigSchema: true,
@@ -298,6 +301,24 @@ describe("resolveDocsMcpConfig", () => {
         },
       ],
     });
+  });
+
+  it("publishes and resolves the hydrate_content_changes tool toggle", () => {
+    expect(getDocsConfigSchema({ option: "mcp.tools.hydrateContentChanges" })).toMatchObject({
+      resultCount: 1,
+      options: [
+        {
+          path: "mcp.tools.hydrateContentChanges",
+          name: "hydrateContentChanges",
+          type: "boolean",
+          default: true,
+          description: expect.stringContaining("hydrate_content_changes"),
+        },
+      ],
+    });
+    expect(
+      resolveDocsMcpConfig({ tools: { hydrateContentChanges: false } }).tools.hydrateContentChanges,
+    ).toBe(false);
   });
 
   it("resolves custom HTTP security without enabling authentication by default", () => {
@@ -1023,6 +1044,18 @@ describe("MCP content-change synchronization", () => {
         code: -32602,
         message: expect.stringContaining("not found"),
       });
+      const hydrationPayload = await parseMcpPayload<{
+        error?: { code?: number; message?: string };
+      }>(
+        await callMcpTool(handlers, "hydrate_content_changes", {
+          since: `sha256:${"a".repeat(64)}`,
+          tokenBudget: 5_000,
+        }),
+      );
+      expect(hydrationPayload.error).toMatchObject({
+        code: -32602,
+        message: expect.stringContaining("not found"),
+      });
 
       const resourcePayload = await parseMcpPayload<{
         error?: { code?: number; message?: string };
@@ -1132,6 +1165,149 @@ describe("MCP content-change synchronization", () => {
         since: null,
         indexGeneration: second?.indexGeneration,
       });
+    } finally {
+      await handlers.close?.();
+    }
+  });
+
+  it("hydrates changed sections and deletion tombstones with budget cursors", async () => {
+    const pages: DocsMcpPage[] = [
+      {
+        slug: "stable",
+        url: "/docs/stable",
+        title: "Stable",
+        content: "# Stable\n\nStable content.",
+      },
+      {
+        slug: "install",
+        url: "/docs/install",
+        title: "Install",
+        content: "# Install\n\nOld content.",
+      },
+      {
+        slug: "removed",
+        url: "/docs/removed",
+        title: "Removed",
+        content: "# Removed\n\nThis page will be removed.",
+      },
+    ];
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        baseUrl: "https://docs.example.com",
+        getPages: () => pages,
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+
+    try {
+      const firstPayload = await parseMcpPayload<{
+        result?: { structuredContent?: { indexGeneration?: string } };
+      }>(await callMcpTool(handlers, "list_content_changes", {}));
+      const since = firstPayload.result?.structuredContent?.indexGeneration;
+      expect(since).toMatch(/^sha256:/u);
+
+      pages.splice(
+        1,
+        2,
+        {
+          slug: "install",
+          url: "/docs/install",
+          title: "Install",
+          content: [
+            "# Install",
+            "",
+            "Run the updated installer and inspect every generated file before continuing.",
+            "",
+            "## Verify",
+            "",
+            "Start the development server and verify that the documentation route responds.",
+          ].join("\n"),
+        },
+        {
+          slug: "added",
+          url: "/docs/added",
+          title: "Added",
+          content: "# Added\n\nThis page was added.",
+        },
+      );
+
+      const responses: Array<{
+        result?: {
+          isError?: boolean;
+          structuredContent?: {
+            indexGeneration: string;
+            resultCount: number;
+            total: number;
+            hasMore: boolean;
+            nextCursor?: string;
+            budget: { usedUtf8Bytes: number };
+            content: Array<{
+              canonicalUrl: string;
+              digest: string;
+              sectionDigest: string;
+              chunkDigest: string;
+            }>;
+            tombstones: Array<{ canonicalUrl: string; digest: string }>;
+          };
+        };
+      }> = [];
+      let cursor: string | undefined;
+      do {
+        const payload = await parseMcpPayload<(typeof responses)[number]>(
+          await callMcpTool(handlers, "hydrate_content_changes", {
+            since,
+            tokenBudget: 48,
+            ...(cursor ? { cursor } : {}),
+          }),
+        );
+        expect(payload.result?.isError).not.toBe(true);
+        responses.push(payload);
+        cursor = payload.result?.structuredContent?.nextCursor;
+      } while (cursor);
+
+      const results = responses.map((response) => response.result!.structuredContent!);
+      expect(results.length).toBeGreaterThan(1);
+      expect(results.every((result) => result.budget.usedUtf8Bytes <= 48)).toBe(true);
+      expect(results.at(-1)).toMatchObject({ hasMore: false });
+      expect(
+        results.flatMap((result) => result.content).map((item) => item.canonicalUrl),
+      ).not.toContain("https://docs.example.com/docs/stable");
+      expect(
+        new Set(results.flatMap((result) => result.content).map((item) => item.canonicalUrl)),
+      ).toEqual(
+        new Set(["https://docs.example.com/docs/added", "https://docs.example.com/docs/install"]),
+      );
+      expect(results.flatMap((result) => result.tombstones)).toEqual([
+        expect.objectContaining({
+          canonicalUrl: "https://docs.example.com/docs/removed",
+          digest: expect.stringMatching(/^sha256:/u),
+        }),
+      ]);
+      expect(
+        results
+          .flatMap((result) => result.content)
+          .every(
+            (item) =>
+              item.digest.startsWith("sha256:") &&
+              item.sectionDigest.startsWith("sha256:") &&
+              item.chunkDigest.startsWith("sha256:"),
+          ),
+      ).toBe(true);
+
+      const invalidCursor = responses[0]?.result?.structuredContent?.nextCursor;
+      const invalidPayload = await parseMcpPayload<{
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      }>(
+        await callMcpTool(handlers, "hydrate_content_changes", {
+          since,
+          tokenBudget: 49,
+          cursor: invalidCursor,
+        }),
+      );
+      expect(invalidPayload.result?.isError).toBe(true);
+      expect(invalidPayload.result?.content?.[0]?.text).toContain(
+        "Invalid or stale pagination cursor",
+      );
     } finally {
       await handlers.close?.();
     }
@@ -2361,6 +2537,7 @@ sidebar:
         "get_config_schema",
         "get_context",
         "list_content_changes",
+        "hydrate_content_changes",
       ]),
     );
     expect(listedTools).toEqual(
@@ -2378,6 +2555,7 @@ sidebar:
           "get_config_schema",
           "get_context",
           "list_content_changes",
+          "hydrate_content_changes",
         ].map((name) =>
           expect.objectContaining({
             name,

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -67,6 +67,28 @@ import {
   resolveDocsContentChangesConfig,
   type DocsContentChangeFeed,
 } from "./content-changes.js";
+import {
+  DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+  DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  hydrateDocsContentChanges,
+  MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+} from "./content-change-hydration.js";
+export {
+  DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+  hydrateDocsContentChanges,
+  MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+} from "./content-change-hydration.js";
+export type {
+  DocsContentChangeHydrationBudget,
+  DocsContentChangeHydrationContent,
+  DocsContentChangeHydrationResponse,
+  DocsContentChangeHydrationSection,
+  DocsContentChangeHydrationTombstone,
+  HydrateDocsContentChangesOptions,
+} from "./content-change-hydration.js";
 import { resolvePageSidebarFolderIndexBehavior } from "./sidebar.js";
 import type { DocsPublishedAgentSkill } from "./standards-discovery.js";
 import {
@@ -422,6 +444,8 @@ export interface DocsMcpResolvedConfig {
     searchFacets?: boolean;
     /** Optional so manually constructed resolved configs from older releases remain assignable. */
     listContentChanges?: boolean;
+    /** Optional so manually constructed resolved configs from older releases remain assignable. */
+    hydrateContentChanges?: boolean;
     getNavigation: boolean;
     getCodeExamples: boolean;
     getConfigSchema: boolean;
@@ -2118,6 +2142,14 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
               "Expose list_content_changes polling and docs://changes resources when agent.contentChanges is enabled.",
           },
           {
+            path: "mcp.tools.hydrateContentChanges",
+            name: "hydrateContentChanges",
+            type: "boolean",
+            default: true,
+            description:
+              "Expose hydrate_content_changes for budget-aware changed section bodies, deletion tombstones, digests, and continuation cursors.",
+          },
+          {
             path: "mcp.tools.readPage",
             name: "readPage",
             type: "boolean",
@@ -2490,6 +2522,18 @@ const listContentChangesInputSchema = z.object({
   locale: z.string().trim().min(1).max(128).optional(),
 });
 
+const hydrateContentChangesInputSchema = z.object({
+  since: z.string().refine(isDocsContentChangeGeneration, "Expected a SHA-256 index generation"),
+  tokenBudget: z
+    .number()
+    .int()
+    .min(MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET)
+    .max(MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET)
+    .default(DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET),
+  cursor: paginationCursorInputSchema,
+  locale: z.string().trim().min(1).max(128).optional(),
+});
+
 const getConfigSchemaInputSchema = z.object({
   option: z.string().trim().min(1).optional(),
   query: z.string().trim().min(1).optional(),
@@ -2639,6 +2683,55 @@ const contentChangesOutputSchema = z.object({
     }),
   ),
   deleted: z.array(contentChangeDocumentOutputSchema),
+});
+const contentChangeHydrationContentOutputSchema = contentChangeDocumentOutputSchema.extend({
+  type: z.literal("content"),
+  change: z.enum(["added", "changed"]),
+  previousDigest: retrievalSourceDigestOutputSchema.optional(),
+  previousLastModified: z.string().optional(),
+  section: z.object({
+    id: z.string(),
+    heading: z.string(),
+    level: z.number().int().positive(),
+  }),
+  sectionDigest: retrievalSourceDigestOutputSchema,
+  chunkDigest: retrievalSourceDigestOutputSchema,
+  chunk: z.object({
+    index: z.number().int().nonnegative(),
+    count: z.number().int().positive(),
+  }),
+  content: z.string(),
+  utf8Bytes: z.number().int().nonnegative(),
+});
+const contentChangeHydrationTombstoneOutputSchema = contentChangeDocumentOutputSchema.extend({
+  type: z.literal("tombstone"),
+  change: z.literal("deleted"),
+});
+const contentChangeHydrationOutputSchema = z.object({
+  format: z.literal(DOCS_CONTENT_CHANGE_HYDRATION_FORMAT),
+  audience: z.literal("agent"),
+  locale: z.string().optional(),
+  since: retrievalSourceDigestOutputSchema,
+  indexGeneration: retrievalSourceDigestOutputSchema,
+  mode: z.enum(["snapshot", "delta", "reset"]),
+  resetRequired: z.boolean(),
+  documentCount: z.number().int().nonnegative(),
+  counts: z.object({
+    added: z.number().int().nonnegative(),
+    changed: z.number().int().nonnegative(),
+    deleted: z.number().int().nonnegative(),
+  }),
+  budget: z.object({
+    requestedTokens: z.number().int().positive(),
+    strategy: z.literal("utf8-bytes"),
+    maxUtf8Bytes: z.number().int().positive(),
+    usedUtf8Bytes: z.number().int().nonnegative(),
+    conservativeTokenUpperBound: z.number().int().nonnegative(),
+    remainingUtf8Bytes: z.number().int().nonnegative(),
+  }),
+  ...paginationOutputShape,
+  content: z.array(contentChangeHydrationContentOutputSchema),
+  tombstones: z.array(contentChangeHydrationTombstoneOutputSchema),
 });
 const retrievalSourceOutputSchema = z.object({
   canonicalUrl: z
@@ -2890,6 +2983,7 @@ export function resolveDocsMcpConfig(
         searchDocs: true,
         searchFacets: true,
         listContentChanges: true,
+        hydrateContentChanges: true,
         getNavigation: true,
         getCodeExamples: true,
         getConfigSchema: true,
@@ -2916,6 +3010,7 @@ export function resolveDocsMcpConfig(
       searchDocs: config.tools?.searchDocs ?? true,
       searchFacets: config.tools?.searchFacets ?? true,
       listContentChanges: config.tools?.listContentChanges ?? true,
+      hydrateContentChanges: config.tools?.hydrateContentChanges ?? true,
       getNavigation: config.tools?.getNavigation ?? true,
       getCodeExamples: config.tools?.getCodeExamples ?? true,
       getConfigSchema: config.tools?.getConfigSchema ?? true,
@@ -3430,6 +3525,8 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   const contentChangesConfig = resolveDocsContentChangesConfig(options.contentChanges);
   const contentChangesEnabled =
     contentChangesConfig.enabled && resolved.tools.listContentChanges !== false;
+  const contentChangeHydrationEnabled =
+    contentChangesEnabled && resolved.tools.hydrateContentChanges !== false;
   const server = new McpServer({
     name: resolved.name,
     version: resolved.version,
@@ -3501,10 +3598,14 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   const contentChangeFeed =
     options.contentChangeFeed ?? createDocsContentChangeFeed(options.contentChanges);
 
-  async function resolveContentChanges(
+  async function resolveContentChangeState(
     since?: string,
     locale?: string,
-  ): Promise<DocsContentChangesResponse> {
+  ): Promise<{
+    result: DocsContentChangesResponse;
+    pages: DocsMcpPage[];
+    resolvedLocale?: string;
+  }> {
     if (!contentChangesEnabled) {
       throw new ProtocolError(ProtocolErrorCode.MethodNotFound, "Content changes are disabled.");
     }
@@ -3515,11 +3616,12 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
       );
     }
     const resolvedLocale = resolveSourceLocale(locale);
+    const pages = dedupePages(
+      await options.source.getPages(resolvedLocale, options.requestContext),
+    );
     try {
-      return await contentChangeFeed.resolve({
-        pages: toSearchSourcePages(
-          dedupePages(await options.source.getPages(resolvedLocale, options.requestContext)),
-        ),
+      const result = await contentChangeFeed.resolve({
+        pages: toSearchSourcePages(pages),
         search: options.search,
         audience: "agent",
         locale: resolvedLocale,
@@ -3533,12 +3635,24 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           ? { request: options.requestContext.request.clone() }
           : {}),
       });
+      return {
+        result,
+        pages,
+        ...(resolvedLocale ? { resolvedLocale } : {}),
+      };
     } catch (error) {
       if (error instanceof DocsContentChangesRequestError) {
         throw new ProtocolError(ProtocolErrorCode.InvalidParams, error.message);
       }
       throw error;
     }
+  }
+
+  async function resolveContentChanges(
+    since?: string,
+    locale?: string,
+  ): Promise<DocsContentChangesResponse> {
+    return (await resolveContentChangeState(since, locale)).result;
   }
 
   registerResource(
@@ -3658,6 +3772,61 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         return createStructuredTextResult(result);
       },
     );
+
+    if (contentChangeHydrationEnabled) {
+      registerTool(
+        "hydrate_content_changes",
+        {
+          title: "Hydrate docs content changes",
+          description:
+            "Fetch only added and changed agent-facing sections after list_content_changes. Returns deletion tombstones and digest-bound continuation cursors under a conservative token budget.",
+          inputSchema: hydrateContentChangesInputSchema,
+          outputSchema: contentChangeHydrationOutputSchema,
+          annotations: { readOnlyHint: true },
+        },
+        async ({ since, tokenBudget, cursor, locale }) => {
+          const startedAt = nowMs();
+          const state = await resolveContentChangeState(since, locale);
+          let result;
+          try {
+            result = hydrateDocsContentChanges({
+              changes: state.result,
+              pages: state.pages,
+              since,
+              tokenBudget,
+              cursor,
+              cursorScope: protocolScope,
+            });
+          } catch (error) {
+            if (error instanceof DocsPaginationCursorError) {
+              throw new ProtocolError(ProtocolErrorCode.InvalidParams, error.message);
+            }
+            throw error;
+          }
+          trackMcpTool("hydrate_content_changes", {
+            locale: state.resolvedLocale,
+            resultCount: result.resultCount,
+          });
+          await emitDocsAnalyticsEvent(options.analytics, {
+            type: "mcp_tool",
+            source: "mcp",
+            locale: state.resolvedLocale,
+            properties: {
+              tool: "hydrate_content_changes",
+              mode: result.mode,
+              resetRequired: result.resetRequired,
+              resultCount: result.resultCount,
+              total: result.total,
+              hasMore: result.hasMore,
+              tokenBudget,
+              usedUtf8Bytes: result.budget.usedUtf8Bytes,
+              durationMs: durationMs(startedAt),
+            },
+          });
+          return createStructuredTextResult(result);
+        },
+      );
+    }
   }
 
   for (const page of defaultPages) {

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -124,6 +124,21 @@ export type {
   DocsResolvedContentChangesConfig,
   ResolveDocsContentChangesOptions,
 } from "./content-changes.js";
+export {
+  DEFAULT_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  DOCS_CONTENT_CHANGE_HYDRATION_FORMAT,
+  hydrateDocsContentChanges,
+  MAX_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+  MIN_DOCS_CONTENT_CHANGE_HYDRATION_TOKEN_BUDGET,
+} from "./content-change-hydration.js";
+export type {
+  DocsContentChangeHydrationBudget,
+  DocsContentChangeHydrationContent,
+  DocsContentChangeHydrationResponse,
+  DocsContentChangeHydrationSection,
+  DocsContentChangeHydrationTombstone,
+  HydrateDocsContentChangesOptions,
+} from "./content-change-hydration.js";
 export { runDocsGoldenTasks } from "./agent-evals.js";
 export {
   resolveConfiguredAgentSkills,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1382,6 +1382,11 @@ export interface DocsMcpToolsConfig {
   searchFacets?: boolean;
   /** Expose body-free document changes with polling through `list_content_changes`. */
   listContentChanges?: boolean;
+  /**
+   * Expose `hydrate_content_changes` for budget-aware section bodies and deletion
+   * tombstones after polling `list_content_changes`.
+   */
+  hydrateContentChanges?: boolean;
   /** Expose a `get_navigation` tool for the docs tree. */
   getNavigation?: boolean;
   /** Expose a `get_code_examples` tool for fenced code blocks and their metadata. */

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -3938,6 +3938,7 @@ description: "Start building quickly"
         searchDocs: false,
         searchFacets: true,
         listContentChanges: true,
+        hydrateContentChanges: true,
         getNavigation: true,
         getCodeExamples: true,
         getConfigSchema: true,


### PR DESCRIPTION
## Summary

- add a `hydrate_content_changes` MCP tool that composes with `list_content_changes`
- accept `since`, `tokenBudget`, `cursor`, and optional `locale`
- return only agent-facing sections from added or changed documents plus deletion tombstones
- include document, section, and chunk digests with exact chunk metadata
- add conservative UTF-8 budget accounting and opaque continuation cursors
- bind cursors to the server, prior generation, current hydrated unit set, locale, and budget so stale or reset continuations fail safely
- expose an opt-out `mcp.tools.hydrateContentChanges` configuration toggle and public hydration types/constants

## Why

`list_content_changes` intentionally returns metadata only. Agents previously had to fetch every changed page individually and manage their own response budgets. This adds one budget-aware hydration call while preserving the body-free polling contract.

```json
{
  "since": "sha256:...",
  "tokenBudget": 5000,
  "cursor": "..."
}
```

The response contains added/changed section chunks, deletion tombstones, digests, budget usage, `hasMore`, `nextCursor`, and totals. A missing historical snapshot remains an explicit reset.

## Validation

- `pnpm --filter @farming-labs/docs test` — 1,295 tests passed
- `pnpm --dir packages/fumadocs test` — 170 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` — 0 errors; 43 existing warnings
- `pnpm test:smoke-agent-surfaces` — 24 passed, 1 intentional skip
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP tool to hydrate `list_content_changes` into agent-facing section bodies and deletion tombstones with budgeted, cursor-based pagination. This lets agents fetch only changed content under a conservative UTF-8 budget instead of pulling full pages.

- **New Features**
  - New MCP tool `hydrate_content_changes` with input: `since`, `tokenBudget`, `cursor`, optional `locale`.
  - Returns added/changed section chunks and deletion tombstones, plus section/chunk/document digests and exact chunk metadata.
  - Conservative UTF-8 budget accounting with min/max bounds; page size 25; `hasMore` + `nextCursor` for continuation.
  - Opaque cursors bound to server scope, prior generation, current generation, locale, and budget; stale/invalid cursors error safely.
  - Public exports of hydration API, types, constants, and format `docs-content-change-hydration.v1` via `packages/docs/src/index.ts` and `server.ts`.
  - Config toggle `mcp.tools.hydrateContentChanges` (default true) to enable/disable the tool.
  - Comprehensive tests for hydration, cursor safety, multi-byte content, and config/schema wiring.

<sup>Written for commit 66ed47ffcc5e2c1c853acc46a8a23b3dd6a5f779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

