### PR TITLE
feat: harden OpenAPI MCP egress

### DIFF
--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -578,6 +578,7 @@ describe("P1 trust and OpenAPI tools", () => {
           enabled: true,
           operations: ["getUser"],
           headers: { Authorization: "Bearer server-secret" },
+          resolveHost: async () => ["93.184.216.34"],
         },
         document: {
           openapi: "3.1.0",

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -99,7 +99,13 @@ import {
   normalizeDocsOkfTrustMetadataInput,
   resolveDocsOkfConfig,
 } from "./okf.js";
-import { resolveDocsOpenApiMcpBaseUrl, resolveDocsOpenApiMcpOperations } from "./openapi-mcp.js";
+import {
+  acquireDocsOpenApiMcpBudget,
+  readDocsOpenApiMcpResponse,
+  resolveDocsOpenApiMcpBaseUrl,
+  resolveDocsOpenApiMcpOperations,
+  validateDocsOpenApiMcpUrl,
+} from "./openapi-mcp.js";
 import type { DocsPublishedAgentSkill } from "./standards-discovery.js";
 import {
   isDocsMcpProtectedResourceMetadataPath,
@@ -3381,6 +3387,7 @@ const openApiOperationOutputSchema = z.object({
   status: z.number().int(),
   ok: z.boolean(),
   contentType: z.string().optional(),
+  responseTruncated: z.boolean().optional(),
   body: z.unknown(),
 });
 const readPagesOutputSchema = z.object({
@@ -4575,10 +4582,12 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
           `${baseUrl.replace(/\/+$/u, "")}/`,
         );
         for (const [name, value] of query) requestUrl.searchParams.append(name, value);
-        if (requestUrl.protocol !== "https:" && requestUrl.protocol !== "http:") {
+        try {
+          await validateDocsOpenApiMcpUrl(requestUrl, openapiConfig);
+        } catch (error) {
           throw new ProtocolError(
             ProtocolErrorCode.InvalidParams,
-            "OpenAPI MCP server URLs must use HTTP or HTTPS.",
+            error instanceof Error ? error.message : "OpenAPI MCP destination was blocked.",
           );
         }
         const configuredHeaders =
@@ -4602,17 +4611,48 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         if (body !== undefined) requestHeaders.set("Content-Type", "application/json");
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), openapiConfig.timeoutMs ?? 10_000);
+        const budgetKey = `${options.requestContext?.auth?.id ?? "anonymous"}:${operation.operationId}`;
+        let releaseBudget: (() => void) | undefined;
         try {
-          const response = await fetch(requestUrl, {
-            method: operation.method,
-            headers: requestHeaders,
-            ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-            signal: controller.signal,
-          });
+          releaseBudget = acquireDocsOpenApiMcpBudget(budgetKey, openapiConfig);
+          let response: Response | undefined;
+          let destination = requestUrl;
+          const maxRedirects = Math.max(0, openapiConfig.maxRedirects ?? 0);
+          for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+            response = await fetch(destination, {
+              method: operation.method,
+              headers: requestHeaders,
+              ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+              redirect: "manual",
+              signal: controller.signal,
+            });
+            if (![301, 302, 303, 307, 308].includes(response.status)) break;
+            const location = response.headers.get("location");
+            if (!location || redirectCount >= maxRedirects) {
+              throw new ProtocolError(
+                ProtocolErrorCode.InvalidRequest,
+                "OpenAPI MCP redirect blocked. Increase maxRedirects to follow validated redirects.",
+              );
+            }
+            destination = new URL(location, destination);
+            try {
+              await validateDocsOpenApiMcpUrl(destination, openapiConfig);
+            } catch (error) {
+              throw new ProtocolError(
+                ProtocolErrorCode.InvalidRequest,
+                error instanceof Error ? error.message : "OpenAPI MCP redirect was blocked.",
+              );
+            }
+          }
+          if (!response)
+            throw new ProtocolError(ProtocolErrorCode.InternalError, "No API response.");
           const contentType = response.headers.get("content-type") ?? undefined;
-          const text = (await response.text()).slice(0, 1_000_000);
+          const { text, truncated } = await readDocsOpenApiMcpResponse(
+            response,
+            openapiConfig.maxResponseBytes,
+          );
           let responseBody: unknown = text;
-          if (contentType?.includes("json") && text) {
+          if (contentType?.includes("json") && text && !truncated) {
             try {
               responseBody = JSON.parse(text);
             } catch {
@@ -4624,6 +4664,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             status: response.status,
             ok: response.ok,
             ...(contentType ? { contentType } : {}),
+            ...(truncated ? { responseTruncated: true } : {}),
             body: responseBody,
           };
           trackMcpTool(operation.toolName, { resultCount: 1 });
@@ -4632,6 +4673,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
             ...(response.ok ? {} : { isError: true }),
           };
         } finally {
+          releaseBudget?.();
           clearTimeout(timeout);
         }
       },

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -104,8 +104,8 @@ import {
   readDocsOpenApiMcpResponse,
   resolveDocsOpenApiMcpBaseUrl,
   resolveDocsOpenApiMcpOperations,
-  validateDocsOpenApiMcpUrl,
 } from "./openapi-mcp.js";
+import { validateDocsOpenApiMcpUrl } from "./openapi-mcp-node.js";
 import type { DocsPublishedAgentSkill } from "./standards-discovery.js";
 import {
   isDocsMcpProtectedResourceMetadataPath,

--- a/packages/docs/src/openapi-mcp-node.ts
+++ b/packages/docs/src/openapi-mcp-node.ts
@@ -1,0 +1,77 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import type { DocsOpenApiMcpConfig } from "./types.js";
+
+function isPrivateIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) return true;
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && (b === 0 || b === 168)) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+export function isDocsOpenApiMcpPrivateAddress(address: string): boolean {
+  const normalized = address
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/gu, "");
+  const family = isIP(normalized);
+  if (family === 4) return isPrivateIpv4(normalized);
+  if (family !== 6) return true;
+  const mappedIpv4 = normalized.match(/^(?:::ffff:)(\d+\.\d+\.\d+\.\d+)$/u)?.[1];
+  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
+  return (
+    normalized === "::" ||
+    normalized === "::1" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    /^fe[89ab]/u.test(normalized) ||
+    normalized.startsWith("ff")
+  );
+}
+
+async function defaultResolveHost(hostname: string): Promise<readonly string[]> {
+  if (isIP(hostname)) return [hostname];
+  return (await lookup(hostname, { all: true, verbatim: true })).map((entry) => entry.address);
+}
+
+export async function validateDocsOpenApiMcpUrl(
+  url: URL,
+  config: DocsOpenApiMcpConfig,
+): Promise<void> {
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && config.allowInsecureHttp)) {
+    throw new Error("OpenAPI MCP destinations must use HTTPS unless allowInsecureHttp is enabled.");
+  }
+  if (url.username || url.password) {
+    throw new Error("OpenAPI MCP destinations cannot contain URL credentials.");
+  }
+  if (config.allowPrivateNetwork) return;
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/gu, "");
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname === "metadata.google.internal"
+  ) {
+    throw new Error(`OpenAPI MCP blocked private destination: ${hostname}`);
+  }
+  let addresses: readonly string[];
+  try {
+    addresses = await (config.resolveHost ?? defaultResolveHost)(hostname);
+  } catch {
+    throw new Error(`OpenAPI MCP could not safely resolve destination: ${hostname}`);
+  }
+  if (addresses.length === 0 || addresses.some(isDocsOpenApiMcpPrivateAddress)) {
+    throw new Error(`OpenAPI MCP blocked private or unresolved destination: ${hostname}`);
+  }
+}

--- a/packages/docs/src/openapi-mcp.test.ts
+++ b/packages/docs/src/openapi-mcp.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   acquireDocsOpenApiMcpBudget,
-  isDocsOpenApiMcpPrivateAddress,
   readDocsOpenApiMcpResponse,
   resolveDocsOpenApiMcpBaseUrl,
   resolveDocsOpenApiMcpOperations,
-  validateDocsOpenApiMcpUrl,
 } from "./openapi-mcp.js";
+import { isDocsOpenApiMcpPrivateAddress, validateDocsOpenApiMcpUrl } from "./openapi-mcp-node.js";
 
 const document = {
   openapi: "3.1.0",

--- a/packages/docs/src/openapi-mcp.test.ts
+++ b/packages/docs/src/openapi-mcp.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { resolveDocsOpenApiMcpBaseUrl, resolveDocsOpenApiMcpOperations } from "./openapi-mcp.js";
+import {
+  acquireDocsOpenApiMcpBudget,
+  isDocsOpenApiMcpPrivateAddress,
+  readDocsOpenApiMcpResponse,
+  resolveDocsOpenApiMcpBaseUrl,
+  resolveDocsOpenApiMcpOperations,
+  validateDocsOpenApiMcpUrl,
+} from "./openapi-mcp.js";
 
 const document = {
   openapi: "3.1.0",
@@ -85,5 +92,56 @@ describe("OpenAPI MCP projection", () => {
       resolveDocsOpenApiMcpBaseUrl(document, { baseUrl: "https://override.example.com" }),
     ).toBe("https://override.example.com");
     expect(resolveDocsOpenApiMcpBaseUrl(document, {})).toBe("https://api.example.com/v1");
+  });
+
+  it("blocks private destinations and insecure HTTP by default", async () => {
+    await expect(
+      validateDocsOpenApiMcpUrl(new URL("https://api.example.com"), {
+        resolveHost: async () => ["127.0.0.1"],
+      }),
+    ).rejects.toThrow("private");
+    await expect(validateDocsOpenApiMcpUrl(new URL("http://93.184.216.34"), {})).rejects.toThrow(
+      "HTTPS",
+    );
+    expect(isDocsOpenApiMcpPrivateAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isDocsOpenApiMcpPrivateAddress("93.184.216.34")).toBe(false);
+  });
+
+  it("validates public destinations with a server-owned resolver", async () => {
+    await expect(
+      validateDocsOpenApiMcpUrl(new URL("https://api.example.com"), {
+        resolveHost: async () => ["93.184.216.34"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("caps streamed response bodies before buffering the full payload", async () => {
+    const result = await readDocsOpenApiMcpResponse(new Response("abcdefghij"), 5);
+    expect(result).toEqual({ text: "abcde", truncated: true });
+  });
+
+  it("enforces per-principal rate and concurrency budgets", () => {
+    const first = acquireDocsOpenApiMcpBudget("test:getUser", {
+      requestsPerMinute: 2,
+      maxConcurrentRequests: 1,
+    });
+    expect(() =>
+      acquireDocsOpenApiMcpBudget("test:getUser", {
+        requestsPerMinute: 2,
+        maxConcurrentRequests: 1,
+      }),
+    ).toThrow("concurrency");
+    first();
+    const second = acquireDocsOpenApiMcpBudget("test:getUser", {
+      requestsPerMinute: 2,
+      maxConcurrentRequests: 1,
+    });
+    second();
+    expect(() =>
+      acquireDocsOpenApiMcpBudget("test:getUser", {
+        requestsPerMinute: 2,
+        maxConcurrentRequests: 1,
+      }),
+    ).toThrow("rate limit");
   });
 });

--- a/packages/docs/src/openapi-mcp.ts
+++ b/packages/docs/src/openapi-mcp.ts
@@ -1,6 +1,149 @@
 import type { DocsOpenApiMcpConfig } from "./types.js";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+const OPENAPI_RATE_WINDOW_MS = 60_000;
+const openApiRateWindows = new Map<string, { startedAt: number; count: number; active: number }>();
+
+function isPrivateIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) return true;
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && (b === 0 || b === 168)) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+export function isDocsOpenApiMcpPrivateAddress(address: string): boolean {
+  const normalized = address
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/gu, "");
+  const family = isIP(normalized);
+  if (family === 4) return isPrivateIpv4(normalized);
+  if (family !== 6) return true;
+  const mappedIpv4 = normalized.match(/^(?:::ffff:)(\d+\.\d+\.\d+\.\d+)$/u)?.[1];
+  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
+  return (
+    normalized === "::" ||
+    normalized === "::1" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    /^fe[89ab]/u.test(normalized) ||
+    normalized.startsWith("ff")
+  );
+}
+
+async function defaultResolveHost(hostname: string): Promise<readonly string[]> {
+  if (isIP(hostname)) return [hostname];
+  return (await lookup(hostname, { all: true, verbatim: true })).map((entry) => entry.address);
+}
+
+export async function validateDocsOpenApiMcpUrl(
+  url: URL,
+  config: DocsOpenApiMcpConfig,
+): Promise<void> {
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && config.allowInsecureHttp)) {
+    throw new Error("OpenAPI MCP destinations must use HTTPS unless allowInsecureHttp is enabled.");
+  }
+  if (url.username || url.password) {
+    throw new Error("OpenAPI MCP destinations cannot contain URL credentials.");
+  }
+  if (config.allowPrivateNetwork) return;
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/gu, "");
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname === "metadata.google.internal"
+  ) {
+    throw new Error(`OpenAPI MCP blocked private destination: ${hostname}`);
+  }
+  let addresses: readonly string[];
+  try {
+    addresses = await (config.resolveHost ?? defaultResolveHost)(hostname);
+  } catch {
+    throw new Error(`OpenAPI MCP could not safely resolve destination: ${hostname}`);
+  }
+  if (addresses.length === 0 || addresses.some(isDocsOpenApiMcpPrivateAddress)) {
+    throw new Error(`OpenAPI MCP blocked private or unresolved destination: ${hostname}`);
+  }
+}
+
+export function acquireDocsOpenApiMcpBudget(
+  key: string,
+  config: DocsOpenApiMcpConfig,
+  now = Date.now(),
+): () => void {
+  const requestsPerMinute = Math.max(1, config.requestsPerMinute ?? 60);
+  const maxConcurrentRequests = Math.max(1, config.maxConcurrentRequests ?? 4);
+  let window = openApiRateWindows.get(key);
+  if (!window || now - window.startedAt >= OPENAPI_RATE_WINDOW_MS) {
+    window = { startedAt: now, count: 0, active: window?.active ?? 0 };
+    openApiRateWindows.set(key, window);
+  }
+  if (window.count >= requestsPerMinute) {
+    throw new Error("OpenAPI MCP rate limit exceeded for this principal and operation.");
+  }
+  if (window.active >= maxConcurrentRequests) {
+    throw new Error("OpenAPI MCP concurrency limit exceeded for this principal and operation.");
+  }
+  window.count += 1;
+  window.active += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    window.active = Math.max(0, window.active - 1);
+  };
+}
+
+export async function readDocsOpenApiMcpResponse(
+  response: Response,
+  maxBytes = 1_000_000,
+): Promise<{ text: string; truncated: boolean }> {
+  const limit = Math.max(1, maxBytes);
+  if (!response.body) return { text: "", truncated: false };
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let used = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (used + value.byteLength > limit) {
+        const remaining = limit - used;
+        if (remaining > 0) chunks.push(value.subarray(0, remaining));
+        used = limit;
+        truncated = true;
+        await reader.cancel("OpenAPI MCP response byte limit reached");
+        break;
+      }
+      chunks.push(value);
+      used += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(used);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { text: new TextDecoder().decode(bytes), truncated };
+}
 
 export interface DocsOpenApiMcpParameter {
   name: string;

--- a/packages/docs/src/openapi-mcp.ts
+++ b/packages/docs/src/openapi-mcp.ts
@@ -1,84 +1,8 @@
 import type { DocsOpenApiMcpConfig } from "./types.js";
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 
 const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
 const OPENAPI_RATE_WINDOW_MS = 60_000;
 const openApiRateWindows = new Map<string, { startedAt: number; count: number; active: number }>();
-
-function isPrivateIpv4(address: string): boolean {
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) return true;
-  const [a, b] = octets;
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && (b === 0 || b === 168)) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    a >= 224
-  );
-}
-
-export function isDocsOpenApiMcpPrivateAddress(address: string): boolean {
-  const normalized = address
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/gu, "");
-  const family = isIP(normalized);
-  if (family === 4) return isPrivateIpv4(normalized);
-  if (family !== 6) return true;
-  const mappedIpv4 = normalized.match(/^(?:::ffff:)(\d+\.\d+\.\d+\.\d+)$/u)?.[1];
-  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
-  return (
-    normalized === "::" ||
-    normalized === "::1" ||
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd") ||
-    /^fe[89ab]/u.test(normalized) ||
-    normalized.startsWith("ff")
-  );
-}
-
-async function defaultResolveHost(hostname: string): Promise<readonly string[]> {
-  if (isIP(hostname)) return [hostname];
-  return (await lookup(hostname, { all: true, verbatim: true })).map((entry) => entry.address);
-}
-
-export async function validateDocsOpenApiMcpUrl(
-  url: URL,
-  config: DocsOpenApiMcpConfig,
-): Promise<void> {
-  if (url.protocol !== "https:" && !(url.protocol === "http:" && config.allowInsecureHttp)) {
-    throw new Error("OpenAPI MCP destinations must use HTTPS unless allowInsecureHttp is enabled.");
-  }
-  if (url.username || url.password) {
-    throw new Error("OpenAPI MCP destinations cannot contain URL credentials.");
-  }
-  if (config.allowPrivateNetwork) return;
-  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/gu, "");
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname.endsWith(".local") ||
-    hostname.endsWith(".internal") ||
-    hostname === "metadata.google.internal"
-  ) {
-    throw new Error(`OpenAPI MCP blocked private destination: ${hostname}`);
-  }
-  let addresses: readonly string[];
-  try {
-    addresses = await (config.resolveHost ?? defaultResolveHost)(hostname);
-  } catch {
-    throw new Error(`OpenAPI MCP could not safely resolve destination: ${hostname}`);
-  }
-  if (addresses.length === 0 || addresses.some(isDocsOpenApiMcpPrivateAddress)) {
-    throw new Error(`OpenAPI MCP blocked private or unresolved destination: ${hostname}`);
-  }
-}
 
 export function acquireDocsOpenApiMcpBudget(
   key: string,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -3072,6 +3072,10 @@ export type DocsOpenApiMcpHeaders =
       context: DocsOpenApiMcpCredentialContext,
     ) => Readonly<Record<string, string>> | Promise<Readonly<Record<string, string>>>);
 
+export type DocsOpenApiMcpHostResolver = (
+  hostname: string,
+) => readonly string[] | Promise<readonly string[]>;
+
 /** Explicit, deny-by-default projection of OpenAPI operations into MCP tools. */
 export interface DocsOpenApiMcpConfig {
   /** Enable operation projection. No tools are exposed until an operation is explicitly allowed. */
@@ -3086,6 +3090,20 @@ export interface DocsOpenApiMcpConfig {
   headers?: DocsOpenApiMcpHeaders;
   /** Per-operation request timeout. @default 10000 */
   timeoutMs?: number;
+  /** Permit plain HTTP destinations. Disabled by default. */
+  allowInsecureHttp?: boolean;
+  /** Permit loopback, private, link-local, and reserved network destinations. Disabled by default. */
+  allowPrivateNetwork?: boolean;
+  /** Server-owned DNS resolver used before every request and redirect. */
+  resolveHost?: DocsOpenApiMcpHostResolver;
+  /** Number of validated redirects to follow. @default 0 */
+  maxRedirects?: number;
+  /** Maximum downstream response bytes buffered into an MCP result. @default 1000000 */
+  maxResponseBytes?: number;
+  /** Per-principal operation calls allowed in a rolling minute. @default 60 */
+  requestsPerMinute?: number;
+  /** Concurrent downstream operation calls allowed per principal. @default 4 */
+  maxConcurrentRequests?: number;
 }
 
 export interface ApiReferenceConfig {

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1618,10 +1618,22 @@ from the hosted spec instead.
 | `allowMutations` | `boolean` | `false` | Permit allowlisted POST, PUT, PATCH, and DELETE operations |
 | `headers` | `Record<string, string> \| callback` | — | Server-owned credentials resolved for each operation |
 | `timeoutMs` | `number` | `10000` | Request timeout |
+| `allowInsecureHttp` | `boolean` | `false` | Permit plain HTTP destinations for explicitly trusted development environments |
+| `allowPrivateNetwork` | `boolean` | `false` | Permit loopback, private, link-local, and reserved destinations |
+| `resolveHost` | `callback` | Node DNS | Server-owned DNS resolver used to validate every destination |
+| `maxRedirects` | `number` | `0` | Validated redirects to follow; redirects are blocked by default |
+| `maxResponseBytes` | `number` | `1000000` | Maximum response bytes read into an MCP result |
+| `requestsPerMinute` | `number` | `60` | Per-principal, per-operation request budget |
+| `maxConcurrentRequests` | `number` | `4` | Per-principal, per-operation concurrency budget |
 
 An operation can also opt in with `x-farming-labs-mcp: true`. Security requirements and only the
 referenced `components.securitySchemes` are included in the tool metadata. Credentials remain
 server-owned and are applied after parsed tool parameters.
+
+Every request and redirect is DNS-checked before egress. HTTPS, public-network destinations,
+bounded response streaming, rate limits, and concurrency limits are enforced by default. Development
+servers on private networks must opt in explicitly; never enable those exceptions for untrusted
+OpenAPI documents or model-supplied destinations.
 
 This does not remove the framework route requirement on non-Next adapters. TanStack Start,
 SvelteKit, Astro, and Nuxt still need their `/{path}` handler files so the docs app has a route


### PR DESCRIPTION
## What changed

- validates every OpenAPI MCP destination and redirect through DNS before egress
- requires HTTPS and blocks private, loopback, link-local, reserved, and metadata destinations by default
- disables redirects by default and validates each opted-in redirect
- streams downstream responses with a configurable byte cap
- adds per-principal operation rate and concurrency budgets
- documents the new security controls and development-only escape hatches

## Why

Generated OpenAPI tools previously accepted the configured or advertised server URL, followed redirects automatically, and buffered the complete response before slicing it. That left avoidable SSRF, redirect, and memory-pressure risk at the MCP trust boundary.

## Impact

Existing public HTTPS API integrations continue to work. Private-network or plain-HTTP development APIs must now opt in explicitly. Redirects must also be enabled explicitly.

## Validation

- pnpm --filter @farming-labs/docs typecheck
- pnpm --filter @farming-labs/docs exec vitest run src/openapi-mcp.test.ts src/mcp.test.ts
- 90 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened OpenAPI MCP egress to prevent SSRF, unsafe redirects, and memory pressure. Adds isolated DNS checks, strict HTTPS defaults, credential blocking, and per-principal budgets while keeping public HTTPS APIs working.

- New Features
  - DNS-validate every destination and redirect; block loopback, private, link‑local, reserved, and metadata hosts by default; require HTTPS; reject URL credentials.
  - Opt-ins: `allowInsecureHttp`, `allowPrivateNetwork`, `resolveHost`, and `maxRedirects` (redirects are blocked by default).
  - Stream responses with `maxResponseBytes`; set `responseTruncated` when capped; skip JSON parse if truncated.
  - Per-principal limits via `requestsPerMinute` and `maxConcurrentRequests`.
  - Docs updated with the new security controls and escape hatches.

- Migration
  - Public HTTPS APIs work without changes.
  - For private-network or plain-HTTP dev services, enable `allowPrivateNetwork` and/or `allowInsecureHttp`.
  - To follow redirects, set `maxRedirects`; each redirect is validated before egress.

<sup>Written for commit b56ebf6d69cfd287177117d6ea7ab013a309507d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

