### PR TITLE
feat: define adapter-owned runtime protocol

### DIFF
--- a/packages/farmjs/README.md
+++ b/packages/farmjs/README.md
@@ -26,8 +26,9 @@ export default withDocs(
 ```
 
 Farm discovers `docs.config.ts` from the application root. The wrapper writes
-Farm's native `docs` configuration and leaves routing, development middleware,
-and production output to `@farm.js/core`. A different path can
+an adapter runtime descriptor into Farm's `docs` configuration. Farm uses that
+versioned contract to load page rendering, server behavior, and MDX integration
+from `@farming-labs/farmjs` without selecting a docs theme itself. A different path can
 be provided explicitly:
 
 ```ts
@@ -35,6 +36,21 @@ export default withDocs(defineConfig({}), {
   configPath: "config/docs.config.ts",
 });
 ```
+
+Import the selected theme from the application-owned global stylesheet. This
+also gives the application a normal place for project-specific overrides:
+
+```css
+/* src/app/globals.css */
+@import "@farming-labs/theme/pixel-border/css";
+
+:root {
+  --color-fd-primary: #8b5cf6;
+}
+```
+
+The theme factory in `docs.config.ts` and the CSS entrypoint must describe the
+same theme.
 
 ## Server wrapper
 

--- a/packages/farmjs/package.json
+++ b/packages/farmjs/package.json
@@ -52,6 +52,11 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js",
       "default": "./dist/vite.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.js",
+      "default": "./dist/runtime.js"
     }
   },
   "scripts": {

--- a/packages/farmjs/src/config.test.ts
+++ b/packages/farmjs/src/config.test.ts
@@ -6,7 +6,19 @@ describe("withDocs", () => {
     const input = { preset: "vercel" } as const;
     const result = withDocs(input);
 
-    expect(result).toEqual({ preset: "vercel", docs: { enabled: true } });
+    expect(result).toMatchObject({
+      preset: "vercel",
+      docs: {
+        enabled: true,
+        adapter: {
+          id: "@farming-labs/farmjs",
+          protocol: 1,
+          server: "@farming-labs/farmjs/server",
+          react: "@farming-labs/farmjs/react",
+          vite: "@farming-labs/farmjs/vite",
+        },
+      },
+    });
     expect("docs" in input).toBe(false);
   });
 
@@ -20,6 +32,7 @@ describe("withDocs", () => {
 
     expect(result.docs).toEqual({
       enabled: true,
+      adapter: expect.objectContaining({ id: "@farming-labs/farmjs", protocol: 1 }),
       entry: "/guide",
       contentDir: "content/guide",
     });
@@ -41,12 +54,16 @@ describe("withDocs", () => {
 
     expect(result.docs).toEqual({
       enabled: true,
+      adapter: expect.objectContaining({ id: "@farming-labs/farmjs", protocol: 1 }),
       configPath: "docs.config.ts",
       config: { entry: "docs", search: true },
     });
   });
 
   it("supports explicitly disabling the adapter", () => {
-    expect(withDocs({}, { enabled: false }).docs).toEqual({ enabled: false });
+    expect(withDocs({}, { enabled: false }).docs).toMatchObject({
+      enabled: false,
+      adapter: { id: "@farming-labs/farmjs", protocol: 1 },
+    });
   });
 });

--- a/packages/farmjs/src/config.ts
+++ b/packages/farmjs/src/config.ts
@@ -1,9 +1,12 @@
 import type { DocsConfig } from "@farming-labs/docs";
+import { farmDocsRuntimeAdapter, type FarmDocsRuntimeAdapter } from "./runtime.js";
 
 export interface FarmDocsCoreConfig extends Partial<DocsConfig> {
   enabled?: boolean;
   configPath?: string;
   config?: Partial<DocsConfig>;
+  /** Runtime entrypoints owned by the official Farm adapter. */
+  adapter?: FarmDocsRuntimeAdapter;
 }
 
 export interface FarmDocsAdapterOptions {
@@ -48,6 +51,7 @@ export function withDocs<TConfig extends FarmConfigLike>(
     docs: {
       ...existing,
       enabled,
+      adapter: farmDocsRuntimeAdapter,
       ...(options.configPath ? { configPath: options.configPath } : {}),
       ...(options.config
         ? {

--- a/packages/farmjs/src/index.ts
+++ b/packages/farmjs/src/index.ts
@@ -18,4 +18,10 @@ export {
 export { createDocsServer, type DocsServer, type DocsServerLoadResult } from "./server.js";
 export { FarmDocsPage } from "./react.js";
 export { docsMdx } from "./vite.js";
+export {
+  FARM_DOCS_ADAPTER_ID,
+  FARM_DOCS_ADAPTER_PROTOCOL,
+  farmDocsRuntimeAdapter,
+  type FarmDocsRuntimeAdapter,
+} from "./runtime.js";
 export { createFarmjsApiReference } from "./api-reference.js";

--- a/packages/farmjs/src/runtime.ts
+++ b/packages/farmjs/src/runtime.ts
@@ -1,0 +1,26 @@
+/** Stable identifier used by Farm core to discover the official docs runtime. */
+export const FARM_DOCS_ADAPTER_ID = "@farming-labs/farmjs" as const;
+
+/**
+ * Versioned boundary between Farm core and the official adapter.
+ *
+ * Increment this only when Farm must change how it loads an adapter entrypoint.
+ */
+export const FARM_DOCS_ADAPTER_PROTOCOL = 1 as const;
+
+export interface FarmDocsRuntimeAdapter {
+  id: typeof FARM_DOCS_ADAPTER_ID;
+  protocol: typeof FARM_DOCS_ADAPTER_PROTOCOL;
+  server: "@farming-labs/farmjs/server";
+  react: "@farming-labs/farmjs/react";
+  vite: "@farming-labs/farmjs/vite";
+}
+
+/** Serializable runtime descriptor placed in Farm's resolved docs config. */
+export const farmDocsRuntimeAdapter: FarmDocsRuntimeAdapter = Object.freeze({
+  id: FARM_DOCS_ADAPTER_ID,
+  protocol: FARM_DOCS_ADAPTER_PROTOCOL,
+  server: "@farming-labs/farmjs/server",
+  react: "@farming-labs/farmjs/react",
+  vite: "@farming-labs/farmjs/vite",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,16 +89,16 @@ importers:
         specifier: ^10.0.8
         version: 10.0.8(91736b4062d4b29442bffb56c3f0bd97)
       '@farming-labs/astro':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/astro
       '@farming-labs/astro-theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/astro-theme
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       astro:
         specifier: 6.4.8
@@ -110,13 +110,13 @@ importers:
   examples/fumadocs-cloud:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -159,13 +159,13 @@ importers:
   examples/next:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/next':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/next
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       lucide-react:
         specifier: ^0.564.0
@@ -214,16 +214,16 @@ importers:
   examples/nuxt:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/nuxt':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/nuxt
       '@farming-labs/nuxt-theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/nuxt-theme
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -242,16 +242,16 @@ importers:
   examples/sveltekit:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/svelte':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/svelte
       '@farming-labs/svelte-theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/svelte-theme
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       three:
         specifier: ^0.180.0
@@ -279,13 +279,13 @@ importers:
   examples/tanstack-start:
     dependencies:
       '@farming-labs/docs':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/docs
       '@farming-labs/tanstack-start':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/tanstack-start
       '@farming-labs/theme':
-        specifier: 0.2.92
+        specifier: 0.2.94
         version: link:../../packages/fumadocs
       '@tanstack/react-router':
         specifier: ^1.0.0


### PR DESCRIPTION
## Summary

- publish a versioned, serializable Farm adapter runtime descriptor
- have `withDocs()` attach the official server, React, and Vite entrypoints to Farm config
- document application-owned theme CSS and custom global overrides

## Why

Farm core currently owns too much documentation-specific rendering and theme glue. This establishes the stable seam required to move those responsibilities into `@farming-labs/farmjs` incrementally without breaking development or production routing.

## Validation

- Farm adapter config tests (4 passed)
- Farm adapter TypeScript check
- paired consumer changes tested in farming-labs/farm.js#302

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a versioned, adapter-owned docs runtime protocol so Farm core loads docs server/React/Vite from `@farming-labs/farmjs`. `withDocs()` now writes a serializable runtime descriptor, creating a stable boundary to move rendering and theme logic out of core without breaking dev/prod.

- **New Features**
  - Added `FarmDocsRuntimeAdapter` descriptor and constants `FARM_DOCS_ADAPTER_ID` and `FARM_DOCS_ADAPTER_PROTOCOL`.
  - `withDocs()` injects `docs.adapter` with id, protocol, and entrypoints (`@farming-labs/farmjs/server`, `@farming-labs/farmjs/react`, `@farming-labs/farmjs/vite`), including when disabled.
  - New public export at `@farming-labs/farmjs/runtime` plus top-level re-exports.

- **Migration**
  - Import the chosen theme CSS in your app’s global stylesheet (e.g., `src/app/globals.css`).
  - Ensure the theme factory in `docs.config.ts` matches the CSS entrypoint.

<sup>Written for commit 5ca3fbef55d285f3cc3a57c134e15115144d628a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

