### PR TITLE
fix: restore frozen installs for CI and deployments

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,16 +87,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.51.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.51.3)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(astro@6.4.8(@types/node@22.19.11)(@vercel/functions@3.7.1(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.1)(jiti@2.7.0)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(next@16.2.11(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(svelte@5.51.3)(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))(ws@8.21.0)
       '@farming-labs/astro':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -108,13 +108,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -157,13 +157,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -212,16 +212,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -240,16 +240,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -277,13 +277,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.84
+        specifier: 0.2.85
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0


### PR DESCRIPTION
## Summary

- synchronize the lockfile importers for all six versioned example applications with their declared Farming Labs `0.2.85` dependencies
- keep existing package resolutions unchanged
- restore frozen-install compatibility for GitHub Actions, package previews, MCP conformance, docs review, and both Vercel projects

## Root cause

The example package manifests were bumped from `0.2.84` to `0.2.85`, but their importer specifiers in `pnpm-lock.yaml` were not updated. Every remote job stopped at `pnpm install --frozen-lockfile`; Nuxt appeared in the logs only because pnpm reports the first mismatched importer and exits.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm test` — 70 files, 1,326 tests
- `pnpm --dir examples/fumadocs-cloud run build`
- `pnpm --dir website run build`

Both Vercel build roots complete locally after the repair.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced `pnpm-lock.yaml` importers for all six example apps to `0.2.85` for `@farming-labs/*` packages to match their manifests. Fixes lockfile drift that broke `pnpm install --frozen-lockfile` in CI, previews, docs review, and Vercel builds; existing package resolutions remain unchanged.

<sup>Written for commit 0f3d1837fdbe6ccea63f48a1185a0b3c8b52600c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

