### PR TITLE
fix: include Farm adapter in releases

### DIFF
--- a/bump.config.ts
+++ b/bump.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     "packages/svelte-theme/package.json",
     "packages/astro/package.json",
     "packages/astro-theme/package.json",
+    "packages/farmjs/package.json",
     "packages/nuxt/package.json",
     "packages/nuxt-theme/package.json",
   ],

--- a/packages/farmjs/package.json
+++ b/packages/farmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/farmjs",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "description": "Farm.js adapter for @farming-labs/docs",
   "keywords": [
     "docs",


### PR DESCRIPTION
## Summary

- bump `@farming-labs/farmjs` to `0.2.93` alongside the other `0.2.93` packages
- include the Farm adapter package in future `bumpp` releases

## Why

The Farm adapter was merged before the `0.2.93` release, but `bump.config.ts` omitted its package manifest. This left npm on `@farming-labs/farmjs@0.2.92` while the core docs and theme packages moved to `0.2.93`.

## Validation

- `oxfmt --check bump.config.ts packages/farmjs/package.json`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the Farm adapter in automated `bumpp` releases and align its version with the rest. Updated `@farming-labs/farmjs` to `0.2.93` and added `packages/farmjs/package.json` to `bump.config.ts`.

<sup>Written for commit 322ab9cb36882705aa78494089f7a3a9ae446574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

