### PR TITLE
fix: resolve doctor config project root

### DIFF
--- a/packages/docs/src/cli/config.test.ts
+++ b/packages/docs/src/cli/config.test.ts
@@ -13,6 +13,7 @@ import {
   readStringProperty,
   readTopLevelStringProperty,
   resolveDocsContentDir,
+  resolveDocsProjectRoot,
 } from "./config.js";
 
 const tempDirs: string[] = [];
@@ -65,6 +66,32 @@ describe("resolveDocsContentDir", () => {
         "docs",
       ),
     ).toBe("app/docs");
+  });
+});
+
+describe("resolveDocsProjectRoot", () => {
+  it("uses the nested package that owns an explicitly selected config", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "docs-project-root-"));
+    tempDirs.push(workspaceRoot);
+    const appRoot = join(workspaceRoot, "website");
+    mkdirSync(appRoot, { recursive: true });
+    writeFileSync(join(workspaceRoot, "package.json"), '{"private":true}', "utf-8");
+    writeFileSync(join(appRoot, "package.json"), '{"private":true}', "utf-8");
+    const configPath = join(appRoot, "docs.config.tsx");
+    writeFileSync(configPath, "export default {};\n", "utf-8");
+
+    expect(resolveDocsProjectRoot(workspaceRoot, configPath)).toBe(appRoot);
+  });
+
+  it("keeps configs below an application anchored to the package root", () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "docs-project-root-"));
+    tempDirs.push(appRoot);
+    const configPath = join(appRoot, "src", "lib", "docs.config.ts");
+    mkdirSync(join(appRoot, "src", "lib"), { recursive: true });
+    writeFileSync(join(appRoot, "package.json"), '{"private":true}', "utf-8");
+    writeFileSync(configPath, "export default {};\n", "utf-8");
+
+    expect(resolveDocsProjectRoot(appRoot, configPath)).toBe(appRoot);
   });
 });
 

--- a/packages/docs/src/cli/config.ts
+++ b/packages/docs/src/cli/config.ts
@@ -103,6 +103,39 @@ export function resolveDocsConfigPath(rootDir: string, explicitPath?: string): s
   );
 }
 
+/**
+ * Resolve the application root that owns a docs config selected from another
+ * working directory. This keeps config-relative paths anchored to a nested
+ * workspace package without changing the behavior of configs stored below a
+ * project's root (for example, src/lib/docs.config.ts).
+ */
+export function resolveDocsProjectRoot(rootDir: string, configPath: string): string {
+  const invocationRoot = resolve(rootDir);
+  const resolvedConfigPath = resolve(configPath);
+  const configDir = dirname(resolvedConfigPath);
+  const relativeConfigDir = relative(invocationRoot, configDir);
+  const configIsInsideInvocationRoot =
+    relativeConfigDir === "" ||
+    (relativeConfigDir !== ".." && !relativeConfigDir.startsWith(`..${sep}`));
+  const fallbackRoot = configIsInsideInvocationRoot ? invocationRoot : configDir;
+  let currentDir = configDir;
+
+  while (true) {
+    if (existsSync(join(currentDir, "package.json"))) return currentDir;
+    if (configIsInsideInvocationRoot && currentDir === invocationRoot) return invocationRoot;
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) return fallbackRoot;
+    if (configIsInsideInvocationRoot) {
+      const relativeParent = relative(invocationRoot, parentDir);
+      if (relativeParent === ".." || relativeParent.startsWith(`..${sep}`)) {
+        return invocationRoot;
+      }
+    }
+    currentDir = parentDir;
+  }
+}
+
 export function readStringProperty(content: string, key: string): string | undefined {
   const match = content.match(createPropertyPattern(key, `["']([^"']+)["']`));
   return match?.[1];

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -480,6 +480,64 @@ If module evaluation fails, restore \`docs.config.ts\` and retry the doctor comm
     );
   }
 
+  it("resolves an explicit nested app config from the monorepo root", async () => {
+    const appRoot = path.join(tmpDir, "website");
+    mkdirSync(appRoot, { recursive: true });
+    writePackageJson(tmpDir, "doctor-workspace");
+    writePackageJson(appRoot, "doctor-website", { next: "16.0.0" });
+    writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - website\n", "utf-8");
+    writeDocsConfig(
+      appRoot,
+      "docs.config.tsx",
+      `export default {
+  entry: "docs",
+  contentDir: "app/docs",
+  agent: { skills: "../skills/farming-labs" },
+};`,
+    );
+    writeDocsPage(appRoot, "app/docs");
+    writeDocsConfig(
+      tmpDir,
+      "skills/farming-labs/migration/SKILL.md",
+      `---
+name: migration
+description: Migrate an existing documentation project to Farming Labs Docs.
+---
+
+# Workflow
+
+Review the source project before changing its documentation.
+`,
+    );
+    process.chdir(tmpDir);
+
+    const agentReport = await inspectAgentReadiness({
+      configPath: "website/docs.config.tsx",
+    });
+    const humanReport = await inspectHumanReadiness({
+      configPath: "website/docs.config.tsx",
+    });
+
+    expect(agentReport).toMatchObject({
+      framework: "nextjs",
+      configPath: "docs.config.tsx",
+      contentDir: "app/docs",
+      coverage: { totalPages: 1 },
+    });
+    expect(
+      agentReport.checks.find((check) => check.id === "agent-skills-frontmatter"),
+    ).toMatchObject({
+      status: "pass",
+      detail: expect.stringContaining("migration"),
+    });
+    expect(humanReport).toMatchObject({
+      framework: "nextjs",
+      configPath: "docs.config.tsx",
+      contentDir: "app/docs",
+      coverage: { totalPages: 1 },
+    });
+  });
+
   it("scores a healthy Next.js docs app as agent-optimized", async () => {
     writePackageJson(tmpDir, "doctor-next", { next: "16.0.0" });
 

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -85,6 +85,7 @@ import {
   readTopLevelStringProperty,
   resolveDocsConfigPath,
   resolveDocsContentDir,
+  resolveDocsProjectRoot,
 } from "./config.js";
 import { compactAgentDocs, inspectAgentCompactionState, scanDocsPageTargets } from "./agent.js";
 import type { AgentCompactOptions } from "./agent.js";
@@ -2904,16 +2905,23 @@ function makeCheck(
 export async function inspectAgentReadiness(
   options: DoctorOptions = {},
 ): Promise<AgentDoctorReport> {
-  const rootDir = process.cwd();
-  const files = listProjectFiles(rootDir);
-  const framework = detectFramework(rootDir) ?? detectFrameworkFromFiles(files) ?? "unknown";
+  const invocationRoot = process.cwd();
+  let rootDir = invocationRoot;
+  let files: string[] = [];
+  let framework: Framework | "unknown" = "unknown";
   const configCheckMax = 10;
 
   let configPath: string | undefined;
   try {
-    configPath = resolveDocsConfigPath(rootDir, options.configPath);
+    configPath = resolveDocsConfigPath(invocationRoot, options.configPath);
+    rootDir = resolveDocsProjectRoot(invocationRoot, configPath);
+    files = listProjectFiles(rootDir);
+    framework = detectFramework(rootDir) ?? detectFrameworkFromFiles(files) ?? "unknown";
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const invocationFiles = listProjectFiles(invocationRoot);
+    framework =
+      detectFramework(invocationRoot) ?? detectFrameworkFromFiles(invocationFiles) ?? "unknown";
     const checks = [
       makeCheck(
         "config",
@@ -2953,7 +2961,7 @@ export async function inspectAgentReadiness(
   }
 
   const configContent = readFileSync(configPath, "utf-8");
-  const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, options.configPath);
+  const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, configPath);
   const config = configLoad.status === "evaluated" ? configLoad.config : undefined;
   let configuredAgentSkillNames: string[] | undefined;
   let configuredAgentSkillsError: string | undefined;
@@ -3805,16 +3813,23 @@ export async function inspectAgentReadiness(
 export async function inspectHumanReadiness(
   options: DoctorOptions = {},
 ): Promise<HumanDoctorReport> {
-  const rootDir = process.cwd();
-  const files = listProjectFiles(rootDir);
-  const framework = detectFramework(rootDir) ?? detectFrameworkFromFiles(files) ?? "unknown";
+  const invocationRoot = process.cwd();
+  let rootDir = invocationRoot;
+  let files: string[] = [];
+  let framework: Framework | "unknown" = "unknown";
   const configCheckMax = 10;
 
   let configPath: string | undefined;
   try {
-    configPath = resolveDocsConfigPath(rootDir, options.configPath);
+    configPath = resolveDocsConfigPath(invocationRoot, options.configPath);
+    rootDir = resolveDocsProjectRoot(invocationRoot, configPath);
+    files = listProjectFiles(rootDir);
+    framework = detectFramework(rootDir) ?? detectFrameworkFromFiles(files) ?? "unknown";
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const invocationFiles = listProjectFiles(invocationRoot);
+    framework =
+      detectFramework(invocationRoot) ?? detectFrameworkFromFiles(invocationFiles) ?? "unknown";
     const checks = [
       makeCheck(
         "config",
@@ -3848,7 +3863,7 @@ export async function inspectHumanReadiness(
   }
 
   const configContent = readFileSync(configPath, "utf-8");
-  const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, options.configPath);
+  const configLoad = await loadDocsConfigModuleResultWithProjectEnv(rootDir, configPath);
   const config = configLoad.status === "evaluated" ? configLoad.config : undefined;
   const entry = config?.entry ?? readTopLevelStringProperty(configContent, "entry") ?? "docs";
   const contentDir = config?.contentDir ?? resolveDocsContentDir(rootDir, configContent, entry);


### PR DESCRIPTION
## Summary

- resolve the application that owns an explicitly selected nested docs config
- anchor agent and site doctor content, skills, environment loading, and framework detection to that application
- preserve existing behavior for configs stored below an application root, such as `src/lib/docs.config.ts`
- add monorepo regression coverage for both doctor modes

## Root cause

`docs doctor --config website/docs.config.tsx` resolved the config file correctly, but continued using `process.cwd()` as the project root. From a monorepo root, relative content and Agent Skill paths therefore pointed at the wrong directories and produced a false readiness score.

## Validation

- `pnpm --filter @farming-labs/docs run test` — 71 files and 1,333 tests passed
- focused config and doctor tests — 85 tests passed
- `pnpm --filter @farming-labs/docs run typecheck`
- targeted `oxlint` and `oxfmt`
- verified the root and in-app CLI invocations both report 99/100, 53 pages, Next.js, and passing Agent Skills


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `docs doctor` to anchor analysis to the app that owns an explicitly selected nested `docs.config.*`, ensuring correct paths, env, and framework detection in monorepos and accurate readiness scores.

- **Bug Fixes**
  - Added `resolveDocsProjectRoot` to find the owning package (nearest `package.json`) for an explicit config path.
  - Updated doctor to use that root for content, skills, env loading, and framework detection; preserved behavior for configs under an app root (e.g., `src/lib/docs.config.ts`).
  - Added monorepo tests for both agent and human doctor modes using `website/docs.config.tsx` from the workspace root.

<sup>Written for commit d574df6ee6e37a6c86d6514ee1ccc03c7a8d9303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

