### PR TITLE
superseded: add trust metadata and OpenAPI tools

### DIFF
--- a/packages/astro/src/content.ts
+++ b/packages/astro/src/content.ts
@@ -12,10 +12,12 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
+  type DocsOkfTrustMetadataInput,
   type ResolvedDocsRelatedLink,
   type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
@@ -51,6 +53,7 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   icon?: string;
   sourcePath?: string;
   lastmod?: string;
@@ -126,6 +129,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -64,6 +64,7 @@ import {
   isDocsSkillRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   parseDocsAgentFeedbackData,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -108,6 +109,7 @@ import {
   buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -534,6 +536,7 @@ function searchIndexFromMap(
       description: data.description as string | undefined,
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
+      okf: normalizeDocsOkfTrustMetadataInput(data.okf),
       icon: data.icon as string | undefined,
       lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
@@ -1005,7 +1008,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const page = findDocsMarkdownPage(entry, getSearchIndex(ctx), requestedPath);
     return page
       ? {
-          document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
+          document: renderDocsMarkdownDocument(page, {
+            origin,
+            sitemap: config.sitemap,
+            okf: config.agent?.okf,
+          }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
@@ -2033,6 +2040,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     typeof (config.nav as Record<string, unknown>)?.title === "string"
       ? ((config.nav as Record<string, unknown>).title as string)
       : "Documentation";
+  const mcpApiReference = resolveApiReferenceConfig(config.apiReference).mcp;
 
   const MCP = createDocsMcpHttpHandler({
     source: {
@@ -2089,6 +2097,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    okf: config.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(config as any, {
+              framework: "astro",
+              rootDir,
+              baseUrl: markdownMetadataBaseUrl || undefined,
+            }),
+        }
+      : undefined,
     contentChanges: config.agent?.contentChanges,
     evaluations: config.agent?.evaluations,
     contentChangeFeed,

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1,6 +1,9 @@
 import type {
   DocsConfig,
   DocsAgentContentChangesConfig,
+  DocsOkfConfig,
+  DocsOkfTrustMetadata,
+  DocsOkfTrustMetadataInput,
   DocsRobotsConfig,
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
@@ -14,6 +17,7 @@ import type {
   PageAgentFrontmatter,
   ResolvedDocsRelatedLink,
 } from "./types.js";
+import { resolveDocsOkfConfig, resolveDocsOkfTrustMetadata } from "./okf.js";
 import type { ResolvedDocsI18n } from "./i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "./mcp.js";
 import {
@@ -739,6 +743,8 @@ export interface DocsMarkdownPage {
   markdownUrl?: string;
   lastModified?: string;
   lastmod?: string;
+  sourcePath?: string;
+  okf?: DocsOkfTrustMetadataInput;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
   content: string;
@@ -751,6 +757,7 @@ export interface DocsMarkdownPage {
 
 export interface DocsMarkdownDocumentOptions {
   llms?: boolean | DocsLlmsDiscoveryConfig | LlmsTxtConfig;
+  okf?: boolean | DocsOkfConfig;
   origin?: string;
   sitemap?: boolean | DocsSitemapConfig;
 }
@@ -2980,6 +2987,7 @@ function renderDocsMarkdownFrontmatter({
   canonicalUrl,
   markdownUrl,
   lastUpdated,
+  trust,
   agent,
   generatedPreamble,
 }: {
@@ -2988,6 +2996,7 @@ function renderDocsMarkdownFrontmatter({
   canonicalUrl: string;
   markdownUrl: string;
   lastUpdated?: string;
+  trust?: DocsOkfTrustMetadata;
   agent?: PageAgentFrontmatter;
   generatedPreamble?: boolean;
 }): string {
@@ -2998,6 +3007,7 @@ function renderDocsMarkdownFrontmatter({
     `canonical_url: ${toYamlString(canonicalUrl)}`,
     `markdown_url: ${toYamlString(markdownUrl)}`,
     ...(lastUpdated ? [`last_updated: ${toYamlString(lastUpdated)}`] : []),
+    ...(trust ? [`okf: ${JSON.stringify(trust)}`] : []),
     ...(generatedPreamble ? [`${DOCS_MARKDOWN_GENERATED_PREAMBLE_FIELD}: true`] : []),
     ...renderPageAgentFrontmatterYamlLines(agent),
     "---",
@@ -3388,16 +3398,23 @@ function resolveDocsMarkdownPageMetadata(
   page: DocsMarkdownPage,
   options?: DocsMarkdownDocumentOptions,
 ): Parameters<typeof renderDocsMarkdownFrontmatter>[0] {
+  const canonicalUrl = resolveDocsMarkdownMetadataUrl(page.url, options?.origin);
+  const okfEnabled = resolveDocsOkfConfig(options?.okf).enabled || page.okf !== undefined;
   return {
     title: page.title,
     description: page.description,
-    canonicalUrl: resolveDocsMarkdownMetadataUrl(page.url, options?.origin),
+    canonicalUrl,
     markdownUrl: resolveDocsMarkdownMetadataUrl(
       page.markdownUrl ?? toDocsMarkdownUrl(page.url),
       options?.origin,
     ),
     lastUpdated: normalizeDocsMarkdownLastUpdated(page.lastmod ?? page.lastModified),
     agent: page.agent,
+    ...(okfEnabled
+      ? {
+          trust: resolveDocsOkfTrustMetadata({ ...page, canonicalUrl }, options?.okf),
+        }
+      : {}),
   };
 }
 

--- a/packages/docs/src/api-reference.ts
+++ b/packages/docs/src/api-reference.ts
@@ -1,7 +1,13 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, relative } from "node:path";
 import { getHtmlDocument } from "@scalar/core/libs/html-rendering";
-import type { ApiReferenceRenderer, DocsConfig, DocsTheme } from "./types.js";
+import type {
+  ApiReferenceRenderer,
+  ApiReferenceConfig,
+  DocsConfig,
+  DocsOpenApiMcpConfig,
+  DocsTheme,
+} from "./types.js";
 
 export type { ApiReferenceRenderer };
 
@@ -32,6 +38,7 @@ export interface ResolvedApiReferenceConfig {
   specUrl?: string;
   catalogTargets?: string[];
   renderer?: ApiReferenceRenderer;
+  mcp?: DocsOpenApiMcpConfig;
   routeRoot: string;
   exclude: string[];
 }
@@ -80,6 +87,7 @@ export function resolveApiReferenceConfig(
       specUrl: undefined,
       catalogTargets: undefined,
       renderer: undefined,
+      mcp: undefined,
       routeRoot: "api",
       exclude: [],
     };
@@ -92,6 +100,7 @@ export function resolveApiReferenceConfig(
       specUrl: undefined,
       catalogTargets: undefined,
       renderer: undefined,
+      mcp: undefined,
       routeRoot: "api",
       exclude: [],
     };
@@ -103,9 +112,17 @@ export function resolveApiReferenceConfig(
     specUrl: normalizeRemoteSpecUrl(value.specUrl),
     catalogTargets: normalizeApiReferenceCatalogTargets(value.catalogTargets),
     renderer: normalizeApiReferenceRenderer(value.renderer),
+    mcp: resolveOpenApiMcpConfig(value.mcp),
     routeRoot: normalizePathSegment(value.routeRoot ?? "api") || "api",
     exclude: normalizeApiReferenceExcludes(value.exclude),
   };
+}
+
+function resolveOpenApiMcpConfig(
+  value: ApiReferenceConfig["mcp"],
+): DocsOpenApiMcpConfig | undefined {
+  if (!value) return undefined;
+  return value === true ? { enabled: true } : { ...value, enabled: value.enabled !== false };
 }
 
 function normalizeApiReferenceRenderer(value?: string): ApiReferenceRenderer | undefined {

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -41,7 +41,7 @@ describe("agent export cli", () => {
   });
 
   function writeProject(
-    options: { staticExport?: boolean; llms?: boolean; apiRoute?: string } = {},
+    options: { staticExport?: boolean; llms?: boolean; apiRoute?: string; okf?: boolean } = {},
   ) {
     writeFileSync(
       path.join(tmpDir, "docs.config.ts"),
@@ -66,6 +66,7 @@ describe("agent export cli", () => {
   search: true,
   mcp: true,
   feedback: { agent: true },
+  ${options.okf ? "agent: { okf: true }," : ""}
   apiReference: true,
 };
 `,
@@ -130,6 +131,38 @@ pnpm add example
 
   it("requires explicit publication outside check mode", async () => {
     await expect(exportAgentBundle()).rejects.toThrow("Pass --public");
+  });
+
+  it("exports an OKF v0.2 bundle and page trust frontmatter when enabled", async () => {
+    writeProject({ okf: true });
+    process.chdir(tmpDir);
+
+    await exportAgentBundle({ public: true });
+
+    const bundle = JSON.parse(
+      readFileSync(path.join(tmpDir, "public", ".well-known", "okf.json"), "utf-8"),
+    );
+    expect(bundle).toMatchObject({
+      format: "open-knowledge-format.v0.2",
+      spec_version: "0.2",
+      documents: [
+        expect.objectContaining({
+          url: "https://docs.example.com/docs",
+          trust: expect.objectContaining({ trust_tier: "unverified", stale: false }),
+        }),
+        expect.objectContaining({
+          url: "https://docs.example.com/docs/guides/install",
+        }),
+      ],
+    });
+    expect(readFileSync(path.join(tmpDir, "public", "docs.md"), "utf-8")).toContain(
+      'okf: {"sources":',
+    );
+
+    const manifest = JSON.parse(
+      readFileSync(path.join(tmpDir, ".farming-labs", "agent-bundle-manifest.json"), "utf-8"),
+    ) as AgentBundleManifest;
+    expect(manifest.files.find((file) => file.path === ".well-known/okf.json")?.kind).toBe("okf");
   });
 
   it("exports a complete deterministic bundle and validates it", async () => {

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -62,6 +62,7 @@ import {
   type DocsSitemapManifest,
 } from "../sitemap.js";
 import { createFilesystemDocsMcpSource, resolveDocsMcpConfig } from "../server.js";
+import { buildDocsOkfBundle, resolveDocsOkfConfig } from "../okf.js";
 import type {
   DocsConfig,
   DocsI18nConfig,
@@ -102,7 +103,8 @@ type AgentBundleFileKind =
   | "skill"
   | "agents"
   | "sitemap"
-  | "robots";
+  | "robots"
+  | "okf";
 
 export interface AgentBundleManifestFile {
   path: string;
@@ -733,7 +735,7 @@ function resolveUserOwnedOverrides(
   outputs: PlannedOutput[],
   previous: AgentBundleManifest | undefined,
 ): PlannedOutput[] {
-  const preserveKinds = new Set<AgentBundleFileKind>(["page", "llms", "discovery", "skill"]);
+  const preserveKinds = new Set<AgentBundleFileKind>(["page", "llms", "discovery", "skill", "okf"]);
   const previousByPath = new Map(previous?.files.map((file) => [file.path, file] as const) ?? []);
 
   return outputs.map((output) => {
@@ -1148,6 +1150,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
     throw new Error(`No docs content was found under ${contentDir}.`);
   }
   const pages = localizedPages.map(({ page }) => page);
+  const okfConfig = resolveDocsOkfConfig(config?.agent?.okf);
   const sitemap = resolveDocsSitemapConfig(sitemapInput, { baseUrl });
   const robots = resolveDocsRobotsConfig(robotsInput, {
     baseUrl:
@@ -1211,12 +1214,31 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
         },
         {
           llms,
+          okf: config?.agent?.okf,
           origin: baseUrl,
           sitemap: sitemapInput,
         },
       ),
     );
     output.lastModified = resolveDocsHttpDate(page.lastModified);
+  }
+
+  if (okfConfig.enabled) {
+    const okfBundle = buildDocsOkfBundle(
+      pages.map((page) => ({
+        ...page,
+        canonicalUrl: baseUrl ? new URL(page.url, baseUrl).toString() : page.url,
+      })),
+      okfConfig,
+    );
+    addOutput(
+      outputs,
+      publicDir,
+      okfConfig.route,
+      "okf",
+      "application/json",
+      JSON.stringify(okfBundle, null, 2),
+    );
   }
 
   if (llmsEnabled) {

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -66,6 +66,7 @@ import {
 } from "../agent-skills-archive.js";
 import { httpLinkHeaderHasTargetRelation } from "../http-link.js";
 import { resolveDocsMetadataBaseUrl } from "../metadata.js";
+import { resolveDocsOkfConfig, resolveDocsOkfTrustMetadata } from "../okf.js";
 import { isDocsMcpOAuthScopeToken, normalizeDocsMcpAuthorizationServerUrls } from "../mcp-auth.js";
 import {
   createFilesystemDocsMcpSource,
@@ -3887,6 +3888,28 @@ export async function inspectAgentReadiness(
       evaluationCoverage.status === "measured"
         ? undefined
         : "Add golden-task safety expectations, actual-answer assertions, and execute-level example checks so each confidence dimension is measured explicitly.",
+    ),
+  );
+
+  const okfConfig = resolveDocsOkfConfig(config?.agent?.okf);
+  const staleOkfPages = okfConfig.enabled
+    ? pages.filter((page) => resolveDocsOkfTrustMetadata(page, okfConfig).stale)
+    : [];
+  checks.push(
+    makeCheck(
+      "okf-trust",
+      "OKF trust metadata",
+      staleOkfPages.length > 0 ? "warn" : "pass",
+      staleOkfPages.length > 0 ? 1 : 2,
+      2,
+      !okfConfig.enabled
+        ? "OKF export is optional and not configured."
+        : staleOkfPages.length === 0
+          ? `OKF v0.2 trust metadata is enabled at ${okfConfig.route}; ${pages.length} page${pages.length === 1 ? "" : "s"} passed the configured staleness policy.`
+          : `${staleOkfPages.length}/${pages.length} OKF document${staleOkfPages.length === 1 ? " is" : "s are"} beyond stale_after.`,
+      staleOkfPages.length > 0
+        ? "Review or regenerate stale pages, then update okf.verified or stale_after with an auditable timestamp."
+        : undefined,
     ),
   );
 

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -428,6 +428,9 @@ export type {
   ChangelogFrontmatter,
   ApiReferenceConfig,
   ApiReferenceRenderer,
+  DocsOpenApiMcpConfig,
+  DocsOpenApiMcpCredentialContext,
+  DocsOpenApiMcpHeaders,
   DocsI18nConfig,
   DocsMcpAllowedOrigins,
   DocsMcpAuthPrincipal,
@@ -509,6 +512,13 @@ export type {
   PageAgentFailureMode,
   PageAgentFrontmatter,
   PageAgentVerification,
+  DocsOkfActorTimestamp,
+  DocsOkfConfig,
+  DocsOkfSource,
+  DocsOkfStatus,
+  DocsOkfTrustMetadata,
+  DocsOkfTrustMetadataInput,
+  DocsOkfTrustTier,
   UIConfig,
   FontStyle,
   TypographyConfig,
@@ -640,6 +650,23 @@ export {
   isDocsRetrievalCanonicalUrl,
   sha256DocsContent,
 } from "./retrieval-digest.js";
+export {
+  DEFAULT_DOCS_OKF_ROUTE,
+  DOCS_OKF_BUNDLE_FORMAT,
+  DOCS_OKF_VERSION,
+  buildDocsOkfBundle,
+  normalizeDocsOkfTrustMetadataInput,
+  resolveDocsOkfConfig,
+  resolveDocsOkfTrustMetadata,
+} from "./okf.js";
+export { resolveDocsOpenApiMcpBaseUrl, resolveDocsOpenApiMcpOperations } from "./openapi-mcp.js";
+export type { DocsOpenApiMcpOperation, DocsOpenApiMcpParameter } from "./openapi-mcp.js";
+export type {
+  DocsOkfBundle,
+  DocsOkfKnowledgeDocument,
+  DocsOkfPageLike,
+  DocsOkfResolvedConfig,
+} from "./okf.js";
 export {
   createDocsCacheableResponse,
   formatDocsContentDigest,

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -229,6 +229,7 @@ describe("resolveDocsMcpConfig", () => {
         getCodeExamples: true,
         getConfigSchema: true,
         getContext: true,
+        getTrustMetadata: true,
       },
       prompts: DEFAULT_RESOLVED_MCP_PROMPTS,
       security: {
@@ -262,6 +263,7 @@ describe("resolveDocsMcpConfig", () => {
         getCodeExamples: true,
         getConfigSchema: true,
         getContext: true,
+        getTrustMetadata: true,
       },
       prompts: DEFAULT_RESOLVED_MCP_PROMPTS,
       security: {
@@ -299,6 +301,7 @@ describe("resolveDocsMcpConfig", () => {
         getCodeExamples: true,
         getConfigSchema: true,
         getContext: true,
+        getTrustMetadata: true,
       },
       prompts: DEFAULT_RESOLVED_MCP_PROMPTS,
       security: {
@@ -532,6 +535,88 @@ describe("resolveDocsMcpConfig", () => {
     expect(buildDocsMcpProtectedResourceMetadataRoute("/mcp/")).toBe(
       "/.well-known/oauth-protected-resource/mcp/",
     );
+  });
+});
+
+describe("P1 trust and OpenAPI tools", () => {
+  it("publishes OKF trust and executes only allowlisted OpenAPI operations", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.example.com/v1/users/42?expand=teams");
+      expect(init?.method).toBe("GET");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer server-secret");
+      return Response.json({ id: 42, name: "Ada" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const server = await createDocsMcpServer({
+      source: {
+        entry: "docs",
+        siteTitle: "Trust Docs",
+        getPages: () => [
+          {
+            slug: "install",
+            url: "/docs/install",
+            title: "Install",
+            content: "Install content",
+            lastmod: "2026-01-01",
+            okf: {
+              verified: [{ by: "human:docs-team", at: "2026-01-02" }],
+            },
+          },
+        ],
+        getNavigation: () => ({ name: "Docs", children: [] }),
+      },
+      okf: { staleAfterDays: 30 },
+      openapi: {
+        config: {
+          enabled: true,
+          operations: ["getUser"],
+          headers: { Authorization: "Bearer server-secret" },
+        },
+        document: {
+          openapi: "3.1.0",
+          servers: [{ url: "https://api.example.com/v1" }],
+          paths: {
+            "/users/{id}": {
+              get: {
+                operationId: "getUser",
+                parameters: [
+                  { name: "id", in: "path", required: true },
+                  { name: "expand", in: "query" },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    const client = new Client({ name: "p1-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(["get_trust_metadata", "api_getUser"]),
+      );
+      const trust = await client.callTool({
+        name: "get_trust_metadata",
+        arguments: { path: "install" },
+      });
+      expect(JSON.stringify(trust)).toContain('"trust_tier":"human-reviewed"');
+
+      const result = await client.callTool({
+        name: "api_getUser",
+        arguments: { parameters: { id: 42, expand: "teams" } },
+      });
+      expect(JSON.stringify(result)).toContain('"name":"Ada"');
+      expect(fetchMock).toHaveBeenCalledOnce();
+    } finally {
+      await client.close();
+      await server.close();
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -92,6 +92,12 @@ export type {
   HydrateDocsContentChangesOptions,
 } from "./content-change-hydration.js";
 import { resolvePageSidebarFolderIndexBehavior } from "./sidebar.js";
+import {
+  buildDocsOkfBundle,
+  normalizeDocsOkfTrustMetadataInput,
+  resolveDocsOkfConfig,
+} from "./okf.js";
+import { resolveDocsOpenApiMcpBaseUrl, resolveDocsOpenApiMcpOperations } from "./openapi-mcp.js";
 import type { DocsPublishedAgentSkill } from "./standards-discovery.js";
 import {
   isDocsMcpProtectedResourceMetadataPath,
@@ -119,6 +125,9 @@ import type {
   DocsAgentContentChangesConfig,
   DocsAgentEvaluationsConfig,
   DocsAgentGoldenTask,
+  DocsOkfConfig,
+  DocsOkfTrustMetadataInput,
+  DocsOpenApiMcpConfig,
   DocsContentChangesResponse,
   DocsMcpAllowedOrigins,
   DocsMcpAuthPrincipal,
@@ -147,6 +156,7 @@ export interface DocsMcpPage {
   sourcePath?: string;
   lastmod?: string;
   lastModified?: string;
+  okf?: DocsOkfTrustMetadataInput;
   locale?: string;
   framework?: string;
   version?: string;
@@ -454,6 +464,8 @@ export interface DocsMcpResolvedConfig {
     getCodeExamples: boolean;
     getConfigSchema: boolean;
     getContext: boolean;
+    /** Optional so manually constructed resolved configs from older releases remain assignable. */
+    getTrustMetadata?: boolean;
   };
   /** Resolved built-in prompt projection. Optional for legacy constructed values. */
   prompts?: DocsMcpResolvedPromptsConfig;
@@ -490,6 +502,15 @@ export interface CreateDocsMcpServerOptions {
   contentChanges?: boolean | DocsAgentContentChangesConfig;
   /** Golden-task definitions available for explicit, expectation-blind prompt projection. */
   evaluations?: boolean | DocsAgentEvaluationsConfig;
+  /** OKF v0.2 trust metadata projected into page output and the trust tool. */
+  okf?: boolean | DocsOkfConfig;
+  /** Explicit deny-by-default OpenAPI operation projection. */
+  openapi?: {
+    config?: DocsOpenApiMcpConfig;
+    document:
+      | Record<string, unknown>
+      | (() => Record<string, unknown> | Promise<Record<string, unknown>>);
+  };
   /** @internal Shared feed instance keeps HTTP and MCP snapshot history aligned. */
   contentChangeFeed?: DocsContentChangeFeed;
   /** @internal Check interval while at least one 2026 content subscription is open. */
@@ -752,6 +773,54 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
       "Agent synchronization, reusable skills, compaction defaults, and offline-by-default usefulness evaluations.",
     docs: "/docs/getting-started/agent-ready-docs",
     children: [
+      {
+        path: "agent.okf",
+        name: "okf",
+        type: "boolean | DocsOkfConfig",
+        default: false,
+        description:
+          "Publish Open Knowledge Format v0.2 source, generation, verification, lifecycle, and staleness metadata.",
+        children: [
+          {
+            path: "agent.okf.route",
+            name: "route",
+            type: "string",
+            default: "/.well-known/okf.json",
+            description: "Public route used by static Agent Bundle export.",
+          },
+          {
+            path: "agent.okf.generatedBy",
+            name: "generatedBy",
+            type: "string",
+            default: "software:@farming-labs/docs",
+            description: "Generator actor used when a page omits okf.generated.",
+          },
+          {
+            path: "agent.okf.staleAfterDays",
+            name: "staleAfterDays",
+            type: "number",
+            description: "Derive stale_after this many days after the best page timestamp.",
+          },
+          {
+            path: "agent.okf.sources",
+            name: "sources",
+            type: "readonly DocsOkfSource[]",
+            description: "Default source provenance inherited by pages without authored sources.",
+          },
+          {
+            path: "agent.okf.verified",
+            name: "verified",
+            type: "readonly DocsOkfActorTimestamp[]",
+            description: "Default machine or human verification records.",
+          },
+          {
+            path: "agent.okf.status",
+            name: "status",
+            type: '"draft" | "stable" | "deprecated"',
+            description: "Default lifecycle status for knowledge documents.",
+          },
+        ],
+      },
       {
         path: "agent.contentChanges",
         name: "contentChanges",
@@ -2402,6 +2471,13 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
             description:
               "Expose deterministic get_context retrieval with a conservative UTF-8 byte ceiling.",
           },
+          {
+            path: "mcp.tools.getTrustMetadata",
+            name: "getTrustMetadata",
+            type: "boolean",
+            default: true,
+            description: "Expose OKF v0.2 trust metadata when agent.okf is enabled.",
+          },
         ],
       },
     ],
@@ -2433,6 +2509,48 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
         type: "string[]",
         description:
           "Product API base URLs that the OpenAPI document describes in the RFC 9727 catalog.",
+      },
+      {
+        path: "apiReference.mcp",
+        name: "mcp",
+        type: "boolean | DocsOpenApiMcpConfig",
+        default: false,
+        description:
+          "Project explicitly allowlisted OpenAPI operations into server-executed MCP tools.",
+        children: [
+          {
+            path: "apiReference.mcp.operations",
+            name: "operations",
+            type: "readonly string[]",
+            description: "Allowed operationIds or METHOD /path selectors; empty exposes nothing.",
+          },
+          {
+            path: "apiReference.mcp.baseUrl",
+            name: "baseUrl",
+            type: "string",
+            description: "Override the first OpenAPI server URL used for tool requests.",
+          },
+          {
+            path: "apiReference.mcp.allowMutations",
+            name: "allowMutations",
+            type: "boolean",
+            default: false,
+            description: "Permit explicitly allowlisted write operations.",
+          },
+          {
+            path: "apiReference.mcp.headers",
+            name: "headers",
+            type: "DocsOpenApiMcpHeaders",
+            description: "Server-owned credential headers applied after model-provided input.",
+          },
+          {
+            path: "apiReference.mcp.timeoutMs",
+            name: "timeoutMs",
+            type: "number",
+            default: 10000,
+            description: "Per-operation HTTP timeout.",
+          },
+        ],
       },
     ],
   },
@@ -2623,6 +2741,16 @@ const readPageInputSchema = z.object({
   locale: z.string().trim().min(1).max(128).optional(),
   section: z.string().trim().min(1).optional(),
   maxChars: z.number().int().min(256).max(1_000_000).optional(),
+});
+
+const trustMetadataInputSchema = z.object({
+  path: z.string().trim().min(1).optional(),
+  locale: z.string().trim().min(1).max(128).optional(),
+});
+
+const openApiOperationInputSchema = z.object({
+  parameters: z.record(z.string(), z.unknown()).optional(),
+  body: z.unknown().optional(),
 });
 
 const listPageSectionsInputSchema = z.object({
@@ -2984,6 +3112,7 @@ const searchResultOutputSchema = z.object({
   score: z.number().optional(),
   section: z.string().optional(),
   source: retrievalSourceOutputSchema.optional(),
+  trust: z.record(z.string(), z.unknown()).optional(),
 });
 const searchFiltersOutputSchema = z.object({
   framework: z.array(z.string()).optional(),
@@ -3171,6 +3300,19 @@ const readPageOutputSchema = z.object({
   totalChars: z.number().int().nonnegative(),
   truncated: z.boolean(),
 });
+const trustMetadataOutputSchema = z.object({
+  format: z.literal("open-knowledge-format.v0.2"),
+  spec_version: z.literal("0.2"),
+  generated: z.object({ by: z.string(), at: z.string() }),
+  documents: z.array(z.record(z.string(), z.unknown())),
+});
+const openApiOperationOutputSchema = z.object({
+  operationId: z.string(),
+  status: z.number().int(),
+  ok: z.boolean(),
+  contentType: z.string().optional(),
+  body: z.unknown(),
+});
 const pageSectionMetadataOutputSchema = z.object({
   id: z.string(),
   heading: z.string(),
@@ -3280,6 +3422,7 @@ export function resolveDocsMcpConfig(
         getCodeExamples: true,
         getConfigSchema: true,
         getContext: true,
+        getTrustMetadata: true,
       },
       prompts: resolveDocsMcpPromptsConfig(),
       security: resolveDocsMcpSecurityConfig(),
@@ -3308,6 +3451,7 @@ export function resolveDocsMcpConfig(
       getCodeExamples: config.tools?.getCodeExamples ?? true,
       getConfigSchema: config.tools?.getConfigSchema ?? true,
       getContext: config.tools?.getContext ?? true,
+      getTrustMetadata: config.tools?.getTrustMetadata ?? true,
     },
     prompts: resolveDocsMcpPromptsConfig(config.prompts),
     security: resolveDocsMcpSecurityConfig(config.security),
@@ -4203,6 +4347,17 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   const defaultPages = dedupePages(await getSourcePages());
   const defaultTree = await getSourceNavigation();
   const defaultSkills = await getSourceSkills();
+  const okfConfig = resolveDocsOkfConfig(options.okf);
+  const openapiDocument = options.openapi
+    ? typeof options.openapi.document === "function"
+      ? await options.openapi.document()
+      : options.openapi.document
+    : undefined;
+  const openapiConfig = options.openapi?.config;
+  const openapiOperations =
+    openapiDocument && openapiConfig
+      ? resolveDocsOpenApiMcpOperations(openapiDocument, openapiConfig)
+      : [];
   const prompts = resolved.prompts ?? resolveDocsMcpPromptsConfig();
   const contractPromptDefinitions = prompts.enabled
     ? resolveDocsMcpContractPromptDefinitions(defaultPages, prompts.contracts, options.source.entry)
@@ -4216,6 +4371,176 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
     // listChanged would require a live mutation path and subscription notification
     // that this static catalog intentionally does not expose.
     server.server.registerCapabilities({ prompts: { listChanged: false } });
+  }
+
+  if (okfConfig.enabled && resolved.tools.getTrustMetadata !== false) {
+    registerTool(
+      "get_trust_metadata",
+      {
+        title: "Get documentation trust metadata",
+        description:
+          "Return OKF v0.2 sources, generation, verification, lifecycle status, trust tier, and staleness for one page or the docs corpus.",
+        inputSchema: trustMetadataInputSchema,
+        outputSchema: trustMetadataOutputSchema,
+        annotations: { readOnlyHint: true },
+      },
+      async ({ path: requestedPath, locale }) => {
+        const pages = dedupePages(await getSourcePages(locale));
+        const selected = requestedPath
+          ? pages.filter((page) =>
+              Boolean(findDocsPage([page], requestedPath, options.source.entry)),
+            )
+          : pages;
+        if (requestedPath && selected.length === 0) {
+          return {
+            content: [{ type: "text", text: `No docs page matched "${requestedPath}".` }],
+            isError: true,
+          };
+        }
+        const bundle = buildDocsOkfBundle(selected, okfConfig);
+        trackMcpTool("get_trust_metadata", { locale, resultCount: bundle.documents.length });
+        return createStructuredTextResult(bundle);
+      },
+    );
+  }
+
+  for (const operation of openapiOperations) {
+    registerTool(
+      operation.toolName,
+      {
+        title: operation.title,
+        description:
+          operation.description ??
+          `${operation.method} ${operation.path} (${operation.operationId})`,
+        inputSchema: openApiOperationInputSchema,
+        outputSchema: openApiOperationOutputSchema,
+        annotations: {
+          readOnlyHint: operation.readOnly,
+          destructiveHint: operation.destructive,
+          idempotentHint: operation.idempotent,
+          openWorldHint: true,
+        },
+        _meta: {
+          "dev.farming-labs/openapi": {
+            operationId: operation.operationId,
+            method: operation.method,
+            path: operation.path,
+            security: operation.security,
+            securitySchemes: operation.securitySchemes,
+          },
+        },
+      },
+      async ({ parameters = {}, body }) => {
+        if (!openapiDocument || !openapiConfig) {
+          throw new ProtocolError(ProtocolErrorCode.InternalError, "OpenAPI MCP is unavailable.");
+        }
+        const baseUrl = resolveDocsOpenApiMcpBaseUrl(openapiDocument, openapiConfig);
+        if (!baseUrl) {
+          throw new ProtocolError(
+            ProtocolErrorCode.InvalidParams,
+            `OpenAPI operation ${operation.operationId} has no server URL. Configure apiReference.mcp.baseUrl.`,
+          );
+        }
+        let requestPath = operation.path;
+        const query = new URLSearchParams();
+        const requestHeaders = new Headers({ Accept: "application/json, text/plain, */*" });
+        const requestCookies = new URLSearchParams();
+        for (const parameter of operation.parameters) {
+          const value = parameters[parameter.name];
+          if (value === undefined || value === null || value === "") {
+            if (parameter.required) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Missing required ${parameter.in} parameter: ${parameter.name}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            continue;
+          }
+          const values = Array.isArray(value) ? value : [value];
+          if (parameter.in === "path") {
+            requestPath = requestPath.replaceAll(
+              `{${parameter.name}}`,
+              encodeURIComponent(String(values[0])),
+            );
+          } else if (parameter.in === "query") {
+            for (const item of values) query.append(parameter.name, String(item));
+          } else if (parameter.in === "header") {
+            requestHeaders.set(parameter.name, String(values[0]));
+          } else if (parameter.in === "cookie") {
+            requestCookies.set(parameter.name, String(values[0]));
+          }
+        }
+        const requestUrl = new URL(
+          requestPath.replace(/^\/+/, ""),
+          `${baseUrl.replace(/\/+$/u, "")}/`,
+        );
+        for (const [name, value] of query) requestUrl.searchParams.append(name, value);
+        if (requestUrl.protocol !== "https:" && requestUrl.protocol !== "http:") {
+          throw new ProtocolError(
+            ProtocolErrorCode.InvalidParams,
+            "OpenAPI MCP server URLs must use HTTP or HTTPS.",
+          );
+        }
+        const configuredHeaders =
+          typeof openapiConfig.headers === "function"
+            ? await openapiConfig.headers({
+                operationId: operation.operationId,
+                method: operation.method,
+                path: operation.path,
+                security: operation.security,
+              })
+            : openapiConfig.headers;
+        for (const [name, value] of Object.entries(configuredHeaders ?? {})) {
+          requestHeaders.set(name, value);
+        }
+        if (requestCookies.size > 0) {
+          requestHeaders.set(
+            "Cookie",
+            [...requestCookies].map(([name, value]) => `${name}=${value}`).join("; "),
+          );
+        }
+        if (body !== undefined) requestHeaders.set("Content-Type", "application/json");
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), openapiConfig.timeoutMs ?? 10_000);
+        try {
+          const response = await fetch(requestUrl, {
+            method: operation.method,
+            headers: requestHeaders,
+            ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+            signal: controller.signal,
+          });
+          const contentType = response.headers.get("content-type") ?? undefined;
+          const text = (await response.text()).slice(0, 1_000_000);
+          let responseBody: unknown = text;
+          if (contentType?.includes("json") && text) {
+            try {
+              responseBody = JSON.parse(text);
+            } catch {
+              responseBody = text;
+            }
+          }
+          const result = {
+            operationId: operation.operationId,
+            status: response.status,
+            ok: response.ok,
+            ...(contentType ? { contentType } : {}),
+            body: responseBody,
+          };
+          trackMcpTool(operation.toolName, { resultCount: 1 });
+          return {
+            ...createStructuredTextResult(result),
+            ...(response.ok ? {} : { isError: true }),
+          };
+        } finally {
+          clearTimeout(timeout);
+        }
+      },
+    );
   }
 
   for (const definition of contractPromptDefinitions) {
@@ -7159,6 +7484,7 @@ function scanFilesystemDocsPages(
         description: data.description as string | undefined,
         relatedInput: data.related,
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: path.relative(rootDir, full).replace(/\\/g, "/"),
         lastmod: normalizeFrontmatterLastmod(data.lastmod),

--- a/packages/docs/src/okf.test.ts
+++ b/packages/docs/src/okf.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocsOkfBundle,
+  normalizeDocsOkfTrustMetadataInput,
+  resolveDocsOkfConfig,
+  resolveDocsOkfTrustMetadata,
+} from "./okf.js";
+import { renderDocsMarkdownDocument } from "./agent.js";
+
+describe("OKF trust metadata", () => {
+  it("normalizes OKF v0.2 provenance without accepting malformed records", () => {
+    expect(
+      normalizeDocsOkfTrustMetadataInput({
+        sources: [
+          {
+            resource: " https://docs.example.com/source ",
+            usage_count: 3,
+            usage_window: {
+              start: "2026-01-01",
+              end: "2026-02-01",
+            },
+          },
+          { title: "missing resource" },
+        ],
+        generated: { by: " software:generator ", at: "2026-02-02" },
+        verified: [{ by: "human:docs-team", at: "2026-02-03" }, { by: "bad" }],
+        status: "stable",
+        stale_after: "2026-05-01",
+      }),
+    ).toEqual({
+      sources: [
+        {
+          resource: "https://docs.example.com/source",
+          usage_count: 3,
+          usage_window: {
+            start: "2026-01-01T00:00:00.000Z",
+            end: "2026-02-01T00:00:00.000Z",
+          },
+        },
+      ],
+      generated: { by: "software:generator", at: "2026-02-02T00:00:00.000Z" },
+      verified: [{ by: "human:docs-team", at: "2026-02-03T00:00:00.000Z" }],
+      status: "stable",
+      stale_after: "2026-05-01",
+    });
+  });
+
+  it("derives conservative trust tiers and an explicit staleness result", () => {
+    const trust = resolveDocsOkfTrustMetadata(
+      {
+        url: "/docs/install",
+        canonicalUrl: "https://docs.example.com/docs/install",
+        sourcePath: "docs/install/page.mdx",
+        title: "Install",
+        lastmod: "2026-01-01",
+        okf: {
+          verified: [{ by: "human:docs-team", at: "2026-01-02" }],
+        },
+      },
+      { staleAfterDays: 30 },
+      new Date("2026-03-01T00:00:00.000Z"),
+    );
+
+    expect(trust).toMatchObject({
+      trust_tier: "human-reviewed",
+      stale_after: "2026-01-31",
+      stale: true,
+      sources: [
+        {
+          resource: "https://docs.example.com/docs/install",
+          id: "docs/install/page.mdx",
+        },
+      ],
+    });
+  });
+
+  it("builds a deterministic, URL-sorted knowledge bundle", () => {
+    const bundle = buildDocsOkfBundle(
+      [
+        { url: "/docs/z", title: "Z", content: "z", lastmod: "2026-02-01" },
+        { url: "/docs/a", title: "A", content: "a", lastmod: "2026-01-01" },
+      ],
+      true,
+    );
+
+    expect(bundle.format).toBe("open-knowledge-format.v0.2");
+    expect(bundle.spec_version).toBe("0.2");
+    expect(bundle.documents.map((document) => document.url)).toEqual(["/docs/a", "/docs/z"]);
+    expect(bundle.generated.at).toBe("2026-02-01T00:00:00.000Z");
+    expect(resolveDocsOkfConfig(undefined).enabled).toBe(false);
+  });
+
+  it("surfaces trust metadata in the Markdown representation when enabled", () => {
+    const markdown = renderDocsMarkdownDocument(
+      {
+        url: "/docs/install",
+        title: "Install",
+        content: "Run the installer.",
+        lastmod: "2026-01-01",
+      },
+      { origin: "https://docs.example.com", okf: true },
+    );
+
+    expect(markdown).toContain('okf: {"sources":');
+    expect(markdown).toContain('"resource":"https://docs.example.com/docs/install"');
+    expect(markdown).toContain('"trust_tier":"unverified"');
+  });
+});

--- a/packages/docs/src/okf.ts
+++ b/packages/docs/src/okf.ts
@@ -1,0 +1,239 @@
+import type {
+  DocsOkfActorTimestamp,
+  DocsOkfConfig,
+  DocsOkfSource,
+  DocsOkfStatus,
+  DocsOkfTrustMetadata,
+  DocsOkfTrustMetadataInput,
+  DocsOkfTrustTier,
+} from "./types.js";
+
+export const DOCS_OKF_VERSION = "0.2";
+export const DOCS_OKF_BUNDLE_FORMAT = "open-knowledge-format.v0.2";
+export const DEFAULT_DOCS_OKF_ROUTE = "/.well-known/okf.json";
+
+export interface DocsOkfPageLike {
+  url: string;
+  title: string;
+  canonicalUrl?: string;
+  sourcePath?: string;
+  lastModified?: string;
+  lastmod?: string;
+  okf?: DocsOkfTrustMetadataInput;
+}
+
+export interface DocsOkfResolvedConfig extends DocsOkfTrustMetadataInput {
+  enabled: boolean;
+  route: string;
+  generatedBy: string;
+  staleAfterDays?: number;
+}
+
+export interface DocsOkfKnowledgeDocument {
+  id: string;
+  url: string;
+  title: string;
+  content?: string;
+  trust: DocsOkfTrustMetadata;
+}
+
+export interface DocsOkfBundle {
+  format: typeof DOCS_OKF_BUNDLE_FORMAT;
+  spec_version: typeof DOCS_OKF_VERSION;
+  generated: DocsOkfActorTimestamp;
+  documents: DocsOkfKnowledgeDocument[];
+}
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function normalizeDate(value: unknown): string | undefined {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  const stringValue = cleanString(value);
+  if (!stringValue) return undefined;
+  const parsed = new Date(stringValue);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : undefined;
+}
+
+function normalizeDateOnly(value: unknown): string | undefined {
+  const date = normalizeDate(value);
+  return date?.slice(0, 10);
+}
+
+function normalizeStatus(value: unknown): DocsOkfStatus | undefined {
+  return value === "draft" || value === "stable" || value === "deprecated" ? value : undefined;
+}
+
+function normalizeActorTimestamp(value: unknown): DocsOkfActorTimestamp | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const by = cleanString(record.by);
+  const at = normalizeDate(record.at);
+  return by && at ? { by, at } : undefined;
+}
+
+function normalizeSource(value: unknown): DocsOkfSource | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const resource = cleanString(record.resource);
+  if (!resource) return undefined;
+  const usageCount =
+    typeof record.usage_count === "number" && Number.isInteger(record.usage_count)
+      ? Math.max(0, record.usage_count)
+      : undefined;
+  const usageWindowRecord =
+    record.usage_window &&
+    typeof record.usage_window === "object" &&
+    !Array.isArray(record.usage_window)
+      ? (record.usage_window as Record<string, unknown>)
+      : undefined;
+  const usageWindow = usageWindowRecord
+    ? {
+        ...(normalizeDate(usageWindowRecord.start)
+          ? { start: normalizeDate(usageWindowRecord.start) }
+          : {}),
+        ...(normalizeDate(usageWindowRecord.end)
+          ? { end: normalizeDate(usageWindowRecord.end) }
+          : {}),
+      }
+    : undefined;
+  return {
+    resource,
+    ...(cleanString(record.id) ? { id: cleanString(record.id) } : {}),
+    ...(cleanString(record.title) ? { title: cleanString(record.title) } : {}),
+    ...(cleanString(record.author) ? { author: cleanString(record.author) } : {}),
+    ...(usageCount !== undefined ? { usage_count: usageCount } : {}),
+    ...(normalizeDate(record.last_modified)
+      ? { last_modified: normalizeDate(record.last_modified) }
+      : {}),
+    ...(usageWindow && Object.keys(usageWindow).length > 0 ? { usage_window: usageWindow } : {}),
+  };
+}
+
+export function normalizeDocsOkfTrustMetadataInput(
+  value: unknown,
+): DocsOkfTrustMetadataInput | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const sources = Array.isArray(record.sources)
+    ? record.sources.flatMap((source) => {
+        const normalized = normalizeSource(source);
+        return normalized ? [normalized] : [];
+      })
+    : undefined;
+  const verified = Array.isArray(record.verified)
+    ? record.verified.flatMap((entry) => {
+        const normalized = normalizeActorTimestamp(entry);
+        return normalized ? [normalized] : [];
+      })
+    : undefined;
+  const generated = normalizeActorTimestamp(record.generated);
+  const status = normalizeStatus(record.status);
+  const staleAfter = normalizeDateOnly(record.stale_after);
+  const result: DocsOkfTrustMetadataInput = {
+    ...(sources && sources.length > 0 ? { sources } : {}),
+    ...(generated ? { generated } : {}),
+    ...(verified && verified.length > 0 ? { verified } : {}),
+    ...(status ? { status } : {}),
+    ...(staleAfter ? { stale_after: staleAfter } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function resolveDocsOkfConfig(value?: boolean | DocsOkfConfig): DocsOkfResolvedConfig {
+  const config = value && typeof value === "object" ? value : {};
+  return {
+    enabled:
+      value === true || (typeof value === "object" && value !== null && value.enabled !== false),
+    route: cleanString(config.route) ?? DEFAULT_DOCS_OKF_ROUTE,
+    generatedBy: cleanString(config.generatedBy) ?? "software:@farming-labs/docs",
+    ...(Number.isInteger(config.staleAfterDays) && (config.staleAfterDays ?? 0) > 0
+      ? { staleAfterDays: config.staleAfterDays }
+      : {}),
+    ...normalizeDocsOkfTrustMetadataInput(config),
+  };
+}
+
+function addDays(value: string, days: number): string | undefined {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) return undefined;
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+function trustTier(verified: readonly DocsOkfActorTimestamp[]): DocsOkfTrustTier {
+  if (verified.some((entry) => entry.by.toLowerCase().startsWith("human:"))) {
+    return "human-reviewed";
+  }
+  return verified.length > 0 ? "machine-confirmed" : "unverified";
+}
+
+export function resolveDocsOkfTrustMetadata(
+  page: DocsOkfPageLike,
+  value?: boolean | DocsOkfConfig,
+  now = new Date(),
+): DocsOkfTrustMetadata {
+  const config = resolveDocsOkfConfig(value);
+  const authored = normalizeDocsOkfTrustMetadataInput(page.okf) ?? {};
+  const bestTimestamp = normalizeDate(page.lastmod) ?? normalizeDate(page.lastModified);
+  const generated = authored.generated ??
+    config.generated ?? {
+      by: config.generatedBy,
+      at: bestTimestamp ?? "1970-01-01T00:00:00.000Z",
+    };
+  const sources = [...(authored.sources ?? config.sources ?? [])];
+  if (sources.length === 0) {
+    sources.push({
+      resource: page.canonicalUrl ?? page.url,
+      ...(page.sourcePath ? { id: page.sourcePath } : {}),
+      title: page.title,
+      ...(bestTimestamp ? { last_modified: bestTimestamp } : {}),
+    });
+  }
+  const verified = [...(authored.verified ?? config.verified ?? [])];
+  const staleAfter =
+    authored.stale_after ??
+    config.stale_after ??
+    (config.staleAfterDays && bestTimestamp
+      ? addDays(bestTimestamp, config.staleAfterDays)
+      : undefined);
+  return {
+    sources,
+    generated,
+    verified,
+    status: authored.status ?? config.status ?? "stable",
+    ...(staleAfter ? { stale_after: staleAfter } : {}),
+    trust_tier: trustTier(verified),
+    stale: staleAfter ? now.getTime() > new Date(`${staleAfter}T23:59:59.999Z`).getTime() : false,
+  };
+}
+
+export function buildDocsOkfBundle(
+  pages: readonly (DocsOkfPageLike & { content?: string })[],
+  value?: boolean | DocsOkfConfig,
+): DocsOkfBundle {
+  const config = resolveDocsOkfConfig(value);
+  const documents = pages
+    .map((page) => ({
+      id: page.sourcePath ?? page.url,
+      url: page.canonicalUrl ?? page.url,
+      title: page.title,
+      ...(page.content ? { content: page.content } : {}),
+      trust: resolveDocsOkfTrustMetadata(page, config),
+    }))
+    .sort((left, right) => left.url.localeCompare(right.url));
+  const generatedAt = documents.reduce(
+    (latest, document) =>
+      document.trust.generated.at > latest ? document.trust.generated.at : latest,
+    "1970-01-01T00:00:00.000Z",
+  );
+  return {
+    format: DOCS_OKF_BUNDLE_FORMAT,
+    spec_version: DOCS_OKF_VERSION,
+    generated: { by: config.generatedBy, at: generatedAt },
+    documents,
+  };
+}

--- a/packages/docs/src/openapi-mcp.test.ts
+++ b/packages/docs/src/openapi-mcp.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { resolveDocsOpenApiMcpBaseUrl, resolveDocsOpenApiMcpOperations } from "./openapi-mcp.js";
+
+const document = {
+  openapi: "3.1.0",
+  servers: [{ url: "https://api.example.com/v1" }],
+  security: [{ bearerAuth: ["read:users"] }],
+  components: {
+    securitySchemes: {
+      bearerAuth: { type: "http", scheme: "bearer" },
+      unusedKey: { type: "apiKey", in: "header", name: "x-unused" },
+    },
+  },
+  paths: {
+    "/users/{id}": {
+      parameters: [{ name: "id", in: "path", required: true }],
+      get: {
+        operationId: "getUser",
+        summary: "Get a user",
+        parameters: [{ name: "expand", in: "query" }],
+      },
+      delete: {
+        operationId: "deleteUser",
+        summary: "Delete a user",
+      },
+    },
+    "/health": {
+      get: {
+        operationId: "healthCheck",
+        "x-farming-labs-mcp": true,
+      },
+    },
+  },
+};
+
+describe("OpenAPI MCP projection", () => {
+  it("is deny-by-default and requires an explicit config", () => {
+    expect(resolveDocsOpenApiMcpOperations(document)).toEqual([]);
+    expect(resolveDocsOpenApiMcpOperations(document, { enabled: true, operations: [] })).toEqual([
+      expect.objectContaining({ operationId: "healthCheck", readOnly: true }),
+    ]);
+  });
+
+  it("projects only allowed safe operations with security metadata", () => {
+    const operations = resolveDocsOpenApiMcpOperations(document, {
+      enabled: true,
+      operations: ["getUser", "deleteUser"],
+    });
+
+    expect(operations.map((operation) => operation.operationId)).toEqual([
+      "getUser",
+      "healthCheck",
+    ]);
+    expect(operations.find((operation) => operation.operationId === "getUser")).toMatchObject({
+      toolName: "api_getUser",
+      method: "GET",
+      parameters: [
+        { name: "id", in: "path", required: true },
+        { name: "expand", in: "query", required: false },
+      ],
+      security: [{ bearerAuth: ["read:users"] }],
+      securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } },
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+    });
+  });
+
+  it("requires a second opt-in before exposing mutations", () => {
+    const operations = resolveDocsOpenApiMcpOperations(document, {
+      enabled: true,
+      operations: ["deleteUser"],
+      allowMutations: true,
+    });
+
+    expect(operations.find((operation) => operation.operationId === "deleteUser")).toMatchObject({
+      method: "DELETE",
+      destructive: true,
+      idempotent: true,
+    });
+  });
+
+  it("resolves an explicit base URL before the OpenAPI servers list", () => {
+    expect(
+      resolveDocsOpenApiMcpBaseUrl(document, { baseUrl: "https://override.example.com" }),
+    ).toBe("https://override.example.com");
+    expect(resolveDocsOpenApiMcpBaseUrl(document, {})).toBe("https://api.example.com/v1");
+  });
+});

--- a/packages/docs/src/openapi-mcp.ts
+++ b/packages/docs/src/openapi-mcp.ts
@@ -1,0 +1,167 @@
+import type { DocsOpenApiMcpConfig } from "./types.js";
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+
+export interface DocsOpenApiMcpParameter {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  required: boolean;
+}
+
+export interface DocsOpenApiMcpOperation {
+  toolName: string;
+  operationId: string;
+  method: string;
+  path: string;
+  title: string;
+  description?: string;
+  parameters: DocsOpenApiMcpParameter[];
+  security: Array<Record<string, string[]>>;
+  securitySchemes: Record<string, unknown>;
+  readOnly: boolean;
+  destructive: boolean;
+  idempotent: boolean;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function selectorFor(method: string, path: string): string {
+  return `${method.toUpperCase()} ${path}`;
+}
+
+function sanitizeToolName(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 56);
+  return `api_${normalized || "operation"}`;
+}
+
+function operationExtensionEnabled(operation: Record<string, unknown>): boolean {
+  const extension = operation["x-farming-labs-mcp"];
+  return extension === true || asRecord(extension)?.enabled === true;
+}
+
+function normalizeSecurity(value: unknown): Array<Record<string, string[]>> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((requirement) => {
+    const record = asRecord(requirement);
+    if (!record) return [];
+    const normalized: Record<string, string[]> = {};
+    for (const [name, scopes] of Object.entries(record)) {
+      normalized[name] = Array.isArray(scopes)
+        ? scopes.filter((scope): scope is string => typeof scope === "string")
+        : [];
+    }
+    return [normalized];
+  });
+}
+
+function normalizeParameters(...values: unknown[]): DocsOpenApiMcpParameter[] {
+  const parameters = values.flatMap((value) => (Array.isArray(value) ? value : []));
+  const seen = new Set<string>();
+  return parameters.flatMap((parameter) => {
+    const record = asRecord(parameter);
+    if (!record) return [];
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const location = record?.in;
+    if (
+      !name ||
+      (location !== "path" &&
+        location !== "query" &&
+        location !== "header" &&
+        location !== "cookie")
+    ) {
+      return [];
+    }
+    const key = `${location}:${name}`;
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{ name, in: location, required: record.required === true || location === "path" }];
+  });
+}
+
+export function resolveDocsOpenApiMcpOperations(
+  document: Record<string, unknown>,
+  config?: DocsOpenApiMcpConfig,
+): DocsOpenApiMcpOperation[] {
+  if (!config || config.enabled === false) return [];
+  const allow = new Set((config.operations ?? []).map((value) => value.trim()).filter(Boolean));
+  const paths = asRecord(document.paths) ?? {};
+  const components = asRecord(document.components);
+  const securitySchemes = asRecord(components?.securitySchemes) ?? {};
+  const globalSecurity = normalizeSecurity(document.security);
+  const operations: DocsOpenApiMcpOperation[] = [];
+  const names = new Set<string>();
+
+  for (const [path, rawPathItem] of Object.entries(paths)) {
+    const pathItem = asRecord(rawPathItem);
+    if (!pathItem) continue;
+    for (const method of HTTP_METHODS) {
+      const operation = asRecord(pathItem[method]);
+      if (!operation) continue;
+      const operationId =
+        typeof operation.operationId === "string" && operation.operationId.trim()
+          ? operation.operationId.trim()
+          : `${method}_${path.replace(/[^a-zA-Z0-9]+/g, "_")}`;
+      const explicitlyAllowed =
+        allow.has(operationId) ||
+        allow.has(selectorFor(method, path)) ||
+        operationExtensionEnabled(operation);
+      if (!explicitlyAllowed) continue;
+      const mutation = !["get", "head", "options"].includes(method);
+      if (mutation && config.allowMutations !== true) continue;
+      const toolName = sanitizeToolName(operationId);
+      if (names.has(toolName)) {
+        throw new Error(`OpenAPI MCP tool name collision: ${toolName}`);
+      }
+      names.add(toolName);
+      const security =
+        operation.security === undefined ? globalSecurity : normalizeSecurity(operation.security);
+      const usedSchemeNames = new Set(security.flatMap((requirement) => Object.keys(requirement)));
+      const usedSecuritySchemes = Object.fromEntries(
+        Object.entries(securitySchemes).filter(([name]) => usedSchemeNames.has(name)),
+      );
+      operations.push({
+        toolName,
+        operationId,
+        method: method.toUpperCase(),
+        path,
+        title:
+          (typeof operation.summary === "string" && operation.summary.trim()) ||
+          (typeof operation.description === "string" && operation.description.trim()) ||
+          selectorFor(method, path),
+        ...(typeof operation.description === "string" && operation.description.trim()
+          ? { description: operation.description.trim() }
+          : {}),
+        parameters: normalizeParameters(pathItem.parameters, operation.parameters),
+        security,
+        securitySchemes: usedSecuritySchemes,
+        readOnly: method === "get" || method === "head",
+        destructive: method === "delete",
+        idempotent: ["GET", "HEAD", "PUT", "DELETE", "OPTIONS"].includes(method.toUpperCase()),
+      });
+    }
+  }
+
+  return operations.sort((left, right) => left.toolName.localeCompare(right.toolName));
+}
+
+export function resolveDocsOpenApiMcpBaseUrl(
+  document: Record<string, unknown>,
+  config: DocsOpenApiMcpConfig,
+): string | undefined {
+  const configured = config.baseUrl?.trim();
+  if (configured) return configured;
+  const servers = Array.isArray(document.servers) ? document.servers : [];
+  for (const server of servers) {
+    const url = asRecord(server)?.url;
+    if (typeof url === "string" && url.trim()) return url.trim();
+  }
+  return undefined;
+}

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -58,6 +58,7 @@ import {
   stripDocsGeneratedAgentContractMarkers,
 } from "./markdown-sections.js";
 import { isDocsMcpResourcePath } from "./mcp-auth.js";
+import { resolveDocsOkfTrustMetadata } from "./okf.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;
 const MAX_STRUCTURED_SEARCH_LIMIT = 25;
@@ -1966,6 +1967,7 @@ async function enrichDocsSearchResultsWithSources(options: {
       if (page) {
         return {
           ...resultWithoutSource,
+          trust: resolveDocsOkfTrustMetadata(page),
           source: await buildDocsRetrievalSource(page, result.url, {
             audience: options.audience,
             chunking: options.chunking,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -344,6 +344,44 @@ export interface PageSidebarFrontmatter {
   folderIndexBehavior?: SidebarFolderIndexBehavior;
 }
 
+export type DocsOkfStatus = "draft" | "stable" | "deprecated";
+
+export interface DocsOkfSource {
+  resource: string;
+  id?: string;
+  title?: string;
+  author?: string;
+  usage_count?: number;
+  last_modified?: string;
+  usage_window?: { start?: string; end?: string };
+}
+
+export interface DocsOkfActorTimestamp {
+  by: string;
+  at: string;
+}
+
+/** Authored OKF v0.2 trust metadata. Missing fields are derived conservatively at runtime. */
+export interface DocsOkfTrustMetadataInput {
+  sources?: readonly DocsOkfSource[];
+  generated?: DocsOkfActorTimestamp;
+  verified?: readonly DocsOkfActorTimestamp[];
+  status?: DocsOkfStatus;
+  stale_after?: string;
+}
+
+export type DocsOkfTrustTier = "unverified" | "machine-confirmed" | "human-reviewed";
+
+export interface DocsOkfTrustMetadata {
+  sources: DocsOkfSource[];
+  generated: DocsOkfActorTimestamp;
+  verified: DocsOkfActorTimestamp[];
+  status: DocsOkfStatus;
+  stale_after?: string;
+  trust_tier: DocsOkfTrustTier;
+  stale: boolean;
+}
+
 export interface PageFrontmatter {
   title: string;
   description?: string;
@@ -351,6 +389,8 @@ export interface PageFrontmatter {
   related?: DocsRelatedItem[];
   /** Per-page agent-oriented metadata used by machine-readable docs features. */
   agent?: PageAgentFrontmatter;
+  /** OKF v0.2 source, generation, verification, lifecycle, and staleness metadata. */
+  okf?: DocsOkfTrustMetadataInput;
   /** Per-page sidebar metadata used when building the docs navigation tree. */
   sidebar?: PageSidebarFrontmatter;
   /** Override or disable the estimated reading time for this page. */
@@ -1396,6 +1436,8 @@ export interface DocsMcpToolsConfig {
   getConfigSchema?: boolean;
   /** Expose deterministic `get_context` retrieval with a conservative UTF-8 byte ceiling. */
   getContext?: boolean;
+  /** Expose OKF v0.2 source, verification, lifecycle, and staleness metadata. */
+  getTrustMetadata?: boolean;
 }
 
 /** Built-in MCP prompt templates projected from documentation contracts and golden tasks. */
@@ -1557,6 +1599,7 @@ export interface DocsSearchSourcePage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   sourcePath?: string;
   lastModified?: string;
   lastmod?: string;
@@ -1802,6 +1845,8 @@ export interface DocsSearchResult {
   section?: string;
   /** Canonical, scope-aware provenance when supplied or recoverable locally. */
   source?: DocsRetrievalSourceProvenance;
+  /** OKF v0.2 trust metadata for the selected source. */
+  trust?: DocsOkfTrustMetadata;
   /** Present only when the caller opts into retrieval explanations. */
   explanation?: DocsSearchExplanation;
 }
@@ -2979,6 +3024,35 @@ export interface ChangelogConfig {
 
 export type ApiReferenceRenderer = "fumadocs" | "scalar";
 
+export interface DocsOpenApiMcpCredentialContext {
+  operationId: string;
+  method: string;
+  path: string;
+  security: readonly Record<string, readonly string[]>[];
+}
+
+export type DocsOpenApiMcpHeaders =
+  | Readonly<Record<string, string>>
+  | ((
+      context: DocsOpenApiMcpCredentialContext,
+    ) => Readonly<Record<string, string>> | Promise<Readonly<Record<string, string>>>);
+
+/** Explicit, deny-by-default projection of OpenAPI operations into MCP tools. */
+export interface DocsOpenApiMcpConfig {
+  /** Enable operation projection. No tools are exposed until an operation is explicitly allowed. */
+  enabled?: boolean;
+  /** Allowed operationIds or `METHOD /path` selectors. */
+  operations?: readonly string[];
+  /** Override the first OpenAPI server URL used for requests. */
+  baseUrl?: string;
+  /** Allow POST, PUT, PATCH, or DELETE operations. Defaults to false. */
+  allowMutations?: boolean;
+  /** Server-owned credentials added after user input is parsed. */
+  headers?: DocsOpenApiMcpHeaders;
+  /** Per-operation request timeout. @default 10000 */
+  timeoutMs?: number;
+}
+
 export interface ApiReferenceConfig {
   /**
    * Whether to enable generated API reference pages.
@@ -3037,6 +3111,11 @@ export interface ApiReferenceConfig {
    * - TanStack Start / SvelteKit / Astro / Nuxt: `"scalar"`
    */
   renderer?: ApiReferenceRenderer;
+  /**
+   * Explicitly expose selected OpenAPI operations as MCP tools. This is deny-by-default:
+   * set `operations`, or mark an operation with `x-farming-labs-mcp.enabled: true`.
+   */
+  mcp?: boolean | DocsOpenApiMcpConfig;
   /**
    * Filesystem route root to scan for API handlers.
    *
@@ -3625,6 +3704,8 @@ export type DocsAgentA2AConfig = DocsAgentA2ABaseConfig &
   (DocsAgentA2ASingleInterfaceConfig | DocsAgentA2AInterfacesConfig);
 
 export interface DocsAgentConfig {
+  /** Publish OKF v0.2 trust metadata and a machine-readable knowledge bundle. */
+  okf?: boolean | DocsOkfConfig;
   /**
    * Defaults for `docs agent compact`.
    */
@@ -3644,6 +3725,17 @@ export interface DocsAgentConfig {
   contentChanges?: boolean | DocsAgentContentChangesConfig;
   /** Opt in to an A2A Agent Card for a separately implemented A2A service. */
   a2a?: DocsAgentA2AConfig;
+}
+
+export interface DocsOkfConfig extends DocsOkfTrustMetadataInput {
+  /** Enable OKF projection. @default true when configured */
+  enabled?: boolean;
+  /** Public bundle route. @default "/.well-known/okf.json" */
+  route?: string;
+  /** Generator actor used when a page has no authored `okf.generated`. */
+  generatedBy?: string;
+  /** Derive `stale_after` this many days after the best page timestamp. */
+  staleAfterDays?: number;
 }
 
 export interface DocsAgentContentChangesConfig {

--- a/packages/farmjs/src/content.ts
+++ b/packages/farmjs/src/content.ts
@@ -12,10 +12,12 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
+  type DocsOkfTrustMetadataInput,
   type ResolvedDocsRelatedLink,
   type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
@@ -52,6 +54,7 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   icon?: string;
   sourcePath?: string;
   lastmod?: string;
@@ -167,6 +170,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),

--- a/packages/farmjs/src/server.ts
+++ b/packages/farmjs/src/server.ts
@@ -37,6 +37,7 @@ import {
   isDocsSkillRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   parseDocsAgentFeedbackData,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -81,6 +82,7 @@ import {
   buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -650,6 +652,7 @@ function searchIndexFromMap(
       description: data.description as string | undefined,
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
+      okf: normalizeDocsOkfTrustMetadataInput(data.okf),
       icon: data.icon as string | undefined,
       lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
@@ -1155,7 +1158,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const page = findDocsMarkdownPage(entry, getSearchIndex(ctx), requestedPath);
     return page
       ? {
-          document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
+          document: renderDocsMarkdownDocument(page, {
+            origin,
+            sitemap: config.sitemap,
+            okf: config.agent?.okf,
+          }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
@@ -2173,6 +2180,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   }
 
   const mcpSiteTitle = typeof config.nav?.title === "string" ? config.nav.title : "Documentation";
+  const mcpApiReference = resolveApiReferenceConfig(config.apiReference).mcp;
   const MCP = createDocsMcpHttpHandler({
     source: {
       entry,
@@ -2229,6 +2237,18 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       },
     },
     mcp: config.mcp,
+    okf: config.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(config as any, {
+              framework: "farmjs",
+              rootDir,
+              baseUrl: markdownMetadataBaseUrl || undefined,
+            }),
+        }
+      : undefined,
     contentChanges: config.agent?.contentChanges,
     evaluations: config.agent?.evaluations,
     contentChangeFeed,

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -41,6 +41,7 @@ import {
   acceptsDocsMarkdown,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   resolveChangelogConfig,
@@ -106,6 +107,7 @@ import {
   createDocsMcpHttpHandler,
   createFilesystemDocsMcpSource,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -238,6 +240,7 @@ interface DocsMCPAPIOptions {
   telemetry?: boolean | DocsTelemetryConfig;
   observability?: boolean | DocsObservabilityConfig;
   agent?: DocsConfig["agent"];
+  apiReference?: DocsConfig["apiReference"];
   /** @internal Build-time Agent Skills snapshot supplied by framework adapters. */
   _preloadedAgentSkills?: readonly DocsPublishedAgentSkill[];
 }
@@ -1642,6 +1645,7 @@ function scanDocsDir(
             description,
             relatedInput: data.related,
             agent: normalizePageAgentFrontmatter(data.agent),
+            okf: normalizeDocsOkfTrustMetadataInput(data.okf),
             content,
             rawContent,
             agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
@@ -1739,6 +1743,7 @@ function scanChangelogDir(
         description,
         relatedInput: data.related,
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         content,
         rawContent,
         agentFallbackRawContent: agentRawContent !== rawContent ? agentRawContent : undefined,
@@ -2080,12 +2085,18 @@ function resolvePublicMarkdownRequest(
 
 function renderMarkdownDocument(
   page: DocsMcpPage | DocsSearchSourcePage,
-  options: { llmsEnabled?: boolean; origin?: string; sitemap?: boolean | DocsSitemapConfig } = {},
+  options: {
+    llmsEnabled?: boolean;
+    origin?: string;
+    sitemap?: boolean | DocsSitemapConfig;
+    okf?: NonNullable<DocsConfig["agent"]>["okf"];
+  } = {},
 ): string {
   return renderDocsMarkdownDocument(page, {
     llms: options.llmsEnabled !== false,
     origin: options.origin,
     sitemap: options.sitemap,
+    okf: options.okf,
   });
 }
 
@@ -4181,6 +4192,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             llmsEnabled: llmsConfig.enabled,
             origin,
             sitemap: sitemapConfig,
+            okf: options?.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         };
@@ -4197,6 +4209,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           llmsEnabled: llmsConfig.enabled,
           origin,
           sitemap: sitemapConfig,
+          okf: options?.agent?.okf,
         }),
         lastModified: resolveDocsRetrievalLastModified(fallbackPage, "agent"),
       };
@@ -4211,6 +4224,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             llmsEnabled: llmsConfig.enabled,
             origin,
             sitemap: sitemapConfig,
+            okf: options?.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         };
@@ -5042,10 +5056,26 @@ export function createDocsMCPAPI(options: DocsMCPAPIOptions = {}) {
       return [rootSkill, ...configured];
     },
   };
+  const mcpApiReference = resolveApiReferenceConfig(options.apiReference).mcp;
 
   const handlers = createDocsMcpHttpHandler({
     source,
     mcp: mcpConfig,
+    okf: options.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(options as DocsConfig, {
+              framework: "next",
+              rootDir,
+              baseUrl:
+                options.baseUrl?.trim() ||
+                resolveDocsMetadataBaseUrl(options as DocsConfig) ||
+                undefined,
+            }),
+        }
+      : undefined,
     contentChanges: options.agent?.contentChanges,
     evaluations: options.agent?.evaluations,
     contentChangeFeed,

--- a/packages/nuxt/src/content.ts
+++ b/packages/nuxt/src/content.ts
@@ -12,10 +12,12 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
+  type DocsOkfTrustMetadataInput,
   type ResolvedDocsRelatedLink,
   type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
@@ -51,6 +53,7 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   icon?: string;
   sourcePath?: string;
   lastmod?: string;
@@ -126,6 +129,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -54,6 +54,7 @@ import {
   isDocsSkillRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   parseDocsAgentFeedbackData,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -98,6 +99,7 @@ import {
   buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -522,6 +524,7 @@ function searchIndexFromMap(
       description: data.description as string | undefined,
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
+      okf: normalizeDocsOkfTrustMetadataInput(data.okf),
       icon: data.icon as string | undefined,
       lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
@@ -995,7 +998,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const page = findDocsMarkdownPage(entry, getSearchIndex(ctx), requestedPath);
     return page
       ? {
-          document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
+          document: renderDocsMarkdownDocument(page, {
+            origin,
+            sitemap: config.sitemap,
+            okf: config.agent?.okf,
+          }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
@@ -2021,6 +2028,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     typeof (config.nav as Record<string, unknown>)?.title === "string"
       ? ((config.nav as Record<string, unknown>).title as string)
       : "Documentation";
+  const mcpApiReference = resolveApiReferenceConfig(config.apiReference).mcp;
 
   const MCP = createDocsMcpHttpHandler({
     source: {
@@ -2077,6 +2085,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    okf: config.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(config as any, {
+              framework: "nuxt",
+              rootDir,
+              baseUrl: markdownMetadataBaseUrl || undefined,
+            }),
+        }
+      : undefined,
     contentChanges: config.agent?.contentChanges,
     evaluations: config.agent?.evaluations,
     contentChangeFeed,

--- a/packages/svelte/src/content.ts
+++ b/packages/svelte/src/content.ts
@@ -12,10 +12,12 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
+  type DocsOkfTrustMetadataInput,
   type ResolvedDocsRelatedLink,
   type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
@@ -51,6 +53,7 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   icon?: string;
   sourcePath?: string;
   lastmod?: string;
@@ -126,6 +129,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -64,6 +64,7 @@ import {
   isDocsSkillRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   parseDocsAgentFeedbackData,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -110,6 +111,7 @@ import {
   createDocsMcpHttpHandler,
   isDocsCloudAskAIProvider,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -547,6 +549,7 @@ function searchIndexFromMap(
       description: data.description as string | undefined,
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
+      okf: normalizeDocsOkfTrustMetadataInput(data.okf),
       icon: data.icon as string | undefined,
       lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
@@ -1018,7 +1021,11 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     const page = findDocsMarkdownPage(entry, getSearchIndex(ctx), requestedPath);
     return page
       ? {
-          document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
+          document: renderDocsMarkdownDocument(page, {
+            origin,
+            sitemap: config.sitemap,
+            okf: config.agent?.okf,
+          }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
@@ -2059,6 +2066,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     typeof (config.nav as Record<string, unknown>)?.title === "string"
       ? ((config.nav as Record<string, unknown>).title as string)
       : "Documentation";
+  const mcpApiReference = resolveApiReferenceConfig(config.apiReference).mcp;
 
   const MCP = createDocsMcpHttpHandler({
     source: {
@@ -2115,6 +2123,18 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
       },
     },
     mcp: (config as Record<string, unknown>).mcp as Record<string, unknown> | boolean | undefined,
+    okf: config.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(config as any, {
+              framework: "sveltekit",
+              rootDir,
+              baseUrl: markdownMetadataBaseUrl || undefined,
+            }),
+        }
+      : undefined,
     contentChanges: config.agent?.contentChanges,
     evaluations: config.agent?.evaluations,
     contentChangeFeed,

--- a/packages/tanstack-start/src/content.ts
+++ b/packages/tanstack-start/src/content.ts
@@ -12,10 +12,12 @@ import matter from "gray-matter";
 import {
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   resolveDocsAudienceMdxContent,
   resolvePageSidebarFolderIndexBehavior,
   type OrderingItem,
   type PageAgentFrontmatter,
+  type DocsOkfTrustMetadataInput,
   type ResolvedDocsRelatedLink,
   type SidebarFolderIndexBehavior,
 } from "@farming-labs/docs";
@@ -51,6 +53,7 @@ export interface ContentPage {
   description?: string;
   related?: ResolvedDocsRelatedLink[];
   agent?: PageAgentFrontmatter;
+  okf?: DocsOkfTrustMetadataInput;
   icon?: string;
   sourcePath?: string;
   lastmod?: string;
@@ -118,6 +121,7 @@ export function loadDocsContent(contentDir: string, entry: string = "docs"): Con
         description: data.description as string | undefined,
         ...(related.length > 0 ? { related } : {}),
         agent: normalizePageAgentFrontmatter(data.agent),
+        okf: normalizeDocsOkfTrustMetadataInput(data.okf),
         icon: data.icon as string | undefined,
         sourcePath: full.replace(/\\/g, "/"),
         lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -34,6 +34,7 @@ import {
   isDocsSkillRequest,
   normalizeDocsRelated,
   normalizePageAgentFrontmatter,
+  normalizeDocsOkfTrustMetadataInput,
   parseDocsAgentFeedbackData,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -78,6 +79,7 @@ import {
   buildApiReferenceOpenApiDocumentAsync,
   createDocsMcpHttpHandler,
   readDocsSitemapManifest,
+  resolveApiReferenceConfig,
   resolveApiReferenceOpenApiDiscovery,
   resolveDocsMcpConfig,
   resolveConfiguredAgentSkills,
@@ -480,6 +482,7 @@ function searchIndexFromMap(
       description: data.description as string | undefined,
       ...(related.length > 0 ? { related } : {}),
       agent: normalizePageAgentFrontmatter(data.agent),
+      okf: normalizeDocsOkfTrustMetadataInput(data.okf),
       icon: data.icon as string | undefined,
       lastmod: normalizeDocsFrontmatterLastmod(data.lastmod),
       locale: typeof data.locale === "string" ? data.locale : undefined,
@@ -966,7 +969,11 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     const page = findDocsMarkdownPage(entry, getSearchIndex(ctx), requestedPath);
     return page
       ? {
-          document: renderDocsMarkdownDocument(page, { origin, sitemap: config.sitemap }),
+          document: renderDocsMarkdownDocument(page, {
+            origin,
+            sitemap: config.sitemap,
+            okf: config.agent?.okf,
+          }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
         }
       : null;
@@ -1984,6 +1991,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
   }
 
   const mcpSiteTitle = typeof config.nav?.title === "string" ? config.nav.title : "Documentation";
+  const mcpApiReference = resolveApiReferenceConfig(config.apiReference).mcp;
   const MCP = createDocsMcpHttpHandler({
     source: {
       entry,
@@ -2039,6 +2047,18 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
       },
     },
     mcp: config.mcp,
+    okf: config.agent?.okf,
+    openapi: mcpApiReference
+      ? {
+          config: mcpApiReference,
+          document: () =>
+            buildApiReferenceOpenApiDocumentAsync(config as any, {
+              framework: "tanstack-start",
+              rootDir,
+              baseUrl: markdownMetadataBaseUrl || undefined,
+            }),
+        }
+      : undefined,
     contentChanges: config.agent?.contentChanges,
     evaluations: config.agent?.evaluations,
     contentChangeFeed,

--- a/skills/farming-labs/cli/references/agent-and-static-outputs.md
+++ b/skills/farming-labs/cli/references/agent-and-static-outputs.md
@@ -58,7 +58,8 @@ pnpm exec docs agent export --public --config src/lib/docs.config.ts
 - `--check` resolves the same outputs without writing.
 - Pages use sibling `agent.md`, then the agent audience projection.
 - Exports include page Markdown, llms files, discovery JSON, hashed skills/direct companions,
-  skills and AGENTS aliases, sitemaps, and robots.
+  skills and AGENTS aliases, sitemaps, robots, and `/.well-known/okf.json` when `agent.okf` is
+  enabled.
 - Manifests include deterministic SHA-256 hashes.
 - Static discovery disables search, MCP, feedback, API reference, and OpenAPI.
 - RFC 9727 API catalog output is intentionally omitted because generic static hosting cannot

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -45,6 +45,7 @@ Doctor checks:
 - golden retrieval, citation, version, answer, example, and budget tasks
 - Agent Skill frontmatter, budgets, shallow references, compatibility, and script guidance
 - generated `agent.md` freshness and compaction defaults
+- OKF trust-metadata enablement and pages beyond their resolved `stale_after` date
 
 Command health is static. It recognizes constrained package/CLI commands and safe probes but never
 executes arbitrary documentation snippets or makes implicit network requests.

--- a/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
+++ b/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
@@ -10,6 +10,27 @@ golden tasks, or setting agent compaction defaults.
 - [A2A agent cards](#a2a-agent-cards)
 - [Golden evaluations](#golden-evaluations)
 - [Agent compaction](#agent-compaction)
+- [OKF trust metadata](#okf-trust-metadata)
+
+## OKF trust metadata
+
+Enable OKF v0.2 projection with `agent.okf: true`, or configure corpus defaults:
+
+```ts
+agent: {
+  okf: {
+    generatedBy: "software:docs-build",
+    staleAfterDays: 90,
+    verified: [{ by: "human:docs-team", at: "2026-08-01" }],
+  },
+}
+```
+
+Page `okf` frontmatter may set `sources`, `generated`, `verified`, `status`, and `stale_after`.
+Resolved metadata adds `trust_tier` (`unverified`, `machine-confirmed`, or `human-reviewed`) and a
+boolean `stale`. It appears in Markdown, local search, MCP `get_trust_metadata`, doctor output, and
+the `/.well-known/okf.json` Static Agent Bundle export. Use `human:` verifier prefixes only for
+actual human review.
 
 ## Reusable Agent Skills
 

--- a/skills/farming-labs/configuration/references/mcp-and-api-reference.md
+++ b/skills/farming-labs/configuration/references/mcp-and-api-reference.md
@@ -213,3 +213,25 @@ are bundled.
 When `specUrl` is set, local `routeRoot` and `exclude` are ignored. The shared API exposes
 `GET /api/docs?format=openapi`; discovery, llms, AGENTS.md, and skill.md advertise it. Static Next
 export skips the generated API route.
+
+## OpenAPI operations as MCP tools
+
+`apiReference.mcp` is deny-by-default. Allow operations by `operationId`, `METHOD /path`, or the
+operation-level `x-farming-labs-mcp: true` extension. Mutations also require
+`allowMutations: true`.
+
+```ts
+apiReference: {
+  enabled: true,
+  mcp: {
+    operations: ["getUser", "GET /projects/{id}"],
+    baseUrl: "https://api.example.com",
+    headers: { Authorization: `Bearer ${process.env.PRODUCT_API_TOKEN}` },
+  },
+}
+```
+
+Configured headers are server-owned and override model-provided header inputs. Tool metadata
+includes the method, path, OpenAPI security requirements, referenced security schemes, and MCP
+read-only/destructive/idempotent annotations. Never expose broad service credentials through a
+public MCP endpoint.

--- a/website/app/docs/customization/mcp/page.mdx
+++ b/website/app/docs/customization/mcp/page.mdx
@@ -95,11 +95,47 @@ The current built-in surface includes:
 - `get_code_examples`
 - `get_config_schema`
 - `get_context`
+- `get_trust_metadata` when `agent.okf` is enabled
+- explicitly allowlisted `api_*` operation tools when `apiReference.mcp` is configured
 
 It also exposes resources for:
 
 - `docs://navigation`
 - one `docs://…` resource per page
+
+## Project selected OpenAPI operations as tools
+
+`apiReference.mcp` can project API operations into MCP tools. It is deny-by-default: enabling the
+object alone exposes no operation unless its `operationId`, its `METHOD /path` selector, or its
+OpenAPI `x-farming-labs-mcp` extension explicitly allows it. Write methods need the additional
+`allowMutations: true` opt-in.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  apiReference: {
+    enabled: true,
+    mcp: {
+      operations: ["getUser", "GET /projects/{id}"],
+      baseUrl: "https://api.example.com",
+      headers: ({ security }) => ({
+        Authorization: `Bearer ${process.env.PRODUCT_API_TOKEN}`,
+        "X-Declared-Security": JSON.stringify(security),
+      }),
+      // allowMutations: true,
+    },
+  },
+});
+```
+
+Each projected tool carries its HTTP method, path, OpenAPI security requirements and referenced
+security schemes in MCP metadata. Server-owned headers are applied after tool input, so a model
+cannot replace configured credentials. Keep tokens on the server and restrict them to the smallest
+scopes required by the allowlist.
+
+<Callout type="warning" title="Public MCP tools call your API">
+  A public MCP endpoint makes every projected operation callable by public clients. Protect the MCP
+  endpoint, keep mutations disabled unless required, and use narrowly scoped service credentials.
+</Callout>
 
 ## Default behavior
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -789,10 +789,42 @@ See [MCP Server](/docs/customization/mcp) for the route snippets and examples.
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
+| `okf` | `boolean \| DocsOkfConfig` | Publish OKF v0.2 trust metadata in Markdown, search, MCP, doctor, and Static Agent Bundles |
 | `compact` | `DocsAgentCompactConfig` | Defaults for `docs agent compact` |
 | `evaluations` | `boolean \| DocsAgentEvaluationsConfig` | Offline-by-default golden tasks used by `docs doctor` and `docs review` |
 | `skills` | `DocsAgentSkillsInput` | Project or workspace skills published by the runtime, Static Agent Bundle, and MCP |
 | `a2a` | `DocsAgentA2AConfig` | Opt-in Agent Card metadata for a real A2A interface |
+
+### `agent.okf` and `DocsOkfConfig`
+
+OKF metadata makes provenance and freshness explicit for machine readers. `agent.okf: true` derives
+conservative defaults; an object can provide corpus defaults and a staleness policy.
+
+```ts title="docs.config.ts"
+agent: {
+  okf: {
+    generatedBy: "software:docs-build",
+    staleAfterDays: 90,
+    verified: [{ by: "human:docs-team", at: "2026-08-01" }],
+  },
+},
+```
+
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `enabled` | `boolean` | `true` inside the object | Enable OKF projection |
+| `route` | `string` | `"/.well-known/okf.json"` | Static knowledge-bundle route |
+| `generatedBy` | `string` | `"software:@farming-labs/docs"` | Generator actor for derived records |
+| `staleAfterDays` | `number` | — | Derive `stale_after` from the best page timestamp |
+| `sources` | `DocsOkfSource[]` | derived per page | Default source provenance |
+| `generated` | `{ by, at }` | derived | Explicit generation record |
+| `verified` | `{ by, at }[]` | `[]` | Verification records; a `human:` actor produces `human-reviewed` trust |
+| `status` | `"draft" \| "stable" \| "deprecated"` | `"stable"` | Knowledge lifecycle status |
+| `stale_after` | `string` | derived when configured | Explicit expiry date |
+
+Pages can override these fields with `okf` frontmatter. `docs agent export --public` writes the
+JSON bundle, Markdown frontmatter carries the resolved trust object, local search results expose a
+`trust` field, MCP adds `get_trust_metadata`, and `docs doctor --agent` reports expired pages.
 ### `agent.contentChanges` and `DocsAgentContentChangesConfig`
 
 Body-free runtime document synchronization feed. Enabled by default on server-rendered adapters; always disabled (`false`) in static bundles produced by `docs agent export`.
@@ -1536,6 +1568,7 @@ deployed elsewhere and already exposes an `openapi.json`.
 | `specUrl`   | `string`   | —                 | Absolute URL to a hosted OpenAPI JSON document. When set, local route scanning is skipped |
 | `routeRoot` | `string`   | `"api"`           | Filesystem route root to scan. Bare values like `"api"` resolve inside `app/` or `src/app/`; full values like `"app/internal-api"` and `"src/app/v2/api"` are supported |
 | `exclude`   | `string[]` | `[]`              | Route entries to omit from the generated reference. Accepts URL-style paths like `"/api/hello"` or route-root-relative values like `"hello"` / `"hello/route.ts"` |
+| `mcp`       | `boolean \| DocsOpenApiMcpConfig` | `false` | Deny-by-default projection of selected OpenAPI operations into MCP tools |
 
 ```ts title="docs.config.ts"
 apiReference: {
@@ -1556,6 +1589,20 @@ apiReference: {
 
 When `specUrl` is set, `routeRoot` and `exclude` are ignored and the API reference is rendered
 from the hosted spec instead.
+
+### `DocsOpenApiMcpConfig`
+
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `operations` | `readonly string[]` | `[]` | Allowed `operationId` or `METHOD /path` selectors |
+| `baseUrl` | `string` | first OpenAPI server | API origin used for operation requests |
+| `allowMutations` | `boolean` | `false` | Permit allowlisted POST, PUT, PATCH, and DELETE operations |
+| `headers` | `Record<string, string> \| callback` | — | Server-owned credentials resolved for each operation |
+| `timeoutMs` | `number` | `10000` | Request timeout |
+
+An operation can also opt in with `x-farming-labs-mcp: true`. Security requirements and only the
+referenced `components.securitySchemes` are included in the tool metadata. Credentials remain
+server-owned and are applied after parsed tool parameters.
 
 This does not remove the framework route requirement on non-Next adapters. TanStack Start,
 SvelteKit, Astro, and Nuxt still need their `/{path}` handler files so the docs app has a route


### PR DESCRIPTION
Superseded by #463 after the source branch was renamed to remove internal planning labels.