### PR TITLE
fix: report doctor evaluation coverage confidence

### DIFF
--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -123,6 +123,40 @@ describe("runDocsGoldenTasks", () => {
       taskCount: 0,
       passedTaskCount: 0,
       failedTaskCount: 0,
+      quality: {
+        status: "unmeasured",
+        passed: null,
+        score: null,
+        taskCount: 0,
+        passedTaskCount: 0,
+        failedTaskCount: 0,
+      },
+      coverage: {
+        status: "unmeasured",
+        measuredTaskDimensions: 0,
+        totalTaskDimensions: 0,
+        coveragePercent: 0,
+        dimensions: {
+          safety: {
+            status: "unmeasured",
+            measuredTaskCount: 0,
+            totalTaskCount: 0,
+            coveragePercent: 0,
+          },
+          answerQuality: {
+            status: "unmeasured",
+            measuredTaskCount: 0,
+            totalTaskCount: 0,
+            coveragePercent: 0,
+          },
+          executableExamples: {
+            status: "unmeasured",
+            measuredTaskCount: 0,
+            totalTaskCount: 0,
+            coveragePercent: 0,
+          },
+        },
+      },
       tasks: [],
     });
   });
@@ -133,6 +167,22 @@ describe("runDocsGoldenTasks", () => {
 
     expect(report.status).toBe("passed");
     expect(report.passed).toBe(true);
+    expect(report.quality).toMatchObject({
+      status: "passed",
+      passed: true,
+      score: 100,
+      taskCount: 1,
+    });
+    expect(report.coverage).toMatchObject({
+      status: "unmeasured",
+      measuredTaskDimensions: 0,
+      totalTaskDimensions: 3,
+      dimensions: {
+        safety: { status: "unmeasured", measuredTaskCount: 0 },
+        answerQuality: { status: "unmeasured", measuredTaskCount: 0 },
+        executableExamples: { status: "unmeasured", measuredTaskCount: 0 },
+      },
+    });
     expect(result.retrieval).toMatchObject({
       recallAtK: 1,
       firstRelevantRank: 1,
@@ -257,6 +307,12 @@ Use the verified public configuration and preserve its canonical citation.
         { kind: "ambiguous", passed: true },
         { kind: "typo", passed: true },
       ],
+    });
+    expect(report.coverage.dimensions.safety).toMatchObject({
+      status: "measured",
+      measuredTaskCount: 1,
+      totalTaskCount: 1,
+      coveragePercent: 100,
     });
     expect(report.tasks[0].score).toBe(100);
   });

--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -228,6 +228,34 @@ describe("runDocsGoldenTasks", () => {
     expect(result.score).toBe(100);
   });
 
+  it("keeps an empty safety declaration unmeasured", async () => {
+    const report = await runDocsGoldenTasks(pages, [
+      {
+        ...passingTask,
+        id: "empty-safety",
+        expect: { ...passingTask.expect, safety: {} },
+      },
+    ]);
+
+    expect(report.tasks[0].safety).toMatchObject({
+      expected: true,
+      passed: false,
+      cases: [],
+      queryVariants: [],
+    });
+    expect(report.tasks[0].issues).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("must enable at least one adversarial assertion"),
+      ]),
+    );
+    expect(report.coverage.dimensions.safety).toMatchObject({
+      status: "unmeasured",
+      measuredTaskCount: 0,
+      totalTaskCount: 1,
+      coveragePercent: 0,
+    });
+  });
+
   it("passes first-class adversarial retrieval safety assertions", async () => {
     const safetyPage = page({
       slug: "safe-retrieval",

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -3448,7 +3448,10 @@ function buildGoldenEvaluationCoverage(
     };
   };
   const dimensions = {
-    safety: dimension(tasks.filter((task) => task.safety.expected).length),
+    safety: dimension(
+      tasks.filter((task) => task.safety.cases.length > 0 || task.safety.queryVariants.length > 0)
+        .length,
+    ),
     answerQuality: dimension(tasks.filter((task) => task.answer.expected).length),
     executableExamples: dimension(
       tasks.filter((task) =>

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -82,6 +82,7 @@ const EXECUTABLE_LANGUAGES = new Set([
 ]);
 
 export type DocsGoldenEvaluationStatus = "unmeasured" | "passed" | "failed";
+export type DocsGoldenEvaluationCoverageStatus = "measured" | "partially-measured" | "unmeasured";
 
 export type DocsGoldenTaskFilters = DocsAgentGoldenTaskFilters;
 export type DocsGoldenExpectedExample = DocsAgentGoldenExpectedExample;
@@ -255,11 +256,44 @@ export interface DocsGoldenTaskReport {
 export interface DocsGoldenTasksReport {
   status: DocsGoldenEvaluationStatus;
   passed: boolean | null;
+  /** Compatibility alias for quality.score. */
   score: number | null;
   taskCount: number;
   passedTaskCount: number;
   failedTaskCount: number;
+  /** Quality across only the expectations configured by each task. */
+  quality: DocsGoldenEvaluationQuality;
+  /** Coverage is intentionally separate so absent evaluation dimensions cannot look perfect. */
+  coverage: DocsGoldenEvaluationCoverage;
   tasks: DocsGoldenTaskReport[];
+}
+
+export interface DocsGoldenEvaluationQuality {
+  status: DocsGoldenEvaluationStatus;
+  passed: boolean | null;
+  score: number | null;
+  taskCount: number;
+  passedTaskCount: number;
+  failedTaskCount: number;
+}
+
+export interface DocsGoldenEvaluationDimensionCoverage {
+  status: DocsGoldenEvaluationCoverageStatus;
+  measuredTaskCount: number;
+  totalTaskCount: number;
+  coveragePercent: number;
+}
+
+export interface DocsGoldenEvaluationCoverage {
+  status: DocsGoldenEvaluationCoverageStatus;
+  measuredTaskDimensions: number;
+  totalTaskDimensions: number;
+  coveragePercent: number;
+  dimensions: {
+    safety: DocsGoldenEvaluationDimensionCoverage;
+    answerQuality: DocsGoldenEvaluationDimensionCoverage;
+    executableExamples: DocsGoldenEvaluationDimensionCoverage;
+  };
 }
 
 interface NormalizedScope {
@@ -3394,6 +3428,59 @@ async function evaluateTask(
  * Configured external retrieval, HTTP answers, and runtime execution require explicit opt-in.
  * An empty task list is intentionally unmeasured so CI cannot turn absent coverage into a pass.
  */
+function buildGoldenEvaluationCoverage(
+  tasks: readonly DocsGoldenTaskReport[],
+): DocsGoldenEvaluationCoverage {
+  const totalTaskCount = tasks.length;
+  const dimension = (measuredTaskCount: number): DocsGoldenEvaluationDimensionCoverage => {
+    const coveragePercent =
+      totalTaskCount === 0 ? 0 : Math.round((measuredTaskCount / totalTaskCount) * 100);
+    return {
+      status:
+        measuredTaskCount === 0
+          ? "unmeasured"
+          : measuredTaskCount === totalTaskCount
+            ? "measured"
+            : "partially-measured",
+      measuredTaskCount,
+      totalTaskCount,
+      coveragePercent,
+    };
+  };
+  const dimensions = {
+    safety: dimension(tasks.filter((task) => task.safety.expected).length),
+    answerQuality: dimension(tasks.filter((task) => task.answer.expected).length),
+    executableExamples: dimension(
+      tasks.filter((task) =>
+        task.examples.results.some((result) => result.verification === "execute"),
+      ).length,
+    ),
+  };
+  const dimensionValues = Object.values(dimensions);
+  const measuredTaskDimensions = dimensionValues.reduce(
+    (total, value) => total + value.measuredTaskCount,
+    0,
+  );
+  const totalTaskDimensions = totalTaskCount * dimensionValues.length;
+  const coveragePercent =
+    totalTaskDimensions === 0
+      ? 0
+      : Math.round((measuredTaskDimensions / totalTaskDimensions) * 100);
+
+  return {
+    status:
+      coveragePercent === 100
+        ? "measured"
+        : coveragePercent === 0
+          ? "unmeasured"
+          : "partially-measured",
+    measuredTaskDimensions,
+    totalTaskDimensions,
+    coveragePercent,
+    dimensions,
+  };
+}
+
 export async function runDocsGoldenTasks(
   pages: readonly DocsMcpPage[],
   tasks: readonly DocsGoldenTask[] | undefined,
@@ -3408,6 +3495,15 @@ export async function runDocsGoldenTasks(
       taskCount: 0,
       passedTaskCount: 0,
       failedTaskCount: 0,
+      quality: {
+        status: "unmeasured",
+        passed: null,
+        score: null,
+        taskCount: 0,
+        passedTaskCount: 0,
+        failedTaskCount: 0,
+      },
+      coverage: buildGoldenEvaluationCoverage([]),
       tasks: [],
     };
   }
@@ -3429,13 +3525,18 @@ export async function runDocsGoldenTasks(
   );
   const passedTaskCount = reports.filter((task) => task.passed).length;
   const failedTaskCount = reports.length - passedTaskCount;
-  return {
-    status: failedTaskCount === 0 ? "passed" : "failed",
+  const quality = {
+    status: failedTaskCount === 0 ? ("passed" as const) : ("failed" as const),
     passed: failedTaskCount === 0,
     score: round(reports.reduce((sum, task) => sum + task.score, 0) / reports.length),
     taskCount: reports.length,
     passedTaskCount,
     failedTaskCount,
+  };
+  return {
+    ...quality,
+    quality,
+    coverage: buildGoldenEvaluationCoverage(reports),
     tasks: reports,
   };
 }

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -554,7 +554,7 @@ Review the source project before changing its documentation.
     });
   });
 
-  it("scores a healthy Next.js docs app as agent-optimized", async () => {
+  it("keeps a healthy app agent-ready when confidence dimensions are unmeasured", async () => {
     writePackageJson(tmpDir, "doctor-next", { next: "16.0.0" });
 
     writeFileSync(
@@ -701,7 +701,7 @@ Use this docs site through markdown routes and MCP.
     const report = await inspectAgentReadiness();
 
     expect(report.framework).toBe("nextjs");
-    expect(report.grade).toBe("Agent-optimized");
+    expect(report.grade).toBe("Agent-ready");
     expect(report.score).toBeGreaterThanOrEqual(90);
     expect(report.maxScore).toBe(100);
     expect(report.coverage.totalPages).toBe(3);
@@ -726,7 +726,27 @@ Use this docs site through markdown routes and MCP.
       "pass",
     );
     expect(report.checks.find((check) => check.id === "golden-tasks")?.status).toBe("pass");
-    expect(report.evaluations).toMatchObject({ status: "passed", passedTaskCount: 1 });
+    expect(report.checks.find((check) => check.id === "golden-task-coverage")).toMatchObject({
+      status: "warn",
+      score: 0,
+      maxScore: 5,
+      detail: expect.stringMatching(
+        /safety: unmeasured.*answer quality: unmeasured.*executable examples: unmeasured/,
+      ),
+    });
+    expect(report.evaluations).toMatchObject({
+      status: "passed",
+      passedTaskCount: 1,
+      coverage: {
+        status: "unmeasured",
+        coveragePercent: 0,
+        dimensions: {
+          safety: { status: "unmeasured", measuredTaskCount: 0 },
+          answerQuality: { status: "unmeasured", measuredTaskCount: 0 },
+          executableExamples: { status: "unmeasured", measuredTaskCount: 0 },
+        },
+      },
+    });
   });
 
   it("reports full-spec errors in every configured Agent Skill", async () => {
@@ -1117,6 +1137,11 @@ pnpm exec docs imaginary
     try {
       printAgentDoctorReport(report);
       const textOutput = stripAnsi(logSpy.mock.calls.flat().join("\n"));
+      expect(textOutput).toContain("Golden task quality: unmeasured");
+      expect(textOutput).toContain("Evaluation coverage: unmeasured");
+      expect(textOutput).toContain("safety unmeasured");
+      expect(textOutput).toContain("answer quality unmeasured");
+      expect(textOutput).toContain("executable examples unmeasured");
       expect(textOutput).toContain("app/docs/page.mdx:6");
       expect(textOutput).toContain("Command: pnpm run missing");
       expect(textOutput).toContain('Reason: Command references package script "missing"');
@@ -1285,8 +1310,8 @@ related:
 
     expect(report.evaluations).toMatchObject({ status: "failed" });
     expect(report.evaluations?.score).toBeLessThan(100);
-    expect(goldenTasks).toMatchObject({ status: "fail", maxScore: 15 });
-    expect(goldenTasks?.score).toBeLessThan(15);
+    expect(goldenTasks).toMatchObject({ status: "fail", maxScore: 10 });
+    expect(goldenTasks?.score).toBeLessThan(10);
     expect(report.score).toBeGreaterThanOrEqual(90);
     expect(report.grade).toBe("Agent-ready");
   });

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1040,7 +1040,11 @@ function gradeForAgentScore(
   const hasBlockingFailure = checks.some(
     (check) => check.status === "fail" && AGENT_OPTIMIZATION_BLOCKING_CHECKS.has(check.id),
   );
-  if (score >= 90 && !hasBlockingFailure) return "Agent-optimized";
+  const hasIncompleteEvaluationCoverage = checks.some(
+    (check) => check.id === "golden-task-coverage" && check.status !== "pass",
+  );
+  if (score >= 90 && !hasBlockingFailure && !hasIncompleteEvaluationCoverage)
+    return "Agent-optimized";
   if (score >= 75) return "Agent-ready";
   if (score >= 60) return "Promising";
   return "Needs work";
@@ -3837,31 +3841,52 @@ export async function inspectAgentReadiness(
     values.length === 0
       ? 0
       : Math.round((values.reduce((total, value) => total + value, 0) / values.length) * 100) / 100;
+  const evaluationQuality = evaluations.quality;
   const proportionalEvaluationScore =
-    evaluations.score === null ? 0 : Math.round((evaluations.score / 100) * 15);
+    evaluationQuality.score === null ? 0 : Math.round((evaluationQuality.score / 100) * 10);
   const evaluationScore =
-    evaluations.status === "failed"
-      ? Math.min(14, proportionalEvaluationScore)
+    evaluationQuality.status === "failed"
+      ? Math.min(9, proportionalEvaluationScore)
       : proportionalEvaluationScore;
-  const safetyEvaluations = evaluations.tasks.filter((task) => task.safety.expected);
-  const safetyEvaluationSummary = safetyEvaluations.length
-    ? `${safetyEvaluations.filter((task) => task.safety.passed).length}/${safetyEvaluations.length} adversarial safety suites passed`
-    : "no adversarial safety suites configured";
   checks.push(
     makeCheck(
       "golden-tasks",
-      "Golden agent tasks",
-      evaluations.status === "passed" ? "pass" : evaluations.status === "failed" ? "fail" : "warn",
+      "Golden task quality",
+      evaluationQuality.status === "passed"
+        ? "pass"
+        : evaluationQuality.status === "failed"
+          ? "fail"
+          : "warn",
       evaluationScore,
-      15,
-      evaluations.status === "unmeasured"
-        ? "No golden agent tasks are configured; retrieval usefulness is unmeasured."
-        : `${evaluations.passedTaskCount}/${evaluations.taskCount} golden tasks passed with ${evaluations.score}/100 average score, ${averageMetric(evaluations.tasks.map((task) => task.retrieval.recallAtK))} retrieval recall, ${averageMetric(evaluations.tasks.map((task) => task.citations.recall))} citation recall, ${safetyEvaluationSummary}, and ${evaluations.tasks.reduce((total, task) => total + task.usage.usedUtf8Bytes, 0)} UTF-8 context bytes used.`,
-      evaluations.status === "passed"
+      10,
+      evaluationQuality.status === "unmeasured"
+        ? "No golden agent tasks are configured; evaluation quality is unmeasured."
+        : `${evaluationQuality.passedTaskCount}/${evaluationQuality.taskCount} golden tasks passed with ${evaluationQuality.score}/100 average quality across configured expectations, ${averageMetric(evaluations.tasks.map((task) => task.retrieval.recallAtK))} retrieval recall, ${averageMetric(evaluations.tasks.map((task) => task.citations.recall))} citation recall, and ${evaluations.tasks.reduce((total, task) => total + task.usage.usedUtf8Bytes, 0)} UTF-8 context bytes used.`,
+      evaluationQuality.status === "passed"
         ? undefined
-        : evaluations.status === "unmeasured"
+        : evaluationQuality.status === "unmeasured"
           ? "Configure agent.evaluations.tasks so doctor and review can measure retrieval, citations, framework/version selection, adversarial safety, executable examples, and token usage."
           : "Inspect the failed golden task metrics and fix retrieval ranking, citations, applicability metadata, adversarial safety, examples, or context budgets.",
+    ),
+  );
+
+  const evaluationCoverage = evaluations.coverage;
+  const formatDimensionCoverage = (
+    label: string,
+    dimension: typeof evaluationCoverage.dimensions.safety,
+  ) =>
+    `${label}: ${dimension.status} (${dimension.measuredTaskCount}/${dimension.totalTaskCount} tasks)`;
+  checks.push(
+    makeCheck(
+      "golden-task-coverage",
+      "Golden evaluation coverage",
+      evaluationCoverage.status === "measured" ? "pass" : "warn",
+      Math.round((evaluationCoverage.coveragePercent / 100) * 5),
+      5,
+      `${evaluationCoverage.status} coverage across optional confidence dimensions (${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.totalTaskDimensions} task-dimensions, ${evaluationCoverage.coveragePercent}%): ${formatDimensionCoverage("safety", evaluationCoverage.dimensions.safety)}; ${formatDimensionCoverage("answer quality", evaluationCoverage.dimensions.answerQuality)}; ${formatDimensionCoverage("executable examples", evaluationCoverage.dimensions.executableExamples)}.`,
+      evaluationCoverage.status === "measured"
+        ? undefined
+        : "Add golden-task safety expectations, actual-answer assertions, and execute-level example checks so each confidence dimension is measured explicitly.",
     ),
   );
 
@@ -4200,8 +4225,13 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
     );
   }
   if (report.evaluations) {
+    const evaluationQuality = report.evaluations.quality;
     console.log(
-      `${pc.bold("Golden tasks:")} ${report.evaluations.status === "unmeasured" ? "unmeasured" : `${report.evaluations.passedTaskCount}/${report.evaluations.taskCount} passed (${report.evaluations.score}/100)`}`,
+      `${pc.bold("Golden task quality:")} ${evaluationQuality.status === "unmeasured" ? "unmeasured" : `${evaluationQuality.passedTaskCount}/${evaluationQuality.taskCount} passed (${evaluationQuality.score}/100)`}`,
+    );
+    const evaluationCoverage = report.evaluations.coverage;
+    console.log(
+      `${pc.bold("Evaluation coverage:")} ${evaluationCoverage.status} ${pc.dim(`(${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.totalTaskDimensions} task-dimensions, ${evaluationCoverage.coveragePercent}%)`)} ${pc.dim("•")} safety ${evaluationCoverage.dimensions.safety.status} ${pc.dim("•")} answer quality ${evaluationCoverage.dimensions.answerQuality.status} ${pc.dim("•")} executable examples ${evaluationCoverage.dimensions.executableExamples.status}`,
     );
   }
   console.log(

--- a/packages/docs/src/server.ts
+++ b/packages/docs/src/server.ts
@@ -150,6 +150,10 @@ export { renderDocsAgentSkillsBundle } from "./agent-skills-vite.js";
 export type {
   DocsGoldenAnswerMetrics,
   DocsGoldenCitationMetrics,
+  DocsGoldenEvaluationCoverage,
+  DocsGoldenEvaluationCoverageStatus,
+  DocsGoldenEvaluationDimensionCoverage,
+  DocsGoldenEvaluationQuality,
   DocsGoldenEvaluationStatus,
   DocsGoldenExampleMetrics,
   DocsGoldenExampleResult,

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -50,7 +50,10 @@ Command health is static. It recognizes constrained package/CLI commands and saf
 executes arbitrary documentation snippets or makes implicit network requests.
 
 Golden evaluations default to local `mcp-context`. Configured search, HTTP answers, and runtime
-example execution need explicit network permission. No configured tasks means `unmeasured`, not a
+example execution need explicit network permission. Doctor reports golden-task quality separately
+from evaluation coverage. Safety, actual-answer quality, and execute-level examples remain
+`unmeasured` until tasks explicitly exercise them; partial task coverage is reported as
+`partially-measured`. No configured tasks means both quality and coverage are `unmeasured`, not a
 perfect pass.
 
 ## Hosted probes
@@ -83,7 +86,8 @@ Score: 82% (Agent-ready)
 Framework: nextjs • Entry: docs • Content: app/docs
 Explicit agent-friendly pages: 10/41 pages (24%)
 Useful Agent blocks: 8/14 • 6/12 actionable pages task-complete
-Golden tasks: 3/4 passed (88/100)
+Golden task quality: 3/4 passed (88/100)
+Evaluation coverage: partially-measured (5/12 task-dimensions, 42%)
 ```
 
 Explain:

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -51,8 +51,8 @@ executes arbitrary documentation snippets or makes implicit network requests.
 
 Golden evaluations default to local `mcp-context`. Configured search, HTTP answers, and runtime
 example execution need explicit network permission. Doctor reports golden-task quality separately
-from evaluation coverage. Safety, actual-answer quality, and execute-level examples remain
-`unmeasured` until tasks explicitly exercise them; partial task coverage is reported as
+from evaluation coverage. Safety, answer quality, and executable examples remain `unmeasured`
+until tasks explicitly exercise them; partial task coverage is reported as
 `partially-measured`. No configured tasks means both quality and coverage are `unmeasured`, not a
 perfect pass.
 


### PR DESCRIPTION
## Summary

- separate golden-task quality from evaluation coverage in doctor text and JSON output
- mark safety, actual-answer quality, and execute-level example coverage as measured, partially-measured, or unmeasured
- reserve five doctor points for confidence coverage and prevent incomplete coverage from earning the Agent-optimized grade
- preserve the existing evaluation score fields while exposing explicit quality and coverage objects

## Root cause

Golden task scoring considered only configured expectations. Passing retrieval and citation tasks could therefore produce a near-perfect doctor score without showing that safety, generated-answer quality, and executable examples had never been exercised.

## Validation

- pnpm --dir packages/docs typecheck
- pnpm --dir packages/docs test (71 files, 1,348 tests)
- pnpm lint
- pnpm format:check
- website doctor audit: quality 99.5536/100, optional confidence coverage 0/63 task-dimensions, overall 96/100 Agent-ready

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes evaluation coverage confidence in `doctor` by separating golden-task quality from coverage, scoring coverage explicitly, and blocking Agent-optimized when coverage is incomplete. Adds clear per-dimension coverage in CLI and JSON, and treats empty safety declarations as unmeasured.

- **Bug Fixes**
  - Split evaluation output into `quality` and `coverage`; keep `score` as a compatibility alias for quality.
  - Track coverage for safety, actual-answer quality, and execute-level examples with `measured`/`partially-measured`/`unmeasured` and coverage percent; keep empty safety declarations unmeasured with a helpful issue.
  - Add a `golden-task-coverage` check (max 5) and reduce quality weighting to 10; incomplete coverage prevents the Agent-optimized grade even at ≥90.
  - Update `doctor` output to show "Golden task quality" and "Evaluation coverage" with per-dimension status and task-dimension counts.
  - Export new types (`DocsGoldenEvaluationQuality`, `DocsGoldenEvaluationCoverage`, `DocsGoldenEvaluationDimensionCoverage`, `DocsGoldenEvaluationCoverageStatus`) and update tests/docs.

<sup>Written for commit 855573030bf685246073007c4ea488497699a759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

