### PR TITLE
fix: resolve ip-address security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       "undici": "7.29.0",
       "postcss@<=8.5.17": "8.5.18",
       "seroval@<=1.5.2": "1.5.3",
+      "ip-address@<=10.3.0": "10.4.0",
       "ws": "^8.21.0",
       "readdir-glob>minimatch": "10.2.4",
       "glob@10>minimatch": "10.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   undici: 7.29.0
   postcss@<=8.5.17: 8.5.18
   seroval@<=1.5.2: 1.5.3
+  ip-address@<=10.3.0: 10.4.0
   ws: ^8.21.0
   readdir-glob>minimatch: 10.2.4
   glob@10>minimatch: 10.2.4
@@ -5227,8 +5228,8 @@ packages:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   iron-webcrypto@1.2.1:
@@ -12600,7 +12601,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.1.0: {}
+  ip-address@10.4.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -14928,7 +14929,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}


### PR DESCRIPTION
## Summary

- override vulnerable `ip-address` releases (`<=10.3.0`) with patched `10.4.0`
- update the lockfile resolution used by the transitive Puppeteer SOCKS proxy chain
- keep the override range-scoped so unrelated dependencies remain unchanged

## Root cause

The CI bulk-advisory scan detected [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr). Puppeteer resolves `socks@2.8.7`, whose compatible `ip-address` dependency was locked at vulnerable `10.1.0`.

## Impact

The `security-audit` job can install with the frozen lockfile and no longer reports a high-severity vulnerability. There are no runtime API or application code changes.

## Validation

- `pnpm install --frozen-lockfile`
- exact CI bulk-advisory script: scanned 1,308 package names; no high or critical vulnerabilities
- `pnpm why -r ip-address`: every path resolves to `10.4.0`
- registry integrity matches the updated lockfile
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override vulnerable `ip-address` (<=10.3.0) to `10.4.0` to resolve GHSA-mwp4-54f8-5fhr in the transitive `socks` chain used by `puppeteer`. This clears the CI security audit with no runtime changes.

- **Dependencies**
  - Added `ip-address@<=10.3.0: 10.4.0` override in `package.json` and updated `pnpm-lock.yaml` accordingly.

<sup>Written for commit 2f58d0fc32e392de2594545eb161b1f1ee686988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

