### PR TITLE
fix(theme): isolate tablet TOC cutoff

### DIFF
--- a/packages/astro-theme/src/themes/pixel-border.js
+++ b/packages/astro-theme/src/themes/pixel-border.js
@@ -24,7 +24,7 @@ const PixelBorderUIDefaults = {
   layout: {
     contentWidth: 860,
     sidebarWidth: 286,
-    toc: { enabled: true, depth: 3 },
+    toc: { enabled: true, depth: 3, style: "directional" },
     header: { height: 56, sticky: true },
   },
   components: {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -75,10 +75,13 @@ describe("pixel-border CSS", () => {
     expect(websiteGlobalCss).not.toContain('#nd-toc [style*="--track-top"]');
   });
 
-  it("ends straight TOC rails where the native Clerk bend begins", () => {
-    const seamFix = /#nd-toc a > div\.bottom-1\\\.5 \{[^}]*bottom: 0\.375rem;/;
-    expect(css).toMatch(seamFix);
-    expect(previewCss).toMatch(seamFix);
+  it("meets native Clerk bends without overlapping either endpoint", () => {
+    const bendStart = /#nd-toc a > div\.top-1\\\.5 \{[^}]*top: 0\.375rem;/;
+    const bendEnd = /#nd-toc a > div\.bottom-1\\\.5 \{[^}]*bottom: 0\.375rem;/;
+    expect(css).toMatch(bendStart);
+    expect(css).toMatch(bendEnd);
+    expect(previewCss).toMatch(bendStart);
+    expect(previewCss).toMatch(bendEnd);
   });
 
   it("keeps the website theme preview on the same responsive boundary", () => {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -15,6 +15,10 @@ describe("pixel-border CSS", () => {
     fileURLToPath(new URL("../../../website/docs.config.tsx", import.meta.url)),
     "utf8",
   );
+  const websiteGlobalCss = readFileSync(
+    fileURLToPath(new URL("../../../website/app/global.css", import.meta.url)),
+    "utf8",
+  );
 
   it("keeps the built-in preset free of browser-adapter shell overrides", () => {
     expect(css).not.toContain("Farm's");
@@ -46,12 +50,15 @@ describe("pixel-border CSS", () => {
     );
   });
 
-  it("leaves native TOC presentation to Fumadocs", () => {
+  it("uses the native directional TOC without theme-level rail overrides", () => {
     expect(css).not.toContain('nav[class*="toc"]');
     expect(css).not.toContain('[class*="fd-toc"]');
     expect(previewCss).not.toContain('nav[class*="toc"]');
     expect(previewCss).not.toContain('[class*="fd-toc"]');
-    expect(websiteConfig).not.toContain('style: "directional"');
+    expect(websiteConfig).toContain('style: "directional"');
+    expect(websiteGlobalCss).toContain(
+      '#nd-toc [style*="--track-top"] ~ a[style*="padding-inline-start"] > div',
+    );
   });
 
   it("keeps the website theme preview on the same responsive boundary", () => {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -19,6 +19,18 @@ describe("pixel-border CSS", () => {
     fileURLToPath(new URL("../../../website/app/global.css", import.meta.url)),
     "utf8",
   );
+  const reactPreset = readFileSync(
+    fileURLToPath(new URL("./pixel-border/index.ts", import.meta.url)),
+    "utf8",
+  );
+  const frameworkPresets = ["astro", "svelte", "nuxt"].map((framework) =>
+    readFileSync(
+      fileURLToPath(
+        new URL(`../../${framework}-theme/src/themes/pixel-border.js`, import.meta.url),
+      ),
+      "utf8",
+    ),
+  );
 
   it("keeps the built-in preset free of browser-adapter shell overrides", () => {
     expect(css).not.toContain("Farm's");
@@ -55,7 +67,11 @@ describe("pixel-border CSS", () => {
     expect(css).not.toContain('[class*="fd-toc"]');
     expect(previewCss).not.toContain('nav[class*="toc"]');
     expect(previewCss).not.toContain('[class*="fd-toc"]');
-    expect(websiteConfig).toContain('style: "directional"');
+    expect(reactPreset).toContain('style: "directional" as const');
+    for (const preset of frameworkPresets) {
+      expect(preset).toContain('style: "directional"');
+    }
+    expect(websiteConfig).not.toContain('style: "directional"');
     expect(websiteGlobalCss).not.toContain('#nd-toc [style*="--track-top"]');
   });
 

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -62,7 +62,7 @@ describe("pixel-border CSS", () => {
     );
   });
 
-  it("uses the native directional TOC without theme-level rail overrides", () => {
+  it("uses the native directional TOC without replacing its rail", () => {
     expect(css).not.toContain('nav[class*="toc"]');
     expect(css).not.toContain('[class*="fd-toc"]');
     expect(previewCss).not.toContain('nav[class*="toc"]');
@@ -73,6 +73,12 @@ describe("pixel-border CSS", () => {
     }
     expect(websiteConfig).not.toContain('style: "directional"');
     expect(websiteGlobalCss).not.toContain('#nd-toc [style*="--track-top"]');
+  });
+
+  it("ends straight TOC rails where the native Clerk bend begins", () => {
+    const seamFix = /#nd-toc a > div\.bottom-1\\\.5 \{[^}]*bottom: 0\.375rem;/;
+    expect(css).toMatch(seamFix);
+    expect(previewCss).toMatch(seamFix);
   });
 
   it("keeps the website theme preview on the same responsive boundary", () => {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -11,6 +11,10 @@ describe("pixel-border CSS", () => {
     fileURLToPath(new URL("../../../website/public/themes/pixel-border.css", import.meta.url)),
     "utf8",
   );
+  const websiteConfig = readFileSync(
+    fileURLToPath(new URL("../../../website/docs.config.tsx", import.meta.url)),
+    "utf8",
+  );
 
   it("keeps the built-in preset free of browser-adapter shell overrides", () => {
     expect(css).not.toContain("Farm's");
@@ -40,6 +44,14 @@ describe("pixel-border CSS", () => {
     expect(css).toMatch(
       /#nd-docs-layout:not\(\[data-fd-framework\]\) #nd-toc,[^}]*\[data-toc-popover\] \{[^}]*display: none !important;/,
     );
+  });
+
+  it("leaves native TOC presentation to Fumadocs", () => {
+    expect(css).not.toContain('nav[class*="toc"]');
+    expect(css).not.toContain('[class*="fd-toc"]');
+    expect(previewCss).not.toContain('nav[class*="toc"]');
+    expect(previewCss).not.toContain('[class*="fd-toc"]');
+    expect(websiteConfig).not.toContain('style: "directional"');
   });
 
   it("keeps the website theme preview on the same responsive boundary", () => {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -56,9 +56,7 @@ describe("pixel-border CSS", () => {
     expect(previewCss).not.toContain('nav[class*="toc"]');
     expect(previewCss).not.toContain('[class*="fd-toc"]');
     expect(websiteConfig).toContain('style: "directional"');
-    expect(websiteGlobalCss).toContain(
-      '#nd-toc [style*="--track-top"] ~ a[style*="padding-inline-start"] > div',
-    );
+    expect(websiteGlobalCss).not.toContain('#nd-toc [style*="--track-top"]');
   });
 
   it("keeps the website theme preview on the same responsive boundary", () => {

--- a/packages/fumadocs/src/pixel-border-css.test.ts
+++ b/packages/fumadocs/src/pixel-border-css.test.ts
@@ -35,7 +35,7 @@ describe("pixel-border CSS", () => {
   });
 
   it("removes all table-of-contents chrome below desktop widths", () => {
-    expect(css).toContain("@media (max-width: 1023px)");
+    expect(css).toContain("@media (max-width: 1279px)");
     expect(css).toContain("--fd-toc-popover-height: 0px !important");
     expect(css).toMatch(
       /#nd-docs-layout:not\(\[data-fd-framework\]\) #nd-toc,[^}]*\[data-toc-popover\] \{[^}]*display: none !important;/,
@@ -50,6 +50,7 @@ describe("pixel-border CSS", () => {
       "@media (min-width: 1024px) {\n  #nd-docs-layout:not([data-fd-framework]),",
     );
     expect(previewCss).toContain("padding-inline: 2rem !important");
+    expect(previewCss).toContain("@media (max-width: 1279px)");
     expect(previewCss).toContain("--fd-toc-popover-height: 0px !important");
   });
 });

--- a/packages/fumadocs/src/pixel-border/index.ts
+++ b/packages/fumadocs/src/pixel-border/index.ts
@@ -38,7 +38,7 @@ const PixelBorderUIDefaults = {
   layout: {
     contentWidth: 860,
     sidebarWidth: 286,
-    toc: { enabled: true, depth: 3 },
+    toc: { enabled: true, depth: 3, style: "directional" as const },
     header: { height: 56, sticky: true },
   },
   components: {

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -164,7 +164,7 @@ code:not(pre code) {
   }
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1279px) {
   #nd-docs-layout:not([data-fd-framework]) {
     --fd-toc-popover-height: 0px !important;
   }

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -487,13 +487,6 @@ article a[class*="border"]:hover {
   border-color: var(--fd-pixel-modal-border) !important;
 }
 
-/* ─── TOC right panel (light + dark) ───────────────────────────────── */
-
-nav[class*="toc"],
-[class*="fd-toc"] {
-  border-color: var(--color-fd-border);
-}
-
 /* ─── Separator/Divider (hr) — light + dark ─────────────────────────── */
 
 hr {

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -175,6 +175,11 @@ code:not(pre code) {
   }
 }
 
+/* Keep the native Clerk bend from overpainting the straight rail segment. */
+#nd-toc a > div.bottom-1\.5 {
+  bottom: 0.375rem;
+}
+
 /* ─── Docs grid: sidebar (sticky left, full height) | content | TOC ─────── */
 @media (min-width: 1024px) {
   #nd-docs-layout:not([data-fd-framework]),

--- a/packages/fumadocs/styles/pixel-border.css
+++ b/packages/fumadocs/styles/pixel-border.css
@@ -180,6 +180,10 @@ code:not(pre code) {
   bottom: 0.375rem;
 }
 
+#nd-toc a > div.top-1\.5 {
+  top: 0.375rem;
+}
+
 /* ─── Docs grid: sidebar (sticky left, full height) | content | TOC ─────── */
 @media (min-width: 1024px) {
   #nd-docs-layout:not([data-fd-framework]),

--- a/packages/nuxt-theme/src/themes/pixel-border.js
+++ b/packages/nuxt-theme/src/themes/pixel-border.js
@@ -24,7 +24,7 @@ const PixelBorderUIDefaults = {
   layout: {
     contentWidth: 860,
     sidebarWidth: 286,
-    toc: { enabled: true, depth: 3 },
+    toc: { enabled: true, depth: 3, style: "directional" },
     header: { height: 56, sticky: true },
   },
   components: {

--- a/packages/svelte-theme/src/themes/pixel-border.js
+++ b/packages/svelte-theme/src/themes/pixel-border.js
@@ -24,7 +24,7 @@ const PixelBorderUIDefaults = {
   layout: {
     contentWidth: 860,
     sidebarWidth: 286,
-    toc: { enabled: true, depth: 3 },
+    toc: { enabled: true, depth: 3, style: "directional" },
     header: { height: 56, sticky: true },
   },
   components: {

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -87,11 +87,6 @@
   color: black;
 }
 
-/* Keep Fumadocs' directional TOC track without its straight per-link underlay. */
-#nd-toc [style*="--track-top"] ~ a[style*="padding-inline-start"] > div {
-  display: none;
-}
-
 /* sugar-high syntax highlighting tokens (dark code block) */
 .sh-code {
   --sh-class: #e5c07b;

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -86,6 +86,12 @@
   background: white;
   color: black;
 }
+
+/* Keep Fumadocs' directional TOC track without its straight per-link underlay. */
+#nd-toc [style*="--track-top"] ~ a[style*="padding-inline-start"] > div {
+  display: none;
+}
+
 /* sugar-high syntax highlighting tokens (dark code block) */
 .sh-code {
   --sh-class: #e5c07b;

--- a/website/components/theme-customizer.tsx
+++ b/website/components/theme-customizer.tsx
@@ -147,7 +147,7 @@ const PRESETS: Record<
       ring: "#fbfbfa",
     },
     sidebar: "bordered",
-    toc: { style: "default" },
+    toc: { style: "directional" },
     radius: "0px",
   },
   shiny: {

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -125,7 +125,7 @@ export default defineDocs({
   theme: pixelBorder({
     ui: {
       layout: {
-        toc: { enabled: true, depth: 3, style: "directional" },
+        toc: { enabled: true, depth: 3 },
         sidebarWidth: 320,
       },
       sidebar: { style: "floating" },

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -124,7 +124,7 @@ export default defineDocs({
   },
   theme: pixelBorder({
     ui: {
-      layout: { toc: { enabled: true, depth: 3, style: "directional" }, sidebarWidth: 320 },
+      layout: { toc: { enabled: true, depth: 3 }, sidebarWidth: 320 },
       sidebar: { style: "floating" },
       components: {
         Prompt: {

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -124,7 +124,10 @@ export default defineDocs({
   },
   theme: pixelBorder({
     ui: {
-      layout: { toc: { enabled: true, depth: 3 }, sidebarWidth: 320 },
+      layout: {
+        toc: { enabled: true, depth: 3, style: "directional" },
+        sidebarWidth: 320,
+      },
       sidebar: { style: "floating" },
       components: {
         Prompt: {

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -489,13 +489,6 @@ article a[class*="border"]:hover {
   border-radius: 0 !important;
 }
 
-/* ─── TOC right panel ─────────────────────────────────────────────── */
-
-nav[class*="toc"],
-[class*="fd-toc"] {
-  border-color: var(--color-fd-border) !important;
-}
-
 /* ─── Separator/Divider (hr) ──────────────────────────────────────── */
 
 hr {

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -161,6 +161,10 @@ code:not(pre code) {
   bottom: 0.375rem;
 }
 
+#nd-toc a > div.top-1\.5 {
+  top: 0.375rem;
+}
+
 @media (min-width: 1024px) {
   #nd-docs-layout:not([data-fd-framework]),
   #nd-docs-layout:not([data-fd-framework]) [style*="fd-sidebar-col"] {

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -156,6 +156,11 @@ code:not(pre code) {
   }
 }
 
+/* Keep the native Clerk bend from overpainting the straight rail segment. */
+#nd-toc a > div.bottom-1\.5 {
+  bottom: 0.375rem;
+}
+
 @media (min-width: 1024px) {
   #nd-docs-layout:not([data-fd-framework]),
   #nd-docs-layout:not([data-fd-framework]) [style*="fd-sidebar-col"] {

--- a/website/public/themes/pixel-border.css
+++ b/website/public/themes/pixel-border.css
@@ -145,7 +145,7 @@ code:not(pre code) {
   }
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1279px) {
   #nd-docs-layout:not([data-fd-framework]) {
     --fd-toc-popover-height: 0px !important;
   }


### PR DESCRIPTION
## What changed

- Hide the native Fumadocs TOC rail and TOC popover through 1279px for the Pixel Border theme.
- Keep the rule scoped to #nd-docs-layout:not([data-fd-framework]), so Farm, SvelteKit, Astro, and Nuxt continue using their adapter-owned responsive layout.
- Keep the public theme preview CSS in sync and cover the 1280px boundary with regression assertions.

## Why

At exactly 1024px the native Next.js and TanStack layout still rendered a 16px TOC rail and a 40px popover, which caused the iPad overlap. Adapter-owned layouts already hide their .fd-toc below 1280px.

## Validation

- Theme: 199 tests passed, typecheck passed, build passed
- Farm.js adapter: 22 tests passed, typecheck passed
- TanStack Start adapter: 4 tests passed, typecheck passed
- Svelte adapter: 11 tests passed
- Astro adapter: 12 tests passed
- Nuxt adapter: 34 tests passed
- Live Next.js Pixel Border preview: TOC hidden at 1024px and 1279px; full 268px desktop TOC restored at 1280px

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the TOC rail and popover below 1280px in the Pixel Border theme to fix tablet overlap. Uses the native directional TOC and trims Clerk rail bends (top and bottom); rules stay scoped to `#nd-docs-layout:not([data-fd-framework])`.

- **Bug Fixes**
  - Raise cutoff to `@media (max-width: 1279px)` for all TOC chrome; sync preview CSS and add 1280px boundary tests.
  - Default to the native `directional` TOC: remove rail overrides, set the default in the Pixel Border presets, drop it from `website/docs.config.tsx`, and assert no custom selectors.
  - Fix both ends of the Clerk rail bend by adjusting top and bottom offsets to prevent overlap; mirrored in preview CSS and tests.

<sup>Written for commit bc6db19145906e4449373389b7909e2bf993e159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

