### PR TITLE
fix: refine shadcn docs layout

### DIFF
--- a/packages/docs/styles/themes/shadcn.css
+++ b/packages/docs/styles/themes/shadcn.css
@@ -187,6 +187,24 @@ aside#nd-sidebar-mobile {
 
 aside#nd-sidebar::after,
 .fd-sidebar::after {
+  position: absolute;
+  inset-block: 1.25rem 1.5rem;
+  inset-inline-end: 0;
+  z-index: 1;
+  display: block !important;
+  width: 1px;
+  content: "";
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--color-fd-border) 10%,
+    var(--color-fd-border) 90%,
+    transparent 100%
+  );
+}
+
+aside#nd-sidebar-mobile::after {
   display: none !important;
 }
 
@@ -197,10 +215,10 @@ aside#nd-sidebar-mobile .fd-sidebar {
   background: transparent !important;
 }
 
-/* Match shadcn/ui's compact, unframed navigation rail. */
+/* Match shadcn/ui's compact navigation rail while preserving built-in controls. */
 aside#nd-sidebar > div:first-child {
   gap: 0.375rem !important;
-  padding: 0.5rem 1rem 0.25rem !important;
+  padding: 0.75rem 1.25rem 0.5rem !important;
 }
 
 aside#nd-sidebar .fd-api-reference-switcher {
@@ -208,7 +226,14 @@ aside#nd-sidebar .fd-api-reference-switcher {
 }
 
 aside#nd-sidebar [data-radix-scroll-area-viewport] {
-  padding: 0 4rem 1rem 1.625rem !important;
+  padding: 1.25rem 1.25rem 2rem 1.5rem !important;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    black 1.25rem,
+    black calc(100% - 1.5rem),
+    transparent 100%
+  ) !important;
 }
 
 aside#nd-sidebar-mobile [data-radix-scroll-area-viewport] {
@@ -305,7 +330,7 @@ aside#nd-sidebar-mobile
 }
 
 aside#nd-sidebar > div:last-child {
-  padding: 0.5rem 4rem 1rem 1.625rem !important;
+  padding: 0.5rem 1.25rem 1rem 1.5rem !important;
 }
 
 aside#nd-sidebar > div:last-child > div {
@@ -567,6 +592,15 @@ aside#nd-sidebar button.text-fd-muted-foreground,
   line-height: 1.5 !important;
 }
 
+.fd-generated-page-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.fd-generated-page-header .fd-page-title {
+  margin: 0 0 0.5rem;
+}
+
 .fd-docs-content,
 #nd-page .prose {
   color: var(--color-fd-foreground);
@@ -597,6 +631,7 @@ aside#nd-sidebar button.text-fd-muted-foreground,
 .fd-copy-btn,
 .fd-ai-code-copy,
 .fd-ai-model-dropdown-btn,
+.fd-page-footer > a,
 .fd-page-nav-card,
 .fd-page-nav a,
 #nd-page > div[class~="@container"] > a {
@@ -613,10 +648,25 @@ aside#nd-sidebar button.text-fd-muted-foreground,
 .fd-copy-btn:hover,
 .fd-ai-code-copy:hover,
 .fd-ai-model-dropdown-btn:hover,
+.fd-page-footer > a:hover,
 .fd-page-nav-card:hover,
 .fd-page-nav a:hover,
 #nd-page > div[class~="@container"] > a:hover {
   background: var(--fd-shadcn-control-hover) !important;
+}
+
+.fd-page-footer > a {
+  min-height: 2rem;
+  padding: 0.5rem 0.75rem !important;
+  text-decoration: none !important;
+}
+
+.fd-llms-txt-links {
+  display: none !important;
+}
+
+#nd-docs-layout a[href$="/llms.txt"] {
+  display: none !important;
 }
 
 .fd-page-nav,
@@ -1013,6 +1063,21 @@ article :not(pre) > code,
 @media (hover: none) {
   .fd-ai-code-copy {
     opacity: 1;
+  }
+}
+
+@media (max-width: 767px) {
+  figure.shiki pre,
+  .fd-docs-content figure.shiki pre {
+    padding: 0.625rem 0.75rem !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  aside#nd-sidebar a,
+  aside#nd-sidebar button {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }
 

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createDocsLayout, createPageMetadata } from "./docs-layout.js";
+import { shadcn } from "./shadcn/index.js";
 
 function findDocsPageClientProps(node: unknown): Record<string, unknown> | null {
   if (!node || typeof node !== "object") return null;
@@ -132,6 +133,60 @@ agent:
     expect(props?.openDocs).toBe(true);
     expect(props?.pageActionsAlignment).toBe("right");
     expect(props?.pageActionsPosition).toBe("below-title");
+  });
+
+  it("generates frontmatter titles only when the MDX body does not author an h1", () => {
+    const pages = {
+      generated: ["---", "title: Generated", "---", "", "Body without a heading."],
+      fenced: ["---", "title: Fenced", "---", "", "```md", "# Example heading", "```"],
+      markdown: ["---", "title: Markdown", "---", "", "# Markdown"],
+      html: ["---", "title: HTML", "---", "", "<h1>HTML</h1>"],
+      setext: ["---", "title: Setext", "---", "", "Setext", "======"],
+    };
+
+    for (const [slug, lines] of Object.entries(pages)) {
+      mkdirSync(join(tmpDir, "app", "docs", slug), { recursive: true });
+      writeFileSync(join(tmpDir, "app", "docs", slug, "page.mdx"), lines.join("\n"), "utf-8");
+    }
+
+    const Layout = createDocsLayout({ entry: "docs" });
+    const tree = Layout({ children: React.createElement("div", null, "child") });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props?.generatedTitleMap).toEqual({
+      "/docs/generated": "Generated",
+      "/docs/fenced": "Fenced",
+    });
+  });
+
+  it("uses a readable Shadcn folder label for Introduction landing pages", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "statewire", "authoring-js"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "statewire", "page.mdx"),
+      "---\ntitle: Introduction\n---\n\n# Introduction\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(tmpDir, "app", "docs", "statewire", "authoring-js", "page.mdx"),
+      "---\ntitle: Authoring JavaScript\n---\n\n# Authoring JavaScript\n",
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({
+      entry: "docs",
+      theme: shadcn(),
+    });
+    const tree = Layout({ children: React.createElement("div", null, "child") });
+    const pageTree = findDocsLayoutTree(tree) as {
+      children?: Array<{ type?: string; name?: string; index?: { name?: string } }>;
+    } | null;
+    const statewire = pageTree?.children?.find((node) => node.type === "folder");
+
+    expect(statewire).toMatchObject({
+      type: "folder",
+      name: "Statewire",
+    });
+    expect(statewire?.index).toBeUndefined();
   });
 
   it("enables llms.txt footer links by default", () => {

--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -149,7 +149,7 @@ agent:
       writeFileSync(join(tmpDir, "app", "docs", slug, "page.mdx"), lines.join("\n"), "utf-8");
     }
 
-    const Layout = createDocsLayout({ entry: "docs" });
+    const Layout = createDocsLayout({ entry: "docs", theme: shadcn() });
     const tree = Layout({ children: React.createElement("div", null, "child") });
     const props = findDocsPageClientProps(tree);
 
@@ -157,6 +157,21 @@ agent:
       "/docs/generated": "Generated",
       "/docs/fenced": "Fenced",
     });
+  });
+
+  it("does not change title rendering for non-Shadcn themes", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "generated"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "generated", "page.mdx"),
+      "---\ntitle: Generated\n---\n\nBody without a heading.",
+      "utf-8",
+    );
+
+    const Layout = createDocsLayout({ entry: "docs" });
+    const tree = Layout({ children: React.createElement("div", null, "child") });
+    const props = findDocsPageClientProps(tree);
+
+    expect(props?.generatedTitleMap).toEqual({});
   });
 
   it("uses a readable Shadcn folder label for Introduction landing pages", () => {

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -100,6 +100,41 @@ function readFrontmatter(filePath: string): Record<string, unknown> {
   }
 }
 
+function hasAuthoredPageTitle(source: string): boolean {
+  const { content } = matter(source);
+  const lines = content.split(/\r?\n/);
+  let fence: string | undefined;
+  let previousTextLine = "";
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]?.[0];
+      fence = fence === marker ? undefined : (fence ?? marker);
+      previousTextLine = "";
+      continue;
+    }
+    if (fence) continue;
+    if (/^ {0,3}#(?:\s+|$)/.test(line) || /^\s*<h1(?:\s|>)/i.test(line)) return true;
+    if (previousTextLine && /^ {0,3}=+\s*$/.test(line)) return true;
+    previousTextLine = line.trim() && !line.trimStart().startsWith("<") ? line : "";
+  }
+
+  return false;
+}
+
+function resolveSidebarFolderName(themeName: string | undefined, slug: string, pageTitle: string) {
+  if (themeName !== "shadcn" || pageTitle.trim().toLowerCase() !== "introduction") {
+    return pageTitle;
+  }
+
+  return slug
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 /** Check if a directory has any subdirectories that contain page.mdx. */
 function isWithinDir(candidate: string, target: string): boolean {
   const relative = path.relative(target, candidate);
@@ -343,6 +378,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
     const url = publicDocsRoute(ctx, slug);
     const icon = resolveIcon(data.icon as string | undefined, icons);
     const displayName = (data.title as string) ?? name.replace(/-/g, " ");
+    const folderName = resolveSidebarFolderName(config.theme?.name, name, displayName);
     const hasChildren = hasChildPages(full, excludedDirs);
 
     if (data.hidden === true) {
@@ -351,7 +387,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
       const folderChildren = scanDir(full, slug, slugOrder);
       return {
         type: "folder",
-        name: displayName,
+        name: folderName,
         icon,
         children: folderChildren,
         ...(flat ? { collapsible: false, defaultOpen: true } : {}),
@@ -362,7 +398,7 @@ function buildTree(config: DocsConfig, ctx: DocsLocaleContext, flat = false) {
       const folderChildren = scanDir(full, slug, slugOrder);
       return {
         type: "folder",
-        name: displayName,
+        name: folderName,
         icon,
         index: { type: "page", name: displayName, url, icon },
         folderIndexBehavior: resolvePageSidebarFolderIndexBehavior(data.sidebar),
@@ -542,6 +578,38 @@ function buildDescriptionMap(config: DocsConfig, ctx: DocsLocaleContext): Record
       if (fs.statSync(full).isDirectory()) {
         scan(full, [...slugParts, name]);
       }
+    }
+  }
+
+  scan(docsDir, []);
+  return map;
+}
+
+/** Build titles only for pages whose MDX body does not already author an h1. */
+function buildGeneratedTitleMap(
+  config: DocsConfig,
+  ctx: DocsLocaleContext,
+): Record<string, string> {
+  const docsDir = ctx.docsDir;
+  const map: Record<string, string> = {};
+  const excludedDirs = getExcludedDocsDirs(config, ctx);
+
+  function scan(dir: string, slugParts: string[]) {
+    if (!fs.existsSync(dir)) return;
+    if (isExcludedDir(dir, excludedDirs)) return;
+
+    const pagePath = findDocsPageFile(dir);
+    if (pagePath) {
+      const source = fs.readFileSync(pagePath, "utf-8");
+      const { data } = matter(source);
+      if (typeof data.title === "string" && !hasAuthoredPageTitle(source)) {
+        map[publicDocsRoute(ctx, slugParts)] = data.title;
+      }
+    }
+
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      if (fs.statSync(full).isDirectory()) scan(full, [...slugParts, name]);
     }
   }
 
@@ -1056,6 +1124,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
 
   // Build description map from frontmatter
   const descriptionMap = buildDescriptionMap(config, localeContext);
+  const generatedTitleMap = buildGeneratedTitleMap(config, localeContext);
   const readingTimeMap = buildReadingTimeMap(config, localeContext, {
     enabledByDefault: readingTimeEnabledByDefault,
     wordsPerMinute: readingTimeWordsPerMinute,
@@ -1180,6 +1249,7 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             readingTimeMap={readingTimeMap}
             structuredDataMap={structuredDataMap}
             llmsTxtEnabled={llmsTxtEnabled}
+            generatedTitleMap={generatedTitleMap}
             descriptionMap={descriptionMap}
             feedbackEnabled={feedbackConfig.enabled}
             feedbackQuestion={feedbackConfig.question}

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1124,7 +1124,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
 
   // Build description map from frontmatter
   const descriptionMap = buildDescriptionMap(config, localeContext);
-  const generatedTitleMap = buildGeneratedTitleMap(config, localeContext);
+  const generatedTitleMap =
+    config.theme?.name === "shadcn" ? buildGeneratedTitleMap(config, localeContext) : {};
   const readingTimeMap = buildReadingTimeMap(config, localeContext, {
     enabledByDefault: readingTimeEnabledByDefault,
     wordsPerMinute: readingTimeWordsPerMinute,

--- a/packages/fumadocs/src/docs-page-client.test.ts
+++ b/packages/fumadocs/src/docs-page-client.test.ts
@@ -69,6 +69,33 @@ describe("DocsPageClient structured data", () => {
   });
 });
 
+describe("DocsPageClient generated page header", () => {
+  it("renders title, description, and below-title actions before preserved page content", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DocsPageClient, {
+        tocEnabled: false,
+        breadcrumbEnabled: false,
+        copyMarkdown: true,
+        pageActionsPosition: "below-title",
+        generatedTitleMap: { "/docs/installation": "Installation" },
+        descriptionMap: { "/docs/installation": "Install the framework." },
+        children: React.createElement("article", null, "Preserved page content"),
+      }),
+    );
+
+    const titleIndex = html.indexOf("Installation");
+    const descriptionIndex = html.indexOf("Install the framework.");
+    const actionsIndex = html.indexOf("Mock Actions");
+    const contentIndex = html.indexOf("Preserved page content");
+
+    expect(html).toContain('class="fd-generated-page-header not-prose"');
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(descriptionIndex).toBeGreaterThan(titleIndex);
+    expect(actionsIndex).toBeGreaterThan(descriptionIndex);
+    expect(contentIndex).toBeGreaterThan(actionsIndex);
+  });
+});
+
 describe("DocsPageClient reading time", () => {
   it("renders the reading-time row when enabled", () => {
     const html = renderToStaticMarkup(

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -107,6 +107,8 @@ interface DocsPageClientProps {
   lastUpdatedPosition?: "footer" | "below-title";
   /** Whether llms.txt is enabled — shows links in footer */
   llmsTxtEnabled?: boolean;
+  /** Frontmatter titles for pages whose MDX body does not author an h1 */
+  generatedTitleMap?: Record<string, string>;
   /** Map of pathname → frontmatter description */
   descriptionMap?: Record<string, string>;
   /** Frontmatter description to display below the page title (overrides descriptionMap) */
@@ -533,6 +535,7 @@ export function DocsPageClient({
   lastUpdatedLabel = "Last updated",
   lastUpdatedPosition = "footer",
   llmsTxtEnabled = false,
+  generatedTitleMap,
   descriptionMap,
   description,
   feedbackEnabled = false,
@@ -561,8 +564,9 @@ export function DocsPageClient({
   const resolvedPublicPath = normalizePublicDocsPath(publicPath, entry);
   const llmsLangQuery = activeLocale ? `?lang=${encodeURIComponent(activeLocale)}` : "";
 
-  const pageDescription = description ?? descriptionMap?.[pathname.replace(/\/$/, "") || "/"];
   const normalizedPath = (browserPathname || pathname).replace(/\/$/, "") || "/";
+  const pageTitle = generatedTitleMap?.[normalizedPath];
+  const pageDescription = description ?? descriptionMap?.[normalizedPath];
   const isChangelogRoute = !!(
     changelogBasePath &&
     (normalizedPath === changelogBasePath || normalizedPath.startsWith(`${changelogBasePath}/`))
@@ -860,7 +864,7 @@ export function DocsPageClient({
     ) : undefined;
 
   const decoratedChildren = children;
-  const needsTitleDecorationsPortal = !!titleDescription || !!belowTitleBlock;
+  const needsTitleDecorationsPortal = !pageTitle && (!!titleDescription || !!belowTitleBlock);
 
   useEffect(() => {
     if (!needsTitleDecorationsPortal) {
@@ -894,6 +898,12 @@ export function DocsPageClient({
       ? createPortal(titleDecorations, titlePortalHost, "title-decorations")
       : null;
   const titleDecorationsFallback = titleDecorations && !titlePortalHost ? titleDecorations : null;
+  const generatedPageHeader = pageTitle ? (
+    <div className="fd-generated-page-header not-prose">
+      <h1 className="fd-page-title">{pageTitle}</h1>
+      <TitleDecorations description={titleDescription} belowTitle={belowTitleBlock} />
+    </div>
+  ) : null;
   const titleControlsPortal =
     showActionsInToc && titleControlsPortalHost
       ? createPortal(<ThreadlinePageControls />, titleControlsPortalHost, "title-controls")
@@ -994,10 +1004,11 @@ export function DocsPageClient({
         )}
         {!showReadingTimeAboveTitle && !showReadingTimeBelowTitle ? readingTimeBlock : null}
         <DocsBody key="body" style={{ display: "flex", flexDirection: "column" }}>
+          {generatedPageHeader}
           <div key="content" style={{ flex: 1 }}>
             {renderedChildren}
           </div>
-          {titleDecorationsFallback}
+          {!generatedPageHeader && titleDecorationsFallback}
           {titleDecorationsPortal}
           {!isChangelogRoute && feedbackEnabled && (
             <DocsFeedback

--- a/website/public/themes/shadcn.css
+++ b/website/public/themes/shadcn.css
@@ -187,6 +187,24 @@ aside#nd-sidebar-mobile {
 
 aside#nd-sidebar::after,
 .fd-sidebar::after {
+  position: absolute;
+  inset-block: 1.25rem 1.5rem;
+  inset-inline-end: 0;
+  z-index: 1;
+  display: block !important;
+  width: 1px;
+  content: "";
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--color-fd-border) 10%,
+    var(--color-fd-border) 90%,
+    transparent 100%
+  );
+}
+
+aside#nd-sidebar-mobile::after {
   display: none !important;
 }
 
@@ -197,10 +215,10 @@ aside#nd-sidebar-mobile .fd-sidebar {
   background: transparent !important;
 }
 
-/* Match shadcn/ui's compact, unframed navigation rail. */
+/* Match shadcn/ui's compact navigation rail while preserving built-in controls. */
 aside#nd-sidebar > div:first-child {
   gap: 0.375rem !important;
-  padding: 0.5rem 1rem 0.25rem !important;
+  padding: 0.75rem 1.25rem 0.5rem !important;
 }
 
 aside#nd-sidebar .fd-api-reference-switcher {
@@ -208,7 +226,14 @@ aside#nd-sidebar .fd-api-reference-switcher {
 }
 
 aside#nd-sidebar [data-radix-scroll-area-viewport] {
-  padding: 0 4rem 1rem 1.625rem !important;
+  padding: 1.25rem 1.25rem 2rem 1.5rem !important;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    black 1.25rem,
+    black calc(100% - 1.5rem),
+    transparent 100%
+  ) !important;
 }
 
 aside#nd-sidebar-mobile [data-radix-scroll-area-viewport] {
@@ -305,7 +330,7 @@ aside#nd-sidebar-mobile
 }
 
 aside#nd-sidebar > div:last-child {
-  padding: 0.5rem 4rem 1rem 1.625rem !important;
+  padding: 0.5rem 1.25rem 1rem 1.5rem !important;
 }
 
 aside#nd-sidebar > div:last-child > div {
@@ -567,6 +592,15 @@ aside#nd-sidebar button.text-fd-muted-foreground,
   line-height: 1.5 !important;
 }
 
+.fd-generated-page-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.fd-generated-page-header .fd-page-title {
+  margin: 0 0 0.5rem;
+}
+
 .fd-docs-content,
 #nd-page .prose {
   color: var(--color-fd-foreground);
@@ -597,6 +631,7 @@ aside#nd-sidebar button.text-fd-muted-foreground,
 .fd-copy-btn,
 .fd-ai-code-copy,
 .fd-ai-model-dropdown-btn,
+.fd-page-footer > a,
 .fd-page-nav-card,
 .fd-page-nav a,
 #nd-page > div[class~="@container"] > a {
@@ -613,10 +648,25 @@ aside#nd-sidebar button.text-fd-muted-foreground,
 .fd-copy-btn:hover,
 .fd-ai-code-copy:hover,
 .fd-ai-model-dropdown-btn:hover,
+.fd-page-footer > a:hover,
 .fd-page-nav-card:hover,
 .fd-page-nav a:hover,
 #nd-page > div[class~="@container"] > a:hover {
   background: var(--fd-shadcn-control-hover) !important;
+}
+
+.fd-page-footer > a {
+  min-height: 2rem;
+  padding: 0.5rem 0.75rem !important;
+  text-decoration: none !important;
+}
+
+.fd-llms-txt-links {
+  display: none !important;
+}
+
+#nd-docs-layout a[href$="/llms.txt"] {
+  display: none !important;
 }
 
 .fd-page-nav,
@@ -825,6 +875,62 @@ figure.shiki pre,
   box-shadow: none !important;
 }
 
+/* Compact code surfaces modeled after the current shadcn docs. */
+figure.shiki,
+.fd-docs-content figure.shiki {
+  margin-block: 1.25rem !important;
+  border: 0 !important;
+  border-radius: calc(var(--radius) * 1.8) !important;
+  background: var(--fd-shadcn-code) !important;
+  padding-block: 0 !important;
+}
+
+figure.shiki pre,
+.fd-docs-content figure.shiki pre {
+  max-width: 100%;
+  margin: 0 !important;
+  padding: 0.625rem 0.75rem !important;
+  overflow-x: auto !important;
+  overscroll-behavior-inline: contain;
+  scrollbar-color: color-mix(in oklab, var(--color-fd-foreground) 18%, transparent)
+    transparent;
+  scrollbar-width: thin;
+}
+
+figure.shiki pre > code,
+.fd-docs-content figure.shiki pre > code {
+  font-family: var(--fd-font-mono, "Geist Mono", ui-monospace, monospace) !important;
+  font-size: 0.875rem !important;
+  font-variant-ligatures: none;
+  line-height: 1.75 !important;
+  tab-size: 2;
+}
+
+figure.shiki pre > code > :is(.line, [data-line]) {
+  min-height: 1.53125rem;
+}
+
+figure.shiki pre > code > :is(.line, [data-line])[data-highlighted-line] {
+  background: var(--fd-shadcn-code-highlight) !important;
+}
+
+figure.shiki > button,
+figure.shiki > div:first-child button {
+  width: 2rem !important;
+  height: 2rem !important;
+  border: 0 !important;
+  border-radius: calc(var(--radius) * 0.8) !important;
+  background: color-mix(in oklab, var(--fd-shadcn-code) 82%, transparent) !important;
+  color: var(--color-fd-muted-foreground) !important;
+  backdrop-filter: blur(8px);
+}
+
+figure.shiki > button:hover,
+figure.shiki > div:first-child button:hover {
+  background: var(--fd-shadcn-control-hover) !important;
+  color: var(--color-fd-foreground) !important;
+}
+
 .fd-codeblock-title,
 figure.shiki:has(figcaption) > div:first-child,
 .fd-ai-code-header {
@@ -941,20 +1047,37 @@ figure.shiki figcaption {
   padding: 0 !important;
 }
 
+article :not(pre) > code,
 .fd-docs-content :not(pre) > code,
 :is(.fd-ai-bubble-ai, .fd-ai-fm-msg-content) :not(pre) > code {
   border: 0 !important;
-  border-radius: calc(var(--radius) * 0.6);
-  background: var(--color-fd-muted);
+  border-radius: calc(var(--radius) * 0.5) !important;
+  background: color-mix(in oklab, var(--color-fd-muted) 48%, transparent) !important;
   color: var(--color-fd-foreground);
   font-family: var(--fd-font-mono, "Geist Mono", ui-monospace, monospace);
   font-size: 0.85em;
-  padding: 0.125em 0.3em;
+  padding: 0.08em 0.24em !important;
+  box-decoration-break: clone;
 }
 
 @media (hover: none) {
   .fd-ai-code-copy {
     opacity: 1;
+  }
+}
+
+@media (max-width: 767px) {
+  figure.shiki pre,
+  .fd-docs-content figure.shiki pre {
+    padding: 0.625rem 0.75rem !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  aside#nd-sidebar a,
+  aside#nd-sidebar button {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- render frontmatter titles in the page frame only when the MDX body does not already author an h1
- keep title, description, last-updated metadata, and page actions above preserved page content
- refine the Shadcn sidebar with balanced spacing, a faded right separator, and top/bottom scroll fading while retaining the built-in controls
- preserve the existing Farming header and default table of contents
- align the Edit on GitHub action with the navigation controls and remove the visual llms.txt footer links
- keep the public Shadcn theme preview synchronized with the shipped theme CSS

## Root cause

Page decorations mounted relative to an authored h1. Pages that relied only on a frontmatter title had no mount target, so their description and page actions fell back beneath the content. The Shadcn sidebar also lacked a clear rail separator and used uneven horizontal spacing.

## Impact

Existing MDX content remains unchanged. Pages with authored headings continue to render as before, while pages without an authored h1 receive exactly one generated page title and correctly ordered page metadata and actions. The custom header work is intentionally out of scope.

## Validation

- 176 @farming-labs/theme tests
- @farming-labs/theme typecheck
- Shadcn theme asset synchronization test
- @farming-labs/docs, @farming-labs/theme, and @farming-labs/next package builds
- desktop and mobile browser verification, including the mobile sidebar and a frontmatter-title-only page
- no framework error overlay during final browser verification

After merge, the release workflow can publish these changes as 0.2.98.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined the `shadcn` docs layout to fix missing page headers when MDX has no H1, improve sidebar spacing and visuals, and keep page metadata/actions above content. Scoped generated titles to `shadcn` only; other themes are unchanged, and the public theme CSS is synced.

- **Bug Fixes**
  - Generate frontmatter titles only when the MDX body doesn’t author an H1 (handles Markdown, HTML, setext; ignores fenced code).
  - Scope generated titles to `shadcn`; non-`shadcn` themes keep existing title behavior.
  - Render title, description, last updated, and below-title actions before preserved content.
  - Use readable folder labels for “Introduction” landing pages in the Shadcn sidebar; hide the index page entry.

- **UI Improvements**
  - Sidebar: balanced padding, a faded right rail separator, and top/bottom scroll masking; built-in controls preserved.
  - Align “Edit on GitHub” with navigation; hide visible `llms.txt` links in the footer for this theme.
  - Compact code block styling and improved inline code tokens; respects reduced motion.
  - Keep the public theme preview (`website/public/themes/shadcn.css`) synchronized with shipped CSS.

<sup>Written for commit 9446b7c936ff8834054730389b63327effea5b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

