### PR TITLE
fix: label shadcn theme with official icon

### DIFF
--- a/website/app/docs/themes/page.mdx
+++ b/website/app/docs/themes/page.mdx
@@ -71,7 +71,7 @@ If config builds but visuals do not change, repair the CSS entrypoint; if the fa
 | [Concrete](/docs/themes/concrete)         | `@farming-labs/theme/concrete`     | Brutalist poster-style hard-edge theme  |
 | [Command Grid](/docs/themes/command-grid) | `@farming-labs/theme/command-grid` | Mono-first paper-grid preset inspired by better-cmdk |
 | [Ledger](/docs/themes/ledger)             | `@farming-labs/theme/ledger`       | Stripe Docs-inspired product docs shell |
-| [Shadcn Docs](/docs/themes/shadcn)        | `@farming-labs/theme/shadcn`       | Compact neutral shadcn/ui docs shell |
+| [Shadcn](/docs/themes/shadcn)             | `@farming-labs/theme/shadcn`       | Compact neutral shadcn/ui docs shell |
 | [Hardline](/docs/themes/hardline)         | `@farming-labs/theme/hardline`     | Original hard-edge theme with strong borders |
 
 ## Using a Theme

--- a/website/app/docs/themes/shadcn/page.mdx
+++ b/website/app/docs/themes/shadcn/page.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Shadcn Docs"
+title: "Shadcn"
 description: "Compact neutral theme matching the layout, typography, and controls of the shadcn/ui documentation"
-icon: "layoutGrid"
+icon: "shadcn"
 order: 4.86
 related:
   - /docs/themes
@@ -12,10 +12,10 @@ agent:
   tokenBudget: 700
 ---
 
-# Shadcn Docs Theme
+# Shadcn Theme
 
 <Agent>
-Apply the Shadcn Docs preset through `shadcn` from `@farming-labs/theme/shadcn`, `theme: shadcn()`, and `@import "@farming-labs/theme/shadcn/css"` in the global stylesheet.
+Apply the Shadcn preset through `shadcn` from `@farming-labs/theme/shadcn`, `theme: shadcn()`, and `@import "@farming-labs/theme/shadcn/css"` in the global stylesheet.
 Expect a 56px header, 288px sidebar, 640px reading column, 256px table of contents, Geist typography, neutral surfaces, and compact controls in light and dark mode.
 If the page keeps the default shell, verify that the `/shadcn/css` entrypoint and `shadcn()` factory are both configured.
 </Agent>

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -75,6 +75,31 @@ const T3ChatIcon = () => (
   </svg>
 );
 
+const ShadcnIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 256 256" fill="none" aria-hidden="true">
+    <line
+      x1="208"
+      y1="128"
+      x2="128"
+      y2="208"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
+    <line
+      x1="192"
+      y1="40"
+      x2="40"
+      y2="192"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
+  </svg>
+);
+
 export default defineDocs({
   entry: "docs",
   search: searchConfig,
@@ -173,6 +198,7 @@ export default defineDocs({
     infrastructure: <Building2 size={16} />,
     dollarSign: <DollarSign size={16} />,
     route: <Route size={16} />,
+    shadcn: <ShadcnIcon />,
   },
   github: {
     url: "https://github.com/farming-labs/docs",


### PR DESCRIPTION
## What changed

- rename the docs sidebar entry and theme guide from **Shadcn Docs** to **Shadcn**
- register the official two-line Shadcn mark in the website icon registry
- point the Shadcn theme page frontmatter at the new icon key
- keep the built-in themes index label consistent

## Why

The theme page referenced an unregistered `layoutGrid` icon key, so its sidebar icon was missing. The visible label also repeated “Docs” inside the Themes section.

## Impact

The Themes sidebar now shows a concise **Shadcn** label with the recognizable Shadcn mark, and the guide heading and theme index use the same name.

## Validation

- `pnpm --dir website exec tsc --noEmit`
- `git diff --check`
- visually verified `/docs/themes/shadcn` in the local website preview


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing Shadcn icon and cleans up labeling in the Themes section. The theme page and index now use the official `shadcn` icon and the concise “Shadcn” name.

- **Bug Fixes**
  - Registered the official Shadcn mark as `shadcn` in `website/docs.config.tsx` and set `icon: "shadcn"` in the theme page (replacing the unregistered `layoutGrid` key).
  - Renamed "Shadcn Docs" to "Shadcn" in the themes index and guide heading for consistency.

<sup>Written for commit c09791b34e05787c1ad466d2ca4dfa4e27ffe30a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

