### PR TITLE
chore: upgrade @clack/prompts to v1

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -79,7 +79,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@clack/prompts": "^0.9.1",
+    "@clack/prompts": "^1.7.0",
     "@mdx-js/mdx": "^3.1.1",
     "@modelcontextprotocol/server": "2.0.0",
     "@scalar/core": "^0.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,8 +374,8 @@ importers:
   packages/docs:
     dependencies:
       '@clack/prompts':
-        specifier: ^0.9.1
-        version: 0.9.1
+        specifier: ^1.7.0
+        version: 1.7.0
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1(supports-color@10.2.2)
@@ -1212,11 +1212,19 @@ packages:
     resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
     engines: {node: '>= 20.12.0'}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@0.9.1':
     resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
   '@clack/prompts@1.5.1':
     resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
@@ -10510,6 +10518,11 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@clack/prompts@0.9.1':
     dependencies:
       '@clack/core': 0.4.1
@@ -10519,6 +10532,13 @@ snapshots:
   '@clack/prompts@1.5.1':
     dependencies:
       '@clack/core': 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5


### PR DESCRIPTION
## Summary

- upgrade `@clack/prompts` from `^0.9.1` to `^1.7.0`
- refresh the pnpm lockfile for `@clack/prompts` and `@clack/core`

## Why

The direct dependency range was pinned to the 0.x line, so package analysis correctly reported it as one major version behind. The docs package is already ESM-only and requires Node.js 20, which satisfies the v1 runtime requirements.

## Impact

The CLI keeps its existing prompt behavior while picking up the current stable release and the fixes added across the v1 line.

## Validation

- `pnpm install --frozen-lockfile --lockfile-only --offline --ignore-scripts`
- `pnpm --filter @farming-labs/docs run build`
- `pnpm --filter @farming-labs/docs exec vitest run src/cli/init.test.ts src/cli/upgrade.flow.test.ts src/cli/downgrade.flow.test.ts` (26 tests passed)
- `pnpm --filter @farming-labs/docs run typecheck`
- `node_modules/.bin/oxfmt packages/docs --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `@clack/prompts` to v1.7.0 to adopt the stable v1 and its fixes without changing CLI prompt behavior. The docs package already targets Node 20 and ESM, so no migration is needed.

- **Dependencies**
  - Bump `@clack/prompts` from `^0.9.1` to `^1.7.0`.
  - Refresh lockfile; `@clack/core` resolved to `1.4.3`.

<sup>Written for commit be23e929e2473bd3b92ceb446b02d7f2063aa494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

