### PR TITLE
chore: refresh website agent compaction outputs

### DIFF
--- a/website/app/docs/cli/agent.md
+++ b/website/app/docs/cli/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:794d072d0a443798
+sourceHash=fnv1a64:627607fb4f5451f6
 settingsHash=fnv1a64:e50e89e221226fc3
 outputHash=fnv1a64:2612254b737d2c09
-generatedAt=2026-07-30T09:43:36.421Z
+generatedAt=2026-08-01T13:49:56.427Z
 -->
 # CLI
 

--- a/website/app/docs/reference/agent.md
+++ b/website/app/docs/reference/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:15d10d4a42682400
+sourceHash=fnv1a64:196e9e5dd8fb1f2f
 settingsHash=fnv1a64:aa433a28ef4afd1f
-outputHash=fnv1a64:d4876e8116ad0a3a
-generatedAt=2026-07-30T09:43:36.687Z
+outputHash=fnv1a64:99e9aed8b5d79935
+generatedAt=2026-08-01T13:49:56.427Z
 -->
 # API Reference
 
@@ -42,6 +42,16 @@ SvelteKit or Astro, append `--config src/lib/docs.config.ts`. If TypeScript reje
 shape, first align all `@farming-labs/*` package versions and rename the config to `.tsx` when it
 contains JSX. If diagnostics and public discovery disagree, restore the previous value and repair
 the adapter route or stale static export before enabling the capability again.
+
+## API Reference Agent Skills progressive disclosure
+
+`agent.skills` accepts a path, an array of paths, or an object with `paths` and an optional
+`progressiveDisclosure` policy. Use `maxSkillLines`, `instructionTokenBudget`, and
+`maxReferenceDepth` to bound activated context. Set `compatibility` to `"when-needed"` (default),
+`"always"`, or `"off"`; use `checkScripts` to verify that bundled scripts document dependencies
+and validation. `docs doctor --agent` checks every configured skill, while `docs review` runs the
+same checks when a configured skill, companion file, or docs config changes.
+
 ## API Reference PageAgentFrontmatter fields
 
 `PageAgentFrontmatter` defines `task`, `outcome`, `appliesTo`, `prerequisites`, `verification`, `rollback`, and `failureModes`; each failure mode pairs a `symptom` with its `resolution`.


### PR DESCRIPTION
## Summary

- refresh the CLI compact output provenance after the Markdown fence repair
- refresh the API Reference compact output with the new Agent Skills progressive-disclosure options
- leave the three handwritten in-place agent sources unchanged

## Why

The website agent audit reported two stale generated outputs: `/docs/cli` and `/docs/reference`. The CLI source change was structural and did not change the existing compact guidance; the reference source added new configuration behavior that needed to be included.

## Validation

- `git diff --check`
- `pnpm --dir website exec docs doctor --agent --json --config docs.config.tsx`
- 49 fresh, 0 stale, 0 modified, 3 intentional unknown, and 0 missing compact outputs
- 21/21 golden tasks pass with a 99.5536 evaluation score

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed generated agent docs for CLI and API Reference to match the latest outputs, and documented new Agent Skills progressive disclosure options. CLI guidance stays the same; metadata was regenerated after the Markdown fence fix.

- **New Features**
  - Documented `agent.skills` progressive disclosure: `paths`, `progressiveDisclosure` with `maxSkillLines`, `instructionTokenBudget`, and `maxReferenceDepth`.
  - Clarified `compatibility` (`"when-needed"`, `"always"`, `"off"`) and `checkScripts`, and noted checks via `docs doctor --agent` and `docs review`.

<sup>Written for commit ecd544bfc2a792bbffc26081868fdce248bad25c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

