### PR TITLE
feat: add useful MCP cache hints

### DIFF
--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -100,6 +100,45 @@ async function callMcpMethod(
   });
 }
 
+const MCP_2026_PROTOCOL_VERSION = "2026-07-28";
+
+async function callModernMcpMethod(
+  handlers: ReturnType<typeof createDocsMcpHttpHandler>,
+  method: string,
+  params: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+) {
+  return handlers.POST({
+    request: new Request("http://localhost/api/docs/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-method": method,
+        ...(typeof params.uri === "string" ? { "mcp-name": params.uri } : {}),
+        "mcp-protocol-version": MCP_2026_PROTOCOL_VERSION,
+        ...headers,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: `call-modern-${method}`,
+        method,
+        params: {
+          ...params,
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": MCP_2026_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo": {
+              name: "cache-hints-test",
+              version: "1.0.0",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    }),
+  });
+}
+
 function expectSuccessfulStructuredTextResult(payload: {
   result?: {
     content?: Array<{ text?: string }>;
@@ -480,6 +519,13 @@ describe("MCP cursor pagination", () => {
     nextCursor?: string;
   };
 
+  type ProtocolCacheableResult = {
+    resultType?: "complete" | "input_required";
+    ttlMs?: number;
+    cacheScope?: "public" | "private";
+    nextCursor?: string;
+  };
+
   async function readStructuredToolResult<T>(response: Response): Promise<{
     result?: {
       structuredContent?: T;
@@ -517,6 +563,126 @@ Shared MCP cursor marker ${number}.
       };
     });
   }
+
+  it("emits useful public cache hints for completed discovery, every list page, and resource reads", async () => {
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        getPages: () => createPaginationPages(25),
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+    });
+
+    const expectCacheHint = (
+      result: ProtocolCacheableResult | undefined,
+      ttlMs: number,
+      cacheScope: "public" | "private" = "public",
+    ) => {
+      expect(result).toMatchObject({
+        resultType: "complete",
+        ttlMs,
+        cacheScope,
+      });
+    };
+
+    try {
+      const discovery = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+        await callModernMcpMethod(handlers, "server/discover"),
+      );
+      expectCacheHint(discovery.result, 300_000);
+
+      for (const method of ["tools/list", "resources/list"] as const) {
+        let cursor: string | undefined;
+        let pageCount = 0;
+        do {
+          const page = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+            await callModernMcpMethod(handlers, method, cursor ? { cursor } : {}),
+          );
+          expectCacheHint(page.result, 300_000);
+          cursor = page.result?.nextCursor;
+          pageCount += 1;
+        } while (cursor);
+        expect(pageCount).toBeGreaterThan(1);
+      }
+
+      const templates = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+        await callModernMcpMethod(handlers, "resources/templates/list"),
+      );
+      expectCacheHint(templates.result, 300_000);
+
+      const read = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+        await callModernMcpMethod(handlers, "resources/read", {
+          uri: "docs://navigation",
+        }),
+      );
+      expectCacheHint(read.result, 60_000);
+
+      const legacy = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+        await callMcpMethod(handlers, "resources/read", {
+          uri: "docs://navigation",
+        }),
+      );
+      expect(legacy.result).not.toHaveProperty("ttlMs");
+      expect(legacy.result).not.toHaveProperty("cacheScope");
+    } finally {
+      await handlers.close?.();
+    }
+  });
+
+  it("keeps cacheable MCP results private when their source is authentication-dependent", async () => {
+    const handlers = createDocsMcpHttpHandler({
+      source: {
+        getPages: (_locale, context) => [
+          {
+            slug: "private",
+            url: "/docs/private",
+            title: `Private docs for ${context?.auth?.id ?? "anonymous"}`,
+            content: "Authenticated documentation.",
+          },
+        ],
+        getNavigation: (_locale, context) => ({
+          name: `Private docs for ${context?.auth?.id ?? "anonymous"}`,
+          children: [],
+        }),
+      },
+      mcp: {
+        security: {
+          authenticate: async () => ({ id: "agent-123" }),
+        },
+      },
+    });
+    const authHeaders = { authorization: "Bearer private-token" };
+
+    try {
+      const cases: Array<{
+        method: string;
+        params?: Record<string, unknown>;
+        ttlMs: number;
+      }> = [
+        { method: "server/discover", ttlMs: 300_000 },
+        { method: "tools/list", ttlMs: 300_000 },
+        { method: "resources/list", ttlMs: 300_000 },
+        { method: "resources/templates/list", ttlMs: 300_000 },
+        {
+          method: "resources/read",
+          params: { uri: "docs://navigation" },
+          ttlMs: 60_000,
+        },
+      ];
+
+      for (const testCase of cases) {
+        const payload = await parseMcpPayload<{ result?: ProtocolCacheableResult }>(
+          await callModernMcpMethod(handlers, testCase.method, testCase.params, authHeaders),
+        );
+        expect(payload.result).toMatchObject({
+          resultType: "complete",
+          ttlMs: testCase.ttlMs,
+          cacheScope: "private",
+        });
+      }
+    } finally {
+      await handlers.close?.();
+    }
+  });
 
   it("paginates MCP protocol resources and tools with stable standard cursors", async () => {
     const pages = createPaginationPages(105);
@@ -1356,7 +1522,11 @@ describe("MCP content-change synchronization", () => {
                 "io.modelcontextprotocol/clientCapabilities": {},
               },
               notifications: {
-                resourceSubscriptions: [DOCS_MCP_CONTENT_CHANGES_CURRENT_URI],
+                resourcesListChanged: true,
+                resourceSubscriptions: [
+                  DOCS_MCP_CONTENT_CHANGES_CURRENT_URI,
+                  "docs://docs/overview",
+                ],
               },
             },
           }),
@@ -1390,8 +1560,11 @@ describe("MCP content-change synchronization", () => {
         ...pages[0]!,
         content: "# Overview\n\nUpdated content.",
       };
-      await readUntil("notifications/resources/updated");
+      await readUntil("notifications/resources/list_changed");
+      await readUntil(`"uri":"${DOCS_MCP_CONTENT_CHANGES_CURRENT_URI}"`);
+      await readUntil('"uri":"docs://docs/overview"');
       expect(received).toContain(`"uri":"${DOCS_MCP_CONTENT_CHANGES_CURRENT_URI}"`);
+      expect(received).toContain("notifications/resources/list_changed");
 
       abortController.abort();
       await reader?.cancel().catch(() => {});

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -13,6 +13,7 @@ import {
 } from "@modelcontextprotocol/server";
 import type {
   AuthInfo,
+  CacheScope,
   ListPromptsResult,
   ListResourcesResult,
   ListResourceTemplatesResult,
@@ -499,6 +500,9 @@ interface ScannedDocsMcpPage extends DocsMcpPage {
 
 const DEFAULT_MCP_VERSION = "0.0.0";
 const DEFAULT_MCP_NAME = "@farming-labs/docs";
+const DOCS_MCP_DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1_000;
+const DOCS_MCP_LIST_CACHE_TTL_MS = 5 * 60 * 1_000;
+const DOCS_MCP_RESOURCE_CACHE_TTL_MS = 60 * 1_000;
 const DEFAULT_MCP_CONTEXT_TOKEN_BUDGET = 4_000;
 const MIN_MCP_CONTEXT_TOKEN_BUDGET = 256;
 const MAX_MCP_CONTEXT_TOKEN_BUDGET = 32_000;
@@ -3344,15 +3348,24 @@ interface DocsMcpContentChangeMonitor<Context> {
   close(): void;
 }
 
+interface DocsMcpContentGenerationState {
+  indexGeneration: string;
+  resourceUris: readonly string[];
+}
+
 function createDocsMcpContentChangeMonitor<Context>(options: {
   pollIntervalMs: number;
-  readGeneration: (context: Context) => Promise<string>;
-  notify: () => void | Promise<void>;
+  readState: (context: Context) => Promise<DocsMcpContentGenerationState>;
+  notify: (change: {
+    context: Context;
+    previous: DocsMcpContentGenerationState;
+    current: DocsMcpContentGenerationState;
+  }) => void | Promise<void>;
   isActive?: () => boolean;
   unrefTimer?: boolean;
 }): DocsMcpContentChangeMonitor<Context> {
   let context: Context | undefined;
-  let generation: string | undefined;
+  let state: DocsMcpContentGenerationState | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let running = false;
   let closed = false;
@@ -3364,12 +3377,15 @@ function createDocsMcpContentChangeMonitor<Context>(options: {
       if (closed || context === undefined || options.isActive?.() === false) return;
       running = true;
       try {
-        const nextGeneration = await options.readGeneration(context);
-        if (generation && nextGeneration !== generation) {
-          generation = nextGeneration;
-          await options.notify();
-        } else {
-          generation = nextGeneration;
+        const nextState = await options.readState(context);
+        const previousState = state;
+        state = nextState;
+        if (previousState && nextState.indexGeneration !== previousState.indexGeneration) {
+          await options.notify({
+            context,
+            previous: previousState,
+            current: nextState,
+          });
         }
       } catch {
         // A transient source or durable-store failure must not terminate a
@@ -3396,9 +3412,9 @@ function createDocsMcpContentChangeMonitor<Context>(options: {
         timer = undefined;
       }
       try {
-        generation = await options.readGeneration(nextContext);
+        state = await options.readState(nextContext);
       } catch {
-        generation = undefined;
+        state = undefined;
       }
       schedule();
     },
@@ -3644,10 +3660,41 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
     contentChangesConfig.enabled && resolved.tools.listContentChanges !== false;
   const contentChangeHydrationEnabled =
     contentChangesEnabled && resolved.tools.hydrateContentChanges !== false;
-  const server = new McpServer({
-    name: resolved.name,
-    version: resolved.version,
-  });
+  const cacheScope: CacheScope = options.requestContext?.auth ? "private" : "public";
+  const server = new McpServer(
+    {
+      name: resolved.name,
+      version: resolved.version,
+    },
+    {
+      cacheHints: {
+        "server/discover": {
+          ttlMs: DOCS_MCP_DISCOVERY_CACHE_TTL_MS,
+          cacheScope,
+        },
+        "tools/list": {
+          ttlMs: DOCS_MCP_LIST_CACHE_TTL_MS,
+          cacheScope,
+        },
+        "prompts/list": {
+          ttlMs: DOCS_MCP_LIST_CACHE_TTL_MS,
+          cacheScope,
+        },
+        "resources/list": {
+          ttlMs: DOCS_MCP_LIST_CACHE_TTL_MS,
+          cacheScope,
+        },
+        "resources/templates/list": {
+          ttlMs: DOCS_MCP_LIST_CACHE_TTL_MS,
+          cacheScope,
+        },
+        "resources/read": {
+          ttlMs: DOCS_MCP_RESOURCE_CACHE_TTL_MS,
+          cacheScope,
+        },
+      },
+    },
+  );
   installDocsMcpSdkRegistrationPagination(server, protocolScope);
   if (contentChangesEnabled) {
     server.server.registerCapabilities({
@@ -5667,7 +5714,9 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
       ? Math.floor(configuredPollInterval)
       : DEFAULT_DOCS_MCP_CONTENT_CHANGE_POLL_INTERVAL_MS;
 
-  async function readMonitoredGeneration(context: DocsMcpRequestContext): Promise<string> {
+  async function readMonitoredState(
+    context: DocsMcpRequestContext,
+  ): Promise<DocsMcpContentGenerationState> {
     const locale = options.source.resolveLocale?.(undefined, context);
     const pages = dedupePages(await options.source.getPages(locale, context));
     const result = await contentChangeFeed.resolve({
@@ -5680,13 +5729,27 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
         (context.request ? new URL(context.request.url).origin : undefined),
       ...(context.request ? { request: context.request.clone() } : {}),
     });
-    return result.indexGeneration;
+    return {
+      indexGeneration: result.indexGeneration,
+      resourceUris: [
+        "docs://navigation",
+        DOCS_MCP_CONTENT_CHANGES_CURRENT_URI,
+        `docs://changes/${result.indexGeneration}`,
+        ...pages.map((page) => toPageResourceUri(page.url)),
+      ],
+    };
   }
 
   const contentChangeMonitor = createDocsMcpContentChangeMonitor({
     pollIntervalMs: contentChangePollIntervalMs,
-    readGeneration: readMonitoredGeneration,
-    notify: () => mcpHandler.notify.resourceUpdated(DOCS_MCP_CONTENT_CHANGES_CURRENT_URI),
+    readState: readMonitoredState,
+    notify: ({ previous, current }) => {
+      mcpHandler.notify.resourcesChanged();
+      const affectedUris = new Set([...previous.resourceUris, ...current.resourceUris]);
+      for (const uri of affectedUris) {
+        mcpHandler.notify.resourceUpdated(uri);
+      }
+    },
     isActive: () => eventBus.listenerCount > 0,
     unrefTimer: true,
   });
@@ -5915,7 +5978,7 @@ export async function runDocsMcpStdio(options: CreateDocsMcpServerOptions): Prom
     });
     if (!contentChangesEnabled) return server;
 
-    const readGeneration = async () => {
+    const readState = async (): Promise<DocsMcpContentGenerationState> => {
       const locale = options.source.resolveLocale?.(undefined, requestContext);
       const pages = dedupePages(await options.source.getPages(locale, requestContext));
       const result = await contentChangeFeed.resolve({
@@ -5925,15 +5988,26 @@ export async function runDocsMcpStdio(options: CreateDocsMcpServerOptions): Prom
         locale,
         baseUrl: options.source.baseUrl,
       });
-      return result.indexGeneration;
+      return {
+        indexGeneration: result.indexGeneration,
+        resourceUris: [
+          "docs://navigation",
+          DOCS_MCP_CONTENT_CHANGES_CURRENT_URI,
+          `docs://changes/${result.indexGeneration}`,
+          ...pages.map((page) => toPageResourceUri(page.url)),
+        ],
+      };
     };
     const monitor = createDocsMcpContentChangeMonitor({
       pollIntervalMs,
-      readGeneration: () => readGeneration(),
-      notify: () =>
-        server.server.sendResourceUpdated({
-          uri: DOCS_MCP_CONTENT_CHANGES_CURRENT_URI,
-        }),
+      readState: () => readState(),
+      notify: async ({ previous, current }) => {
+        await server.server.sendResourceListChanged();
+        const affectedUris = new Set([...previous.resourceUris, ...current.resourceUris]);
+        for (const uri of affectedUris) {
+          await server.server.sendResourceUpdated({ uri });
+        }
+      },
     });
     await monitor.start(requestContext);
 


### PR DESCRIPTION
## Summary

- add intentional MCP 2026 cache hints for discovery, list, template-list, and resource-read results
- use shared public caching for public documentation and principal-scoped private caching for authenticated sources
- invalidate paginated resource lists and affected resource reads when the agent index generation changes, over both HTTP subscriptions and stdio notifications
- preserve 2025 protocol responses without cache fields

## Cache policy

- discovery and list results: 5 minutes
- resource reads: 1 minute
- public docs: `cacheScope: "public"`
- auth-dependent docs: `cacheScope: "private"`

## Validation

- `pnpm --filter @farming-labs/docs test` (1,334 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with existing unrelated warnings)
- `pnpm format:check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP 2026 cache hints to `@farming-labs/docs` for discovery, list, template-list, and resource-read methods, with correct public/private scope. Also sends list-changed and per-resource update notifications so caches invalidate when the docs index generation changes.

- **New Features**
  - Cache TTLs: discovery/list/templates 5m; resource reads 1m.
  - Cache scope: public docs use `public`; auth-dependent docs use `private`.
  - Invalidation: on index generation change, emit `resources/list_changed` and `resourceUpdated` for all affected URIs over HTTP subscriptions and stdio.
  - Backward compatible: 2025 protocol responses omit cache fields.
  - Tests: added coverage for cache hints (public/private) and change notifications.

<sup>Written for commit 13811c84f318f6086075667531738a915488f80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

