### PR TITLE
fix: add agent surface cache integrity parity

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -929,7 +929,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
-  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1061,7 +1060,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
-      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1136,7 +1134,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1232,7 +1229,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1251,7 +1247,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1354,7 +1349,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content: selected.content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -40,6 +40,7 @@ import {
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
   createDocsContentChangesHttpResponse,
+  createDocsCacheableResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -928,6 +929,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
+  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1059,6 +1061,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
+      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1115,33 +1118,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : JSON.stringify(
-              buildDocsAgentDiscoverySpec({
-                ...discoveryOptions,
-                publishedSkills: [
-                  await resolveDocsPublishedAgentSkill({
-                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-                  }),
-                  ...(await getPublishedAgentSkills()),
-                ],
-                agentCard: config.agent?.a2a,
-              }),
-              null,
-              2,
-            ),
-        {
-          headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: agentManifestLinkHeader,
-          },
+      const content = `${JSON.stringify(
+        buildDocsAgentDiscoverySpec({
+          ...discoveryOptions,
+          publishedSkills: [
+            await resolveDocsPublishedAgentSkill({
+              preferredDocument: readRootSkillDocument(preloaded, rootDir),
+              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+            }),
+            ...(await getPublishedAgentSkills()),
+          ],
+          agentCard: config.agent?.a2a,
+        }),
+        null,
+        2,
+      )}\n`;
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: agentManifestLinkHeader,
         },
-      );
+      });
     }
 
     if (isDocsContentChangesRequest(url)) {
@@ -1225,40 +1227,38 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       isDocsAgentsRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsAgentsFormat(url) === "agents"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootAgentsDocument(preloaded, rootDir) ??
-              renderDocsAgentsDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     if (
       isDocsSkillRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsSkillFormat(url) === "skill"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootSkillDocument(preloaded, rootDir) ??
-              renderDocsSkillDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     const sitemapResponse = createDocsSitemapResponse({
@@ -1351,7 +1351,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         console.warn(`[docs] ${budgetIssue.message}`);
       }
 
-      return new Response(selected.content, {
+      return createDocsCacheableResponse({
+        request: context.request,
+        content: selected.content,
+        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -258,6 +258,82 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
     expect(await cardHead.text()).toBe("");
   });
 
+  it("applies cache validators and RFC 9530 integrity metadata across agent surfaces", async () => {
+    const { createDocsServer } = await loadCreateDocsServer();
+    const server = createDocsServer({
+      entry: "docs",
+      nav: { title: "Cache Integrity Docs" },
+      mcp: true,
+      agent: {
+        a2a: {
+          name: "Cache integrity agent",
+          description: "Answers questions from the cache integrity documentation.",
+          supportedInterfaces: [{ url: "https://agent.example.com/a2a" }],
+          skills: [
+            {
+              id: "docs",
+              name: "Documentation",
+              description: "Answers questions from the cache integrity documentation.",
+              tags: ["documentation"],
+            },
+          ],
+        },
+      },
+      _preloadedContent: {
+        "/docs/page.md": `---\ntitle: Home\nlastmod: 2026-07-31T12:00:00.000Z\n---\n\n# Home\n\nWelcome.`,
+      },
+    });
+
+    for (const path of [
+      "/docs.md",
+      "/llms.txt",
+      "/.well-known/agent.json",
+      "/.well-known/agent-card.json",
+      "/.well-known/api-catalog",
+      "/.well-known/agent-skills/index.json",
+      "/skill.md",
+    ]) {
+      const url = new URL(path, "https://docs.example.com");
+      const response = await server.GET({ request: new Request(url), url });
+      const content = await response.text();
+      const etag = response.headers.get("etag");
+      const contentDigest = response.headers.get("content-digest");
+      const lastModified = response.headers.get("last-modified");
+
+      expect(response.status, path).toBe(200);
+      expect(etag, path).toMatch(/^"[a-f0-9]{64}"$/u);
+      expect(contentDigest, path).toBe(
+        `sha-256=:${createHash("sha256").update(content, "utf8").digest("base64")}:`,
+      );
+      expect(lastModified, path).toMatch(/ GMT$/u);
+
+      const head = await server.HEAD({
+        request: new Request(url, { method: "HEAD" }),
+        url,
+      });
+      expect(head.status, path).toBe(200);
+      expect(head.headers.get("etag"), path).toBe(etag);
+      expect(head.headers.get("content-digest"), path).toBe(contentDigest);
+      expect(head.headers.get("last-modified"), path).toBe(lastModified);
+      expect(await head.text(), path).toBe("");
+
+      const byEtag = await server.GET({
+        request: new Request(url, { headers: { "If-None-Match": etag! } }),
+        url,
+      });
+      expect(byEtag.status, path).toBe(304);
+      expect(byEtag.headers.get("content-digest"), path).toBe(contentDigest);
+      expect(await byEtag.text(), path).toBe("");
+
+      const byDate = await server.GET({
+        request: new Request(url, { headers: { "If-Modified-Since": lastModified! } }),
+        url,
+      });
+      expect(byDate.status, path).toBe(304);
+      expect(await byDate.text(), path).toBe("");
+    }
+  });
+
   it("matches the shared discovery method contract", async () => {
     const { createDocsServer } = await loadCreateDocsServer();
     const server = createDocsServer({
@@ -405,28 +481,33 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
     expect(changesResponse.status).toBe(404);
   });
 
-  it("keeps discovery HEAD requests metadata-only", async () => {
+  it("keeps discovery HEAD requests bodyless with the GET validators", async () => {
     const { createDocsServer } = await loadCreateDocsServer();
     const config: Record<string, unknown> = {
       entry: "docs",
-      agent: { skills: "must-not-resolve-for-agent-manifest-head" },
       _preloadedContent: {
         "/docs/page.md": "# Home\n",
       },
     };
-    Object.defineProperty(config, "_preloadedAgentSkills", {
-      get() {
-        throw new Error("HEAD must not resolve configured skills");
-      },
-    });
 
     const server = createDocsServer(config);
     const agentManifestUrl = new URL("/.well-known/agent.json", "https://docs.example.com");
+    const getResponse = await server.GET({
+      request: new Request(agentManifestUrl),
+      url: agentManifestUrl,
+    });
     const agentManifestResponse = await server.HEAD({
       request: new Request(agentManifestUrl, { method: "HEAD" }),
       url: agentManifestUrl,
     });
     expect(agentManifestResponse.status).toBe(200);
+    expect(agentManifestResponse.headers.get("etag")).toBe(getResponse.headers.get("etag"));
+    expect(agentManifestResponse.headers.get("content-digest")).toBe(
+      getResponse.headers.get("content-digest"),
+    );
+    expect(agentManifestResponse.headers.get("last-modified")).toBe(
+      getResponse.headers.get("last-modified"),
+    );
     expect(await agentManifestResponse.text()).toBe("");
 
     const fetchSpy = vi

--- a/packages/docs/src/adapter-agent-conformance.test.ts
+++ b/packages/docs/src/adapter-agent-conformance.test.ts
@@ -305,7 +305,8 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       expect(contentDigest, path).toBe(
         `sha-256=:${createHash("sha256").update(content, "utf8").digest("base64")}:`,
       );
-      expect(lastModified, path).toMatch(/ GMT$/u);
+      if (path === "/docs.md") expect(lastModified, path).toMatch(/ GMT$/u);
+      else expect(lastModified, path).toBeNull();
 
       const head = await server.HEAD({
         request: new Request(url, { method: "HEAD" }),
@@ -326,11 +327,15 @@ describe.each(adapters)("%s agent surface contract", (adapter, modulePath) => {
       expect(await byEtag.text(), path).toBe("");
 
       const byDate = await server.GET({
-        request: new Request(url, { headers: { "If-Modified-Since": lastModified! } }),
+        request: new Request(url, {
+          headers: {
+            "If-Modified-Since": lastModified ?? "Sat, 01 Aug 2026 00:00:00 GMT",
+          },
+        }),
         url,
       });
-      expect(byDate.status, path).toBe(304);
-      expect(await byDate.text(), path).toBe("");
+      expect(byDate.status, path).toBe(lastModified ? 304 : 200);
+      if (lastModified) expect(await byDate.text(), path).toBe("");
     }
   });
 

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { extractDocsMarkdownPromptBlocks, findDocsAudienceMdxTags } from "./audience.js";
 import {
@@ -1193,7 +1194,9 @@ describe("agent route helpers", () => {
     expect(response.headers.get("link")).toBe(
       '<https://example.com/docs/install?lang=en>; rel="canonical"',
     );
-    expect(response.headers.get("etag")).toMatch(/^W\/"[a-f0-9]+-[a-f0-9]{8}"$/);
+    const responseDigest = createHash("sha256").update(document, "utf8").digest("base64");
+    expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(response.headers.get("content-digest")).toBe(`sha-256=:${responseDigest}:`);
     expect(response.headers.get("last-modified")).toBe("Sat, 18 Jul 2026 14:23:45 GMT");
 
     const dateOnlyResponse = createDocsMarkdownResponse({
@@ -1629,7 +1632,8 @@ describe("agent route helpers", () => {
     );
     expect(response.headers.get("x-docs-markdown-section-count")).toBe("4");
     expect(response.headers.get("x-docs-markdown-token-budget")).toBe("80");
-    expect(response.headers.get("etag")).toMatch(/^W\/"/u);
+    expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/u);
+    expect(response.headers.get("content-digest")).toMatch(/^sha-256=:[A-Za-z0-9+/]{43}=:$/u);
     expect(response.headers.get("last-modified")).toBe("Sat, 25 Jul 2026 10:00:00 GMT");
     expect(index).toMatchObject({
       schemaVersion: 2,

--- a/packages/docs/src/agent.test.ts
+++ b/packages/docs/src/agent.test.ts
@@ -1632,8 +1632,11 @@ describe("agent route helpers", () => {
     );
     expect(response.headers.get("x-docs-markdown-section-count")).toBe("4");
     expect(response.headers.get("x-docs-markdown-token-budget")).toBe("80");
-    expect(response.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/u);
-    expect(response.headers.get("content-digest")).toMatch(/^sha-256=:[A-Za-z0-9+/]{43}=:$/u);
+    const expectedSha256 = createHash("sha256").update(body, "utf8").digest("hex");
+    expect(response.headers.get("etag")).toBe(`"${expectedSha256}"`);
+    expect(response.headers.get("content-digest")).toBe(
+      `sha-256=:${createHash("sha256").update(body, "utf8").digest("base64")}:`,
+    );
     expect(response.headers.get("last-modified")).toBe("Sat, 25 Jul 2026 10:00:00 GMT");
     expect(index).toMatchObject({
       schemaVersion: 2,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -35,6 +35,7 @@ import {
   DOCS_CONTENT_CHANGES_RESPONSE_VALUE,
   resolveDocsContentChangesConfig,
 } from "./content-changes.js";
+import { createDocsCacheableResponse, resolveDocsHttpDate } from "./http-cache.js";
 import {
   DEFAULT_SITEMAP_MD_DOCS_ROUTE,
   DEFAULT_SITEMAP_MD_ROUTE,
@@ -719,6 +720,8 @@ export interface DocsStandardsDiscoveryResponseOptions extends DocsAgentDiscover
   request: Request;
   preferredSkillDocument?: string | null;
   fallbackSkillDocument: string;
+  /** Stable representation generation or source modification time. */
+  lastModified?: string | Date | null;
 }
 
 export interface DocsAgentContractMcpTools {
@@ -2317,6 +2320,7 @@ export async function createDocsStandardsDiscoveryResponse({
   markdown: _markdown,
   publishedSkills,
   agentCard,
+  lastModified,
 }: DocsStandardsDiscoveryResponseOptions): Promise<Response | null> {
   const url = new URL(request.url);
   const resolvedApiRoute = resolveDocsDiscoveryApiRoute(apiRoute);
@@ -2368,6 +2372,7 @@ export async function createDocsStandardsDiscoveryResponse({
     fallbackSkillDocument,
     publishedSkills,
     agentCard,
+    lastModified,
     apiCatalog: apiCatalogEnabled
       ? buildDocsApiCatalog({
           origin: catalogOrigin,
@@ -3500,41 +3505,6 @@ export function renderDocsMarkdownNotFound({
   return appendDocsMarkdownSitemapFooter(document, sitemap);
 }
 
-function hashDocsMarkdownRepresentation(value: string): string {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
-}
-
-function createDocsMarkdownEtag(document: string): string {
-  return `W/"${document.length.toString(16)}-${hashDocsMarkdownRepresentation(document)}"`;
-}
-
-function normalizeDocsMarkdownEtag(value: string): string {
-  return value.trim().replace(/^W\//i, "");
-}
-
-function requestMatchesDocsMarkdownEtag(request: Request, etag: string): boolean {
-  const header = request.headers.get("if-none-match");
-  if (!header) return false;
-  if (header.trim() === "*") return true;
-  const expected = normalizeDocsMarkdownEtag(etag);
-  return header.split(",").some((candidate) => normalizeDocsMarkdownEtag(candidate) === expected);
-}
-
-function resolveDocsMarkdownHttpDate(value?: string | Date | null): string | undefined {
-  if (!value) return undefined;
-  if (typeof value === "string" && !/(?:T|\s)\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?/.test(value.trim())) {
-    return undefined;
-  }
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return date.toUTCString();
-}
-
 function extractDocsMarkdownLastModified(document: string): string | undefined {
   const frontmatter = document.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
   if (!frontmatter) return undefined;
@@ -3544,19 +3514,6 @@ function extractDocsMarkdownLastModified(document: string): string | undefined {
     return raw.slice(1, -1);
   }
   return raw;
-}
-
-function requestHasFreshDocsMarkdownDate(request: Request, lastModified?: string): boolean {
-  if (!lastModified || request.headers.has("if-none-match")) return false;
-  const ifModifiedSince = request.headers.get("if-modified-since");
-  if (!ifModifiedSince) return false;
-  const resourceTime = Date.parse(lastModified);
-  const requestTime = Date.parse(ifModifiedSince);
-  return (
-    Number.isFinite(resourceTime) &&
-    Number.isFinite(requestTime) &&
-    Math.floor(resourceTime / 1000) <= Math.floor(requestTime / 1000)
-  );
 }
 
 function resolveDocsMarkdownContentLocation(canonicalUrl: string): string {
@@ -3661,8 +3618,7 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
       byteBudget: sectionIndexRequest.byteBudget,
     });
     const responseDocument = JSON.stringify(sectionIndex);
-    const etag = createDocsMarkdownEtag(responseDocument);
-    const lastModified = resolveDocsMarkdownHttpDate(
+    const lastModified = resolveDocsHttpDate(
       options.lastModified ?? extractDocsMarkdownLastModified(document),
     );
     const responseHeaders: Record<string, string> = {
@@ -3671,7 +3627,6 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
       Link: `<${canonicalUrl}>; rel="canonical", <${contentLocation}>; rel="alternate"; type="text/markdown"`,
       "Cache-Control": options.cacheControl ?? "public, max-age=0, s-maxage=3600",
       "Content-Type": "application/json; charset=utf-8",
-      ETag: etag,
       "X-Docs-Markdown-Section-Index": DOCS_MARKDOWN_SECTION_INDEX_FORMAT,
       "X-Docs-Markdown-Section-Count": String(sectionIndex.sectionCount),
       "X-Docs-Markdown-Source-Estimated-Tokens": String(sectionIndex.estimatedTokens),
@@ -3687,16 +3642,10 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
       ...(lastModified ? { "Last-Modified": lastModified } : {}),
     };
 
-    if (
-      requestMatchesDocsMarkdownEtag(request, etag) ||
-      requestHasFreshDocsMarkdownDate(request, lastModified)
-    ) {
-      const { "Content-Type": _contentType, ...notModifiedHeaders } = responseHeaders;
-      return new Response(null, { status: 304, headers: notModifiedHeaders });
-    }
-
-    return new Response(request.method.toUpperCase() === "HEAD" ? null : responseDocument, {
-      status: 200,
+    return createDocsCacheableResponse({
+      request,
+      content: responseDocument,
+      lastModified,
       headers: responseHeaders,
     });
   }
@@ -3730,8 +3679,7 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
       }
     : {};
 
-  const etag = createDocsMarkdownEtag(responseDocument);
-  const lastModified = resolveDocsMarkdownHttpDate(
+  const lastModified = resolveDocsHttpDate(
     options.lastModified ?? extractDocsMarkdownLastModified(document),
   );
   const responseHeaders: Record<string, string> = {
@@ -3743,21 +3691,15 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
         ? "no-store"
         : (options.cacheControl ?? "public, max-age=0, s-maxage=3600"),
     "Content-Type": "text/markdown; charset=utf-8",
-    ETag: etag,
     ...sectionHeaders,
     ...(lastModified ? { "Last-Modified": lastModified } : {}),
   };
 
-  if (
-    requestMatchesDocsMarkdownEtag(request, etag) ||
-    requestHasFreshDocsMarkdownDate(request, lastModified)
-  ) {
-    const { "Content-Type": _contentType, ...notModifiedHeaders } = responseHeaders;
-    return new Response(null, { status: 304, headers: notModifiedHeaders });
-  }
-
-  return new Response(responseDocument, {
+  return createDocsCacheableResponse({
+    request,
+    content: responseDocument,
     status: sectionResult?.found === false ? 404 : 200,
+    lastModified,
     headers: responseHeaders,
   });
 }

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -542,6 +542,18 @@ pnpm add example
     mkdirSync(path.join(tmpDir, "public"), { recursive: true });
     writeFileSync(path.join(tmpDir, "public", "docs.md"), "# Custom static home\n", "utf-8");
     writeFileSync(path.join(tmpDir, "public", "llms.txt"), "# Custom llms index\n", "utf-8");
+    execFileSync("git", ["init", "-q"], { cwd: tmpDir });
+    execFileSync("git", ["config", "user.name", "Agent Export Test"], { cwd: tmpDir });
+    execFileSync("git", ["config", "user.email", "agent-export@example.com"], { cwd: tmpDir });
+    execFileSync("git", ["add", "docs.config.ts", "docs"], { cwd: tmpDir });
+    execFileSync("git", ["commit", "-q", "-m", "initial docs"], {
+      cwd: tmpDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2020-01-02T03:04:05Z",
+        GIT_COMMITTER_DATE: "2020-01-02T03:04:05Z",
+      },
+    });
     process.chdir(tmpDir);
 
     await exportAgentBundle({ public: true });
@@ -555,7 +567,14 @@ pnpm add example
     const manifest = JSON.parse(
       readFileSync(path.join(tmpDir, ".farming-labs", "agent-bundle-manifest.json"), "utf-8"),
     ) as AgentBundleManifest;
-    expect(manifest.files.find((file) => file.path === "docs.md")?.managed).toBe(false);
+    const overriddenPage = manifest.files.find((file) => file.path === "docs.md");
+    expect(overriddenPage?.managed).toBe(false);
+    expect(overriddenPage).not.toHaveProperty("lastModified");
+    expect(
+      manifest.files.some(
+        (file) => file.kind === "page" && file.managed && file.lastModified !== undefined,
+      ),
+    ).toBe(true);
     expect(manifest.files.find((file) => file.path === "llms.txt")?.managed).toBe(false);
   });
 

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -644,7 +644,14 @@ pnpm add example
     expect(firstPage).toContain('last_updated: "2020-01-02"');
     const parsedManifest = JSON.parse(firstManifest) as AgentBundleManifest;
     expect(
-      parsedManifest.files.every((file) => file.lastModified === "Thu, 02 Jan 2020 00:00:00 GMT"),
+      parsedManifest.files
+        .filter((file) => file.kind === "page")
+        .every((file) => file.lastModified === "Thu, 02 Jan 2020 03:04:05 GMT"),
+    ).toBe(true);
+    expect(
+      parsedManifest.files
+        .filter((file) => file.kind !== "page")
+        .every((file) => file.lastModified === undefined),
     ).toBe(true);
 
     const future = new Date("2040-12-31T23:59:59Z");

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -674,6 +674,9 @@ pnpm add example
       managed: false,
       orphaned: true,
     });
+    expect(manifest.files.find((file) => file.path === "llms.txt")).not.toHaveProperty(
+      "lastModified",
+    );
     await expect(exportAgentBundle({ check: true })).rejects.toThrow(
       "Static Agent Bundle is stale",
     );

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -250,6 +250,13 @@ pnpm add example
     expect(manifest.format).toBe("farming-labs-agent-bundle.v1");
     expect(manifest.contentHash).toMatch(/^[a-f0-9]{64}$/);
     expect(manifest.files.every((file) => /^[a-f0-9]{64}$/.test(file.sha256))).toBe(true);
+    expect(manifest.files.every((file) => file.etag === `"${file.sha256}"`)).toBe(true);
+    expect(
+      manifest.files.every(
+        (file) =>
+          file.contentDigest === `sha-256=:${Buffer.from(file.sha256, "hex").toString("base64")}:`,
+      ),
+    ).toBe(true);
     expect(manifest.pages).toHaveLength(2);
 
     await expect(exportAgentBundle({ check: true })).resolves.toBeUndefined();
@@ -635,6 +642,10 @@ pnpm add example
     const firstPage = readFileSync(pagePath, "utf-8");
     const firstManifest = readFileSync(manifestPath, "utf-8");
     expect(firstPage).toContain('last_updated: "2020-01-02"');
+    const parsedManifest = JSON.parse(firstManifest) as AgentBundleManifest;
+    expect(
+      parsedManifest.files.every((file) => file.lastModified === "Thu, 02 Jan 2020 00:00:00 GMT"),
+    ).toBe(true);
 
     const future = new Date("2040-12-31T23:59:59Z");
     utimesSync(path.join(tmpDir, "docs", "guides", "install", "page.mdx"), future, future);

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -945,7 +945,6 @@ function preservedStaleManifestFiles(
   publicDir: string,
   previous: AgentBundleManifest | undefined,
   outputs: PlannedOutput[],
-  lastModified?: string,
 ): AgentBundleManifestFile[] {
   if (!previous) return [];
   const expected = new Set(outputs.map((output) => output.publicPath));
@@ -963,7 +962,7 @@ function preservedStaleManifestFiles(
         sha256: digest,
         etag: `"${digest}"`,
         contentDigest: formatDocsContentDigest(digest),
-        lastModified: file.lastModified ?? lastModified,
+        lastModified: undefined,
         managed: false,
         orphaned: true,
       },
@@ -1482,12 +1481,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   const stalePaths = staleManagedPaths(publicDir, previous, outputs);
   const staleInternal = staleInternalPaths(rootDir, previous, internalOutputs);
   const bundleLastModified = resolveAgentBundleLastModified(localizedPages);
-  const orphanedFiles = preservedStaleManifestFiles(
-    publicDir,
-    previous,
-    outputs,
-    bundleLastModified,
-  );
+  const orphanedFiles = preservedStaleManifestFiles(publicDir, previous, outputs);
   const orphanedInternalFiles = preservedStaleInternalManifestFiles(
     rootDir,
     previous,

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -720,7 +720,12 @@ function resolveUserOwnedAgentsOutputs(outputs: PlannedOutput[]): PlannedOutput[
     if (output.kind !== "agents") return output;
     const current = readExisting(output.absolutePath);
     if (current === undefined || isManagedAgentsContent(current)) return output;
-    return { ...output, content: normalizeContent(current), managed: false };
+    return {
+      ...output,
+      content: normalizeContent(current),
+      managed: false,
+      lastModified: undefined,
+    };
   });
 }
 
@@ -745,7 +750,12 @@ function resolveUserOwnedOverrides(
     if (current === undefined || current === output.content) return output;
     const previousFile = previousByPath.get(output.publicPath);
     if (previousFile?.managed && sha256(current) === previousFile.sha256) return output;
-    return { ...output, content: normalizeContent(current), managed: false };
+    return {
+      ...output,
+      content: normalizeContent(current),
+      managed: false,
+      lastModified: undefined,
+    };
   });
 }
 

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -44,7 +44,7 @@ import {
   type DocsLlmsDiscoveryConfig,
 } from "../agent.js";
 import { resolveConfiguredAgentSkills } from "../agent-skills-server.js";
-import { formatDocsContentDigest } from "../http-cache.js";
+import { formatDocsContentDigest, resolveDocsHttpDate } from "../http-cache.js";
 import { resolveDocsI18n } from "../i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "../mcp.js";
 import {
@@ -163,6 +163,8 @@ interface PlannedOutput {
   mediaType: string;
   content: string | Uint8Array;
   managed: boolean;
+  /** Exact modification time for this representation when one is known. */
+  lastModified?: string;
 }
 
 interface PlannedInternalOutput {
@@ -593,8 +595,8 @@ function pageGitLastmod(rootDir: string, page: DocsMcpPage) {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();
-      const lastmod = formatDateOnly(output);
-      if (lastmod) return lastmod;
+      const parsed = new Date(output);
+      if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
     } catch {
       // Static Agent Bundles intentionally omit filesystem mtimes: they vary across checkouts.
     }
@@ -654,7 +656,7 @@ function addOutput(
   content: string | Uint8Array,
   managed = true,
   normalizeText = true,
-): void {
+): PlannedOutput {
   const absolutePath = publicFilePath(publicDir, route);
   const publicManifestPath = publicFilePath(publicDir, AGENT_BUNDLE_MANIFEST_ROUTE);
   if (absolutePath === publicManifestPath) {
@@ -668,7 +670,7 @@ function addOutput(
       `Agent Bundle output collision at ${route} (${collision.kind} and ${kind}). Change the conflicting docs slug or configured route.`,
     );
   }
-  outputs.push({
+  const output: PlannedOutput = {
     absolutePath,
     publicPath: publicRelativePath(publicDir, absolutePath),
     route,
@@ -676,7 +678,9 @@ function addOutput(
     mediaType,
     content: typeof content === "string" && normalizeText ? normalizeContent(content) : content,
     managed,
-  });
+  };
+  outputs.push(output);
+  return output;
 }
 
 function assertOutputPathsDoNotCollide(options: {
@@ -794,7 +798,7 @@ function resolveRobotsOutput(
   };
 }
 
-function toManifestFile(output: PlannedOutput, lastModified?: string): AgentBundleManifestFile {
+function toManifestFile(output: PlannedOutput): AgentBundleManifestFile {
   const digest = sha256(output.content);
   return {
     path: output.publicPath,
@@ -805,7 +809,7 @@ function toManifestFile(output: PlannedOutput, lastModified?: string): AgentBund
     sha256: digest,
     etag: `"${digest}"`,
     contentDigest: formatDocsContentDigest(digest),
-    lastModified,
+    lastModified: output.lastModified,
     managed: output.managed,
   };
 }
@@ -820,10 +824,9 @@ function buildAgentBundleManifest(options: {
   orphanedFiles: AgentBundleManifestFile[];
   orphanedInternalFiles: AgentBundleManifestInternalFile[];
   pages: LocalizedPage[];
-  lastModified?: string;
 }): AgentBundleManifest {
   const files = [
-    ...options.outputs.map((output) => toManifestFile(output, options.lastModified)),
+    ...options.outputs.map((output) => toManifestFile(output)),
     ...options.orphanedFiles,
   ].sort((left, right) => left.path.localeCompare(right.path));
   const internalFiles = [
@@ -859,15 +862,6 @@ function buildAgentBundleManifest(options: {
       }))
       .sort((left, right) => left.markdownRoute.localeCompare(right.markdownRoute)),
   };
-}
-
-function resolveAgentBundleLastModified(pages: LocalizedPage[]): string | undefined {
-  const latest = pages.reduce<number | undefined>((current, { page }) => {
-    const timestamp = Date.parse(page.lastModified ?? page.lastmod ?? "");
-    if (!Number.isFinite(timestamp)) return current;
-    return current === undefined || timestamp > current ? timestamp : current;
-  }, undefined);
-  return latest === undefined ? undefined : new Date(latest).toUTCString();
 }
 
 function readPreviousManifest(manifestPath: string): AgentBundleManifest | undefined {
@@ -1194,7 +1188,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   const internalOutputs: PlannedInternalOutput[] = [];
 
   for (const { page } of localizedPages) {
-    addOutput(
+    const output = addOutput(
       outputs,
       publicDir,
       staticMarkdownRoute(page, sourceEntry, routeEntry),
@@ -1212,6 +1206,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
         },
       ),
     );
+    output.lastModified = resolveDocsHttpDate(page.lastModified);
   }
 
   if (llmsEnabled) {
@@ -1480,7 +1475,6 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   outputs.sort((left, right) => left.publicPath.localeCompare(right.publicPath));
   const stalePaths = staleManagedPaths(publicDir, previous, outputs);
   const staleInternal = staleInternalPaths(rootDir, previous, internalOutputs);
-  const bundleLastModified = resolveAgentBundleLastModified(localizedPages);
   const orphanedFiles = preservedStaleManifestFiles(publicDir, previous, outputs);
   const orphanedInternalFiles = preservedStaleInternalManifestFiles(
     rootDir,
@@ -1497,7 +1491,6 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
     orphanedFiles,
     orphanedInternalFiles,
     pages: localizedPages,
-    lastModified: bundleLastModified,
   });
   const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
   const changed = changedOutputs(outputs);

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -44,6 +44,7 @@ import {
   type DocsLlmsDiscoveryConfig,
 } from "../agent.js";
 import { resolveConfiguredAgentSkills } from "../agent-skills-server.js";
+import { formatDocsContentDigest } from "../http-cache.js";
 import { resolveDocsI18n } from "../i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "../mcp.js";
 import {
@@ -110,6 +111,12 @@ export interface AgentBundleManifestFile {
   mediaType: string;
   bytes: number;
   sha256: string;
+  /** Strong HTTP entity tag derived from the exact exported bytes. */
+  etag: string;
+  /** RFC 9530 integrity field value derived from the exact exported bytes. */
+  contentDigest: string;
+  /** Stable source freshness when the bundle can derive one. */
+  lastModified?: string;
   managed: boolean;
   /** A previously managed output that was preserved because its contents were edited. */
   orphaned?: boolean;
@@ -787,14 +794,18 @@ function resolveRobotsOutput(
   };
 }
 
-function toManifestFile(output: PlannedOutput): AgentBundleManifestFile {
+function toManifestFile(output: PlannedOutput, lastModified?: string): AgentBundleManifestFile {
+  const digest = sha256(output.content);
   return {
     path: output.publicPath,
     route: output.route,
     kind: output.kind,
     mediaType: output.mediaType,
     bytes: byteLength(output.content),
-    sha256: sha256(output.content),
+    sha256: digest,
+    etag: `"${digest}"`,
+    contentDigest: formatDocsContentDigest(digest),
+    lastModified,
     managed: output.managed,
   };
 }
@@ -809,10 +820,12 @@ function buildAgentBundleManifest(options: {
   orphanedFiles: AgentBundleManifestFile[];
   orphanedInternalFiles: AgentBundleManifestInternalFile[];
   pages: LocalizedPage[];
+  lastModified?: string;
 }): AgentBundleManifest {
-  const files = [...options.outputs.map(toManifestFile), ...options.orphanedFiles].sort(
-    (left, right) => left.path.localeCompare(right.path),
-  );
+  const files = [
+    ...options.outputs.map((output) => toManifestFile(output, options.lastModified)),
+    ...options.orphanedFiles,
+  ].sort((left, right) => left.path.localeCompare(right.path));
   const internalFiles = [
     ...options.internalOutputs.map((output) => ({
       path: output.path,
@@ -846,6 +859,15 @@ function buildAgentBundleManifest(options: {
       }))
       .sort((left, right) => left.markdownRoute.localeCompare(right.markdownRoute)),
   };
+}
+
+function resolveAgentBundleLastModified(pages: LocalizedPage[]): string | undefined {
+  const latest = pages.reduce<number | undefined>((current, { page }) => {
+    const timestamp = Date.parse(page.lastModified ?? page.lastmod ?? "");
+    if (!Number.isFinite(timestamp)) return current;
+    return current === undefined || timestamp > current ? timestamp : current;
+  }, undefined);
+  return latest === undefined ? undefined : new Date(latest).toUTCString();
 }
 
 function readPreviousManifest(manifestPath: string): AgentBundleManifest | undefined {
@@ -923,6 +945,7 @@ function preservedStaleManifestFiles(
   publicDir: string,
   previous: AgentBundleManifest | undefined,
   outputs: PlannedOutput[],
+  lastModified?: string,
 ): AgentBundleManifestFile[] {
   if (!previous) return [];
   const expected = new Set(outputs.map((output) => output.publicPath));
@@ -932,11 +955,15 @@ function preservedStaleManifestFiles(
     if (!existsSync(filePath)) return [];
     const current = readFileSync(filePath);
     if (file.orphaned !== true && sha256(current) === file.sha256) return [];
+    const digest = sha256(current);
     return [
       {
         ...file,
         bytes: byteLength(current),
-        sha256: sha256(current),
+        sha256: digest,
+        etag: `"${digest}"`,
+        contentDigest: formatDocsContentDigest(digest),
+        lastModified: file.lastModified ?? lastModified,
         managed: false,
         orphaned: true,
       },
@@ -1454,7 +1481,13 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   outputs.sort((left, right) => left.publicPath.localeCompare(right.publicPath));
   const stalePaths = staleManagedPaths(publicDir, previous, outputs);
   const staleInternal = staleInternalPaths(rootDir, previous, internalOutputs);
-  const orphanedFiles = preservedStaleManifestFiles(publicDir, previous, outputs);
+  const bundleLastModified = resolveAgentBundleLastModified(localizedPages);
+  const orphanedFiles = preservedStaleManifestFiles(
+    publicDir,
+    previous,
+    outputs,
+    bundleLastModified,
+  );
   const orphanedInternalFiles = preservedStaleInternalManifestFiles(
     rootDir,
     previous,
@@ -1470,6 +1503,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
     orphanedFiles,
     orphanedInternalFiles,
     pages: localizedPages,
+    lastModified: bundleLastModified,
   });
   const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
   const changed = changedOutputs(outputs);

--- a/packages/docs/src/http-cache.test.ts
+++ b/packages/docs/src/http-cache.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createDocsCacheableResponse, formatDocsContentDigest } from "./http-cache.js";
+
+describe("agent surface HTTP cache integrity", () => {
+  it("hashes the exact UTF-8 response bytes and preserves validators on HEAD and 304", async () => {
+    const url = "https://docs.example.com/llms.txt";
+    const content = "# Café ☕\n";
+    const lastModified = "2026-07-31T12:00:00.000Z";
+    const get = createDocsCacheableResponse({
+      request: new Request(url),
+      content,
+      lastModified,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+    const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
+
+    expect(get.headers.get("etag")).toBe(`"${sha256}"`);
+    expect(get.headers.get("content-digest")).toBe(
+      `sha-256=:${createHash("sha256").update(content, "utf8").digest("base64")}:`,
+    );
+    expect(get.headers.get("last-modified")).toBe("Fri, 31 Jul 2026 12:00:00 GMT");
+    expect(await get.text()).toBe(content);
+
+    const head = createDocsCacheableResponse({
+      request: new Request(url, { method: "HEAD" }),
+      content,
+      lastModified,
+    });
+    expect(head.headers.get("etag")).toBe(get.headers.get("etag"));
+    expect(head.headers.get("content-digest")).toBe(get.headers.get("content-digest"));
+    expect(await head.text()).toBe("");
+
+    const notModified = createDocsCacheableResponse({
+      request: new Request(url, { headers: { "If-None-Match": `W/"${sha256}"` } }),
+      content,
+      lastModified,
+    });
+    expect(notModified.status).toBe(304);
+    expect(notModified.headers.get("content-digest")).toBe(get.headers.get("content-digest"));
+  });
+
+  it("honors If-None-Match precedence and formats binary SHA-256 digests", () => {
+    const url = "https://docs.example.com/.well-known/agent-skills/example.tar.gz";
+    const content = new Uint8Array([0, 1, 2, 254, 255]);
+    const sha256 = createHash("sha256").update(content).digest("hex");
+    expect(formatDocsContentDigest(sha256)).toBe(
+      `sha-256=:${createHash("sha256").update(content).digest("base64")}:`,
+    );
+
+    const response = createDocsCacheableResponse({
+      request: new Request(url, {
+        headers: {
+          "If-None-Match": '"different"',
+          "If-Modified-Since": "Sat, 01 Aug 2026 00:00:00 GMT",
+        },
+      }),
+      content,
+      lastModified: "2026-07-31T12:00:00.000Z",
+    });
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/docs/src/http-cache.test.ts
+++ b/packages/docs/src/http-cache.test.ts
@@ -40,7 +40,7 @@ describe("agent surface HTTP cache integrity", () => {
     expect(notModified.headers.get("content-digest")).toBe(get.headers.get("content-digest"));
   });
 
-  it("honors If-None-Match precedence and formats binary SHA-256 digests", () => {
+  it("honors If-None-Match precedence and formats binary SHA-256 digests", async () => {
     const url = "https://docs.example.com/.well-known/agent-skills/example.tar.gz";
     const content = new Uint8Array([0, 1, 2, 254, 255]);
     const sha256 = createHash("sha256").update(content).digest("hex");
@@ -60,6 +60,7 @@ describe("agent surface HTTP cache integrity", () => {
       lastModified: "2026-07-31T12:00:00.000Z",
     });
     expect(response.status).toBe(200);
+    expect([...new Uint8Array(await response.arrayBuffer())]).toEqual([...content]);
 
     const preconditionFailed = createDocsCacheableResponse({
       request: new Request(url, {

--- a/packages/docs/src/http-cache.test.ts
+++ b/packages/docs/src/http-cache.test.ts
@@ -50,6 +50,7 @@ describe("agent surface HTTP cache integrity", () => {
 
     const response = createDocsCacheableResponse({
       request: new Request(url, {
+        method: "POST",
         headers: {
           "If-None-Match": '"different"',
           "If-Modified-Since": "Sat, 01 Aug 2026 00:00:00 GMT",
@@ -59,5 +60,16 @@ describe("agent surface HTTP cache integrity", () => {
       lastModified: "2026-07-31T12:00:00.000Z",
     });
     expect(response.status).toBe(200);
+
+    const preconditionFailed = createDocsCacheableResponse({
+      request: new Request(url, {
+        method: "POST",
+        headers: { "If-None-Match": `"${sha256}"` },
+      }),
+      content,
+      lastModified: "2026-07-31T12:00:00.000Z",
+    });
+    expect(preconditionFailed.status).toBe(412);
+    expect(preconditionFailed.headers.get("content-digest")).toBe(formatDocsContentDigest(sha256));
   });
 });

--- a/packages/docs/src/http-cache.test.ts
+++ b/packages/docs/src/http-cache.test.ts
@@ -73,4 +73,21 @@ describe("agent surface HTTP cache integrity", () => {
     expect(preconditionFailed.status).toBe(412);
     expect(preconditionFailed.headers.get("content-digest")).toBe(formatDocsContentDigest(sha256));
   });
+
+  it("preserves an error response when its validator matches", async () => {
+    const content = "Section not found";
+    const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
+    const response = createDocsCacheableResponse({
+      request: new Request("https://docs.example.com/docs/install.md?section=missing", {
+        headers: { "If-None-Match": `"${sha256}"` },
+      }),
+      content,
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("etag")).toBe(`"${sha256}"`);
+    expect(await response.text()).toBe(content);
+  });
 });

--- a/packages/docs/src/http-cache.ts
+++ b/packages/docs/src/http-cache.ts
@@ -1,6 +1,16 @@
 import { sha256DocsContent } from "./retrieval-digest.js";
 
 const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const MAX_CACHED_TEXT_REPRESENTATIONS = 64;
+const MAX_CACHED_TEXT_CHARACTERS = 8 * 1024 * 1024;
+
+interface DocsContentValidators {
+  sha256: string;
+  contentDigest: string;
+}
+
+const textValidatorCache = new Map<string, DocsContentValidators>();
+let cachedTextCharacters = 0;
 
 export interface DocsCacheableResponseOptions {
   request: Request;
@@ -42,6 +52,46 @@ function sha256HexBytes(sha256: string): Uint8Array {
 /** Format an RFC 9530 Content-Digest field from a SHA-256 hex digest. */
 export function formatDocsContentDigest(sha256: string): string {
   return `sha-256=:${encodeBase64(sha256HexBytes(sha256))}:`;
+}
+
+function resolveDocsContentValidators(
+  content: string | Uint8Array,
+  suppliedSha256?: string,
+): DocsContentValidators {
+  if (suppliedSha256) {
+    return {
+      sha256: suppliedSha256,
+      contentDigest: formatDocsContentDigest(suppliedSha256),
+    };
+  }
+
+  const cached = typeof content === "string" ? textValidatorCache.get(content) : undefined;
+  if (cached) {
+    if (typeof content === "string") {
+      textValidatorCache.delete(content);
+      textValidatorCache.set(content, cached);
+    }
+    return cached;
+  }
+
+  const sha256 = sha256DocsContent(content);
+  const validators = { sha256, contentDigest: formatDocsContentDigest(sha256) };
+  if (typeof content !== "string") return validators;
+
+  if (content.length <= MAX_CACHED_TEXT_CHARACTERS) {
+    textValidatorCache.set(content, validators);
+    cachedTextCharacters += content.length;
+    while (
+      textValidatorCache.size > MAX_CACHED_TEXT_REPRESENTATIONS ||
+      cachedTextCharacters > MAX_CACHED_TEXT_CHARACTERS
+    ) {
+      const oldest = textValidatorCache.keys().next().value;
+      if (oldest === undefined) break;
+      textValidatorCache.delete(oldest);
+      cachedTextCharacters -= oldest.length;
+    }
+  }
+  return validators;
 }
 
 /** Normalize an exact source timestamp for Last-Modified. */
@@ -104,11 +154,11 @@ function exposeValidatorHeaders(headers: Headers): void {
 export function createDocsCacheableResponse(options: DocsCacheableResponseOptions): Response {
   const method = options.request.method.toUpperCase();
   const isSafeRetrieval = method === "GET" || method === "HEAD";
-  const sha256 = options.sha256 ?? sha256DocsContent(options.content);
+  const { sha256, contentDigest } = resolveDocsContentValidators(options.content, options.sha256);
   const etag = `"${sha256}"`;
   const lastModified = resolveDocsHttpDate(options.lastModified);
   const headers = new Headers(options.headers);
-  headers.set("Content-Digest", formatDocsContentDigest(sha256));
+  headers.set("Content-Digest", contentDigest);
   headers.set("ETag", etag);
   if (lastModified) headers.set("Last-Modified", lastModified);
   exposeValidatorHeaders(headers);
@@ -128,6 +178,8 @@ export function createDocsCacheableResponse(options: DocsCacheableResponseOption
       ? null
       : typeof options.content === "string"
         ? options.content
-        : new Uint8Array(options.content).buffer;
+        : // Fetch accepts BufferSource bodies at runtime. TypeScript's DOM declarations narrow
+          // Uint8Array to an ArrayBuffer-backed variant, so retain the bytes and bridge that gap.
+          (options.content as unknown as BodyInit);
   return new Response(body, { status: options.status ?? 200, headers });
 }

--- a/packages/docs/src/http-cache.ts
+++ b/packages/docs/src/http-cache.ts
@@ -154,6 +154,8 @@ function exposeValidatorHeaders(headers: Headers): void {
 export function createDocsCacheableResponse(options: DocsCacheableResponseOptions): Response {
   const method = options.request.method.toUpperCase();
   const isSafeRetrieval = method === "GET" || method === "HEAD";
+  const status = options.status ?? 200;
+  const canApplyConditionalRequest = status === 200;
   const { sha256, contentDigest } = resolveDocsContentValidators(options.content, options.sha256);
   const etag = `"${sha256}"`;
   const lastModified = resolveDocsHttpDate(options.lastModified);
@@ -163,12 +165,16 @@ export function createDocsCacheableResponse(options: DocsCacheableResponseOption
   if (lastModified) headers.set("Last-Modified", lastModified);
   exposeValidatorHeaders(headers);
 
-  if (requestMatchesDocsEtag(options.request, etag)) {
+  if (canApplyConditionalRequest && requestMatchesDocsEtag(options.request, etag)) {
     headers.delete("Content-Type");
     return new Response(null, { status: isSafeRetrieval ? 304 : 412, headers });
   }
 
-  if (isSafeRetrieval && requestHasFreshDocsDate(options.request, lastModified)) {
+  if (
+    canApplyConditionalRequest &&
+    isSafeRetrieval &&
+    requestHasFreshDocsDate(options.request, lastModified)
+  ) {
     headers.delete("Content-Type");
     return new Response(null, { status: 304, headers });
   }
@@ -181,5 +187,5 @@ export function createDocsCacheableResponse(options: DocsCacheableResponseOption
         : // Fetch accepts BufferSource bodies at runtime. TypeScript's DOM declarations narrow
           // Uint8Array to an ArrayBuffer-backed variant, so retain the bytes and bridge that gap.
           (options.content as unknown as BodyInit);
-  return new Response(body, { status: options.status ?? 200, headers });
+  return new Response(body, { status, headers });
 }

--- a/packages/docs/src/http-cache.ts
+++ b/packages/docs/src/http-cache.ts
@@ -1,0 +1,127 @@
+import { sha256DocsContent } from "./retrieval-digest.js";
+
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+export interface DocsCacheableResponseOptions {
+  request: Request;
+  content: string | Uint8Array;
+  status?: number;
+  headers?: HeadersInit;
+  /** Stable SHA-256 hex digest when the caller already hashed the exact response bytes. */
+  sha256?: string;
+  /** Exact representation modification time. Invalid values are omitted. */
+  lastModified?: string | Date | null;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let encoded = "";
+  for (let offset = 0; offset < bytes.length; offset += 3) {
+    const first = bytes[offset]!;
+    const second = bytes[offset + 1];
+    const third = bytes[offset + 2];
+    const value = (first << 16) | ((second ?? 0) << 8) | (third ?? 0);
+    encoded += BASE64_ALPHABET[(value >>> 18) & 63];
+    encoded += BASE64_ALPHABET[(value >>> 12) & 63];
+    encoded += second === undefined ? "=" : BASE64_ALPHABET[(value >>> 6) & 63];
+    encoded += third === undefined ? "=" : BASE64_ALPHABET[value & 63];
+  }
+  return encoded;
+}
+
+function sha256HexBytes(sha256: string): Uint8Array {
+  if (!/^[a-f\d]{64}$/iu.test(sha256)) {
+    throw new Error("A SHA-256 digest must contain exactly 64 hexadecimal characters.");
+  }
+  const bytes = new Uint8Array(32);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(sha256.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/** Format an RFC 9530 Content-Digest field from a SHA-256 hex digest. */
+export function formatDocsContentDigest(sha256: string): string {
+  return `sha-256=:${encodeBase64(sha256HexBytes(sha256))}:`;
+}
+
+/** Normalize an exact source timestamp for Last-Modified. */
+export function resolveDocsHttpDate(value?: string | Date | null): string | undefined {
+  if (!value) return undefined;
+  if (typeof value === "string" && !/(?:T|\s)\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?/.test(value.trim())) {
+    return undefined;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toUTCString();
+}
+
+function normalizeEtag(value: string): string {
+  return value.trim().replace(/^W\//iu, "");
+}
+
+/** Match strong or weak If-None-Match validators for a GET/HEAD representation. */
+export function requestMatchesDocsEtag(request: Request, etag: string): boolean {
+  const header = request.headers.get("if-none-match");
+  if (!header) return false;
+  if (header.trim() === "*") return true;
+  const expected = normalizeEtag(etag);
+  return header.split(",").some((candidate) => normalizeEtag(candidate) === expected);
+}
+
+/** Apply If-Modified-Since only when the stronger If-None-Match validator is absent. */
+export function requestHasFreshDocsDate(request: Request, lastModified?: string): boolean {
+  if (!lastModified || request.headers.has("if-none-match")) return false;
+  const ifModifiedSince = request.headers.get("if-modified-since");
+  if (!ifModifiedSince) return false;
+  const resourceTime = Date.parse(lastModified);
+  const requestTime = Date.parse(ifModifiedSince);
+  return (
+    Number.isFinite(resourceTime) &&
+    Number.isFinite(requestTime) &&
+    Math.floor(resourceTime / 1000) <= Math.floor(requestTime / 1000)
+  );
+}
+
+function exposeValidatorHeaders(headers: Headers): void {
+  if (!headers.has("Access-Control-Allow-Origin")) return;
+  const exposed = new Set(
+    (headers.get("Access-Control-Expose-Headers") ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  exposed.add("Content-Digest");
+  exposed.add("ETag");
+  if (headers.has("Last-Modified")) exposed.add("Last-Modified");
+  headers.set("Access-Control-Expose-Headers", [...exposed].join(", "));
+}
+
+/**
+ * Build a byte-stable GET/HEAD response with HTTP validators and RFC 9530 integrity metadata.
+ */
+export function createDocsCacheableResponse(options: DocsCacheableResponseOptions): Response {
+  const sha256 = options.sha256 ?? sha256DocsContent(options.content);
+  const etag = `"${sha256}"`;
+  const lastModified = resolveDocsHttpDate(options.lastModified);
+  const headers = new Headers(options.headers);
+  headers.set("Content-Digest", formatDocsContentDigest(sha256));
+  headers.set("ETag", etag);
+  if (lastModified) headers.set("Last-Modified", lastModified);
+  exposeValidatorHeaders(headers);
+
+  if (
+    requestMatchesDocsEtag(options.request, etag) ||
+    requestHasFreshDocsDate(options.request, lastModified)
+  ) {
+    headers.delete("Content-Type");
+    return new Response(null, { status: 304, headers });
+  }
+
+  const body =
+    options.request.method.toUpperCase() === "HEAD"
+      ? null
+      : typeof options.content === "string"
+        ? options.content
+        : new Uint8Array(options.content).buffer;
+  return new Response(body, { status: options.status ?? 200, headers });
+}

--- a/packages/docs/src/http-cache.ts
+++ b/packages/docs/src/http-cache.ts
@@ -70,6 +70,8 @@ export function requestMatchesDocsEtag(request: Request, etag: string): boolean 
 
 /** Apply If-Modified-Since only when the stronger If-None-Match validator is absent. */
 export function requestHasFreshDocsDate(request: Request, lastModified?: string): boolean {
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return false;
   if (!lastModified || request.headers.has("if-none-match")) return false;
   const ifModifiedSince = request.headers.get("if-modified-since");
   if (!ifModifiedSince) return false;
@@ -100,6 +102,8 @@ function exposeValidatorHeaders(headers: Headers): void {
  * Build a byte-stable GET/HEAD response with HTTP validators and RFC 9530 integrity metadata.
  */
 export function createDocsCacheableResponse(options: DocsCacheableResponseOptions): Response {
+  const method = options.request.method.toUpperCase();
+  const isSafeRetrieval = method === "GET" || method === "HEAD";
   const sha256 = options.sha256 ?? sha256DocsContent(options.content);
   const etag = `"${sha256}"`;
   const lastModified = resolveDocsHttpDate(options.lastModified);
@@ -109,16 +113,18 @@ export function createDocsCacheableResponse(options: DocsCacheableResponseOption
   if (lastModified) headers.set("Last-Modified", lastModified);
   exposeValidatorHeaders(headers);
 
-  if (
-    requestMatchesDocsEtag(options.request, etag) ||
-    requestHasFreshDocsDate(options.request, lastModified)
-  ) {
+  if (requestMatchesDocsEtag(options.request, etag)) {
+    headers.delete("Content-Type");
+    return new Response(null, { status: isSafeRetrieval ? 304 : 412, headers });
+  }
+
+  if (isSafeRetrieval && requestHasFreshDocsDate(options.request, lastModified)) {
     headers.delete("Content-Type");
     return new Response(null, { status: 304, headers });
   }
 
   const body =
-    options.request.method.toUpperCase() === "HEAD"
+    method === "HEAD"
       ? null
       : typeof options.content === "string"
         ? options.content

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -627,7 +627,20 @@ export type {
   DocsAgentTraceStatus,
 } from "./types.js";
 
-export { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
+export {
+  digestDocsContent,
+  digestDocsRetrievalContent,
+  isDocsRetrievalCanonicalUrl,
+  sha256DocsContent,
+} from "./retrieval-digest.js";
+export {
+  createDocsCacheableResponse,
+  formatDocsContentDigest,
+  requestHasFreshDocsDate,
+  requestMatchesDocsEtag,
+  resolveDocsHttpDate,
+} from "./http-cache.js";
+export type { DocsCacheableResponseOptions } from "./http-cache.js";
 export type {
   DocsAgentTraceContext,
   ResolvedDocsAnalyticsConfig,

--- a/packages/docs/src/retrieval-digest.ts
+++ b/packages/docs/src/retrieval-digest.ts
@@ -24,6 +24,10 @@ function normalizeDigestContent(value: string): string {
     .trimEnd();
 }
 
+function toSha256Bytes(value: string | Uint8Array): Uint8Array {
+  return typeof value === "string" ? new TextEncoder().encode(value) : value;
+}
+
 /** Validate the bounded HTTP(S) URL or root-relative URI reference used by provenance. */
 export function isDocsRetrievalCanonicalUrl(value: string): boolean {
   const hasUnsafeCharacter =
@@ -53,15 +57,9 @@ export function isDocsRetrievalCanonicalUrl(value: string): boolean {
   }
 }
 
-/**
- * Hash a retrieval source projection with portable SHA-256.
- *
- * The projection is normalized by removing one leading BOM, converting CRLF/CR
- * line endings to LF, and trimming trailing whitespace. The helper is exported so
- * agents can independently verify provenance in Node, edge, and browser runtimes.
- */
-export function digestDocsRetrievalContent(value: string): `sha256:${string}` {
-  const input = new TextEncoder().encode(normalizeDigestContent(value));
+/** Hash exact bytes with portable SHA-256 in Node, edge, and browser runtimes. */
+export function sha256DocsContent(value: string | Uint8Array): string {
+  const input = toSha256Bytes(value);
   const paddedLength = Math.ceil((input.length + 9) / 64) * 64;
   const padded = new Uint8Array(paddedLength);
   padded.set(input);
@@ -124,5 +122,20 @@ export function digestDocsRetrievalContent(value: string): `sha256:${string}` {
     state[7] = (state[7]! + h) >>> 0;
   }
 
-  return `sha256:${Array.from(state, (word) => word.toString(16).padStart(8, "0")).join("")}`;
+  return Array.from(state, (word) => word.toString(16).padStart(8, "0")).join("");
+}
+
+/** Hash exact message-content bytes with portable SHA-256. */
+export function digestDocsContent(value: string | Uint8Array): `sha256:${string}` {
+  return `sha256:${sha256DocsContent(value)}`;
+}
+
+/**
+ * Hash the normalized retrieval projection used by search provenance.
+ *
+ * The projection removes one leading BOM, normalizes line endings to LF, and trims
+ * trailing whitespace. This deliberately differs from HTTP digests over exact bytes.
+ */
+export function digestDocsRetrievalContent(value: string): `sha256:${string}` {
+  return digestDocsContent(normalizeDigestContent(value));
 }

--- a/packages/docs/src/standards-discovery.test.ts
+++ b/packages/docs/src/standards-discovery.test.ts
@@ -231,17 +231,27 @@ describe("RFC 9727 API catalog", () => {
   });
 
   it("serves GET and bodyless HEAD with the RFC media type and Link relation", async () => {
+    const lastModified = "2026-07-31T12:00:00.000Z";
     const get = await createDocsStandardsResponse({
       request: new Request(`https://docs.example.com${DEFAULT_API_CATALOG_ROUTE}`),
       apiCatalog: catalog(),
       fallbackSkillDocument: generatedSkill,
+      lastModified,
     });
     expect(get?.status).toBe(200);
     expect(get?.headers.get("content-type")).toBe(
       `${API_CATALOG_MEDIA_TYPE}; profile="${API_CATALOG_PROFILE_URI}"; charset=utf-8`,
     );
     expect(get?.headers.get("link")).toContain('rel="api-catalog"');
-    expect(await get?.json()).toEqual(catalog());
+    const getContent = await get?.text();
+    expect(JSON.parse(getContent ?? "null")).toEqual(catalog());
+    expect(get?.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/u);
+    expect(get?.headers.get("last-modified")).toBe("Fri, 31 Jul 2026 12:00:00 GMT");
+    expect(get?.headers.get("content-digest")).toBe(
+      `sha-256=:${createHash("sha256")
+        .update(getContent ?? "", "utf8")
+        .digest("base64")}:`,
+    );
 
     const head = await createDocsStandardsResponse({
       request: new Request(`https://docs.example.com${DEFAULT_API_CATALOG_ROUTE}`, {
@@ -249,10 +259,34 @@ describe("RFC 9727 API catalog", () => {
       }),
       apiCatalog: catalog(),
       fallbackSkillDocument: generatedSkill,
+      lastModified,
     });
     expect(head?.status).toBe(200);
     expect(head?.headers.get("content-type")).toContain(API_CATALOG_MEDIA_TYPE);
+    expect(head?.headers.get("etag")).toBe(get?.headers.get("etag"));
+    expect(head?.headers.get("content-digest")).toBe(get?.headers.get("content-digest"));
     expect(await head?.text()).toBe("");
+
+    const notModified = await createDocsStandardsResponse({
+      request: new Request(`https://docs.example.com${DEFAULT_API_CATALOG_ROUTE}`, {
+        headers: { "If-None-Match": get?.headers.get("etag") ?? "" },
+      }),
+      apiCatalog: catalog(),
+      fallbackSkillDocument: generatedSkill,
+      lastModified,
+    });
+    expect(notModified?.status).toBe(304);
+    expect(notModified?.headers.get("content-digest")).toBe(get?.headers.get("content-digest"));
+
+    const dateNotModified = await createDocsStandardsResponse({
+      request: new Request(`https://docs.example.com${DEFAULT_API_CATALOG_ROUTE}`, {
+        headers: { "If-Modified-Since": "Sat, 01 Aug 2026 00:00:00 GMT" },
+      }),
+      apiCatalog: catalog(),
+      fallbackSkillDocument: generatedSkill,
+      lastModified,
+    });
+    expect(dateNotModified?.status).toBe(304);
   });
 
   it("keeps the catalog unavailable without disabling Agent Skills discovery", async () => {

--- a/packages/docs/src/standards-discovery.ts
+++ b/packages/docs/src/standards-discovery.ts
@@ -21,6 +21,8 @@ import {
   type DocsAgentSkillFrontmatter,
   type DocsAgentSkillFrontmatterValidationOptions,
 } from "./agent-skills-spec.js";
+import { createDocsCacheableResponse } from "./http-cache.js";
+import { sha256DocsContent } from "./retrieval-digest.js";
 
 export const DEFAULT_API_CATALOG_ROUTE = "/.well-known/api-catalog";
 export const DEFAULT_API_CATALOG_FORMAT = "api-catalog";
@@ -236,6 +238,8 @@ export interface CreateDocsStandardsResponseOptions {
   publishedSkills?: readonly DocsPublishedAgentSkill[];
   /** Identity used to publish the optional A2A Agent Card. */
   agentCard?: DocsA2AAgentCardOptions;
+  /** Stable representation generation or source modification time. */
+  lastModified?: string | Date | null;
 }
 
 function normalizeDocsRoute(value: string): string {
@@ -443,13 +447,6 @@ export function buildDocsApiCatalog(options: DocsApiCatalogOptions): DocsApiCata
   return { linkset };
 }
 
-function toDiscoveryBytes(content: string | Uint8Array): Uint8Array<ArrayBuffer> {
-  if (typeof content === "string") return new TextEncoder().encode(content);
-  const bytes = new Uint8Array(new ArrayBuffer(content.byteLength));
-  bytes.set(content);
-  return bytes;
-}
-
 function toPublishedSkillArray(
   skills: DocsPublishedAgentSkill | readonly DocsPublishedAgentSkill[],
 ): readonly DocsPublishedAgentSkill[] {
@@ -459,12 +456,7 @@ function toPublishedSkillArray(
 }
 
 export async function sha256DocsDiscoveryContent(content: string | Uint8Array): Promise<string> {
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) {
-    throw new Error("Web Crypto SHA-256 support is required for Agent Skills discovery.");
-  }
-  const digest = await subtle.digest("SHA-256", toDiscoveryBytes(content));
-  return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
+  return sha256DocsContent(content);
 }
 
 function createDocsPublishedAgentSkill(
@@ -1415,45 +1407,30 @@ export function appendDocsDiscoveryLinkHeader(headers: Headers, value?: string):
   return next;
 }
 
-function requestMatchesEtag(request: Request, etag: string): boolean {
-  const value = request.headers.get("if-none-match");
-  if (!value) return false;
-  if (value.trim() === "*") return true;
-  return value.split(",").some((candidate) => candidate.trim().replace(/^W\//i, "") === etag);
-}
-
 async function createHashedDiscoveryResponse(options: {
   request: Request;
   content: string | Uint8Array;
   contentType: string;
   sha256?: string;
   linkHeader: string;
+  lastModified?: string | Date | null;
 }): Promise<Response> {
   const sha256 = options.sha256 ?? (await sha256DocsDiscoveryContent(options.content));
-  const etag = `"${sha256}"`;
-  const headers = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Expose-Headers": "ETag, Link",
-    Allow: "GET, HEAD",
-    "Cache-Control": DISCOVERY_CACHE_CONTROL,
-    "Content-Type": options.contentType,
-    ETag: etag,
-    Link: options.linkHeader,
-    "X-Robots-Tag": "noindex",
-  };
-
-  if (requestMatchesEtag(options.request, etag)) {
-    const { "Content-Type": _contentType, ...notModifiedHeaders } = headers;
-    return new Response(null, { status: 304, headers: notModifiedHeaders });
-  }
-
-  const body =
-    options.request.method.toUpperCase() === "HEAD"
-      ? null
-      : typeof options.content === "string"
-        ? options.content
-        : toDiscoveryBytes(options.content).buffer;
-  return new Response(body, { headers });
+  return createDocsCacheableResponse({
+    request: options.request,
+    content: options.content,
+    sha256,
+    lastModified: options.lastModified,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Expose-Headers": "Link",
+      Allow: "GET, HEAD",
+      "Cache-Control": DISCOVERY_CACHE_CONTROL,
+      "Content-Type": options.contentType,
+      Link: options.linkHeader,
+      "X-Robots-Tag": "noindex",
+    },
+  });
 }
 
 function standardsNotFoundResponse(request: Request, linkHeader: string): Response {
@@ -1495,6 +1472,7 @@ export async function createDocsStandardsResponse({
   fallbackSkillDocument,
   publishedSkills = [],
   agentCard,
+  lastModified,
 }: CreateDocsStandardsResponseOptions): Promise<Response | null> {
   const resolved = resolveDocsStandardsDiscoveryRequest(new URL(request.url), { apiRoute });
   if (!resolved) return null;
@@ -1519,6 +1497,7 @@ export async function createDocsStandardsResponse({
       content,
       contentType: `${API_CATALOG_MEDIA_TYPE}; profile="${API_CATALOG_PROFILE_URI}"; charset=utf-8`,
       linkHeader,
+      lastModified,
     });
   }
 
@@ -1555,6 +1534,7 @@ export async function createDocsStandardsResponse({
           ? "application/gzip"
           : "text/markdown; charset=utf-8",
       sha256: file?.sha256 ?? skill.sha256,
+      lastModified,
       linkHeader: [
         linkHeader,
         formatLinkTarget(DEFAULT_AGENT_SKILLS_INDEX_ROUTE, "collection", {
@@ -1574,6 +1554,7 @@ export async function createDocsStandardsResponse({
       content: skill.content,
       contentType: "application/gzip",
       sha256: skill.sha256,
+      lastModified,
       linkHeader: [
         linkHeader,
         formatLinkTarget(DEFAULT_AGENT_SKILLS_INDEX_ROUTE, "collection", {
@@ -1599,6 +1580,7 @@ export async function createDocsStandardsResponse({
       content: file.content,
       contentType: `${file.mediaType}${file.mediaType.startsWith("text/") ? "; charset=utf-8" : ""}`,
       sha256: file.sha256,
+      lastModified,
       linkHeader: [
         linkHeader,
         formatLinkTarget(DEFAULT_AGENT_SKILLS_INDEX_ROUTE, "collection", {
@@ -1616,6 +1598,7 @@ export async function createDocsStandardsResponse({
       content,
       contentType: "application/json; charset=utf-8",
       linkHeader,
+      lastModified,
     });
   }
 
@@ -1626,6 +1609,7 @@ export async function createDocsStandardsResponse({
       content,
       contentType: "application/json; charset=utf-8",
       linkHeader,
+      lastModified,
     });
   }
 
@@ -1634,6 +1618,7 @@ export async function createDocsStandardsResponse({
     request,
     content,
     contentType: "application/json; charset=utf-8",
+    lastModified,
     linkHeader: [
       linkHeader,
       ...skills.map((skill) =>

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1287,7 +1287,7 @@ export default defineDocs({
     expect(cacheResponse.headers.get("content-digest")).toBe(
       `sha-256=:${createHash("sha256").update(cacheContent, "utf8").digest("base64")}:`,
     );
-    expect(cacheResponse.headers.get("last-modified")).toMatch(/ GMT$/u);
+    expect(cacheResponse.headers.get("last-modified")).toBeNull();
     const cacheNotModified = await GET(
       new Request("http://localhost/llms.txt", {
         headers: { "If-None-Match": cacheEtag! },
@@ -1298,6 +1298,12 @@ export default defineDocs({
       cacheResponse.headers.get("content-digest"),
     );
     expect(await cacheNotModified.text()).toBe("");
+    const dateOnlyRevalidation = await GET(
+      new Request("http://localhost/llms.txt", {
+        headers: { "If-Modified-Since": "Sat, 01 Aug 2026 00:00:00 GMT" },
+      }),
+    );
+    expect(dateOnlyRevalidation.status).toBe(200);
 
     const customLlms = await GET(new Request("http://localhost/api/internal/docs?format=llms"));
     expect(customLlms.status).toBe(200);

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -102,6 +102,7 @@ describe("createDocsMCPAPI", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     process.chdir(originalCwd);
     while (tempDirs.length > 0) {
       const dir = tempDirs.pop();
@@ -2329,6 +2330,8 @@ Use the product-specific coding workflow first.
       rootDir,
       entry: "docs",
     });
+    const agentsPath = join(rootDir, "AGENTS.md");
+    const readFileSpy = vi.spyOn(fs, "readFileSync");
 
     const agentsApi = await GET(new Request("http://localhost/api/docs?format=agents"));
     const agentsApiText = await agentsApi.text();
@@ -2350,6 +2353,24 @@ Use the product-specific coding workflow first.
       expect(response.headers.get("content-type")).toContain("text/markdown");
       expect(await response.text()).toBe(agentsApiText);
     }
+
+    expect(
+      readFileSpy.mock.calls.filter(([candidate]) => String(candidate) === agentsPath),
+    ).toHaveLength(1);
+
+    writeFileSync(
+      agentsPath,
+      `# Updated Agent Instructions
+
+Use the newly revised product workflow.
+`,
+    );
+    const updated = await GET(new Request("http://localhost/AGENTS.md"));
+    expect(await updated.text()).toContain("newly revised product workflow");
+    expect(
+      readFileSpy.mock.calls.filter(([candidate]) => String(candidate) === agentsPath),
+    ).toHaveLength(2);
+    readFileSpy.mockRestore();
   });
 
   it("uses the human audience projection for normal search", async () => {

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -1280,6 +1280,25 @@ export default defineDocs({
       expect(await response.text()).toBe(llmsApiText);
     }
 
+    const cacheResponse = await GET(new Request("http://localhost/llms.txt"));
+    const cacheContent = await cacheResponse.text();
+    const cacheEtag = cacheResponse.headers.get("etag");
+    expect(cacheEtag).toMatch(/^"[a-f0-9]{64}"$/u);
+    expect(cacheResponse.headers.get("content-digest")).toBe(
+      `sha-256=:${createHash("sha256").update(cacheContent, "utf8").digest("base64")}:`,
+    );
+    expect(cacheResponse.headers.get("last-modified")).toMatch(/ GMT$/u);
+    const cacheNotModified = await GET(
+      new Request("http://localhost/llms.txt", {
+        headers: { "If-None-Match": cacheEtag! },
+      }),
+    );
+    expect(cacheNotModified.status).toBe(304);
+    expect(cacheNotModified.headers.get("content-digest")).toBe(
+      cacheResponse.headers.get("content-digest"),
+    );
+    expect(await cacheNotModified.text()).toBe("");
+
     const customLlms = await GET(new Request("http://localhost/api/internal/docs?format=llms"));
     expect(customLlms.status).toBe(200);
     expect(await customLlms.text()).toBe(llmsApiText);
@@ -2214,7 +2233,7 @@ Use the product-specific workflow first.
     }
   });
 
-  it("serves legacy discovery HEAD without loading documents and records HEAD analytics", async () => {
+  it("serves legacy discovery HEAD with GET validators and records HEAD analytics", async () => {
     const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-discovery-head-route-"));
     tempDirs.push(rootDir);
 
@@ -2233,7 +2252,7 @@ description: Custom docs skill.
     );
 
     const events: DocsAnalyticsEvent[] = [];
-    const { HEAD, POST } = createDocsAPI({
+    const { GET, HEAD, POST } = createDocsAPI({
       rootDir,
       entry: "docs",
       analytics: {
@@ -2243,41 +2262,37 @@ description: Custom docs skill.
         },
       },
     });
-    const readFileSpy = vi.spyOn(fs, "readFileSync");
-
-    try {
-      for (const path of ["/.well-known/agent.json", "/AGENTS.md", "/skill.md"]) {
-        const response = await HEAD(new Request(`http://localhost${path}`, { method: "HEAD" }));
-        expect(response.status).toBe(200);
-        expect(await response.text()).toBe("");
-        if (path === "/.well-known/agent.json") {
-          expect(response.headers.get("link")).toContain('rel="describedby"');
-          expect(response.headers.get("link")).toContain(
-            `type="${DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE}"`,
-          );
-        }
+    for (const path of ["/.well-known/agent.json", "/AGENTS.md", "/skill.md"]) {
+      const get = await GET(new Request(`http://localhost${path}`));
+      const response = await HEAD(new Request(`http://localhost${path}`, { method: "HEAD" }));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("etag")).toBe(get.headers.get("etag"));
+      expect(response.headers.get("content-digest")).toBe(get.headers.get("content-digest"));
+      expect(response.headers.get("last-modified")).toBe(get.headers.get("last-modified"));
+      expect(await response.text()).toBe("");
+      if (path === "/.well-known/agent.json") {
+        expect(response.headers.get("link")).toContain('rel="describedby"');
+        expect(response.headers.get("link")).toContain(
+          `type="${DOCS_AGENT_MANIFEST_SCHEMA_MEDIA_TYPE}"`,
+        );
       }
-
-      const legacyFiles = new Set([join(rootDir, "AGENTS.md"), join(rootDir, "skill.md")]);
-      expect(
-        readFileSpy.mock.calls.some(([file]) => typeof file === "string" && legacyFiles.has(file)),
-      ).toBe(false);
-      expect(
-        events
-          .filter((event) =>
-            ["agent_spec_request", "agents_request", "skill_request"].includes(event.type),
-          )
-          .map((event) => event.properties?.method),
-      ).toEqual(["HEAD", "HEAD", "HEAD"]);
-
-      const unsupported = await POST(
-        new Request("http://localhost/api/docs?format=agent-skills", { method: "POST" }),
-      );
-      expect(unsupported.status).toBe(405);
-      expect(unsupported.headers.get("allow")).toBe("GET, HEAD");
-    } finally {
-      readFileSpy.mockRestore();
     }
+
+    expect(
+      events
+        .filter(
+          (event) =>
+            ["agent_spec_request", "agents_request", "skill_request"].includes(event.type) &&
+            event.properties?.method === "HEAD",
+        )
+        .map((event) => event.properties?.method),
+    ).toEqual(["HEAD", "HEAD", "HEAD"]);
+
+    const unsupported = await POST(
+      new Request("http://localhost/api/docs?format=agent-skills", { method: "POST" }),
+    );
+    expect(unsupported.status).toBe(405);
+    expect(unsupported.headers.get("allow")).toBe("GET, HEAD");
   });
 
   it("serves a root AGENTS.md file before falling back to generated agent instructions", async () => {
@@ -2624,7 +2639,10 @@ Config content.
     expect(rewrittenFallbackResponse.headers.get("content-location")).toBe(
       "http://localhost/docs/getting-started/quickstart.md",
     );
-    expect(rewrittenFallbackResponse.headers.get("etag")).toMatch(/^W\/"/);
+    expect(rewrittenFallbackResponse.headers.get("etag")).toMatch(/^"[a-f0-9]{64}"$/u);
+    expect(rewrittenFallbackResponse.headers.get("content-digest")).toMatch(
+      /^sha-256=:[A-Za-z0-9+/]{43}=:$/u,
+    );
     expect(rewrittenFallbackResponse.headers.get("last-modified")).toBe(
       "Fri, 17 Jul 2026 00:00:00 GMT",
     );

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -3925,7 +3925,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     includeAgentCard: Boolean(options?.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
-  const agentSurfaceLastModified = new Date().toUTCString();
   const telemetryConfig: Partial<DocsConfig> = {
     entry,
     docsPath,
@@ -4259,7 +4258,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       fallbackSkillDocument,
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: options?.agent?.a2a,
-      lastModified: agentSurfaceLastModified,
       origin: url.origin,
       entry,
       docsPath,
@@ -4382,7 +4380,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         return createDocsCacheableResponse({
           request,
           content,
-          lastModified: agentSurfaceLastModified,
           headers: {
             "Content-Type": "application/json; charset=utf-8",
             "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -4517,7 +4514,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         return createDocsCacheableResponse({
           request,
           content,
-          lastModified: agentSurfaceLastModified,
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
             "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -4559,7 +4555,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         return createDocsCacheableResponse({
           request,
           content,
-          lastModified: agentSurfaceLastModified,
           headers: {
             "Content-Type": "text/markdown; charset=utf-8",
             "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -4756,7 +4751,6 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         return createDocsCacheableResponse({
           request,
           content: selected.content,
-          lastModified: agentSurfaceLastModified,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
             "Cache-Control": "public, max-age=3600",

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -2479,32 +2479,37 @@ function renderAgentsDocument({
   return lines.join("\n");
 }
 
-function readRootSkillDocument(rootDir: string): string | null {
-  const candidate = path.join(rootDir, "skill.md");
-  try {
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return fs.readFileSync(candidate, "utf-8");
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-}
-
-function readRootAgentsDocument(rootDir: string): string | null {
-  for (const fileName of ["AGENTS.md", "AGENT.md"]) {
-    const candidate = path.join(rootDir, fileName);
-    try {
-      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-        return fs.readFileSync(candidate, "utf-8");
+function createRootDocumentReader(rootDir: string, fileNames: readonly string[]) {
+  let cached:
+    | {
+        path: string;
+        signature: string;
+        content: string;
       }
-    } catch {
-      continue;
-    }
-  }
+    | undefined;
 
-  return null;
+  return function readRootDocument(): string | null {
+    for (const fileName of fileNames) {
+      const candidate = path.join(rootDir, fileName);
+      try {
+        const stats = fs.statSync(candidate);
+        if (!stats.isFile()) continue;
+        const signature = [stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs].join(
+          ":",
+        );
+        if (cached?.path === candidate && cached.signature === signature) return cached.content;
+
+        const content = fs.readFileSync(candidate, "utf-8");
+        cached = { path: candidate, signature, content };
+        return content;
+      } catch {
+        continue;
+      }
+    }
+
+    cached = undefined;
+    return null;
+  };
 }
 
 function compactSkillText(value: string): string {
@@ -3860,6 +3865,8 @@ function generateLlmsTxt(
  */
 export function createDocsAPI(options?: DocsAPIOptions) {
   const root = options?.rootDir ?? process.cwd();
+  const readRootSkillDocument = createRootDocumentReader(root, ["skill.md"]);
+  const readRootAgentsDocument = createRootDocumentReader(root, ["AGENTS.md", "AGENT.md"]);
   let publishedAgentSkills: Promise<DocsPublishedAgentSkill[]> | undefined;
   function getPublishedAgentSkills(): Promise<DocsPublishedAgentSkill[]> {
     if (!publishedAgentSkills) {
@@ -4092,6 +4099,8 @@ export function createDocsAPI(options?: DocsAPIOptions) {
   const llmsCache = new BoundedRouteCache<ReturnType<typeof renderDocsLlmsTxt>>(
     MAX_LLMS_CACHE_ROUTES_PER_LOCALE,
   );
+  const generatedAgentsCache = new BoundedRouteCache<string>(MAX_LLMS_CACHE_ROUTES_PER_LOCALE);
+  const generatedSkillCache = new BoundedRouteCache<string>(MAX_LLMS_CACHE_ROUTES_PER_LOCALE);
   const markdownSourcesByLocale = new Map<
     string,
     ReturnType<typeof createFilesystemDocsMcpSource>[]
@@ -4227,6 +4236,51 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     return next;
   }
 
+  function getGeneratedAgentsDocument(origin: string, apiRoute: string): string {
+    const cacheKey = `${origin}\0${apiRoute}`;
+    const cached = generatedAgentsCache.get(undefined, cacheKey);
+    if (cached) return cached;
+    const next = renderAgentsDocument({
+      origin,
+      entry,
+      apiRoute,
+      apiCatalog: apiCatalogEnabled,
+      search: searchConfig,
+      contentChanges: contentChangesConfig.enabled,
+      mcp: mcpConfig,
+      feedback: agentFeedbackConfig,
+      llms: llmsConfig,
+      sitemap: sitemapConfig,
+      robots: robotsConfig,
+      openapi: openapiDiscovery,
+    });
+    generatedAgentsCache.set(undefined, cacheKey, next);
+    return next;
+  }
+
+  function getGeneratedSkillDocument(origin: string, apiRoute: string): string {
+    const cacheKey = `${origin}\0${apiRoute}`;
+    const cached = generatedSkillCache.get(undefined, cacheKey);
+    if (cached) return cached;
+    const next = renderSkillDocument({
+      origin,
+      entry,
+      apiRoute,
+      apiCatalog: apiCatalogEnabled,
+      i18n,
+      search: searchConfig,
+      contentChanges: contentChangesConfig.enabled,
+      mcp: mcpConfig,
+      feedback: agentFeedbackConfig,
+      llms: llmsConfig,
+      sitemap: sitemapConfig,
+      robots: robotsConfig,
+      openapi: openapiDiscovery,
+    });
+    generatedSkillCache.set(undefined, cacheKey, next);
+    return next;
+  }
+
   async function resolveStandardsResponse(request: Request, url: URL): Promise<Response | null> {
     const apiRoute = resolveDocsRequestApiRoute(url, configuredApiRouteInput);
     const resolved = resolveDocsStandardsDiscoveryRequest(url, { apiRoute });
@@ -4234,27 +4288,11 @@ export function createDocsAPI(options?: DocsAPIOptions) {
 
     const method = request.method.toUpperCase();
     const needsSkill = (method === "GET" || method === "HEAD") && resolved.kind !== "api-catalog";
-    const fallbackSkillDocument = needsSkill
-      ? renderSkillDocument({
-          origin: url.origin,
-          entry,
-          apiRoute,
-          apiCatalog: apiCatalogEnabled,
-          i18n,
-          search: searchConfig,
-          contentChanges: contentChangesConfig.enabled,
-          mcp: mcpConfig,
-          feedback: agentFeedbackConfig,
-          llms: llmsConfig,
-          sitemap: sitemapConfig,
-          robots: robotsConfig,
-          openapi: openapiDiscovery,
-        })
-      : "";
+    const fallbackSkillDocument = needsSkill ? getGeneratedSkillDocument(url.origin, apiRoute) : "";
 
     return createDocsStandardsDiscoveryResponse({
       request,
-      preferredSkillDocument: needsSkill ? readRootSkillDocument(root) : null,
+      preferredSkillDocument: needsSkill ? readRootSkillDocument() : null,
       fallbackSkillDocument,
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: options?.agent?.a2a,
@@ -4353,22 +4391,8 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             openapi: openapiDiscovery,
             publishedSkills: [
               await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(root),
-                fallbackDocument: renderSkillDocument({
-                  origin: url.origin,
-                  entry,
-                  apiRoute: requestApiRoute,
-                  apiCatalog: apiCatalogEnabled,
-                  i18n,
-                  search: searchConfig,
-                  contentChanges: contentChangesConfig.enabled,
-                  mcp: mcpConfig,
-                  feedback: agentFeedbackConfig,
-                  llms: llmsConfig,
-                  sitemap: sitemapConfig,
-                  robots: robotsConfig,
-                  openapi: openapiDiscovery,
-                }),
+                preferredDocument: readRootSkillDocument(),
+                fallbackDocument: getGeneratedSkillDocument(url.origin, requestApiRoute),
               }),
               ...(await getPublishedAgentSkills()),
             ],
@@ -4496,21 +4520,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           },
         });
         const content =
-          readRootAgentsDocument(root) ??
-          renderAgentsDocument({
-            origin: url.origin,
-            entry,
-            apiRoute: requestApiRoute,
-            apiCatalog: apiCatalogEnabled,
-            search: searchConfig,
-            contentChanges: contentChangesConfig.enabled,
-            mcp: mcpConfig,
-            feedback: agentFeedbackConfig,
-            llms: llmsConfig,
-            sitemap: sitemapConfig,
-            robots: robotsConfig,
-            openapi: openapiDiscovery,
-          });
+          readRootAgentsDocument() ?? getGeneratedAgentsDocument(url.origin, requestApiRoute);
         return createDocsCacheableResponse({
           request,
           content,
@@ -4536,22 +4546,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           },
         });
         const content =
-          readRootSkillDocument(root) ??
-          renderSkillDocument({
-            origin: url.origin,
-            entry,
-            apiRoute: requestApiRoute,
-            apiCatalog: apiCatalogEnabled,
-            i18n,
-            search: searchConfig,
-            contentChanges: contentChangesConfig.enabled,
-            mcp: mcpConfig,
-            feedback: agentFeedbackConfig,
-            llms: llmsConfig,
-            sitemap: sitemapConfig,
-            robots: robotsConfig,
-            openapi: openapiDiscovery,
-          });
+          readRootSkillDocument() ?? getGeneratedSkillDocument(url.origin, requestApiRoute);
         return createDocsCacheableResponse({
           request,
           content,
@@ -5004,6 +4999,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
  */
 export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
   const rootDir = options.rootDir ?? process.cwd();
+  const readRootSkillDocument = createRootDocumentReader(rootDir, ["skill.md"]);
   const entry = options.entry ?? readEntry(rootDir);
   const appDir = getNextAppDir(rootDir);
   const contentDir = options.contentDir ?? path.join(appDir, entry);
@@ -5036,7 +5032,7 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
     ...filesystemSource,
     async getSkills() {
       const configured = await getConfiguredAgentSkills();
-      const preferredDocument = readRootSkillDocument(rootDir);
+      const preferredDocument = readRootSkillDocument();
       const fallbackDocument = `---\nname: docs\ndescription: Use the project documentation through MCP resources and tools.\n---\n\n# Documentation\n`;
       const rootSkill = await resolveDocsPublishedAgentSkill({
         preferredDocument,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -48,6 +48,7 @@ import {
   createDocsAgentTraceId,
   createDocsContentChangeFeed,
   createDocsContentChangesHttpResponse,
+  createDocsCacheableResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsRobotsResponse,
   createDocsMarkdownResponse,
@@ -3924,6 +3925,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     includeAgentCard: Boolean(options?.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
+  const agentSurfaceLastModified = new Date().toUTCString();
   const telemetryConfig: Partial<DocsConfig> = {
     entry,
     docsPath,
@@ -4257,6 +4259,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       fallbackSkillDocument,
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: options?.agent?.a2a,
+      lastModified: agentSurfaceLastModified,
       origin: url.origin,
       entry,
       docsPath,
@@ -4335,17 +4338,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             method: requestMethod,
           },
         });
-        if (isHeadRequest) {
-          return new Response(null, {
-            headers: {
-              "Content-Type": "application/json",
-              "Cache-Control": "public, max-age=0, s-maxage=3600",
-              Link: agentManifestLinkHeader,
-              "X-Robots-Tag": "noindex",
-            },
-          });
-        }
-        return Response.json(
+        const content = `${JSON.stringify(
           buildAgentSpec({
             origin: url.origin,
             entry,
@@ -4383,14 +4376,20 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             ],
             agentCard: options?.agent?.a2a,
           }),
-          {
-            headers: {
-              "Cache-Control": "public, max-age=0, s-maxage=3600",
-              Link: agentManifestLinkHeader,
-              "X-Robots-Tag": "noindex",
-            },
+          null,
+          2,
+        )}\n`;
+        return createDocsCacheableResponse({
+          request,
+          content,
+          lastModified: agentSurfaceLastModified,
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            Link: agentManifestLinkHeader,
+            "X-Robots-Tag": "noindex",
           },
-        );
+        });
       }
 
       if (isDocsContentChangesRequest(url)) {
@@ -4499,33 +4498,33 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             method: requestMethod,
           },
         });
-        return new Response(
-          isHeadRequest
-            ? null
-            : (readRootAgentsDocument(root) ??
-                renderAgentsDocument({
-                  origin: url.origin,
-                  entry,
-                  apiRoute: requestApiRoute,
-                  apiCatalog: apiCatalogEnabled,
-                  search: searchConfig,
-                  contentChanges: contentChangesConfig.enabled,
-                  mcp: mcpConfig,
-                  feedback: agentFeedbackConfig,
-                  llms: llmsConfig,
-                  sitemap: sitemapConfig,
-                  robots: robotsConfig,
-                  openapi: openapiDiscovery,
-                })),
-          {
-            headers: {
-              "Content-Type": "text/markdown; charset=utf-8",
-              "Cache-Control": "public, max-age=0, s-maxage=3600",
-              Link: discoveryLinkHeader,
-              "X-Robots-Tag": "noindex",
-            },
+        const content =
+          readRootAgentsDocument(root) ??
+          renderAgentsDocument({
+            origin: url.origin,
+            entry,
+            apiRoute: requestApiRoute,
+            apiCatalog: apiCatalogEnabled,
+            search: searchConfig,
+            contentChanges: contentChangesConfig.enabled,
+            mcp: mcpConfig,
+            feedback: agentFeedbackConfig,
+            llms: llmsConfig,
+            sitemap: sitemapConfig,
+            robots: robotsConfig,
+            openapi: openapiDiscovery,
+          });
+        return createDocsCacheableResponse({
+          request,
+          content,
+          lastModified: agentSurfaceLastModified,
+          headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            Link: discoveryLinkHeader,
+            "X-Robots-Tag": "noindex",
           },
-        );
+        });
       }
 
       if (resolveSkillRequest(url)) {
@@ -4540,34 +4539,34 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             method: requestMethod,
           },
         });
-        return new Response(
-          isHeadRequest
-            ? null
-            : (readRootSkillDocument(root) ??
-                renderSkillDocument({
-                  origin: url.origin,
-                  entry,
-                  apiRoute: requestApiRoute,
-                  apiCatalog: apiCatalogEnabled,
-                  i18n,
-                  search: searchConfig,
-                  contentChanges: contentChangesConfig.enabled,
-                  mcp: mcpConfig,
-                  feedback: agentFeedbackConfig,
-                  llms: llmsConfig,
-                  sitemap: sitemapConfig,
-                  robots: robotsConfig,
-                  openapi: openapiDiscovery,
-                })),
-          {
-            headers: {
-              "Content-Type": "text/markdown; charset=utf-8",
-              "Cache-Control": "public, max-age=0, s-maxage=3600",
-              Link: discoveryLinkHeader,
-              "X-Robots-Tag": "noindex",
-            },
+        const content =
+          readRootSkillDocument(root) ??
+          renderSkillDocument({
+            origin: url.origin,
+            entry,
+            apiRoute: requestApiRoute,
+            apiCatalog: apiCatalogEnabled,
+            i18n,
+            search: searchConfig,
+            contentChanges: contentChangesConfig.enabled,
+            mcp: mcpConfig,
+            feedback: agentFeedbackConfig,
+            llms: llmsConfig,
+            sitemap: sitemapConfig,
+            robots: robotsConfig,
+            openapi: openapiDiscovery,
+          });
+        return createDocsCacheableResponse({
+          request,
+          content,
+          lastModified: agentSurfaceLastModified,
+          headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            Link: discoveryLinkHeader,
+            "X-Robots-Tag": "noindex",
           },
-        );
+        });
       }
 
       const robotsResponse = createDocsRobotsResponse({
@@ -4754,7 +4753,10 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             contentLength: selected.content.length,
           },
         });
-        return new Response(selected.content, {
+        return createDocsCacheableResponse({
+          request,
+          content: selected.content,
+          lastModified: agentSurfaceLastModified,
           headers: {
             "Content-Type": "text/plain; charset=utf-8",
             "Cache-Control": "public, max-age=3600",

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -27,6 +27,7 @@ import {
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
   createDocsContentChangesHttpResponse,
+  createDocsCacheableResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -918,6 +919,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
+  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1049,6 +1051,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
+      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1105,33 +1108,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : JSON.stringify(
-              buildDocsAgentDiscoverySpec({
-                ...discoveryOptions,
-                publishedSkills: [
-                  await resolveDocsPublishedAgentSkill({
-                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-                  }),
-                  ...(await getPublishedAgentSkills()),
-                ],
-                agentCard: config.agent?.a2a,
-              }),
-              null,
-              2,
-            ),
-        {
-          headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: agentManifestLinkHeader,
-          },
+      const content = `${JSON.stringify(
+        buildDocsAgentDiscoverySpec({
+          ...discoveryOptions,
+          publishedSkills: [
+            await resolveDocsPublishedAgentSkill({
+              preferredDocument: readRootSkillDocument(preloaded, rootDir),
+              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+            }),
+            ...(await getPublishedAgentSkills()),
+          ],
+          agentCard: config.agent?.a2a,
+        }),
+        null,
+        2,
+      )}\n`;
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: agentManifestLinkHeader,
         },
-      );
+      });
     }
 
     if (isDocsContentChangesRequest(url)) {
@@ -1215,40 +1217,38 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       isDocsAgentsRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsAgentsFormat(url) === "agents"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootAgentsDocument(preloaded, rootDir) ??
-              renderDocsAgentsDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     if (
       isDocsSkillRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsSkillFormat(url) === "skill"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootSkillDocument(preloaded, rootDir) ??
-              renderDocsSkillDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: context.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     const sitemapResponse = createDocsSitemapResponse({
@@ -1341,7 +1341,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         console.warn(`[docs] ${budgetIssue.message}`);
       }
 
-      return new Response(selected.content, {
+      return createDocsCacheableResponse({
+        request: context.request,
+        content: selected.content,
+        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -919,7 +919,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
-  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1051,7 +1050,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
-      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1126,7 +1124,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1222,7 +1219,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1241,7 +1237,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1344,7 +1339,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: context.request,
         content: selected.content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -40,6 +40,7 @@ import {
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
   createDocsContentChangesHttpResponse,
+  createDocsCacheableResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -941,6 +942,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
+  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1072,6 +1074,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
+      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1127,33 +1130,32 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(event.url, { apiRoute: discoveryApiRoute })) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : JSON.stringify(
-              buildDocsAgentDiscoverySpec({
-                ...discoveryOptions,
-                publishedSkills: [
-                  await resolveDocsPublishedAgentSkill({
-                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-                  }),
-                  ...(await getPublishedAgentSkills()),
-                ],
-                agentCard: config.agent?.a2a,
-              }),
-              null,
-              2,
-            ),
-        {
-          headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: agentManifestLinkHeader,
-          },
+      const content = `${JSON.stringify(
+        buildDocsAgentDiscoverySpec({
+          ...discoveryOptions,
+          publishedSkills: [
+            await resolveDocsPublishedAgentSkill({
+              preferredDocument: readRootSkillDocument(preloaded, rootDir),
+              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+            }),
+            ...(await getPublishedAgentSkills()),
+          ],
+          agentCard: config.agent?.a2a,
+        }),
+        null,
+        2,
+      )}\n`;
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: agentManifestLinkHeader,
         },
-      );
+      });
     }
 
     if (isDocsContentChangesRequest(event.url)) {
@@ -1237,40 +1239,38 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       isDocsAgentsRequest(event.url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsAgentsFormat(event.url) === "agents"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootAgentsDocument(preloaded, rootDir) ??
-              renderDocsAgentsDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     if (
       isDocsSkillRequest(event.url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsSkillFormat(event.url) === "skill"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootSkillDocument(preloaded, rootDir) ??
-              renderDocsSkillDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     const sitemapResponse = createDocsSitemapResponse({
@@ -1363,7 +1363,10 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         console.warn(`[docs] ${budgetIssue.message}`);
       }
 
-      return new Response(selected.content, {
+      return createDocsCacheableResponse({
+        request: event.request,
+        content: selected.content,
+        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -942,7 +942,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
-  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(
     (config as Record<string, unknown>).apiReference as any,
   );
@@ -1074,7 +1073,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
-      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1148,7 +1146,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1244,7 +1241,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1263,7 +1259,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1366,7 +1361,6 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content: selected.content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -10,6 +10,7 @@ import {
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
   createDocsContentChangesHttpResponse,
+  createDocsCacheableResponse,
   createDocsStandardsDiscoveryResponse,
   createDocsMarkdownResponse,
   createDocsRobotsResponse,
@@ -896,6 +897,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
+  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(config.apiReference);
   const mcpConfig = resolveDocsMcpConfig(config.mcp, {
     defaultName: llmsTitle,
@@ -1020,6 +1022,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
+      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1075,33 +1078,32 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : JSON.stringify(
-              buildDocsAgentDiscoverySpec({
-                ...discoveryOptions,
-                publishedSkills: [
-                  await resolveDocsPublishedAgentSkill({
-                    preferredDocument: readRootSkillDocument(preloaded, rootDir),
-                    fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-                  }),
-                  ...(await getPublishedAgentSkills()),
-                ],
-                agentCard: config.agent?.a2a,
-              }),
-              null,
-              2,
-            ),
-        {
-          headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: agentManifestLinkHeader,
-          },
+      const content = `${JSON.stringify(
+        buildDocsAgentDiscoverySpec({
+          ...discoveryOptions,
+          publishedSkills: [
+            await resolveDocsPublishedAgentSkill({
+              preferredDocument: readRootSkillDocument(preloaded, rootDir),
+              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+            }),
+            ...(await getPublishedAgentSkills()),
+          ],
+          agentCard: config.agent?.a2a,
+        }),
+        null,
+        2,
+      )}\n`;
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: agentManifestLinkHeader,
         },
-      );
+      });
     }
 
     if (isDocsContentChangesRequest(url)) {
@@ -1185,40 +1187,38 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       isDocsAgentsRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsAgentsFormat(url) === "agents"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootAgentsDocument(preloaded, rootDir) ??
-              renderDocsAgentsDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootAgentsDocument(preloaded, rootDir) ?? renderDocsAgentsDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     if (
       isDocsSkillRequest(url, { apiRoute: discoveryApiRoute }) ||
       resolveDocsSkillFormat(url) === "skill"
     ) {
-      return new Response(
-        isHeadRequest
-          ? null
-          : (readRootSkillDocument(preloaded, rootDir) ??
-              renderDocsSkillDocument(discoveryOptions)),
-        {
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
-            "X-Robots-Tag": "noindex",
-            Link: discoveryLinkHeader,
-          },
+      const content =
+        readRootSkillDocument(preloaded, rootDir) ?? renderDocsSkillDocument(discoveryOptions);
+      return createDocsCacheableResponse({
+        request: event.request,
+        content,
+        lastModified: agentSurfaceLastModified,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "X-Robots-Tag": "noindex",
+          Link: discoveryLinkHeader,
         },
-      );
+      });
     }
 
     const sitemapResponse = createDocsSitemapResponse({
@@ -1311,7 +1311,10 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         console.warn(`[docs] ${budgetIssue.message}`);
       }
 
-      return new Response(selected.content, {
+      return createDocsCacheableResponse({
+        request: event.request,
+        content: selected.content,
+        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -897,7 +897,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     includeAgentCard: Boolean(config.agent?.a2a),
   });
   const agentManifestLinkHeader = getDocsAgentManifestLinkHeader(discoveryLinkHeader);
-  const agentSurfaceLastModified = new Date().toUTCString();
   const openapiDiscovery = resolveApiReferenceOpenApiDiscovery(config.apiReference);
   const mcpConfig = resolveDocsMcpConfig(config.mcp, {
     defaultName: llmsTitle,
@@ -1022,7 +1021,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       fallbackSkillDocument: needsSkill ? renderDocsSkillDocument(discoveryOptions) : "",
       publishedSkills: needsSkill ? await getPublishedAgentSkills() : [],
       agentCard: config.agent?.a2a,
-      lastModified: agentSurfaceLastModified,
     });
   }
 
@@ -1096,7 +1094,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1192,7 +1189,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1211,7 +1207,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/markdown; charset=utf-8",
           "Cache-Control": "public, max-age=0, s-maxage=3600",
@@ -1314,7 +1309,6 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       return createDocsCacheableResponse({
         request: event.request,
         content: selected.content,
-        lastModified: agentSurfaceLastModified,
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
           "Cache-Control": "public, max-age=3600",


### PR DESCRIPTION
## Summary

- centralize strong ETag, Last-Modified, conditional 304, HEAD, and RFC 9530 Content-Digest behavior
- apply the shared response path to Markdown, llms.txt, custom manifests, A2A, API catalogs, Agent Skills, and all five framework adapters
- publish ETag, Content-Digest, and stable source freshness metadata for static Agent Bundle exports
- add cross-adapter conformance coverage for every affected agent surface

## Validation

- pnpm --filter @farming-labs/docs run test (68 files, 1312 tests)
- pnpm --filter @farming-labs/theme run test (16 files, 170 tests)
- pnpm --filter @farming-labs/tanstack-start --filter @farming-labs/svelte --filter @farming-labs/astro --filter @farming-labs/nuxt run test
- type checks for core and all five adapters
- formatting and targeted lint checks

## Standard

Content-Digest uses the RFC 9530 sha-256 structured field over the exact response bytes: https://www.rfc-editor.org/rfc/rfc9530.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies HTTP cache integrity across all agent surfaces with strong SHA‑256 ETags, RFC 9530 `Content-Digest`, normalized `Last-Modified`, consistent GET/HEAD/304, and 412 for unsafe methods when `If-None-Match` matches. Also preserves cache semantics for error surfaces by keeping their status and body (no 304 conversion) while still sending validators.

- **New Features**
  - Added `http-cache` helpers: `createDocsCacheableResponse`, `resolveDocsHttpDate`, `formatDocsContentDigest`, `requestMatchesDocsEtag`, `requestHasFreshDocsDate`. Validators are computed over exact bytes, preserved on HEAD/304, 412 is returned for unsafe methods with matching ETag, and error responses keep their body and status with validators. CORS exposes `ETag`, `Content-Digest`, and `Last-Modified` when allowed.
  - Applied to `@farming-labs/docs` surfaces and adapters `@farming-labs/astro`, `@farming-labs/nuxt`, `@farming-labs/svelte`, `@farming-labs/tanstack-start`, and `@farming-labs/fumadocs`.
  - Agent Bundle manifest includes per-file `etag` and `contentDigest`, with `lastModified` only on page files; orphaned files recompute integrity from current bytes.
  - Exported portable hashing and helpers: `sha256DocsContent` and `digestDocsContent`.

- **Refactors**
  - Replaced ad‑hoc ETag/date logic across Markdown and standards discovery; HEAD is bodyless and mirrors GET validators. `If-Modified-Since` is only applied when `If-None-Match` is absent.
  - Added memoized root document readers and caches for generated Agent/Skill documents to reduce I/O and keep validator parity.
  - Expanded tests for validator parity, RFC 9530 coverage, HEAD including GET validators, date precedence, static bundle metadata, and error surface cache semantics across all adapters.

<sup>Written for commit 4d5324ecfab267d9202ac9b951b0b1699a324ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

