### PR TITLE
fix: make shadcn code blocks theme-aware

### DIFF
--- a/packages/docs/styles/themes/shadcn.css
+++ b/packages/docs/styles/themes/shadcn.css
@@ -839,7 +839,7 @@ figure.shiki pre,
 .fd-docs-content figure.shiki pre {
   max-width: 100%;
   margin: 0 !important;
-  padding: 0.875rem 1rem !important;
+  padding: 0.625rem 0.75rem !important;
   overflow-x: auto !important;
   overscroll-behavior-inline: contain;
   scrollbar-color: color-mix(in oklab, var(--color-fd-foreground) 18%, transparent)

--- a/packages/docs/styles/themes/shadcn.css
+++ b/packages/docs/styles/themes/shadcn.css
@@ -825,6 +825,62 @@ figure.shiki pre,
   box-shadow: none !important;
 }
 
+/* Compact code surfaces modeled after the current shadcn docs. */
+figure.shiki,
+.fd-docs-content figure.shiki {
+  margin-block: 1.25rem !important;
+  border: 0 !important;
+  border-radius: calc(var(--radius) * 1.8) !important;
+  background: var(--fd-shadcn-code) !important;
+  padding-block: 0 !important;
+}
+
+figure.shiki pre,
+.fd-docs-content figure.shiki pre {
+  max-width: 100%;
+  margin: 0 !important;
+  padding: 0.875rem 1rem !important;
+  overflow-x: auto !important;
+  overscroll-behavior-inline: contain;
+  scrollbar-color: color-mix(in oklab, var(--color-fd-foreground) 18%, transparent)
+    transparent;
+  scrollbar-width: thin;
+}
+
+figure.shiki pre > code,
+.fd-docs-content figure.shiki pre > code {
+  font-family: var(--fd-font-mono, "Geist Mono", ui-monospace, monospace) !important;
+  font-size: 0.875rem !important;
+  font-variant-ligatures: none;
+  line-height: 1.75 !important;
+  tab-size: 2;
+}
+
+figure.shiki pre > code > :is(.line, [data-line]) {
+  min-height: 1.53125rem;
+}
+
+figure.shiki pre > code > :is(.line, [data-line])[data-highlighted-line] {
+  background: var(--fd-shadcn-code-highlight) !important;
+}
+
+figure.shiki > button,
+figure.shiki > div:first-child button {
+  width: 2rem !important;
+  height: 2rem !important;
+  border: 0 !important;
+  border-radius: calc(var(--radius) * 0.8) !important;
+  background: color-mix(in oklab, var(--fd-shadcn-code) 82%, transparent) !important;
+  color: var(--color-fd-muted-foreground) !important;
+  backdrop-filter: blur(8px);
+}
+
+figure.shiki > button:hover,
+figure.shiki > div:first-child button:hover {
+  background: var(--fd-shadcn-control-hover) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
 .fd-codeblock-title,
 figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-code-header {
@@ -941,15 +997,17 @@ figure.shiki figcaption {
   padding: 0 !important;
 }
 
+article :not(pre) > code,
 .fd-docs-content :not(pre) > code,
 :is(.fd-ai-bubble-ai, .fd-ai-fm-msg-content) :not(pre) > code {
   border: 0 !important;
-  border-radius: calc(var(--radius) * 0.6);
-  background: var(--color-fd-muted);
+  border-radius: calc(var(--radius) * 0.5) !important;
+  background: color-mix(in oklab, var(--color-fd-muted) 48%, transparent) !important;
   color: var(--color-fd-foreground);
   font-family: var(--fd-font-mono, "Geist Mono", ui-monospace, monospace);
   font-size: 0.85em;
-  padding: 0.125em 0.3em;
+  padding: 0.08em 0.24em !important;
+  box-decoration-break: clone;
 }
 
 @media (hover: none) {

--- a/packages/fumadocs/src/shadcn/index.test.ts
+++ b/packages/fumadocs/src/shadcn/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { shadcn } from "./index.js";
+
+describe("shadcn theme", () => {
+  it("owns the syntax highlighting defaults", () => {
+    expect(shadcn().ui?.codeBlock).toEqual({
+      showCopyButton: true,
+      showLineNumbers: false,
+      theme: "github-light-default",
+      darkTheme: "vesper",
+    });
+  });
+});

--- a/packages/fumadocs/src/shadcn/index.ts
+++ b/packages/fumadocs/src/shadcn/index.ts
@@ -48,6 +48,12 @@ const ShadcnUIDefaults = {
     toc: { enabled: true, depth: 4, style: "default" as const },
     header: { height: 56, sticky: true },
   },
+  codeBlock: {
+    showCopyButton: true,
+    showLineNumbers: false,
+    theme: "github-light-default",
+    darkTheme: "vesper",
+  },
   sidebar: {
     style: "default" as const,
   },

--- a/packages/next/src/code-block-themes.test.ts
+++ b/packages/next/src/code-block-themes.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCodeBlockThemes } from "./code-block-themes.js";
+
+describe("resolveCodeBlockThemes", () => {
+  it("uses the shadcn syntax themes when docs.config imports the preset", () => {
+    const root = mkdtempSync(join(tmpdir(), "farming-docs-code-theme-"));
+    const configPath = "docs.config.ts";
+    try {
+      writeFileSync(
+        join(root, configPath),
+        'import { shadcn } from "@farming-labs/theme/shadcn";\nexport default { theme: shadcn() };\n',
+      );
+
+      expect(resolveCodeBlockThemes({ root, configPath })).toEqual({
+        light: "github-light-default",
+        dark: "vesper",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers code block themes supplied by the live docs theme", () => {
+    expect(
+      resolveCodeBlockThemes({
+        root: tmpdir(),
+        configPath: "missing-docs.config.ts",
+        theme: {
+          ui: {
+            codeBlock: {
+              theme: "min-light",
+              darkTheme: "min-dark",
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      light: "min-light",
+      dark: "min-dark",
+    });
+  });
+
+  it("preserves the existing GitHub themes for other presets", () => {
+    expect(
+      resolveCodeBlockThemes({
+        root: tmpdir(),
+        configPath: "missing-docs.config.ts",
+      }),
+    ).toEqual({
+      light: "github-light",
+      dark: "github-dark",
+    });
+  });
+});

--- a/packages/next/src/code-block-themes.ts
+++ b/packages/next/src/code-block-themes.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { DocsTheme } from "@farming-labs/docs";
+
+export interface CodeBlockThemes {
+  light: string;
+  dark: string;
+}
+
+const DEFAULT_CODE_BLOCK_THEMES: CodeBlockThemes = {
+  light: "github-light",
+  dark: "github-dark",
+};
+
+const SHADCN_CODE_BLOCK_THEMES: CodeBlockThemes = {
+  light: "github-light-default",
+  dark: "vesper",
+};
+
+const SHADCN_THEME_IMPORT = /(?:from\s*|import\s*)["']@farming-labs\/theme\/shadcn["']/;
+
+export function resolveCodeBlockThemes({
+  root,
+  configPath,
+  theme,
+}: {
+  root: string;
+  configPath: string;
+  theme?: DocsTheme;
+}): CodeBlockThemes {
+  const configFile = join(root, configPath);
+  const usesShadcnTheme =
+    existsSync(configFile) && SHADCN_THEME_IMPORT.test(readFileSync(configFile, "utf8"));
+  const fallback = usesShadcnTheme ? SHADCN_CODE_BLOCK_THEMES : DEFAULT_CODE_BLOCK_THEMES;
+  const codeBlock = theme?.ui?.codeBlock;
+
+  return {
+    light: codeBlock?.theme ?? fallback.light,
+    dark: codeBlock?.darkTheme ?? fallback.dark,
+  };
+}

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -60,6 +60,7 @@ import type {
   ObjectProperty,
   Program,
 } from "@babel/types";
+import { resolveCodeBlockThemes } from "./code-block-themes.js";
 
 /** Resolve Next.js App Router directory: prefer src/app when present, else app. */
 function getNextAppDir(root: string): string {
@@ -2365,12 +2366,17 @@ function mergeDocsRedirects(
 
 export function withDocs(
   nextConfig: NextConfig = {},
-  docsConfig?: Pick<DocsConfig, "agent" | "mcp">,
+  docsConfig?: Pick<DocsConfig, "agent" | "mcp" | "theme">,
 ): NextConfig {
   const root = process.cwd();
   const workspaceRoot = findDocsWorkspaceRoot(root);
   const docsConfigPath = readDocsConfigPath(root);
   const docsConfigAbsolutePath = join(root, docsConfigPath);
+  const codeBlockThemes = resolveCodeBlockThemes({
+    root,
+    configPath: docsConfigPath,
+    theme: docsConfig?.theme,
+  });
   const mcp = docsConfig ? resolveMcpConfig(docsConfig.mcp) : readMcpConfig(root);
   const nextBasePath = normalizeRoutePrefix(nextConfig.basePath);
   if (mcp.enabled && mcp.protectedResource && nextBasePath) {
@@ -2589,10 +2595,7 @@ export function withDocs(
   );
   const rehypePlugins: MdxPluginEntry[] = [
     "@farming-labs/next/mdx-plugins/rehype-toc",
-    [
-      "@farming-labs/next/mdx-plugins/rehype-code",
-      { themes: { dark: "github-dark", light: "github-light" } },
-    ],
+    ["@farming-labs/next/mdx-plugins/rehype-code", { themes: codeBlockThemes }],
   ];
 
   const withMDX = createMDX({


### PR DESCRIPTION
## Summary

- make the Shadcn preset own its GitHub Light Default and Vesper syntax themes
- resolve MDX compiler themes from the built-in Shadcn import or a live theme override
- align block and inline code spacing, surfaces, scrolling, and copy controls with the Shadcn docs style

## Root cause

The Next adapter hardcoded GitHub Light and GitHub Dark in its MDX pipeline, so `ui.codeBlock` and the Shadcn preset could not affect the emitted Shiki tokens.

## Impact

Shadcn consumers get the intended syntax palette and compact code treatment through the theme itself, while other themes retain the existing GitHub defaults. Custom live theme values still take precedence.

## Validation

- 70 Next adapter and Shadcn preset tests
- `@farming-labs/next` typecheck
- `@farming-labs/theme` typecheck
- formatting and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Shadcn code blocks theme-aware and match Shadcn docs styling. The `@farming-labs/next` adapter now resolves syntax themes from the active docs theme or the Shadcn preset import, with tightened code block spacing to mirror Shadcn docs.

- **Bug Fixes**
  - Detect `@farming-labs/theme/shadcn` in `docs.config` and default to `github-light-default` (light) and `vesper` (dark); other presets stay `github-light`/`github-dark`.
  - Prefer live `theme.ui.codeBlock.theme` and `darkTheme` when provided.
  - Pass resolved themes to `@farming-labs/next/mdx-plugins/rehype-code`.
  - Set Shadcn code block defaults in `@farming-labs/theme/shadcn` and update CSS for compact surfaces, tighter pre and inline code padding, scroll behavior, and copy button styles.
  - Add tests for theme resolution and Shadcn defaults.

<sup>Written for commit 835c22f7adf5acd3f69deab58fd7e1d1bc575192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

