### PR TITLE
fix(farmjs): preserve bundled page dates

### DIFF
--- a/packages/farmjs/src/content.ts
+++ b/packages/farmjs/src/content.ts
@@ -69,6 +69,53 @@ export interface ContentPage {
   agentFallbackRawContent?: string;
 }
 
+const FARM_DOCS_LAST_MODIFIED_MANIFEST = ".farm-docs-last-modified.json";
+
+interface FarmDocsLastModifiedManifest {
+  version: 1;
+  pages: Record<string, string>;
+}
+
+function normalizeRelativeContentPath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
+export function readFarmDocsLastModifiedManifest(
+  contentDir: string,
+): FarmDocsLastModifiedManifest | null {
+  const manifestPath = path.join(contentDir, FARM_DOCS_LAST_MODIFIED_MANIFEST);
+  if (!fs.existsSync(manifestPath)) return null;
+
+  try {
+    const parsed = JSON.parse(
+      fs.readFileSync(manifestPath, "utf-8"),
+    ) as Partial<FarmDocsLastModifiedManifest>;
+    if (parsed.version !== 1 || !parsed.pages || typeof parsed.pages !== "object") return null;
+
+    return {
+      version: 1,
+      pages: Object.fromEntries(
+        Object.entries(parsed.pages).filter(
+          (entry): entry is [string, string] =>
+            typeof entry[1] === "string" && !Number.isNaN(new Date(entry[1]).getTime()),
+        ),
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveFarmDocsLastModified(
+  contentDir: string,
+  sourcePath: string,
+  manifest: FarmDocsLastModifiedManifest | null,
+): string | undefined {
+  if (!manifest) return undefined;
+  const relativePath = normalizeRelativeContentPath(path.relative(contentDir, sourcePath));
+  return manifest.pages[relativePath];
+}
+
 export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefined {
   if (typeof value === "string") return value;
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
@@ -78,6 +125,7 @@ export function normalizeDocsFrontmatterLastmod(value: unknown): string | undefi
 export function loadDocsContent(contentDir: string, entry: string = "docs"): ContentPage[] {
   const pages: ContentPage[] = [];
   const absDir = path.resolve(contentDir);
+  const lastModifiedManifest = readFarmDocsLastModifiedManifest(absDir);
 
   function scan(dir: string, slugParts: string[]) {
     if (!fs.existsSync(dir)) return;
@@ -122,7 +170,9 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
-        lastModified: stat.mtime.toISOString(),
+        lastModified:
+          resolveFarmDocsLastModified(absDir, full, lastModifiedManifest) ??
+          stat.mtime.toISOString(),
         locale: typeof data.locale === "string" ? data.locale : undefined,
         framework: typeof data.framework === "string" ? data.framework : undefined,
         version: typeof data.version === "string" ? data.version : undefined,

--- a/packages/farmjs/src/server.test.ts
+++ b/packages/farmjs/src/server.test.ts
@@ -1,4 +1,7 @@
 import { createElement } from "react";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createDocsServer, createFarmDocsRuntimeHandler } from "./server.js";
 
@@ -116,6 +119,44 @@ Build a Farm application.
     expect(page.editOnGithub).toBe(
       "https://github.com/farming-labs/farm.js/edit/next/docs/src/app/docs/page.md",
     );
+  });
+
+  it("uses bundled Git dates instead of deployment file mtimes", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "farm-docs-last-modified-"));
+    const contentDir = path.join(rootDir, "docs");
+    const pagePath = path.join(contentDir, "page.md");
+
+    try {
+      mkdirSync(contentDir, { recursive: true });
+      writeFileSync(pagePath, "# Farm Docs\n");
+      utimesSync(
+        pagePath,
+        new Date("2018-10-20T00:00:00.000Z"),
+        new Date("2018-10-20T00:00:00.000Z"),
+      );
+      writeFileSync(
+        path.join(contentDir, ".farm-docs-last-modified.json"),
+        JSON.stringify({
+          version: 1,
+          pages: { "page.md": "2026-08-09T04:25:45+03:00" },
+        }),
+      );
+
+      const server = createDocsServer({
+        entry: "docs",
+        contentDir,
+        rootDir,
+        nav: { title: "Farm Docs" },
+        sitemap: true,
+      });
+      const page = await server.load({ pathname: "/docs" });
+      const sitemap = await server.handle(new Request("https://farm.example/sitemap.xml"));
+
+      expect(page.lastModified).toBe("August 9, 2026");
+      expect(await sitemap?.text()).toContain("<lastmod>2026-08-09</lastmod>");
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
   });
 
   it("handles docs endpoints and falls through for application routes", async () => {

--- a/packages/farmjs/src/server.ts
+++ b/packages/farmjs/src/server.ts
@@ -92,6 +92,8 @@ import {
   loadDocsContent,
   flattenNavTree,
   normalizeDocsFrontmatterLastmod,
+  readFarmDocsLastModifiedManifest,
+  resolveFarmDocsLastModified,
 } from "./content.js";
 import type { PageNode, NavNode, NavTree, ContentPage } from "./content.js";
 import farmDocsBrowserCss from "./browser-css.generated.js";
@@ -945,8 +947,13 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
 
       raw = fs.readFileSync(filePath, "utf-8");
       const stat = fs.statSync(filePath);
-      lastModifiedIso = stat.mtime.toISOString();
-      lastModified = stat.mtime.toLocaleDateString("en-US", {
+      lastModifiedIso =
+        resolveFarmDocsLastModified(
+          ctx.contentDirAbs,
+          filePath,
+          readFarmDocsLastModifiedManifest(ctx.contentDirAbs),
+        ) ?? stat.mtime.toISOString();
+      lastModified = new Date(lastModifiedIso).toLocaleDateString("en-US", {
         year: "numeric",
         month: "long",
         day: "numeric",


### PR DESCRIPTION
## What changed

- read Farm's bundled `.farm-docs-last-modified.json` manifest in the Farm.js adapter
- use the manifest for rendered page metadata and search/sitemap content
- retain filesystem mtimes as the fallback when no valid manifest is available

## Why

Farm core already bundles correct per-page Git dates for production, but the adapter ignored that manifest and read copied file mtimes. Vercel stamps those copied docs files as October 20, 2018, so every deployed page and sitemap entry showed the same incorrect date.

## Validation

- `pnpm --filter @farming-labs/farmjs exec vitest run src/server.test.ts`
- `pnpm --filter @farming-labs/farmjs typecheck`
- regression test verifies a file with a 2018 mtime renders the bundled August 9, 2026 Git date in both page data and sitemap output


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect last-modified dates for docs by reading the bundled `.farm-docs-last-modified.json` manifest in `@farming-labs/farmjs` instead of deployment file mtimes. Page metadata, sitemap, and search now use Git dates when present, with filesystem mtimes as a fallback, avoiding the Vercel 2018 timestamp issue.

<sup>Written for commit 4daebcda1167836f46e3a6c373f2efee67bd6423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

