### PR TITLE
fix: close CLI search command fence

### DIFF
--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -246,6 +246,9 @@ Optional:
 TYPESENSE_COLLECTION=docs
 TYPESENSE_MODE=hybrid
 TYPESENSE_OLLAMA_MODEL=embeddinggemma
+TYPESENSE_OLLAMA_BASE_URL=http://127.0.0.1:11434
+```
+
 Optionally scope the synced corpus with a namespace (max 1024 characters). The CLI flag and the environment variable are equivalent:
 
 ```bash title="terminal"
@@ -260,8 +263,6 @@ Pass `--site-url` when you want the sync command to embed a canonical public URL
 
 ```bash title="terminal"
 pnpm dlx @farming-labs/docs search sync --typesense --site-url https://docs.example.com
-```
-TYPESENSE_OLLAMA_BASE_URL=http://127.0.0.1:11434
 ```
 
 Algolia example:


### PR DESCRIPTION
## Summary

- close the optional Typesense environment-variable code fence before the namespace guidance
- keep `TYPESENSE_OLLAMA_BASE_URL` with the other optional environment values
- restore the namespace, site URL, and Algolia examples as independent Markdown/code blocks

## Root cause

The optional Typesense fence remained open while namespace prose and nested fence markers followed it. Static command analysis therefore treated one prose line and one Markdown fence marker as shell commands, while the malformed nesting hid the real Algolia command.

## Command-confidence result

Command confidence is now complete with zero unverified findings. The truthful result is `320/320`, not `321/321`: the old denominator included two non-command Markdown lines and omitted the hidden Algolia command. Closing the fence removes those two false candidates and restores the real command instead of preserving an inflated denominator.

## Validation

- `docs doctor --agent` — `320/320` healthy, 0 unhealthy, 0 unverified
- `docs review --ci --base origin/main --head HEAD` — 100/100, 0 findings, 21/21 golden tasks
- `docs codeblocks validate --plan` — 776 blocks parsed, 0 failures
- fence markers balanced
- `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI docs by closing the optional Typesense env code fence and restoring separate command blocks. This prevents prose from being treated as shell commands and makes command validation accurate.

- **Bug Fixes**
  - Closed the optional Typesense env code fence and kept `TYPESENSE_OLLAMA_BASE_URL` with the other optional env vars.
  - Restored the namespace, `--site-url`, and Algolia examples as separate blocks.
  - Static command analysis now includes the real Algolia command; confidence is 320/320 with zero unverified.

<sup>Written for commit c99ec55c302e3dcb101028c37b4a0673798a083d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

