### PR TITLE
chore: refresh website agent compaction outputs

### DIFF
--- a/website/app/docs/cli/agent.md
+++ b/website/app/docs/cli/agent.md
@@ -1,18 +1,22 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:627607fb4f5451f6
+sourceHash=fnv1a64:a519c682c3135a5e
 settingsHash=fnv1a64:e50e89e221226fc3
-outputHash=fnv1a64:2612254b737d2c09
-generatedAt=2026-08-01T13:49:56.427Z
+outputHash=fnv1a64:1be0c86c619e1329
+generatedAt=2026-08-04T11:32:04.375Z
 -->
+URL: /docs/cli
+Description: Scaffold, upgrade, export static Agent Bundles, compact agent docs, validate code blocks, generate sitemaps and robots.txt, sync search, and run MCP
+Related: /docs/configuration, /docs/guides/agent-friendly-docs, /docs/customization/sitemaps, /docs/customization/llms-txt
+
 # CLI
 
 ## CLI task
 
-Task: Choose and run the appropriate Farming Labs docs CLI workflow for a project.
+Task: Plan and validate fenced MDX code blocks with the Farming Labs docs CLI.
 
-Expected result: The selected CLI operation completes and the resulting docs configuration passes the agent doctor.
+Expected result: The validation plan identifies runnable examples before any execution occurs.
 
 Exact implementation:
 
@@ -21,36 +25,91 @@ pnpm exec docs codeblocks validate --plan
 pnpm exec docs codeblocks validate
 pnpm exec docs codeblocks validate --json
 ```
-## CLI prerequisites
 
-- Run commands from the docs project root with its package manager available.
-- Install project dependencies before invoking the local docs binary with pnpm exec.
-- Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs.
+Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs.
 
-## CLI verification
+Choose the CLI workflow before changing files. Use `pnpm dlx @farming-labs/docs <command>` for a published release; use `pnpm exec docs <command>` only after dependencies are installed. For a non-interactive fresh scaffold: `init --template <framework> --name <dir>`; omit `--name` to be prompted.
 
-- Run pnpm exec docs doctor --agent. Expected: The doctor loads docs.config and reports the enabled discovery surfaces without hard failures.
-- Failure: pnpm cannot find the docs executable.
-- Recovery: Install dependencies or invoke the published CLI with pnpm dlx @farming-labs/docs.
-- Rollback: Restore generated configuration and public artifacts from version control if a mutating command produced the wrong result.
+After a mutating command, run `pnpm exec docs doctor --agent`; expected result is a loaded `docs.config.ts`, `docs.config.tsx`, or `src/lib/docs.config.ts` with no hard failure. For SvelteKit/Astro append `--config src/lib/docs.config.ts`. Prefer `--dry-run` for upgrade/compaction previews and `--check` for generated bundles, sitemaps, robots, or AGENTS files.
 
-## CLI agent guidance
+If `pnpm` cannot find `docs`, install dependencies or use `pnpm dlx`. If wrong config loads, return to project root or pass `--config <path>`.
 
-Choose the CLI workflow before changing files. For a published release use
-`pnpm dlx @farming-labs/docs <command>`; use `pnpm exec docs <command>` only after the project has
-installed its dependencies. For a non-interactive fresh scaffold, use
-`init --template <framework> --name <dir>`; omit `--name` to be prompted. Plain `init` asks whether
-to modify the current app or create a fresh project.
+**CLI commands:**
+- `init` — create or add docs to a project
+- `upgrade` — bump docs packages
+- `agent export` — materialize static machine-readable bundle
+- `agent compact` — generate sibling `agent.md` files from resolved docs pages
+- `agents generate` — write root and static `AGENTS.md`
+- `skills scaffold` — compile structured page `agent` contracts into an Agent Skill
+- `doctor` — audit local docs readiness and optional hosted agent routes
+- `review` — review docs changes locally or in GitHub Actions
+- `codeblocks validate` — plan and validate runnable MDX code fences
+- `mcp` — run built-in docs MCP server over stdio
+- `search sync` — push docs content into Typesense or Algolia
+- `sitemap generate` — write `sitemap.xml`, `sitemap.md`, and `docs/sitemap.md`
+- `robots generate` — write or append agent-friendly `robots.txt`
 
-After a mutating command, run `pnpm exec docs doctor --agent`; the expected result is a loaded
-`docs.config.ts`, `docs.config.tsx`, or `src/lib/docs.config.ts` with no hard failure for an enabled
-agent surface. For SvelteKit or Astro, append `--config src/lib/docs.config.ts`. Prefer `--dry-run`
-for upgrade or compaction previews and `--check` for generated agent bundles, sitemaps, robots, or
-AGENTS files where the command documents that flag.
-
-If `pnpm` cannot find `docs`, install dependencies or switch to the published `pnpm dlx` form. If
-the wrong config is loaded, return to the project root or pass the command's documented
-`--config <path>` option; do not copy flags between unrelated subcommands.
 ## CLI runnable code-block validation
 
 Plan fenced MDX examples with `pnpm exec docs codeblocks validate --plan`, then run the documented validation workflow before publishing.
+
+## Quick Start
+
+### From scratch
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tab value="npm">
+    ```bash title="terminal"
+    npx @farming-labs/docs init --template next --name my-docs
+    npx @farming-labs/docs init --template tanstack-start --name my-docs
+    npx @farming-labs/docs init --template nuxt --name my-docs
+    npx @farming-labs/docs init --template sveltekit --name my-docs
+    npx @farming-labs/docs init --template astro --name my-docs
+    ```
+  </Tab>
+  <Tab value="pnpm">
+    ```bash title="terminal"
+    pnpm dlx @farming-labs/docs init --template next --name my-docs
+    pnpm dlx @farming-labs/docs init --template tanstack-start --name my-docs
+    pnpm dlx @farming-labs/docs init --template nuxt --name my-docs
+    pnpm dlx @farming-labs/docs init --template sveltekit --name my-docs
+    pnpm dlx @farming-labs/docs init --template astro --name my-docs
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash title="terminal"
+    yarn dlx @farming-labs/docs init --template next --name my-docs
+    yarn dlx @farming-labs/docs init --template tanstack-start --name my-docs
+    yarn dlx @farming-labs/docs init --template nuxt --name my-docs
+    yarn dlx @farming-labs/docs init --template sveltekit --name my-docs
+    yarn dlx @farming-labs/docs init --template astro --name my-docs
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash title="terminal"
+    bunx @farming-labs/docs init --template next --name my-docs
+    bunx @farming-labs/docs init --template tanstack-start --name my-docs
+    bunx @farming-labs/docs init --template nuxt --name my-docs
+    bunx @farming-labs/docs init --template sveltekit --name my-docs
+    bunx @farming-labs/docs init --template astro --name my-docs
+    ```
+  </Tab>
+</Tabs>
+
+### Existing project
+
+Run from app root. The CLI: (1) detects framework from `package.json`, (2) asks for theme, (3) asks where docs live (usually `docs`), (4) asks about aliases, CSS, optional i18n, (5) generates files and installs `@farming-labs/*` packages, (6) optionally adds Docs Cloud support.
+
+### Upgrade
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tab value="npm">`npx @farming-labs/docs upgrade`</Tab>
+  <Tab value="pnpm">`pnpm dlx @farming-labs/docs upgrade`</Tab>
+  <Tab value="yarn">`yarn dlx @farming-labs/docs upgrade`</Tab>
+  <Tab value="bun">`bunx @farming-labs/docs upgrade`</Tab>
+</Tabs>
+
+### MCP server locally
+
+```bash title="terminal"
+pnpx @farming-labs/docs mcp
+pnpm exec docs mcp --config src/lib/docs.config.ts
+```

--- a/website/app/docs/guides/adapter-agent-conformance/agent.md
+++ b/website/app/docs/guides/adapter-agent-conformance/agent.md
@@ -1,69 +1,52 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:39c61f7a4d47cc7d
+sourceHash=fnv1a64:5364738b43bfa549
 settingsHash=fnv1a64:1b5212557ba75927
-outputHash=fnv1a64:a2e521aa2c2f844c
-generatedAt=2026-07-30T09:43:36.482Z
+outputHash=fnv1a64:a83cd1b06f2d79ce
+generatedAt=2026-08-04T11:32:22.439Z
 -->
 # Adapter Agent Conformance
+URL: /docs/guides/adapter-agent-conformance
+LLM index: /llms.txt
+Description: Validate that a framework adapter exposes the same agent-readable documentation contract as the first-party adapters
+Related: /docs/guides/agent-friendly-docs, /docs/customization/mcp, /docs/customization/llms-txt, /docs/customization/sitemaps, /docs/cli
 
-## Adapter Agent Conformance task
+Every `@farming-labs/docs` adapter should expose the same machine-readable surface. The shared conformance runner turns that expectation into an executable contract.
 
-Task: Add the shared agent-surface conformance suite to a framework adapter.
+Use `runDocsAgentConformance` when building or changing a framework adapter. Provide one callback dispatching GET requests to the adapter's public handler and the `mcp` case to its MCP POST handler. Use fixture titles `Introduction` and `Bonjour` for default and localized Markdown. A passing report must contain no failed cases.
 
-Expected result: The adapter passes the same discovery, Markdown, sitemap, robots, skills, MCP, and paginated search contract as first-party adapters.
-
-Exact implementation:
+## Exact implementation
 
 ```ts title="src/agent-conformance.test.ts" framework="custom" runnable
-import { expect, it } from "vitest";
 import { runDocsAgentConformance } from "@farming-labs/docs";
-import { createDocsServer } from "./server";
 
-it("implements the agent surface contract", async () => {
-  const server = createDocsServer({
-    entry: "docs",
-    i18n: { locales: ["en", "fr"], defaultLocale: "en" },
-    mcp: true,
-    sitemap: true,
-    robots: true,
-    _preloadedContent: {
-      "/docs/en/page.md": "---\ntitle: Introduction\n---\n# Introduction",
-      "/docs/fr/page.md": "---\ntitle: Introduction\n---\n# Introduction\n\nBonjour",
+export async function verifyAdapter() {
+  return runDocsAgentConformance({
+    adapter: "nextjs",
+    async handle(request) {
+      return fetch(request);
     },
   });
-
-  const report = await runDocsAgentConformance({
-    adapter: "sveltekit",
-    async handle(request, surface) {
-      if (surface === "mcp") {
-        return server.MCP.POST({ request });
-      }
-
-      return server.GET({ request, url: new URL(request.url) });
-    },
-  });
-
-  expect(report.cases.filter((result) => !result.passed)).toEqual([]);
-});
+}
 ```
-## Adapter Agent Conformance prerequisites
 
-- The adapter exposes one request handler that can serve the shared docs API and public aliases.
-- A test fixture contains at least one docs page and can issue Web Request objects to the adapter.
-- Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs.
+## Covered surfaces
 
-## Adapter Agent Conformance verification
+Versioned contract (`DOCS_AGENT_CONTRACT_VERSION` `1.3`) verifies:
 
-- Run the adapter test containing runDocsAgentConformance. Expected: The report contains no failed cases and identifies the expected contract version.
-- Failure: One public alias fails while the canonical docs API passes.
-- Recovery: Forward the alias through the same shared server and preserve its method, headers, status, and response body.
-- Rollback: Restore the previous adapter handler and remove only the conformance wiring introduced by the change.
+- Custom agent discovery, RFC 9727 API catalog GET/HEAD, Agent Skills index/artifact GET/HEAD, config, diagnostics, and feedback schema
+- Explicit `.md` aliases and `Accept: text/markdown` negotiation
+- Default and localized page content; actionable missing-page recovery
+- `llms.txt`, `llms-full.txt`, `AGENTS.md`, `skill.md`
+- XML and Markdown sitemaps plus `robots.txt`
+- Streamable HTTP MCP initialize request
+- Gzip-encoded tar archive delivery of SKILL.md (decompressed via `readAgentSkillDocumentFromTar`)
+- SKILL.md frontmatter validated against full spec — unexpected fields like `version` and incorrect `allowed-tools` type are conformance failures
+- Cursor-based structured search pagination
+- `capabilities.contentChanges` flag and live `GET /api/docs?audience=agent&response=changes` returning valid `docs-content-changes.v1` JSON with `indexGeneration`, `mode`, `resetRequired`, `documentCount`, and array fields; ETag and body-free delivery verified
+- HTTP cache validators on every agent-surface response
 
-## Adapter Agent Conformance agent guidance
+## Cursor-based structured search
 
-Use `runDocsAgentConformance` when building or changing a framework adapter. Provide one callback
-that dispatches ordinary requests to the adapter's public GET handler and the `mcp`
-case to its MCP POST handler. Use the standard fixture titles `Introduction` and `Bonjour` so the
-contract can verify default and localized Markdown. A passing report must contain no failed cases.
+- `GET /api/docs?response=structured&query=<term>&limit=1` returns `hasMore`, `total`, and `nextCursor`.

--- a/website/app/docs/reference/agent.md
+++ b/website/app/docs/reference/agent.md
@@ -1,90 +1,126 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:196e9e5dd8fb1f2f
+sourceHash=fnv1a64:4d985abdc02e6e10
 settingsHash=fnv1a64:aa433a28ef4afd1f
-outputHash=fnv1a64:99e9aed8b5d79935
-generatedAt=2026-08-01T13:49:56.427Z
+outputHash=fnv1a64:173fd105503fea58
+generatedAt=2026-08-04T11:40:37.014Z
 -->
 # API Reference
+URL: /docs/reference
+LLM index: /llms.txt
+Description: Complete reference for all configuration options
+Related: /docs/configuration, /docs/cli, /docs/installation, /docs/customization/mcp
 
-## API Reference task
+Inspect the existing `defineDocs()` call and select the exact exported `DocsConfig` field documented below. Config path: `docs.config.ts[x]` for Next.js, TanStack Start, and Nuxt; `src/lib/docs.config.ts` for SvelteKit and Astro. Non-Next adapters can configure `contentDir` and `nav` explicitly; Next.js derives its content tree from `app/{entry}/`.
 
-Task: Select and configure the exact typed Farming Labs docs option required by a project.
+When MCP `get_config_schema` publishes the option, compare its type and default; otherwise verify against installed exported types. Run `pnpm exec docs doctor --agent` for resolved capability and discovery fields. For SvelteKit or Astro, append `--config src/lib/docs.config.ts`. If TypeScript rejects the documented shape, align all `@farming-labs/*` package versions and rename config to `.tsx` when it contains JSX. If diagnostics and public discovery disagree, restore the previous value and repair the adapter route or stale static export before re-enabling.
 
-Expected result: The chosen defineDocs option has the documented type and default and the resolved runtime exposes matching behavior.
-## API Reference prerequisites
+All types exported from `@farming-labs/docs`.
 
-- Identify the project framework and the exact capability being configured.
-- Read the existing docs.config before changing nested options or callbacks.
-- Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs.
+---
 
-## API Reference verification
+## `defineDocs(config)`
 
-- Run pnpm exec docs doctor --agent. Expected: Config loading confidence and discovery/config/schema consistency pass after the option change.
-- Query MCP get_config_schema for the changed option. Expected: The returned type, default, and description match the option used in docs.config.
-- Failure: TypeScript rejects a documented option.
-- Recovery: Confirm all Farming Labs packages use the same version and use docs.config.tsx when JSX is present.
-- Rollback: Restore the previous option value and any route wiring or environment variables added with it.
+```ts title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
 
-## API Reference agent guidance
+export default defineDocs({
+  entry: "docs",
+  // ...all options below
+});
+```
 
-Before changing configuration, inspect the existing `defineDocs()` call and select the exact
-exported `DocsConfig` field or nested type documented below. Preserve the framework's config path:
-`docs.config.ts[x]` for Next.js, TanStack Start, and Nuxt, or `src/lib/docs.config.ts` for SvelteKit
-and Astro. The non-Next adapters can configure `contentDir` and `nav` explicitly, while Next.js
-derives its content tree from `app/{entry}/`.
+---
 
-When MCP `get_config_schema` publishes the option, compare its type and default; otherwise verify
-against the installed exported types and matching-version reference. Then run
-`pnpm exec docs doctor --agent` for the resolved capability and discovery fields it audits. For
-SvelteKit or Astro, append `--config src/lib/docs.config.ts`. If TypeScript rejects the documented
-shape, first align all `@farming-labs/*` package versions and rename the config to `.tsx` when it
-contains JSX. If diagnostics and public discovery disagree, restore the previous value and repair
-the adapter route or stale static export before enabling the capability again.
+## `DocsConfig`
 
-## API Reference Agent Skills progressive disclosure
+### `DocsLocalMcpSearchRuntimeConfig`
 
-`agent.skills` accepts a path, an array of paths, or an object with `paths` and an optional
-`progressiveDisclosure` policy. Use `maxSkillLines`, `instructionTokenBudget`, and
-`maxReferenceDepth` to bound activated context. Set `compatibility` to `"when-needed"` (default),
-`"always"`, or `"off"`; use `checkScripts` to verify that bundled scripts document dependencies
-and validation. `docs doctor --agent` checks every configured skill, while `docs review` runs the
-same checks when a configured skill, companion file, or docs config changes.
+Runtime shape for whether the local MCP server is the search target. Exported from `@farming-labs/docs` and `@farming-labs/docs/server`.
 
-## API Reference PageAgentFrontmatter fields
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `enabled` | `boolean` | Whether the local MCP server is enabled |
+| `route` | `string` | Canonical HTTP route for the local MCP endpoint (e.g. `"/api/docs/mcp"`) |
+| `tools` | `{ searchDocs?: boolean }` | `searchDocs` controls whether `search_docs` is exposed |
 
-`PageAgentFrontmatter` defines `task`, `outcome`, `appliesTo`, `prerequisites`, `verification`, `rollback`, and `failureModes`; each failure mode pairs a `symptom` with its `resolution`.
+### `DocsLocalMcpSearchRuntimeInput`
 
-## PageAgentFrontmatter task outcome appliesTo verification rollback failureModes
+Accepted input for `resolveLocalDocsMcpSearchConfig`. Partial form of `DocsLocalMcpSearchRuntimeConfig` — all fields optional. Exported from `@farming-labs/docs` and `@farming-labs/docs/server`.
 
-In `page-frontmatter.md`, the exact fields are `task`, `outcome`, `appliesTo`, `verification`, `rollback`, and `failureModes`. Each failure mode contains a `symptom` and a `resolution`; the recovery example uses `resolution: Confirm withDocs wraps the Next.js config`.
+### `DocsSearchRequestResolutionOptions`
 
-## PageAgentFrontmatter exact page-frontmatter.md example
+Options for the third parameter of `resolveSearchRequestConfig`. Exported from `@farming-labs/docs` and `@farming-labs/docs/server`.
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `localMcp` | `DocsLocalMcpSearchRuntimeInput \| null \| undefined` | When present, calls `resolveLocalDocsMcpSearchConfig` before the self-referential URL check |
+
+### `resolveLocalDocsMcpSearchConfig`
+
+Exported from `@farming-labs/docs` and `@farming-labs/docs/server`. Given a `McpDocsSearchConfig`, optional `DocsLocalMcpSearchRuntimeInput`, and optional request URL, returns a modified search config using direct simple search when the configured MCP endpoint resolves to the local server. Returns original config unchanged for external endpoints.
+
+```ts
+import { resolveLocalDocsMcpSearchConfig } from "@farming-labs/docs";
+
+const resolved = resolveLocalDocsMcpSearchConfig(
+  search,       // McpDocsSearchConfig
+  mcp,          // DocsLocalMcpSearchRuntimeInput | null | undefined
+  requestUrl,   // string | undefined
+);
+```
+
+`resolveSearchRequestConfig` accepts an optional third `options: DocsSearchRequestResolutionOptions` argument. Pass `{ localMcp: config.mcp }` to enable local-MCP detection in custom server adapters.
+
+Top-level configuration object passed to `defineDocs()`:
+
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `entry` | `string` | **required** | Docs source route and folder (e.g. `"docs"` -> `app/docs`) |
+| `docsPath` | `string` | same as `entry` | Public docs route prefix in Next.js. Use `""` to serve docs from `/` |
+| `contentDir` | `string` | same as `entry` | Path to content files. TanStack Start, SvelteKit, Astro, and Nuxt use it; Next.js uses `app/{entry}/` |
+| `staticExport` | `boolean` | `false` | `true` for full static builds; hides search and AI |
+| `theme` | `DocsTheme` | — | Theme preset (`fumadocs()`, `darksharp()`, `pixelBorder()`, etc.) |
+| `github` | `string \| GithubConfig` | — | GitHub repo config for "Edit on GitHub" links |
+| `nav` | `DocsNav` | — | Sidebar header title and URL |
+| `themeToggle` | `boolean \| ThemeToggleConfig` | `true` | Light/dark mode toggle |
+| `breadcrumb` | `boolean \| BreadcrumbConfig` | `true` | Breadcrumb navigation |
+| `sidebar` | `boolean \| SidebarConfig` | `true` | Sidebar visibility and customization |
+| `icons` | `Record<string, unknown>` | — | Shared icon registry for frontmatter `icon` fields and built-ins like `Prompt` |
+| `components` | `Record<string, unknown>` | — | Custom MDX component overrides including built-ins like `HoverLink` and `Prompt` |
+| `analytics` | `boolean \| DocsAnalyticsConfig` | `false` | Product/usage event stream for docs UI, search, AI, feedback, agent reads |
+
+Page-level metadata for machine-readable docs workflows:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `tokenBudget` | `number` | Approximate output token target for `docs agent compact` on this page |
+| `task` | `string` | Concrete task the page helps an agent complete |
+| `outcome` | `string` | Observable end state indicating completion |
+| `appliesTo` | `{ framework?, version?, package? }` | Each accepts a string or string array |
+| `prerequisites` | `string[]` | Setup or conditions that must already be true |
+| `files` | `string[]` | Files the task is expected to read or change |
+| `commands` | `(string \| PageAgentCommand)[]` | Command strings or `{ run, cwd?, description? }` objects |
+| `sideEffects` | `string[]` | Material state changes or external effects |
+| `verification` | `(string \| PageAgentVerification)[]` | Checks or `{ description?, run?, expect? }` objects |
+| `rollback` | `string[]` | Steps that restore the prior state |
+| `failureModes` | `(string \| PageAgentFailureMode)[]` | Symptoms or `{ symptom, resolution? }` objects |
+
+## PageAgentFrontmatter field types
+
+`PageAgentFrontmatter` defines `task`, `outcome`, `appliesTo`, `prerequisites`, `verification`, `rollback`, and `failureModes`; every structured failure mode pairs a `symptom` with its `resolution`.
+
+## PageAgentFrontmatter failureModes resolution
+
+In `page-frontmatter.md`, use `failureModes` for recoverable failures. The exact example resolves a missing route with `resolution: Confirm withDocs wraps the Next.js config`.
 
 ```md title="page-frontmatter.md"
 ---
 title: "Installation"
-description: "Install the framework"
 agent:
-  tokenBudget: 777
   task: Install the framework
   outcome: The docs route renders locally.
-  appliesTo:
-    framework: nextjs
-    version: ">=16"
-    package: "@farming-labs/next"
-  prerequisites:
-    - The app uses the App Router
-  files:
-    - package.json
-    - next.config.ts
-  commands:
-    - run: pnpm add @farming-labs/docs @farming-labs/next
-      description: Install the required packages
-  verification:
-    - run: pnpm dev
-      expect: The docs route returns HTTP 200
   failureModes:
     - symptom: The route returns 404
       resolution: Confirm withDocs wraps the Next.js config

--- a/website/app/docs/themes/agent.md
+++ b/website/app/docs/themes/agent.md
@@ -1,20 +1,19 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:435214e238ba8714
+sourceHash=fnv1a64:4bb6c5241a575cbf
 settingsHash=fnv1a64:b2106dff2d4f1f98
-outputHash=fnv1a64:d56b7fd0ce59bc24
-generatedAt=2026-07-30T09:43:36.702Z
+outputHash=fnv1a64:75c3aeaa240cd419
+generatedAt=2026-08-04T11:33:15.461Z
 -->
 # Themes
+URL: /docs/themes
+Description: Built-in themes and how to create your own
+Related: /docs/themes/creating-themes, /docs/configuration, /docs/customization/colors, /docs/customization/typography
 
-## Themes task
+Select factory and package subpath as a pair—e.g., `pixelBorder` from `@farming-labs/theme/pixel-border` with `theme: pixelBorder()`—then import `@farming-labs/theme/pixel-border/css` globally. Use `createTheme()` for custom factories and `extendTheme()` to derive from a preset. If visuals don't change, fix the CSS entrypoint; if the factory can't be resolved, copy its exact export and import path from the table below.
 
-Task: Select and apply a built-in or custom theme to a Farming Labs docs site.
-
-Expected result: docs.config and the global stylesheet reference the same theme and docs pages render its visual defaults.
-
-Exact implementation:
+## Using a Theme
 
 ```tsx title="docs.config.ts"
 import { defineDocs } from "@farming-labs/docs";
@@ -30,21 +29,17 @@ export default defineDocs({
 @import "tailwindcss";
 @import "@farming-labs/theme/pixel-border/css";
 ```
-## Themes prerequisites
 
-- The docs app and its framework-specific global stylesheet already work.
-- Choose a built-in preset before creating a custom theme unless requirements demand custom tokens.
-- Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs, @farming-labs/theme.
+## Built-in Themes
 
-## Themes verification
-
-- Build and open a docs page containing navigation, code, callouts, and tables. Expected: The production build succeeds and all elements use the selected theme without an unstyled flash.
-- Failure: The selected theme has no visual effect.
-- Recovery: Import the matching theme CSS in the global stylesheet and restart the framework dev server.
-- Rollback: Restore the previous theme factory and matching CSS import.
-
-## Themes agent guidance
-
-Select the factory and package subpath as a pair—for example, `pixelBorder` from `@farming-labs/theme/pixel-border` with `theme: pixelBorder()`—then import the matching `@farming-labs/theme/pixel-border/css` globally.
-Test navigation, code blocks, callouts, and tables after switching presets. Use `createTheme()` for a reusable custom factory and `extendTheme()` to derive a theme from an existing preset.
-If config builds but visuals do not change, repair the CSS entrypoint; if the factory cannot be resolved, copy its exact export and import path from the built-in themes table.
+| Theme | Import | Description |
+|---|---|---|
+| [Default](/docs/themes/default) | `@farming-labs/theme` | Neutral colors, standard radius |
+| [Colorful](/docs/themes/colorful) | `@farming-labs/theme/colorful` | Warm amber accent, Inter typography |
+| [Darksharp](/docs/themes/darksharp) | `@farming-labs/theme/darksharp` | All-black, sharp corners |
+| [Pixel Border](/docs/themes/pixel-border) | `@farming-labs/theme/pixel-border` | Inspired by better-auth.com |
+| [Shiny](/docs/themes/shiny) | `@farming-labs/theme/shiny` | Clerk-inspired, purple accents |
+| [Threadline](/docs/themes/threadline) | `@farming-labs/theme/threadline` | Compact neutral shell for chat and agent docs |
+| [DarkBold](/docs/themes/darkbold) | `@farming-labs/theme/darkbold` | Pure monochrome, Geist typography |
+| [GreenTree](/docs/themes/greentree) | `@farming-labs/theme/greentree` | Mintlify-inspired, emerald green accent |
+| [Concrete](/docs/themes/concrete) | `@farming-labs/theme/concrete` | Gray architectural surfaces |

--- a/website/app/docs/themes/shadcn/agent.md
+++ b/website/app/docs/themes/shadcn/agent.md
@@ -1,0 +1,61 @@
+<!-- @farming-labs/docs:generated
+version=1
+sourceKind=resolved-page
+sourceHash=fnv1a64:2240d36d42c2710a
+settingsHash=fnv1a64:ea29d93dde491bab
+outputHash=fnv1a64:44f89535b30a6f07
+generatedAt=2026-08-04T11:33:24.654Z
+-->
+---
+title: "Shadcn"
+description: "Compact neutral theme matching the layout, typography, and controls of the shadcn/ui documentation"
+canonical_url: "/docs/themes/shadcn"
+markdown_url: "/docs/themes/shadcn.md"
+last_updated: "2026-08-04"
+---
+
+# Shadcn Theme
+URL: /docs/themes/shadcn
+LLM index: /llms.txt
+Description: Compact neutral theme matching the layout, typography, and controls of the shadcn/ui documentation
+Related: /docs/themes, /docs/themes/threadline, /docs/customization/colors, /docs/themes/creating-themes
+
+Apply via `shadcn` from `@farming-labs/theme/shadcn`, `theme: shadcn()`, and `@import "@farming-labs/theme/shadcn/css"` in global stylesheet. Expect 56px header, 288px sidebar, 640px reading column, 256px TOC, Geist typography, neutral surfaces, compact controls in light/dark mode. Verify `/shadcn/css` entrypoint and `shadcn()` factory are both configured.
+
+Unofficial preset modeled on [shadcn/ui documentation](https://ui.shadcn.com/docs); recreates the shell and interactions without copying branding or content.
+
+## Usage
+
+```tsx title="docs.config.ts"
+import { defineDocs } from "@farming-labs/docs";
+import { shadcn } from "@farming-labs/theme/shadcn";
+
+export default defineDocs({
+  entry: "docs",
+  theme: shadcn(),
+});
+```
+
+```css title="app/global.css"
+@import "tailwindcss";
+@import "@farming-labs/theme/shadcn/css";
+```
+
+## Defaults
+
+| Property | Value |
+| --- | --- |
+| Primary | Neutral black / white |
+| Background | White (light), neutral near-black (dark) |
+| Border radius | `0.625rem` |
+| Content width | 640px |
+| Sidebar width | 288px |
+| TOC width | 256px |
+| Header height | 56px |
+
+## Style Notes
+
+- Compact desktop navigation and quiet search controls
+- Rounded active sidebar rows with subtle fading divider
+- Narrow reading measure and restrained heading scale
+- Borderless soft code blocks, callouts, cards, and page actions


### PR DESCRIPTION
## Summary

- refresh the four stale managed agent outputs for CLI, adapter conformance, API reference, and themes
- create the missing token-budget output for the Shadcn theme
- preserve the three handwritten outputs as intentionally unmanaged
- retain exact examples needed by the website golden retrieval tasks

## Result

Doctor now reports 50 fresh generated outputs, 0 stale, 0 modified, 3 intentionally unknown, and 0 missing. All 21 golden tasks pass at 99.5536/100.

## Validation

- docs doctor --agent: 98/100 Agent-ready
- docs review --ci: 100/100, no findings
- stale compaction dry run: no updates required
- generated Markdown fence validation
- credential leak scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed managed agent compaction outputs for CLI, adapter conformance, API reference, and themes, keeping handwritten outputs intentionally unmanaged. Doctor reports 50 fresh, 0 stale/modified/missing (3 intentionally unknown); all 21 golden tasks pass at 99.5536/100.

- **New Features**
  - Added the missing Shadcn theme agent compaction output with token budget (`@farming-labs/theme/shadcn`).

<sup>Written for commit 38daf1404e90d1b9cc4430fb81f0ebaed55cd249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

