### PR TITLE
chore: refresh website CLI agent compaction output

### DIFF
--- a/website/app/docs/cli/agent.md
+++ b/website/app/docs/cli/agent.md
@@ -1,12 +1,13 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:a519c682c3135a5e
+sourceHash=fnv1a64:db22ce532e615b91
 settingsHash=fnv1a64:e50e89e221226fc3
-outputHash=fnv1a64:1be0c86c619e1329
-generatedAt=2026-08-04T11:32:04.375Z
+outputHash=fnv1a64:c95a0dd048e26147
+generatedAt=2026-08-05T14:32:10.755Z
 -->
 URL: /docs/cli
+LLM index: /llms.txt
 Description: Scaffold, upgrade, export static Agent Bundles, compact agent docs, validate code blocks, generate sitemaps and robots.txt, sync search, and run MCP
 Related: /docs/configuration, /docs/guides/agent-friendly-docs, /docs/customization/sitemaps, /docs/customization/llms-txt
 
@@ -16,9 +17,17 @@ Related: /docs/configuration, /docs/guides/agent-friendly-docs, /docs/customizat
 
 Task: Plan and validate fenced MDX code blocks with the Farming Labs docs CLI.
 
-Expected result: The validation plan identifies runnable examples before any execution occurs.
+Expected result: The validation plan identifies runnable examples before any execution occurs, and
+the follow-up validation reports each configured example without executing unrelated prose.
 
-Exact implementation:
+Applies to Next.js, TanStack Start, SvelteKit, Astro, and Nuxt projects using
+`@farming-labs/docs` version `>=0.2.60`.
+
+Prerequisites:
+
+- Run commands from the docs project root with its package manager available.
+- Install project dependencies before invoking the local `docs` binary.
+- Review the plan before allowing configured runners to execute examples.
 
 ```bash title="terminal"
 pnpm exec docs codeblocks validate --plan
@@ -26,86 +35,66 @@ pnpm exec docs codeblocks validate
 pnpm exec docs codeblocks validate --json
 ```
 
-Applies to framework nextjs, tanstackstart, sveltekit, astro, nuxt; version >=0.2.60; package @farming-labs/docs.
+Verification: confirm the plan lists the expected fenced examples and that validation exits without
+an unhealthy or unverified command. Recovery: correct the reported file, line, command, or runner
+configuration, then rerun `--plan` before executing validation again.
 
-Choose the CLI workflow before changing files. Use `pnpm dlx @farming-labs/docs <command>` for a published release; use `pnpm exec docs <command>` only after dependencies are installed. For a non-interactive fresh scaffold: `init --template <framework> --name <dir>`; omit `--name` to be prompted.
+## Workflow selection
 
-After a mutating command, run `pnpm exec docs doctor --agent`; expected result is a loaded `docs.config.ts`, `docs.config.tsx`, or `src/lib/docs.config.ts` with no hard failure. For SvelteKit/Astro append `--config src/lib/docs.config.ts`. Prefer `--dry-run` for upgrade/compaction previews and `--check` for generated bundles, sitemaps, robots, or AGENTS files.
+- Use `init` for a new docs app or to add docs to an existing supported app.
+- Preview package changes with `upgrade --dry-run` before upgrading.
+- Use `agent compact --stale` for generated page context and `agent export --check` for bundles.
+- Use `doctor --agent` for site-wide readiness and `review --ci` for changed documentation.
+- Use `mcp` for local stdio clients; hosted clients should connect to the configured HTTP route.
 
-If `pnpm` cannot find `docs`, install dependencies or use `pnpm dlx`. If wrong config loads, return to project root or pass `--config <path>`.
+For a published release use `pnpm dlx @farming-labs/docs <command>`; use `pnpm exec docs <command>` only after installing dependencies. For non-interactive scaffold: `init --template <framework> --name <dir>`; omit `--name` to be prompted. Plain `init` asks whether to modify the current app or create a fresh project.
 
-**CLI commands:**
-- `init` — create or add docs to a project
+After a mutating command run `pnpm exec docs doctor --agent`; expected result is a loaded `docs.config.ts`, `docs.config.tsx`, or `src/lib/docs.config.ts` with no hard failure. For SvelteKit or Astro append `--config src/lib/docs.config.ts`. Prefer `--dry-run` for upgrade/compaction previews and `--check` for generated bundles, sitemaps, robots, or AGENTS files.
+
+If `pnpm` cannot find `docs`, install dependencies or use `pnpm dlx`. If the wrong config loads, return to project root or pass `--config <path>`; do not copy flags between unrelated subcommands.
+
+**Main commands:**
+- `init` — create a new docs app or add docs to an existing app
 - `upgrade` — bump docs packages
-- `agent export` — materialize static machine-readable bundle
+- `agent export` — materialize complete machine-readable surface for static hosting
 - `agent compact` — generate sibling `agent.md` files from resolved docs pages
-- `agents generate` — write root and static `AGENTS.md`
-- `skills scaffold` — compile structured page `agent` contracts into an Agent Skill
+- `agents generate` — write root and static `AGENTS.md` instructions
+- `skills scaffold` — compile structured page `agent` contracts into an installable Agent Skill
 - `doctor` — audit local docs readiness and optional hosted agent routes
 - `review` — review docs changes locally or in GitHub Actions
 - `codeblocks validate` — plan and validate runnable MDX code fences
-- `mcp` — run built-in docs MCP server over stdio
+- `mcp` — run the built-in docs MCP server over stdio
 - `search sync` — push docs content into Typesense or Algolia
 - `sitemap generate` — write `sitemap.xml`, `sitemap.md`, and `docs/sitemap.md`
-- `robots generate` — write or append agent-friendly `robots.txt`
-
-## CLI runnable code-block validation
-
-Plan fenced MDX examples with `pnpm exec docs codeblocks validate --plan`, then run the documented validation workflow before publishing.
+- `robots generate` — write or append an agent-friendly `robots.txt`
 
 ## Quick Start
 
 ### From scratch
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tab value="npm">
-    ```bash title="terminal"
-    npx @farming-labs/docs init --template next --name my-docs
-    npx @farming-labs/docs init --template tanstack-start --name my-docs
-    npx @farming-labs/docs init --template nuxt --name my-docs
-    npx @farming-labs/docs init --template sveltekit --name my-docs
-    npx @farming-labs/docs init --template astro --name my-docs
-    ```
-  </Tab>
-  <Tab value="pnpm">
-    ```bash title="terminal"
-    pnpm dlx @farming-labs/docs init --template next --name my-docs
-    pnpm dlx @farming-labs/docs init --template tanstack-start --name my-docs
-    pnpm dlx @farming-labs/docs init --template nuxt --name my-docs
-    pnpm dlx @farming-labs/docs init --template sveltekit --name my-docs
-    pnpm dlx @farming-labs/docs init --template astro --name my-docs
-    ```
-  </Tab>
-  <Tab value="yarn">
-    ```bash title="terminal"
-    yarn dlx @farming-labs/docs init --template next --name my-docs
-    yarn dlx @farming-labs/docs init --template tanstack-start --name my-docs
-    yarn dlx @farming-labs/docs init --template nuxt --name my-docs
-    yarn dlx @farming-labs/docs init --template sveltekit --name my-docs
-    yarn dlx @farming-labs/docs init --template astro --name my-docs
-    ```
-  </Tab>
-  <Tab value="bun">
-    ```bash title="terminal"
-    bunx @farming-labs/docs init --template next --name my-docs
-    bunx @farming-labs/docs init --template tanstack-start --name my-docs
-    bunx @farming-labs/docs init --template nuxt --name my-docs
-    bunx @farming-labs/docs init --template sveltekit --name my-docs
-    bunx @farming-labs/docs init --template astro --name my-docs
-    ```
-  </Tab>
-</Tabs>
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs init --template next --name my-docs
+pnpm dlx @farming-labs/docs init --template tanstack-start --name my-docs
+pnpm dlx @farming-labs/docs init --template nuxt --name my-docs
+pnpm dlx @farming-labs/docs init --template sveltekit --name my-docs
+pnpm dlx @farming-labs/docs init --template astro --name my-docs
+```
 
 ### Existing project
 
-Run from app root. The CLI: (1) detects framework from `package.json`, (2) asks for theme, (3) asks where docs live (usually `docs`), (4) asks about aliases, CSS, optional i18n, (5) generates files and installs `@farming-labs/*` packages, (6) optionally adds Docs Cloud support.
+```bash title="terminal"
+pnpm dlx @farming-labs/docs init
+```
+
+The CLI: detects framework from `package.json`, asks for theme, entry path (default `docs`), aliases, global CSS, optional i18n, generates files, installs `@farming-labs/*` packages, optionally adds Docs Cloud support.
 
 ### Upgrade
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tab value="npm">`npx @farming-labs/docs upgrade`</Tab>
-  <Tab value="pnpm">`pnpm dlx @farming-labs/docs upgrade`</Tab>
-  <Tab value="yarn">`yarn dlx @farming-labs/docs upgrade`</Tab>
-  <Tab value="bun">`bunx @farming-labs/docs upgrade`</Tab>
-</Tabs>
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs upgrade
+```
+
+Pass `--framework` if detection is ambiguous.
 
 ### MCP server locally
 
@@ -113,3 +102,17 @@ Run from app root. The CLI: (1) detects framework from `package.json`, (2) asks 
 pnpx @farming-labs/docs mcp
 pnpm exec docs mcp --config src/lib/docs.config.ts
 ```
+
+HTTP MCP route (start Next example first):
+```txt
+http://127.0.0.1:3000/mcp
+http://127.0.0.1:3000/.well-known/mcp
+```
+
+### Search sync
+
+```bash title="terminal"
+pnpm dlx @farming-labs/docs search sync --typesense
+```
+
+Loads environment files and uploads configured docs.


### PR DESCRIPTION
## Summary

- refresh the stale generated `website/app/docs/cli/agent.md` output against the current CLI page
- preserve the exact code-block validation workflow, applicability, prerequisites, verification, and recovery guidance
- keep representative init, upgrade, MCP, and search commands while removing repeated package-manager boilerplate
- update generated source/output digests and discovery metadata

## Why

The CLI page was the website's only stale managed agent output. A raw refresh reached the configured compaction boundary and omitted the exact `codeblocks validate --plan` workflow, which regressed one golden retrieval task. The final bounded output retains that structured task contract and removes lower-value repetition.

## Impact

- generated compaction freshness improves from 49 fresh / 1 stale to 50 fresh / 0 stale
- doctor improves from 96 to 98
- all 21 golden tasks continue to pass at 99.5536/100
- no source page, runtime behavior, or public authentication behavior changes

## Validation

- `pnpm --dir website exec docs doctor --agent --config docs.config.tsx`
- `pnpm --dir website exec docs review --ci --config docs.config.tsx`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
- generated provenance digest verification

Lint completes with zero errors; its existing repository warnings are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the generated CLI agent compaction page to match the current CLI, preserving the exact `codeblocks validate --plan` workflow while trimming repetition. Improves docs freshness with no runtime or public behavior changes.

- **Refactors**
  - Regenerated `website/app/docs/cli/agent.md` with updated workflows, applicability, prerequisites, verification, and recovery guidance.
  - Preserved the code-block validation contract, including `--plan` and reporting behavior.
  - Simplified init/upgrade examples (use `pnpm dlx`/`pnpm exec`), removed repeated package-manager boilerplate.
  - Clarified workflow selection and main commands; added MCP HTTP route notes and `search sync --typesense` example.
  - Updated generated digests and discovery metadata.

<sup>Written for commit 23c4642af0442f1e8822e6e3952373068fdb89de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

