### PR TITLE
fix: make doctor command findings actionable

### DIFF
--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -796,10 +796,20 @@ pnpm run test -- --filter missing-workspace
         .map((finding) => finding.command),
     ).toEqual(["npm --workspace @acme/app run missing"]);
     expect(
+      commandFindings.find((finding) => finding.code === "command-script-missing"),
+    ).toMatchObject({
+      line: 7,
+      proposedCorrection: expect.stringContaining('Add a "missing" script'),
+    });
+    expect(
       commandFindings
         .filter((finding) => finding.code === "command-unverified")
         .map((finding) => finding.command),
     ).toEqual(["pnpm --filter @acme/app... run missing"]);
+    expect(commandFindings.find((finding) => finding.code === "command-unverified")).toMatchObject({
+      line: 8,
+      proposedCorrection: expect.stringContaining("exact workspace package name or path"),
+    });
     expect(report.metrics.commands).toEqual({
       total: 6,
       healthy: 4,
@@ -935,6 +945,7 @@ echo "operators such as && and > stay literal when quoted"
 npx skills add farming-labs/docs
 claude mcp add-json farming-labs-docs '{"type":"http","url":"https://docs.example.com/mcp"}'
 pnpm exec docs mcp setup --deployment <id>
+pnpm exec docs skills scaffold --dry-run
 curl --imaginary "https://docs.example.com"
 npx skills add not-a-repository
 npx mystery-tool run build
@@ -963,8 +974,8 @@ echo first > output.txt
     );
     expect(unverified).toHaveLength(6);
     expect(report.metrics.commands).toEqual({
-      total: 17,
-      healthy: 11,
+      total: 18,
+      healthy: 12,
       unhealthy: 0,
       unverified: 6,
     });

--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -818,6 +818,59 @@ pnpm run test -- --filter missing-workspace
     });
   });
 
+  it("keeps contract and audience-projected fence findings on their exact source lines", () => {
+    const source = [
+      "---",
+      "title: Command locations",
+      "agent:",
+      "  commands:",
+      "    - run: pnpm run missing",
+      "  verification:",
+      "    - run: pnpm exec docs imaginary",
+      "---",
+      "",
+      "The command `pnpm run fence-missing` is explained before its runnable example.",
+      "",
+      "<Human>",
+      "```bash",
+      "pnpm run human-only",
+      "```",
+      "</Human>",
+      "",
+      "```bash",
+      "pnpm run fence-missing",
+      "```",
+    ].join("\n");
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        {
+          ...page("command-locations", source),
+          agent: {
+            commands: [{ run: "pnpm run missing" }],
+            verification: [
+              {
+                run: "pnpm exec docs imaginary",
+                expect: "Doctor rejects the unsupported command.",
+              },
+            ],
+          },
+          actionable: false,
+        },
+      ],
+    });
+    const commandFindings = report.findings.filter((finding) => finding.category === "command");
+
+    expect(commandFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "pnpm run missing", line: 5 }),
+        expect.objectContaining({ command: "pnpm exec docs imaginary", line: 7 }),
+        expect.objectContaining({ command: "pnpm run fence-missing", line: 19 }),
+      ]),
+    );
+    expect(commandFindings.map((finding) => finding.command)).not.toContain("pnpm run human-only");
+  });
+
   it("resolves named and path selectors from an enclosing package-manager workspace", () => {
     const workspaceRoot = path.join(rootDir, "monorepo");
     const docsRoot = path.join(workspaceRoot, "website");

--- a/packages/docs/src/agent-usefulness.ts
+++ b/packages/docs/src/agent-usefulness.ts
@@ -79,6 +79,8 @@ export interface AgentUsefulnessFinding {
   message: string;
   relatedFiles?: string[];
   command?: string;
+  /** Concrete authoring change that resolves or makes the command finding verifiable. */
+  proposedCorrection?: string;
 }
 
 export interface AgentUsefulnessMetrics {
@@ -204,6 +206,12 @@ interface AnalyzedCommand {
   source: "contract" | "fence";
 }
 
+interface AnalyzedShellLine {
+  run: string;
+  /** Zero-based physical line offset from the first line inside the fence. */
+  lineOffset: number;
+}
+
 interface ProjectPackageManifest {
   directory: string;
   relativePath: string;
@@ -236,6 +244,7 @@ const DEFAULT_DOCS_COMMANDS = [
   "cloud deploy",
   "cloud preview",
   "mcp",
+  "skills scaffold",
   "agent compact",
   "agent export",
   "agents generate",
@@ -1047,6 +1056,7 @@ function analyzeCommand(options: {
         code: "command-cwd-outside-root",
         severity: "error",
         message: `Command working directory resolves outside the project root: ${commandCwd}`,
+        proposedCorrection: `Set cwd to an existing project-relative directory inside the docs project instead of ${JSON.stringify(commandCwd)}.`,
       }),
     );
     return commandAnalysis(findings);
@@ -1058,6 +1068,7 @@ function analyzeCommand(options: {
         code: "command-cwd-missing",
         severity: "error",
         message: `Command working directory does not exist: ${commandCwd}`,
+        proposedCorrection: `Create ${JSON.stringify(commandCwd)} or change cwd to an existing project-relative directory.`,
       }),
     );
     return commandAnalysis(findings);
@@ -1070,6 +1081,8 @@ function analyzeCommand(options: {
         severity: "suggestion",
         message:
           "Compound commands, redirections, and shell expansions are not executed or inferred; this command is unverified.",
+        proposedCorrection:
+          "Split the shell expression into one independently verifiable command per line and document any redirection or expansion as a separate step.",
       }),
     );
     return commandAnalysis(findings);
@@ -1090,6 +1103,7 @@ function analyzeCommand(options: {
         code: "command-package-manager-mismatch",
         severity: "warning",
         message: `Command uses ${commandPackageManager}, but ${expectedPackageManager} is expected for this project or code block.`,
+        proposedCorrection: `Rewrite this command using ${expectedPackageManager}, or explicitly mark the example as a ${commandPackageManager} alternative when that is intentional.`,
       }),
     );
   }
@@ -1110,6 +1124,8 @@ function analyzeCommand(options: {
         code: "command-unverified",
         severity: "suggestion",
         message: `Workspace selector could not be resolved statically (${selectors}); this command is unverified.`,
+        proposedCorrection:
+          "Replace the selector with an exact workspace package name or path declared by the nearest workspace manifest.",
       }),
     );
   }
@@ -1131,6 +1147,8 @@ function analyzeCommand(options: {
           code: "command-unverified",
           severity: "suggestion",
           message: `No package.json could be found for package script "${script}"; this command is unverified.`,
+          proposedCorrection:
+            "Set cwd to the package that owns this script, or add a package.json with the documented script.",
         }),
       );
     }
@@ -1144,6 +1162,7 @@ function analyzeCommand(options: {
             code: "command-script-missing",
             severity: "error",
             message: `Command references package script "${script}", but that script is not defined in ${packageJson.relativePath}.`,
+            proposedCorrection: `Add a ${JSON.stringify(script)} script to ${packageJson.relativePath}, or replace the command with an existing script from that file.`,
           }),
         );
       }
@@ -1160,6 +1179,7 @@ function analyzeCommand(options: {
           code: "command-cli-unknown",
           severity: "error",
           message: `Command references an unknown docs CLI command: docs ${docsCommand}`,
+          proposedCorrection: `Replace "docs ${docsCommand}" with the intended supported command listed by "docs --help".`,
         }),
       );
     }
@@ -1181,6 +1201,8 @@ function analyzeCommand(options: {
         code: "command-unverified",
         severity: "suggestion",
         message: "Command form could not be verified statically; this command is unverified.",
+        proposedCorrection:
+          "Use a documented package-manager or docs CLI command, or configure explicit executable-example validation for this command.",
       }),
     );
   }
@@ -1204,20 +1226,21 @@ function collectPageCommands(
   const commands: AnalyzedCommand[] = [];
 
   for (const command of agent?.commands ?? []) {
-    commands.push(normalizeAgentCommand(command, page.sourcePath));
+    commands.push(normalizeAgentCommand(command, page.sourcePath, page.source));
   }
 
   for (const verification of agent?.verification ?? []) {
     if (typeof verification !== "string" && verification.run) {
       commands.push({
         run: verification.run,
+        line: findCommandSourceLine(page.source, verification.run),
         sourcePath: page.sourcePath,
         source: "contract",
       });
     }
   }
 
-  collectMarkdownCommands(commands, projectedSource, page.sourcePath);
+  collectMarkdownCommands(commands, projectedSource, page.sourcePath, page.source);
   if (page.agentSource) {
     collectMarkdownCommands(commands, page.agentSource, page.agentSourcePath ?? page.sourcePath);
   }
@@ -1225,7 +1248,12 @@ function collectPageCommands(
   return dedupeCommands(commands);
 }
 
-function collectMarkdownCommands(commands: AnalyzedCommand[], source: string, sourcePath: string) {
+function collectMarkdownCommands(
+  commands: AnalyzedCommand[],
+  source: string,
+  sourcePath: string,
+  locationSource = source,
+) {
   const blocks = extractCodeBlocksFromMarkdown({
     source,
     filePath: sourcePath,
@@ -1236,8 +1264,10 @@ function collectMarkdownCommands(commands: AnalyzedCommand[], source: string, so
     if (!/^(?:bash|console|sh|shell|zsh)$/i.test(block.language ?? "")) continue;
     for (const command of shellLines(block.code, block.language)) {
       commands.push({
-        run: command,
-        line: block.lineStart,
+        run: command.run,
+        line:
+          findCommandSourceLine(locationSource, command.run) ??
+          block.lineStart + 1 + command.lineOffset,
         sourcePath,
         packageManagerHint: block.packageManager,
         source: "fence",
@@ -1249,23 +1279,49 @@ function collectMarkdownCommands(commands: AnalyzedCommand[], source: string, so
 function normalizeAgentCommand(
   command: string | PageAgentCommand,
   sourcePath: string,
+  source: string,
 ): AnalyzedCommand {
+  const run = typeof command === "string" ? command : command.run;
+  const line = findCommandSourceLine(source, run);
   return typeof command === "string"
-    ? { run: command, sourcePath, source: "contract" }
-    : { run: command.run, cwd: command.cwd, sourcePath, source: "contract" };
+    ? { run, line, sourcePath, source: "contract" }
+    : { run, cwd: command.cwd, line, sourcePath, source: "contract" };
 }
 
-function shellLines(code: string, language: string | undefined): string[] {
-  const joined = code.replace(/\\\s*\r?\n\s*/g, " ");
-  const lines = joined.split(/\r?\n/);
-  const promptedConsole =
-    language?.toLowerCase() === "console" && lines.some((line) => /^(?:\$|>)\s+/.test(line.trim()));
+function findCommandSourceLine(source: string, command: string): number | undefined {
+  const needle = command.trim();
+  if (!needle) return undefined;
+  const index = source.split(/\r?\n/).findIndex((line) => line.includes(needle));
+  return index >= 0 ? index + 1 : undefined;
+}
 
-  return lines
-    .map((line) => line.trim())
-    .filter((line) => !promptedConsole || /^(?:\$|>)\s+/.test(line))
-    .map((line) => line.replace(/^(?:\$|>)\s+/, ""))
-    .filter((line) => Boolean(line) && !line.startsWith("#") && !/^\w+=\S+$/.test(line));
+function shellLines(code: string, language: string | undefined): AnalyzedShellLine[] {
+  const logicalLines: AnalyzedShellLine[] = [];
+  let pending: AnalyzedShellLine | undefined;
+
+  for (const [lineOffset, physicalLine] of code.split(/\r?\n/).entries()) {
+    const trimmed = physicalLine.trim();
+    if (!pending) pending = { run: "", lineOffset };
+    const continued = /\\\s*$/.test(trimmed);
+    const segment = continued ? trimmed.replace(/\\\s*$/, "").trimEnd() : trimmed;
+    pending.run = `${pending.run}${pending.run && segment ? " " : ""}${segment}`;
+    if (continued) continue;
+    logicalLines.push(pending);
+    pending = undefined;
+  }
+  if (pending) logicalLines.push(pending);
+
+  const promptedConsole =
+    language?.toLowerCase() === "console" &&
+    logicalLines.some((line) => /^(?:\$|>)\s+/.test(line.run.trim()));
+
+  return logicalLines
+    .map((line) => ({ ...line, run: line.run.trim() }))
+    .filter((line) => !promptedConsole || /^(?:\$|>)\s+/.test(line.run))
+    .map((line) => ({ ...line, run: line.run.replace(/^(?:\$|>)\s+/, "") }))
+    .filter(
+      (line) => Boolean(line.run) && !line.run.startsWith("#") && !/^\w+=\S+$/.test(line.run),
+    );
 }
 
 function dedupeCommands(commands: AnalyzedCommand[]): AnalyzedCommand[] {
@@ -2130,7 +2186,7 @@ function isPathInside(rootDir: string, candidate: string): boolean {
 
 function commandFinding(
   options: { page: AgentUsefulnessPage; command: AnalyzedCommand },
-  finding: Pick<AgentUsefulnessFinding, "code" | "severity" | "message">,
+  finding: Pick<AgentUsefulnessFinding, "code" | "severity" | "message" | "proposedCorrection">,
 ): AgentUsefulnessFinding {
   return {
     ...makeFinding(options.page, {

--- a/packages/docs/src/agent-usefulness.ts
+++ b/packages/docs/src/agent-usefulness.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { isMap, isScalar, isSeq, parseDocument, type Scalar } from "yaml";
 import { hasStructuredPageAgentContract, normalizePageAgentFrontmatter } from "./agent-contract.js";
 import {
   agentVersionConstraintsOverlap,
@@ -797,7 +798,7 @@ function analyzePage(page: AgentUsefulnessPage): PageAnalysis {
     sourcePath: page.sourcePath,
     route: page.route,
   });
-  const shellCommands = collectPageCommands(page, agent, projectedSource);
+  const shellCommands = collectPageCommands(page, agent);
   const actionable =
     page.actionable ??
     (hasStructuredPageAgentContract(agent) ||
@@ -1218,42 +1219,179 @@ function commandAnalysis(findings: AgentUsefulnessFinding[]): CommandAnalysis {
   return { findings, status: "healthy" };
 }
 
+interface ContractCommandLocation {
+  run: string;
+  line: number;
+}
+
+interface ContractCommandLocations {
+  commands: ContractCommandLocation[];
+  verification: ContractCommandLocation[];
+}
+
+function collectContractCommandLocations(source: string): ContractCommandLocations {
+  const empty = (): ContractCommandLocations => ({ commands: [], verification: [] });
+  const opening = source.match(/^---[^\S\r\n]*\r?\n/);
+  if (!opening) return empty();
+
+  const frontmatterOffset = opening[0].length;
+  const remainder = source.slice(frontmatterOffset);
+  const closing = /(?:^|\r?\n)---[^\S\r\n]*(?:\r?\n|$)/.exec(remainder);
+  if (!closing) return empty();
+
+  try {
+    const document = parseDocument(remainder.slice(0, closing.index), { uniqueKeys: true });
+    if (document.errors.length > 0 || !isMap(document.contents)) return empty();
+    const agent = document.contents.get("agent", true);
+    if (!isMap(agent)) return empty();
+
+    return {
+      commands: collectContractSequenceLocations(
+        agent.get("commands", true),
+        source,
+        frontmatterOffset,
+      ),
+      verification: collectContractSequenceLocations(
+        agent.get("verification", true),
+        source,
+        frontmatterOffset,
+      ),
+    };
+  } catch {
+    return empty();
+  }
+}
+
+function collectContractSequenceLocations(
+  value: unknown,
+  source: string,
+  frontmatterOffset: number,
+): ContractCommandLocation[] {
+  if (!isSeq(value)) return [];
+  const locations: ContractCommandLocation[] = [];
+
+  for (const item of value.items) {
+    const run = isScalar(item) ? item : isMap(item) ? item.get("run", true) : undefined;
+    if (!isScalar(run) || typeof run.value !== "string") continue;
+    const location = contractScalarLocation(run, source, frontmatterOffset);
+    if (location) locations.push(location);
+  }
+
+  return locations;
+}
+
+function contractScalarLocation(
+  scalar: Scalar,
+  source: string,
+  frontmatterOffset: number,
+): ContractCommandLocation | undefined {
+  const relativeOffset = scalar.range?.[0];
+  if (typeof scalar.value !== "string" || relativeOffset === undefined) return undefined;
+  const absoluteOffset = frontmatterOffset + relativeOffset;
+  return {
+    run: scalar.value,
+    line: source.slice(0, absoluteOffset).split(/\r?\n/).length,
+  };
+}
+
+function claimContractCommandLine(
+  locations: readonly ContractCommandLocation[],
+  command: string,
+  claimedLines: Set<number>,
+): number | undefined {
+  const location = locations.find(
+    (candidate) => candidate.run === command && !claimedLines.has(candidate.line),
+  );
+  if (!location) return undefined;
+  claimedLines.add(location.line);
+  return location.line;
+}
+
+function preserveLineBreaksOnly(value: string): string {
+  return value.replace(/[^\r\n]/g, " ");
+}
+
+/** Agent projection used for command discovery that keeps original source line numbers stable. */
+function projectAgentCommandSource(source: string): string {
+  const tags = findDocsAudienceMdxTags(source);
+  if (tags.length === 0) return source;
+
+  const scopes: Array<Pick<DocsAudienceMdxTag, "name" | "only">> = [];
+  let output = "";
+  let cursor = 0;
+  const visible = () => scopes.every((scope) => scope.only !== "human");
+
+  for (const tag of tags) {
+    const activeScope = scopes.at(-1);
+    if (tag.closing && activeScope?.name !== tag.name) continue;
+
+    const content = source.slice(cursor, tag.index);
+    output += visible() ? content : preserveLineBreaksOnly(content);
+    output += preserveLineBreaksOnly(source.slice(tag.index, tag.end));
+    cursor = tag.end;
+
+    if (tag.closing) {
+      scopes.pop();
+    } else if (!tag.selfClosing) {
+      scopes.push({ name: tag.name, only: tag.only });
+    }
+  }
+
+  const remaining = source.slice(cursor);
+  output += visible() ? remaining : preserveLineBreaksOnly(remaining);
+  return output;
+}
+
 function collectPageCommands(
   page: AgentUsefulnessPage,
   agent: PageAgentFrontmatter | undefined,
-  projectedSource: string,
 ): AnalyzedCommand[] {
   const commands: AnalyzedCommand[] = [];
+  const contractLocations = collectContractCommandLocations(page.source);
+  const claimedContractLines = new Set<number>();
 
   for (const command of agent?.commands ?? []) {
-    commands.push(normalizeAgentCommand(command, page.sourcePath, page.source));
+    commands.push(
+      normalizeAgentCommand(
+        command,
+        page.sourcePath,
+        claimContractCommandLine(
+          contractLocations.commands,
+          typeof command === "string" ? command : command.run,
+          claimedContractLines,
+        ),
+      ),
+    );
   }
 
   for (const verification of agent?.verification ?? []) {
     if (typeof verification !== "string" && verification.run) {
       commands.push({
         run: verification.run,
-        line: findCommandSourceLine(page.source, verification.run),
+        line: claimContractCommandLine(
+          contractLocations.verification,
+          verification.run,
+          claimedContractLines,
+        ),
         sourcePath: page.sourcePath,
         source: "contract",
       });
     }
   }
 
-  collectMarkdownCommands(commands, projectedSource, page.sourcePath, page.source);
+  collectMarkdownCommands(commands, projectAgentCommandSource(page.source), page.sourcePath);
   if (page.agentSource) {
-    collectMarkdownCommands(commands, page.agentSource, page.agentSourcePath ?? page.sourcePath);
+    collectMarkdownCommands(
+      commands,
+      projectAgentCommandSource(page.agentSource),
+      page.agentSourcePath ?? page.sourcePath,
+    );
   }
 
   return dedupeCommands(commands);
 }
 
-function collectMarkdownCommands(
-  commands: AnalyzedCommand[],
-  source: string,
-  sourcePath: string,
-  locationSource = source,
-) {
+function collectMarkdownCommands(commands: AnalyzedCommand[], source: string, sourcePath: string) {
   const blocks = extractCodeBlocksFromMarkdown({
     source,
     filePath: sourcePath,
@@ -1265,9 +1403,7 @@ function collectMarkdownCommands(
     for (const command of shellLines(block.code, block.language)) {
       commands.push({
         run: command.run,
-        line:
-          findCommandSourceLine(locationSource, command.run) ??
-          block.lineStart + 1 + command.lineOffset,
+        line: block.lineStart + 1 + command.lineOffset,
         sourcePath,
         packageManagerHint: block.packageManager,
         source: "fence",
@@ -1279,20 +1415,12 @@ function collectMarkdownCommands(
 function normalizeAgentCommand(
   command: string | PageAgentCommand,
   sourcePath: string,
-  source: string,
+  line: number | undefined,
 ): AnalyzedCommand {
   const run = typeof command === "string" ? command : command.run;
-  const line = findCommandSourceLine(source, run);
   return typeof command === "string"
     ? { run, line, sourcePath, source: "contract" }
     : { run, cwd: command.cwd, line, sourcePath, source: "contract" };
-}
-
-function findCommandSourceLine(source: string, command: string): number | undefined {
-  const needle = command.trim();
-  if (!needle) return undefined;
-  const index = source.split(/\r?\n/).findIndex((line) => line.includes(needle));
-  return index >= 0 ? index + 1 : undefined;
 }
 
 function shellLines(code: string, language: string | undefined): AnalyzedShellLine[] {

--- a/packages/docs/src/cli/codeblocks.test.ts
+++ b/packages/docs/src/cli/codeblocks.test.ts
@@ -3,10 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCodeBlocksValidate } from "./codeblocks.js";
-
-function stripAnsi(value: string): string {
-  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
-}
+import { stripAnsi } from "./test-utils.js";
 
 describe("codeblocks validate cli", () => {
   let tmpDir: string;

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -24,10 +24,7 @@ import {
   probeProtectedMcpDiscovery,
   runDoctor,
 } from "./doctor.js";
-
-function stripAnsi(value: string): string {
-  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
-}
+import { stripAnsi } from "./test-utils.js";
 
 function writePackageJson(
   rootDir: string,
@@ -115,10 +112,16 @@ describe("parseDoctorArgs", () => {
   });
 
   it("parses CI annotation mode", () => {
-    expect(parseDoctorArgs(["--agent", "--ci", "--json"])).toEqual({
+    expect(
+      parseDoctorArgs(["--agent", "--ci", "--json-output", ".farming-labs/doctor.json"]),
+    ).toEqual({
       mode: "agent",
       ci: true,
-      json: true,
+      jsonOutputPath: ".farming-labs/doctor.json",
+    });
+    expect(parseDoctorArgs(["--json-output=reports/doctor.json"])).toEqual({
+      mode: "agent",
+      jsonOutputPath: "reports/doctor.json",
     });
   });
 
@@ -1120,8 +1123,7 @@ pnpm exec docs imaginary
       expect(textOutput).toContain('Proposed correction: Add a "missing" script');
 
       logSpy.mockClear();
-      process.env.GITHUB_ACTIONS = "true";
-      await runDoctor({ mode: "agent", json: true, ci: true });
+      await runDoctor({ mode: "agent", json: true });
 
       expect(logSpy).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
@@ -1130,13 +1132,27 @@ pnpm exec docs imaginary
       expect(payload.checks.find((check) => check.id === "command-health")?.findings).toEqual(
         commandCheck?.findings,
       );
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "::error file=app/docs/page.mdx,line=6,title=Documented command health::Command: pnpm run missing Reason:",
-        ),
+
+      logSpy.mockClear();
+      process.env.GITHUB_ACTIONS = "true";
+      const jsonOutputPath = path.join(tmpDir, "reports", "doctor.json");
+      await runDoctor({ mode: "agent", ci: true, jsonOutputPath });
+
+      const annotationOutput = stripAnsi(logSpy.mock.calls.flat().join("\n"));
+      expect(annotationOutput).toContain(
+        "::error file=app/docs/page.mdx,line=6,title=Documented command health::Command: pnpm run missing Reason:",
       );
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Proposed correction: Add a "missing" script'),
+      expect(annotationOutput).toContain('Proposed correction: Add a "missing" script');
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      const filePayload = JSON.parse(readFileSync(jsonOutputPath, "utf-8")) as {
+        checks: Array<{ id: string; findings?: unknown[] }>;
+      };
+      expect(filePayload.checks.find((check) => check.id === "command-health")?.findings).toEqual(
+        commandCheck?.findings,
+      );
+      await expect(runDoctor({ mode: "agent", ci: true, json: true })).rejects.toThrow(
+        "Use --ci --json-output <path>",
       );
     } finally {
       logSpy.mockRestore();

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -20,6 +20,7 @@ import {
   inspectAgentReadiness,
   inspectHumanReadiness,
   parseDoctorArgs,
+  printAgentDoctorReport,
   probeProtectedMcpDiscovery,
   runDoctor,
 } from "./doctor.js";
@@ -105,6 +106,14 @@ describe("parseDoctorArgs", () => {
     });
     expect(parseDoctorArgs(["--site", "--json"])).toEqual({
       mode: "human",
+      json: true,
+    });
+  });
+
+  it("parses CI annotation mode", () => {
+    expect(parseDoctorArgs(["--agent", "--ci", "--json"])).toEqual({
+      mode: "agent",
+      ci: true,
       json: true,
     });
   });
@@ -1040,6 +1049,94 @@ console.log("verified")
         status: "warn",
         score: 0,
       });
+    }
+  });
+
+  it("reports unhealthy commands with actionable text, JSON, and CI annotations", async () => {
+    writePackageJson(tmpDir, "doctor-actionable-command-findings", { next: "16.0.0" });
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default {
+  entry: "docs",
+  contentDir: "app/docs",
+  agent: { evaluations: false },
+};`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "app", "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, "app", "docs", "page.mdx"),
+      `---
+title: Broken commands
+description: Commands that doctor should explain.
+agent:
+  commands:
+    - pnpm run missing
+---
+
+# Broken commands
+
+\`\`\`bash
+pnpm exec docs imaginary
+\`\`\`
+`,
+      "utf-8",
+    );
+    process.chdir(tmpDir);
+
+    const report = await inspectAgentReadiness();
+    const commandCheck = report.checks.find((check) => check.id === "command-health");
+    expect(commandCheck?.findings).toEqual([
+      expect.objectContaining({
+        code: "command-script-missing",
+        file: "app/docs/page.mdx",
+        line: 6,
+        command: "pnpm run missing",
+        reason: expect.stringContaining('script "missing"'),
+        proposedCorrection: expect.stringContaining('Add a "missing" script'),
+      }),
+      expect.objectContaining({
+        code: "command-cli-unknown",
+        file: "app/docs/page.mdx",
+        line: 12,
+        command: "pnpm exec docs imaginary",
+        reason: expect.stringContaining("unknown docs CLI command"),
+        proposedCorrection: expect.stringContaining("docs --help"),
+      }),
+    ]);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      printAgentDoctorReport(report);
+      const textOutput = logSpy.mock.calls.flat().join("\n");
+      expect(textOutput).toContain("app/docs/page.mdx:6");
+      expect(textOutput).toContain("Command: pnpm run missing");
+      expect(textOutput).toContain('Reason: Command references package script "missing"');
+      expect(textOutput).toContain('Proposed correction: Add a "missing" script');
+
+      logSpy.mockClear();
+      process.env.GITHUB_ACTIONS = "true";
+      await runDoctor({ mode: "agent", json: true, ci: true });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
+        checks: Array<{ id: string; findings?: unknown[] }>;
+      };
+      expect(payload.checks.find((check) => check.id === "command-health")?.findings).toEqual(
+        commandCheck?.findings,
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "::error file=app/docs/page.mdx,line=6,title=Documented command health::Command: pnpm run missing Reason:",
+        ),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Proposed correction: Add a "missing" script'),
+      );
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -25,6 +25,10 @@ import {
   runDoctor,
 } from "./doctor.js";
 
+function stripAnsi(value: string): string {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
 function writePackageJson(
   rootDir: string,
   name: string,
@@ -1109,7 +1113,7 @@ pnpm exec docs imaginary
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       printAgentDoctorReport(report);
-      const textOutput = logSpy.mock.calls.flat().join("\n");
+      const textOutput = stripAnsi(logSpy.mock.calls.flat().join("\n"));
       expect(textOutput).toContain("app/docs/page.mdx:6");
       expect(textOutput).toContain("Command: pnpm run missing");
       expect(textOutput).toContain('Reason: Command references package script "missing"');

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1,4 +1,11 @@
-import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
@@ -105,6 +112,8 @@ export interface DoctorOptions {
   configPath?: string;
   mode?: DoctorMode;
   json?: boolean;
+  /** Write the JSON report to a file without mixing it into annotation stdout. */
+  jsonOutputPath?: string;
   /** Emit file/line GitHub workflow annotations when running in GitHub Actions. */
   ci?: boolean;
   strict?: boolean;
@@ -272,6 +281,25 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg.startsWith("--json-output=")) {
+      const value = parseInlineFlag(arg).value;
+      if (!value) {
+        throw new Error("Missing value for --json-output.");
+      }
+      parsed.jsonOutputPath = value;
+      continue;
+    }
+
+    if (arg === "--json-output") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("Missing value for --json-output.");
+      }
+      parsed.jsonOutputPath = value;
+      index += 1;
+      continue;
+    }
+
     if (arg === "--ci") {
       parsed.ci = true;
       continue;
@@ -407,6 +435,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--human")}            Alias for ${pc.cyan("--site")}
   ${pc.cyan("--only <mode>")}      Run only one doctor suite: ${pc.cyan("agent")} or ${pc.cyan("site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
+  ${pc.cyan("--json-output <path>")} Write the JSON report to a file; use with ${pc.cyan("--ci")} to keep annotation stdout valid
   ${pc.cyan("--ci")}               Emit actionable GitHub annotations when running in GitHub Actions
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
   ${pc.cyan("--fix")}              Refresh stale generated agent.md files and token-budget missing outputs
@@ -4257,6 +4286,16 @@ export function printDoctorJsonReport(report: AgentDoctorReport | HumanDoctorRep
   console.log(JSON.stringify(serializeDoctorJsonReport(report), null, 2));
 }
 
+function writeDoctorJsonReport(report: AgentDoctorReport | HumanDoctorReport, outputPath: string) {
+  const resolvedPath = path.resolve(process.cwd(), outputPath);
+  mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  writeFileSync(
+    resolvedPath,
+    `${JSON.stringify(serializeDoctorJsonReport(report), null, 2)}\n`,
+    "utf-8",
+  );
+}
+
 function escapeGitHubAnnotationData(value: string): string {
   return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
 }
@@ -4284,8 +4323,7 @@ function emitDoctorGitHubAnnotations(report: AgentDoctorReport | HumanDoctorRepo
         .filter(Boolean)
         .join(",");
       const message = `Command: ${finding.command} Reason: ${finding.reason} Proposed correction: ${finding.proposedCorrection}`;
-      // stderr preserves JSON-only stdout while GitHub Actions still recognizes the workflow command.
-      console.error(`::${command} ${location}::${escapeGitHubAnnotationData(message)}`);
+      console.log(`::${command} ${location}::${escapeGitHubAnnotationData(message)}`);
     }
   }
 }
@@ -4388,6 +4426,12 @@ async function runAgentDoctorFixes(
 }
 
 export async function runDoctor(options: DoctorOptions = {}) {
+  if (options.ci && options.json) {
+    throw new Error(
+      "doctor --ci and --json cannot share stdout. Use --ci --json-output <path> to emit GitHub annotations and persist the JSON report in one run.",
+    );
+  }
+
   if (options.mode === "human") {
     if (options.fix) {
       throw new Error("doctor --fix is currently only supported with --agent.");
@@ -4395,9 +4439,11 @@ export async function runDoctor(options: DoctorOptions = {}) {
 
     const report = await inspectHumanReadiness(options);
     applyDoctorExitCode(report, options);
+    if (options.jsonOutputPath) {
+      writeDoctorJsonReport(report, options.jsonOutputPath);
+    }
     if (options.json) {
       printDoctorJsonReport(report);
-      if (options.ci) emitDoctorGitHubAnnotations(report);
       return report;
     }
     printHumanDoctorReport(report);
@@ -4416,9 +4462,11 @@ export async function runDoctor(options: DoctorOptions = {}) {
   }
 
   applyDoctorExitCode(report, options);
+  if (options.jsonOutputPath) {
+    writeDoctorJsonReport(report, options.jsonOutputPath);
+  }
   if (options.json) {
     printDoctorJsonReport(report);
-    if (options.ci) emitDoctorGitHubAnnotations(report);
     return report;
   }
   printAgentDoctorReport(report);

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -41,6 +41,9 @@ import { PAGE_AGENT_CONTRACT_FIELDS } from "../agent-contract.js";
 import {
   analyzeAgentUsefulness,
   createAgentUsefulnessPagesFromMcp,
+  type AgentUsefulnessFinding,
+  type AgentUsefulnessFindingCode,
+  type AgentUsefulnessFindingSeverity,
   type AgentUsefulnessMetrics,
 } from "../agent-usefulness.js";
 import { runDocsGoldenTasks, type DocsGoldenTasksReport } from "../agent-evals.js";
@@ -102,6 +105,8 @@ export interface DoctorOptions {
   configPath?: string;
   mode?: DoctorMode;
   json?: boolean;
+  /** Emit file/line GitHub workflow annotations when running in GitHub Actions. */
+  ci?: boolean;
   strict?: boolean;
   failOn?: DoctorFailOn;
   url?: string;
@@ -121,6 +126,18 @@ export interface AgentDoctorCheck {
   score: number;
   maxScore: number;
   recommendation?: string;
+  /** Actionable source findings that explain this aggregate check. */
+  findings?: AgentDoctorCommandFinding[];
+}
+
+export interface AgentDoctorCommandFinding {
+  code: AgentUsefulnessFindingCode;
+  severity: AgentUsefulnessFindingSeverity;
+  file: string;
+  line?: number;
+  command: string;
+  reason: string;
+  proposedCorrection: string;
 }
 
 export interface AgentDoctorCoverage {
@@ -255,6 +272,11 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg === "--ci") {
+      parsed.ci = true;
+      continue;
+    }
+
     if (arg === "--strict") {
       parsed.strict = true;
       continue;
@@ -385,6 +407,7 @@ ${pc.dim("Options:")}
   ${pc.cyan("--human")}            Alias for ${pc.cyan("--site")}
   ${pc.cyan("--only <mode>")}      Run only one doctor suite: ${pc.cyan("agent")} or ${pc.cyan("site")}
   ${pc.cyan("--json")}             Print the report as JSON for CI, scripts, and other agents
+  ${pc.cyan("--ci")}               Emit actionable GitHub annotations when running in GitHub Actions
   ${pc.cyan("--strict")}           Exit with failure when any check warns or fails
   ${pc.cyan("--fix")}              Refresh stale generated agent.md files and token-budget missing outputs
   ${pc.cyan("--dry-run")}          With ${pc.cyan("--fix")}, report the compaction command without writing files
@@ -2898,8 +2921,35 @@ function makeCheck(
   maxScore: number,
   detail: string,
   recommendation?: string,
+  findings?: AgentDoctorCommandFinding[],
 ): AgentDoctorCheck {
-  return { id, title, status, score, maxScore, detail, recommendation };
+  return { id, title, status, score, maxScore, detail, recommendation, findings };
+}
+
+function toDoctorCommandFindings(
+  findings: readonly AgentUsefulnessFinding[],
+): AgentDoctorCommandFinding[] {
+  return findings
+    .filter(
+      (
+        finding,
+      ): finding is AgentUsefulnessFinding & {
+        command: string;
+        proposedCorrection: string;
+      } =>
+        finding.category === "command" &&
+        Boolean(finding.command) &&
+        Boolean(finding.proposedCorrection),
+    )
+    .map((finding) => ({
+      code: finding.code,
+      severity: finding.severity,
+      file: finding.file,
+      line: finding.line,
+      command: finding.command,
+      reason: finding.message,
+      proposedCorrection: finding.proposedCorrection,
+    }));
 }
 
 export async function inspectAgentReadiness(
@@ -3027,6 +3077,7 @@ export async function inspectAgentReadiness(
     pages: createAgentUsefulnessPagesFromMcp(rootDir, pages),
     projectFramework: framework === "unknown" ? undefined : framework,
   });
+  const commandFindings = toDoctorCommandFindings(usefulness.findings);
   const evaluationInput = config?.agent?.evaluations;
   const evaluation = resolveGoldenEvaluationInput(evaluationInput);
   const evaluationBaseUrl = config ? resolveDocsMetadataBaseUrl(config) : undefined;
@@ -3718,6 +3769,7 @@ export async function inspectAgentReadiness(
         usefulness.metrics.commands.unverified === 0
         ? undefined
         : "Update broken or stale commands and make workspace selectors resolvable so scripts, working directories, package managers, and docs CLI subcommands can be verified.",
+      commandFindings,
     ),
   );
 
@@ -4138,6 +4190,12 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
       `${formatStatus(check.status)} ${check.title} ${pc.dim(`(${check.score}/${check.maxScore})`)}`,
     );
     console.log(`  ${check.detail}`);
+    for (const finding of check.findings ?? []) {
+      const location = `${finding.file}${finding.line ? `:${finding.line}` : ""}`;
+      console.log(`  ${pc.dim(location)} ${pc.bold("Command:")} ${finding.command}`);
+      console.log(`    ${pc.bold("Reason:")} ${finding.reason}`);
+      console.log(`    ${pc.bold("Proposed correction:")} ${finding.proposedCorrection}`);
+    }
   }
 
   if (report.recommendations.length > 0) {
@@ -4197,6 +4255,39 @@ function serializeDoctorJsonReport(report: AgentDoctorReport | HumanDoctorReport
 
 export function printDoctorJsonReport(report: AgentDoctorReport | HumanDoctorReport) {
   console.log(JSON.stringify(serializeDoctorJsonReport(report), null, 2));
+}
+
+function escapeGitHubAnnotationData(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function escapeGitHubAnnotationProperty(value: string): string {
+  return escapeGitHubAnnotationData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+function emitDoctorGitHubAnnotations(report: AgentDoctorReport | HumanDoctorReport) {
+  if (process.env.GITHUB_ACTIONS !== "true" || report.mode !== "agent") return;
+
+  for (const check of report.checks) {
+    for (const finding of check.findings ?? []) {
+      const command =
+        finding.severity === "error"
+          ? "error"
+          : finding.severity === "warning"
+            ? "warning"
+            : "notice";
+      const location = [
+        `file=${escapeGitHubAnnotationProperty(finding.file)}`,
+        finding.line ? `line=${finding.line}` : undefined,
+        `title=${escapeGitHubAnnotationProperty(check.title)}`,
+      ]
+        .filter(Boolean)
+        .join(",");
+      const message = `Command: ${finding.command} Reason: ${finding.reason} Proposed correction: ${finding.proposedCorrection}`;
+      // stderr preserves JSON-only stdout while GitHub Actions still recognizes the workflow command.
+      console.error(`::${command} ${location}::${escapeGitHubAnnotationData(message)}`);
+    }
+  }
 }
 
 function hasNonPassingDoctorCheck(report: AgentDoctorReport | HumanDoctorReport) {
@@ -4306,9 +4397,11 @@ export async function runDoctor(options: DoctorOptions = {}) {
     applyDoctorExitCode(report, options);
     if (options.json) {
       printDoctorJsonReport(report);
+      if (options.ci) emitDoctorGitHubAnnotations(report);
       return report;
     }
     printHumanDoctorReport(report);
+    if (options.ci) emitDoctorGitHubAnnotations(report);
     return report;
   }
 
@@ -4325,8 +4418,10 @@ export async function runDoctor(options: DoctorOptions = {}) {
   applyDoctorExitCode(report, options);
   if (options.json) {
     printDoctorJsonReport(report);
+    if (options.ci) emitDoctorGitHubAnnotations(report);
     return report;
   }
   printAgentDoctorReport(report);
+  if (options.ci) emitDoctorGitHubAnnotations(report);
   return report;
 }

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -458,6 +458,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --site")}                       Score the current docs app for reader-facing docs quality
   ${pc.cyan("doctor --human")}                      Alias for ${pc.cyan("doctor --site")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
+  ${pc.cyan("doctor --json-output <path>")}         Write the JSON report to a file, including alongside ${pc.cyan("--ci")}
   ${pc.cyan("doctor --ci")}                         Emit actionable GitHub annotations in GitHub Actions
   ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
   ${pc.cyan("doctor --agent --fix")}                Refresh stale generated ${pc.dim("agent.md")} files and token-budget missing outputs

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -458,6 +458,7 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --site")}                       Score the current docs app for reader-facing docs quality
   ${pc.cyan("doctor --human")}                      Alias for ${pc.cyan("doctor --site")}
   ${pc.cyan("doctor --json")}                       Print the report as JSON for CI, scripts, and automation
+  ${pc.cyan("doctor --ci")}                         Emit actionable GitHub annotations in GitHub Actions
   ${pc.cyan("doctor --strict")}                     Exit with failure when any doctor check warns or fails
   ${pc.cyan("doctor --agent --fix")}                Refresh stale generated ${pc.dim("agent.md")} files and token-budget missing outputs
   ${pc.cyan("doctor --agent --fix --dry-run")}      Report the fix command without writing generated ${pc.dim("agent.md")} files

--- a/packages/docs/src/cli/test-utils.ts
+++ b/packages/docs/src/cli/test-utils.ts
@@ -1,0 +1,5 @@
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -18,6 +18,7 @@ pnpm exec docs doctor
 pnpm exec docs doctor --agent
 pnpm exec docs doctor --site
 pnpm exec docs doctor --agent --json
+pnpm exec docs doctor --agent --ci --json-output .farming-labs/doctor.json
 pnpm exec docs doctor --agent --config docs.config.tsx
 pnpm exec docs doctor --agent --url https://docs.example.com
 pnpm exec docs doctor --agent --url https://docs.example.com --json
@@ -92,6 +93,8 @@ Explain:
 - Low explicit optimization does not make pages invisible; it means fewer pages contain extra
   machine-only context.
 - `--json` is for CI, dashboards, scripts, and agents.
+- `--ci` emits GitHub annotations on stdout; pair it with `--json-output <path>` when the same run
+  must also persist a machine-readable report.
 - Loader notices may appear separately from JSON stdout.
 - A warning for size/compatibility is advisory; broken or unsafe skill references are blocking.
 


### PR DESCRIPTION
## Summary

- attach actionable command findings to the doctor command-health check in text and JSON output
- preserve exact source lines for frontmatter commands and individual shell-fence commands
- add `docs doctor --ci` GitHub annotations with file, line, command, reason, and proposed correction while keeping JSON stdout parseable
- recognize the valid `docs skills scaffold` command so the website no longer reports three false positives

## Root cause

The usefulness analyzer already retained most command failure context, but doctor reduced it to aggregate counts. Contract commands also lacked source positions, fenced commands used the opening-fence line, and the static docs CLI registry had not been updated for `skills scaffold`.

## Validation

- `pnpm --filter @farming-labs/docs test` — 1,334 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` — passes with existing unrelated warnings
- website dogfood: command health improved from 320/323 to 323/323

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make doctor command-health findings actionable with exact file/line locations and proposed corrections across text, JSON, and GitHub Actions annotations. Adds `--ci` and `--json-output` to keep annotations and JSON output separate without mixing streams.

- **New Features**
  - Attach actionable findings to the `command-health` check in text and JSON (file, line, command, reason, proposedCorrection).
  - Preserve exact source lines for frontmatter and fenced shell commands, including `\` continuations and console prompts; ignore human-only blocks without shifting line numbers.
  - Add `docs doctor --ci` to emit GitHub workflow annotations on stdout, and `--json-output <path>` to write the JSON report; disallow `--ci` with `--json` to avoid stdout collisions.

- **Bug Fixes**
  - Recognize `docs skills scaffold` as a valid CLI subcommand to stop false positives.

<sup>Written for commit 3f74171007001872290cb518e9cd01f6b1b2f139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

