### PR TITLE
fix: remove command confidence false positive

### DIFF
--- a/packages/docs/src/agent-usefulness.test.ts
+++ b/packages/docs/src/agent-usefulness.test.ts
@@ -703,6 +703,38 @@ This page tells an agent to deploy the site.
     );
   });
 
+  it("does not classify prose containing inline code as a shell command", () => {
+    const prose =
+      "Golden tasks measure adversarial safety. Add `expect.safety` to a task to enable these checks.";
+    const report = analyzeAgentUsefulness({
+      rootDir,
+      pages: [
+        {
+          ...page(
+            "inline-code-prose",
+            `# Golden evaluations
+
+${prose}
+
+\`\`\`bash
+pnpm exec docs doctor --agent
+\`\`\``,
+          ),
+          actionable: false,
+        },
+      ],
+    });
+
+    expect(report.findings.map((finding) => finding.command)).not.toContain(prose);
+    expect(report.findings.map((finding) => finding.code)).not.toContain("command-unverified");
+    expect(report.metrics.commands).toEqual({
+      total: 1,
+      healthy: 1,
+      unhealthy: 0,
+      unverified: 0,
+    });
+  });
+
   it("checks package manager, scripts, working directories, and docs CLI commands", () => {
     mkdirSync(path.join(rootDir, "apps", "docs"), { recursive: true });
     writeFileSync(

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -381,7 +381,6 @@ Telemetry can be disabled with either:
 ```bash title=".env.local"
 DOCS_TELEMETRY=false
 # or
-> Golden tasks now also measure adversarial safety: prompt-injection resistance, poisoned-citation rejection, authenticated-content leakage prevention, retrieval freshness, framework-version-conflict rejection, deleted-section tombstones, and query variants. Add `expect.safety` to any task to enable these checks.
 DOCS_TELEMETRY_DISABLED=1
 ```
 


### PR DESCRIPTION
## Summary

- remove an adversarial-safety prose sentence that was accidentally inserted inside the telemetry `bash` fence
- add a regression test proving prose with inline code such as `expect.safety` is not collected as a shell command
- preserve strict validation for actual fenced shell content

## Root cause

The command detector was behaving correctly: Markdown placed the sentence between the opening and closing `bash` fence, so it was parsed as shell input and reported as unverified. Removing the malformed fenced content fixes the finding without weakening command validation.

## Result

Website doctor command confidence changes from 323 healthy out of 324 inspected entries with one unverified entry to 323/323 healthy commands with zero unverified findings. Docs Review reports 100/100 with no findings.

## Validation

- `pnpm --filter @farming-labs/docs test` — 71 files, 1,348 tests passed
- `pnpm --dir website exec next build`
- `pnpm --dir website exec docs doctor --agent --config docs.config.tsx --json`
- `pnpm --dir website exec docs review --ci --config docs.config.tsx`
- scoped formatting and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false “unverified command” by removing a prose line accidentally placed inside a `bash` fence and adds a regression test so inline-code prose (e.g., `expect.safety`) is never treated as a shell command. Restores 100% command confidence in docs checks while keeping strict validation for real fenced shell content.

- **Bug Fixes**
  - Cleaned the `.env.local` bash block in `website/app/docs/reference/page.mdx` to only include env vars.
  - Added `agent-usefulness` test to ensure prose with inline code is not collected as a shell command.

<sup>Written for commit e5349ea6a515dc2757f003930e28958b60a7a656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

