### PR TITLE
fix: improve website Agent Skill disclosure

### DIFF
--- a/skills/farming-labs/ask-ai/SKILL.md
+++ b/skills/farming-labs/ask-ai/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ask-ai
 description: Configure the Ask AI (RAG-powered AI chat) in @farming-labs/docs. Use when enabling AI chat, setting mode (search vs floating), floatingStyle (panel, modal, popover, full-modal), position, providers, models, suggestedQuestions, apiKey, systemPrompt, maxResults, useMcp, feedback, or onActions. Covers Next.js, TanStack Start, SvelteKit, Astro, Nuxt, and env vars.
+compatibility: Requires a JavaScript or TypeScript project using @farming-labs/docs. Live AI responses require network access, a supported LLM endpoint, and provider credentials.
 ---
 
 # @farming-labs/docs — Ask AI (AI Chat)

--- a/skills/farming-labs/creating-themes/SKILL.md
+++ b/skills/farming-labs/creating-themes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: creating-themes
 description: Create and share a custom theme for @farming-labs/docs. Use when building a theme with createTheme(), extendTheme(), cherry-picking built-in defaults, publishing as npm package, or adding CSS overrides. Covers ui.colors, typography, layout, sidebar, radius, ui.components like HoverLink, and package layout for publishing.
+compatibility: Requires a JavaScript or TypeScript project using @farming-labs/docs and its framework theme package. Publishing a theme requires registry credentials and network access.
 ---
 
 # @farming-labs/docs — Creating and Sharing Themes

--- a/skills/farming-labs/getting-started/SKILL.md
+++ b/skills/farming-labs/getting-started/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: getting-started
 description: Get started with @farming-labs/docs — MDX-based documentation for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt. Use when setting up docs, scaffolding with the CLI, choosing themes, changelog, API reference, or writing docs.config. Covers init, manual setup per framework, theme CSS, defineDocs, changelog, apiReference, entry, contentDir, and common gotchas.
+compatibility: Requires Node.js and npm, pnpm, Yarn, or Bun. Setup targets a supported Next.js, TanStack Start, SvelteKit, Astro, or Nuxt project; scaffolding and package installation require network access.
 ---
 
 # @farming-labs/docs — Getting Started
@@ -119,114 +120,12 @@ TanStack Start, SvelteKit, Astro, and Nuxt require `contentDir` (path to markdow
 
 ---
 
-## API reference quick setup
+## Optional generated pages
 
-`apiReference` generates an API reference from your framework's route handlers or from a hosted
-OpenAPI JSON document.
-
-```ts
-export default defineDocs({
-  entry: "docs",
-  apiReference: {
-    enabled: true,
-    path: "api-reference",
-    routeRoot: "api",
-  },
-  theme: fumadocs(),
-});
-```
-
-Important framework behavior:
-
-- **Next.js**: `withDocs()` auto-generates the `/{path}` route when `apiReference` is enabled.
-- **TanStack Start, SvelteKit, Astro, Nuxt**: `docs.config` controls scanning and theming, but the app still needs the `/{path}` route handler.
-- **CLI**: `init --api-reference` writes the config and scaffolds those handler files for you.
-- **Agents**: `GET /api/docs?format=openapi` serves the machine-readable schema and is advertised through agent discovery, generated `llms.txt`, generated `AGENTS.md`, and generated `skill.md`.
-
-Remote OpenAPI JSON example:
-
-```ts
-export default defineDocs({
-  entry: "docs",
-  apiReference: {
-    enabled: true,
-    path: "api-reference",
-    specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
-  },
-  theme: fumadocs(),
-});
-```
-
-When `specUrl` is set, local route scanning is skipped. On TanStack Start, SvelteKit, Astro, and
-Nuxt you still need the `/{path}` route handler because that route serves the generated API
-reference page.
-
-Minimal handler files for non-Next frameworks:
-
-- **TanStack Start**: `src/routes/api-reference.index.ts` and `src/routes/api-reference.$.ts` using `createTanstackApiReference(config)`
-- **SvelteKit**: `src/routes/api-reference/+server.ts` and `src/routes/api-reference/[...slug]/+server.ts` using `createSvelteApiReference(config)`
-- **Astro**: `src/pages/api-reference/index.ts` and `src/pages/api-reference/[...slug].ts` using `createAstroApiReference(config)`
-- **Nuxt**: `server/routes/api-reference/index.ts` and `server/routes/api-reference/[...slug].ts` using `defineApiReferenceHandler(config)`
-
-Route scan conventions:
-
-- **Next.js**: `app/api/**/route.ts` or `src/app/api/**/route.ts`
-- **TanStack Start**: `src/routes/api.*.ts` and nested route files under the configured route root
-- **SvelteKit**: `src/routes/api/**/+server.ts` or `+server.js`
-- **Astro**: `src/pages/api/**/*.ts` or `.js`
-- **Nuxt**: `server/api/**/*.ts` or `.js`
-
-For the full option surface (`path`, `specUrl`, `routeRoot`, `exclude`), use the
-`configuration` skill.
-
----
-
-## Changelog quick setup
-
-Today, the turn-key generated changelog route flow is available in **Next.js** with
-`@farming-labs/next/config`.
-
-```ts
-export default defineDocs({
-  entry: "docs",
-  changelog: {
-    enabled: true,
-    path: "changelogs",
-    contentDir: "changelog",
-    title: "Changelog",
-    description: "Latest product updates and release notes.",
-    search: true,
-  },
-  theme: fumadocs(),
-});
-```
-
-Default content structure:
-
-```text
-app/docs/changelog/
-  2026-04-15/page.mdx
-  2026-04-03/page.mdx
-```
-
-That publishes:
-
-- `/docs/changelogs`
-- `/docs/changelogs/2026-04-15`
-
-Use entry frontmatter like:
-
-```mdx
----
-title: "OpenAPI mode is now the default"
-description: "The docs example now ships with the faster API reference experience."
-version: "v0.1.13"
-tags: ["api-reference", "next"]
----
-```
-
-When you use `withDocs()`, the route files are generated automatically. There is no separate
-`__changelog.generated.tsx` file to maintain.
+- **API reference:** Read [references/api-reference.md](references/api-reference.md) when enabling
+  local route scanning, a hosted OpenAPI document, or non-Next handler routes.
+- **Changelog:** Read [references/changelog.md](references/changelog.md) when adding the generated
+  Next.js release feed and dated entry pages.
 
 ---
 

--- a/skills/farming-labs/getting-started/references/api-reference.md
+++ b/skills/farming-labs/getting-started/references/api-reference.md
@@ -1,0 +1,63 @@
+# API reference setup
+
+Use this reference when `apiReference` should generate an API reference from framework route
+handlers or a hosted OpenAPI document.
+
+## Local route scanning
+
+```ts
+export default defineDocs({
+  entry: "docs",
+  apiReference: {
+    enabled: true,
+    path: "api-reference",
+    routeRoot: "api",
+  },
+  theme: fumadocs(),
+});
+```
+
+- **Next.js:** `withDocs()` generates the `/{path}` route when `apiReference` is enabled.
+- **TanStack Start, SvelteKit, Astro, Nuxt:** `docs.config` controls scanning and theming, but the
+  app still needs the `/{path}` route handler.
+- **CLI:** `init --api-reference` writes the config and scaffolds required handler files.
+- **Agents:** `GET /api/docs?format=openapi` serves the schema and is advertised through agent
+  discovery, generated `llms.txt`, `AGENTS.md`, and `skill.md`.
+
+Route scanning conventions:
+
+- **Next.js:** `app/api/**/route.ts` or `src/app/api/**/route.ts`
+- **TanStack Start:** `src/routes/api.*.ts` and nested route files under the route root
+- **SvelteKit:** `src/routes/api/**/+server.ts` or `+server.js`
+- **Astro:** `src/pages/api/**/*.ts` or `.js`
+- **Nuxt:** `server/api/**/*.ts` or `.js`
+
+## Hosted OpenAPI
+
+```ts
+export default defineDocs({
+  entry: "docs",
+  apiReference: {
+    enabled: true,
+    path: "api-reference",
+    specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
+  },
+  theme: fumadocs(),
+});
+```
+
+`specUrl` disables local route scanning. TanStack Start, SvelteKit, Astro, and Nuxt still need the
+`/{path}` handler because it serves the generated page.
+
+Minimal non-Next handler files:
+
+- **TanStack Start:** `src/routes/api-reference.index.ts` and
+  `src/routes/api-reference.$.ts` using `createTanstackApiReference(config)`
+- **SvelteKit:** `src/routes/api-reference/+server.ts` and
+  `src/routes/api-reference/[...slug]/+server.ts` using `createSvelteApiReference(config)`
+- **Astro:** `src/pages/api-reference/index.ts` and
+  `src/pages/api-reference/[...slug].ts` using `createAstroApiReference(config)`
+- **Nuxt:** `server/routes/api-reference/index.ts` and
+  `server/routes/api-reference/[...slug].ts` using `defineApiReferenceHandler(config)`
+
+For `path`, `specUrl`, `routeRoot`, and `exclude`, use the `configuration` skill.

--- a/skills/farming-labs/getting-started/references/changelog.md
+++ b/skills/farming-labs/getting-started/references/changelog.md
@@ -1,0 +1,43 @@
+# Changelog setup
+
+Use this reference when adding the generated release feed. The turn-key route flow is currently
+available in Next.js through `@farming-labs/next/config`.
+
+```ts
+export default defineDocs({
+  entry: "docs",
+  changelog: {
+    enabled: true,
+    path: "changelogs",
+    contentDir: "changelog",
+    title: "Changelog",
+    description: "Latest product updates and release notes.",
+    search: true,
+  },
+  theme: fumadocs(),
+});
+```
+
+Default content structure:
+
+```text
+app/docs/changelog/
+  2026-04-15/page.mdx
+  2026-04-03/page.mdx
+```
+
+This publishes `/docs/changelogs` and `/docs/changelogs/2026-04-15`.
+
+Use entry frontmatter such as:
+
+```mdx
+---
+title: "OpenAPI mode is now the default"
+description: "The docs example now ships with the faster API reference experience."
+version: "v0.1.13"
+tags: ["api-reference", "next"]
+---
+```
+
+`withDocs()` generates the route files. Do not maintain a separate
+`__changelog.generated.tsx` file.

--- a/skills/farming-labs/page-actions/SKILL.md
+++ b/skills/farming-labs/page-actions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: page-actions
 description: Configure page actions in @farming-labs/docs — Copy Markdown and Open in LLM buttons. Use when enabling copyMarkdown, openDocs, provider presets, target markdown/page/source/github, prompts, custom urlTemplate placeholders, alignment, or position (above-title, below-title).
+compatibility: Requires a JavaScript or TypeScript project using @farming-labs/docs. Open-in-LLM and source actions require browser access to their configured public URLs.
 ---
 
 # @farming-labs/docs — Page Actions


### PR DESCRIPTION
## Summary

- declare environment compatibility for the four configured skills that require tools or network access
- keep the getting-started activation context compact
- move API reference and changelog variants into direct, focused references

## Why

The website Agent Skill audit reported four missing compatibility declarations and a getting-started instruction body above the configured 5,000-token budget.

## Validation

- `git diff --check`
- `pnpm --dir website exec docs doctor --agent --json --config docs.config.tsx`
- 6/6 Agent Skills pass frontmatter and progressive-disclosure validation
- 21/21 golden tasks pass with a 99.5536 evaluation score

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve website Agent Skill disclosure by adding missing compatibility requirements and trimming the Getting Started skill to stay within the 5,000-token budget. Moved API reference and changelog setup into focused reference docs.

- **Bug Fixes**
  - Added compatibility frontmatter to `ask-ai`, `creating-themes`, `getting-started`, and `page-actions` skills.
  - Split `getting-started` details into `references/api-reference.md` and `references/changelog.md` to keep activation context compact.
  - Validation: 6/6 Agent Skills pass; 21/21 golden tasks pass (99.55).

<sup>Written for commit bb68c1bc08df5f68174051240199f27c6b70b8f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

