### PR TITLE
feat: polish agent discovery surfaces

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -36,6 +36,7 @@ import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
@@ -1123,27 +1124,26 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const content = `${JSON.stringify(
-        buildDocsAgentDiscoverySpec({
-          ...discoveryOptions,
-          publishedSkills: [
-            await resolveDocsPublishedAgentSkill({
-              preferredDocument: readRootSkillDocument(preloaded, rootDir),
-              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-            }),
-            ...(await getPublishedAgentSkills()),
-          ],
-          agentCard: config.agent?.a2a,
-        }),
-        null,
-        2,
-      )}\n`;
+      const fullSpec = buildDocsAgentDiscoverySpec({
+        ...discoveryOptions,
+        publishedSkills: [
+          await resolveDocsPublishedAgentSkill({
+            preferredDocument: readRootSkillDocument(preloaded, rootDir),
+            fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+          }),
+          ...(await getPublishedAgentSkills()),
+        ],
+        agentCard: config.agent?.a2a,
+      });
+      const compact = url.searchParams.get("profile") === "compact";
+      const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+      const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
       return createDocsCacheableResponse({
         request: context.request,
         content,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
           "X-Robots-Tag": "noindex",
           Link: agentManifestLinkHeader,
         },

--- a/packages/docs/src/agent-manifest-schema.test.ts
+++ b/packages/docs/src/agent-manifest-schema.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
-import { buildDocsAgentDiscoverySpec } from "./agent.js";
+import { buildDocsAgentDiscoverySpec, compactDocsAgentDiscoverySpec } from "./agent.js";
 import { exportAgentBundle } from "./cli/agent-export.js";
 import { resolveDocsMcpConfig } from "./mcp.js";
 
@@ -95,6 +95,45 @@ describe("Farming Labs agent manifest schema", () => {
     });
     expect(manifest.api).not.toHaveProperty("agentCard");
     expectValid(manifest);
+  });
+
+  it("publishes a compact first-hop profile without skill file inventories", () => {
+    const full = buildManifest({
+      publishedSkills: [
+        {
+          name: "example",
+          description: "Example skill",
+          type: "skill-md",
+          url: "/.well-known/agent-skills/example/SKILL.md",
+          digest: `sha256:${"a".repeat(64)}`,
+          content: "# Example",
+          sha256: "a".repeat(64),
+          skillDocument: "# Example",
+          files: [
+            {
+              path: "references/setup.md",
+              url: "/.well-known/agent-skills/example/references/setup.md",
+              mediaType: "text/markdown; charset=utf-8",
+              content: "# Setup",
+              sha256: "b".repeat(64),
+              digest: `sha256:${"b".repeat(64)}`,
+            },
+          ],
+        },
+      ],
+    });
+    const compact = compactDocsAgentDiscoverySpec(full);
+
+    expect(compact).toMatchObject({
+      profile: "compact",
+      profiles: {
+        full: "/.well-known/agent.json",
+        compact: "/.well-known/agent.json?profile=compact",
+      },
+      skills: { published: [{ name: "example", fileCount: 1, files: [] }] },
+    });
+    expect(JSON.stringify(compact).length).toBeLessThan(JSON.stringify(full).length);
+    expectValid(compact);
   });
 
   it("keeps the published v1 schema immutable and valid for v1 manifests", () => {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -4363,6 +4363,12 @@ export function buildDocsAgentDiscoverySpec({
     format: DOCS_AGENT_MANIFEST_FORMAT,
     version: DOCS_AGENT_MANIFEST_VERSION,
     name: "@farming-labs/docs",
+    profile: "full",
+    profiles: {
+      default: "full",
+      full: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
+      compact: `${DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE}?profile=compact`,
+    },
     baseUrl: origin,
     site: {
       title: llms?.siteTitle ?? "Documentation",
@@ -4684,6 +4690,26 @@ export function buildDocsAgentDiscoverySpec({
       doNotAssumeFeedbackPayloadShape: true,
     },
   };
+}
+
+/** Remove first-hop file inventories while retaining every discovery route and capability. */
+export function compactDocsAgentDiscoverySpec<
+  T extends {
+    skills: { published: Array<Record<string, unknown> & { files: readonly unknown[] }> };
+  },
+>(spec: T): T {
+  return {
+    ...spec,
+    profile: "compact",
+    skills: {
+      ...spec.skills,
+      published: spec.skills.published.map((skill) => ({
+        ...skill,
+        fileCount: skill.files.length,
+        files: [],
+      })),
+    },
+  } as T;
 }
 
 export function acceptsDocsMarkdown(request: Request): boolean {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -171,6 +171,7 @@ export {
   DOCS_MARKDOWN_SIGNATURE_AGENT_HEADER,
   DOCS_TRADITIONAL_BOT_USER_AGENT_HEADER_PATTERN,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsAgentSkillsIndex,
   buildDocsLegacySkillsIndex,
   buildDocsA2AAgentCard,

--- a/packages/farmjs/src/server.ts
+++ b/packages/farmjs/src/server.ts
@@ -9,6 +9,7 @@ import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
@@ -1272,27 +1273,26 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const content = `${JSON.stringify(
-        buildDocsAgentDiscoverySpec({
-          ...discoveryOptions,
-          publishedSkills: [
-            await resolveDocsPublishedAgentSkill({
-              preferredDocument: readRootSkillDocument(preloaded, rootDir),
-              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-            }),
-            ...(await getPublishedAgentSkills()),
-          ],
-          agentCard: config.agent?.a2a,
-        }),
-        null,
-        2,
-      )}\n`;
+      const fullSpec = buildDocsAgentDiscoverySpec({
+        ...discoveryOptions,
+        publishedSkills: [
+          await resolveDocsPublishedAgentSkill({
+            preferredDocument: readRootSkillDocument(preloaded, rootDir),
+            fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+          }),
+          ...(await getPublishedAgentSkills()),
+        ],
+        agentCard: config.agent?.a2a,
+      });
+      const compact = url.searchParams.get("profile") === "compact";
+      const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+      const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
       return createDocsCacheableResponse({
         request: event.request,
         content,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
           "X-Robots-Tag": "noindex",
           Link: agentManifestLinkHeader,
         },

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -4018,6 +4018,20 @@ description: "Start building quickly"
       doNotAssumeFeedbackPayloadShape: true,
     });
 
+    const compactResponse = await GET(
+      new Request("http://localhost/.well-known/agent.json?profile=compact"),
+    );
+    const compactText = await compactResponse.text();
+    const compactSpec = JSON.parse(compactText) as {
+      profile: string;
+      skills: { published: Array<{ fileCount: number; files: unknown[] }> };
+    };
+    expect(compactResponse.headers.get("cache-control")).toContain("stale-while-revalidate=86400");
+    expect(compactText).not.toContain("\n  ");
+    expect(compactText.length).toBeLessThan(JSON.stringify(spec, null, 2).length);
+    expect(compactSpec.profile).toBe("compact");
+    expect(compactSpec.skills.published[0]).toMatchObject({ fileCount: 1, files: [] });
+
     for (const path of ["/.well-known/agent", "/.well-known/agent.json"]) {
       const wellKnownResponse = await GET(new Request(`http://localhost${path}`));
       expect(wellKnownResponse.status).toBe(200);

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -116,6 +116,7 @@ import {
 import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
+  compactDocsAgentDiscoverySpec,
   formatDocsAskAIPackageHints,
   performDocsSearch,
   performDocsSearchWithMetadata,
@@ -536,6 +537,12 @@ function buildAgentSpec({
     format: DOCS_AGENT_MANIFEST_FORMAT,
     version: DOCS_AGENT_MANIFEST_VERSION,
     name: "@farming-labs/docs",
+    profile: "full",
+    profiles: {
+      default: "full",
+      full: DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE,
+      compact: `${DEFAULT_AGENT_SPEC_WELL_KNOWN_JSON_ROUTE}?profile=compact`,
+    },
     baseUrl: origin,
     site: {
       title: llms.siteTitle ?? "Documentation",
@@ -4390,39 +4397,38 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             method: requestMethod,
           },
         });
-        const content = `${JSON.stringify(
-          buildAgentSpec({
-            origin: url.origin,
-            entry,
-            apiRoute: requestApiRoute,
-            apiCatalog: apiCatalogEnabled,
-            i18n,
-            search: searchConfig,
-            contentChanges: contentChangesConfig.enabled,
-            mcp: mcpConfig,
-            feedback: agentFeedbackConfig,
-            llms: llmsConfig,
-            sitemap: sitemapConfig,
-            robots: robotsConfig,
-            openapi: openapiDiscovery,
-            publishedSkills: [
-              await resolveDocsPublishedAgentSkill({
-                preferredDocument: readRootSkillDocument(),
-                fallbackDocument: getGeneratedSkillDocument(url.origin, requestApiRoute),
-              }),
-              ...(await getPublishedAgentSkills()),
-            ],
-            agentCard: options?.agent?.a2a,
-          }),
-          null,
-          2,
-        )}\n`;
+        const fullSpec = buildAgentSpec({
+          origin: url.origin,
+          entry,
+          apiRoute: requestApiRoute,
+          apiCatalog: apiCatalogEnabled,
+          i18n,
+          search: searchConfig,
+          contentChanges: contentChangesConfig.enabled,
+          mcp: mcpConfig,
+          feedback: agentFeedbackConfig,
+          llms: llmsConfig,
+          sitemap: sitemapConfig,
+          robots: robotsConfig,
+          openapi: openapiDiscovery,
+          publishedSkills: [
+            await resolveDocsPublishedAgentSkill({
+              preferredDocument: readRootSkillDocument(),
+              fallbackDocument: getGeneratedSkillDocument(url.origin, requestApiRoute),
+            }),
+            ...(await getPublishedAgentSkills()),
+          ],
+          agentCard: options?.agent?.a2a,
+        });
+        const compact = url.searchParams.get("profile") === "compact";
+        const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+        const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
         return createDocsCacheableResponse({
           request,
           content,
           headers: {
             "Content-Type": "application/json; charset=utf-8",
-            "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
             Link: agentManifestLinkHeader,
             "X-Robots-Tag": "noindex",
           },

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -23,6 +23,7 @@ import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
@@ -1113,27 +1114,26 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const content = `${JSON.stringify(
-        buildDocsAgentDiscoverySpec({
-          ...discoveryOptions,
-          publishedSkills: [
-            await resolveDocsPublishedAgentSkill({
-              preferredDocument: readRootSkillDocument(preloaded, rootDir),
-              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-            }),
-            ...(await getPublishedAgentSkills()),
-          ],
-          agentCard: config.agent?.a2a,
-        }),
-        null,
-        2,
-      )}\n`;
+      const fullSpec = buildDocsAgentDiscoverySpec({
+        ...discoveryOptions,
+        publishedSkills: [
+          await resolveDocsPublishedAgentSkill({
+            preferredDocument: readRootSkillDocument(preloaded, rootDir),
+            fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+          }),
+          ...(await getPublishedAgentSkills()),
+        ],
+        agentCard: config.agent?.a2a,
+      });
+      const compact = url.searchParams.get("profile") === "compact";
+      const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+      const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
       return createDocsCacheableResponse({
         request: context.request,
         content,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
           "X-Robots-Tag": "noindex",
           Link: agentManifestLinkHeader,
         },

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -36,6 +36,7 @@ import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
@@ -1135,27 +1136,26 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(event.url, { apiRoute: discoveryApiRoute })) {
-      const content = `${JSON.stringify(
-        buildDocsAgentDiscoverySpec({
-          ...discoveryOptions,
-          publishedSkills: [
-            await resolveDocsPublishedAgentSkill({
-              preferredDocument: readRootSkillDocument(preloaded, rootDir),
-              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-            }),
-            ...(await getPublishedAgentSkills()),
-          ],
-          agentCard: config.agent?.a2a,
-        }),
-        null,
-        2,
-      )}\n`;
+      const fullSpec = buildDocsAgentDiscoverySpec({
+        ...discoveryOptions,
+        publishedSkills: [
+          await resolveDocsPublishedAgentSkill({
+            preferredDocument: readRootSkillDocument(preloaded, rootDir),
+            fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+          }),
+          ...(await getPublishedAgentSkills()),
+        ],
+        agentCard: config.agent?.a2a,
+      });
+      const compact = event.url.searchParams.get("profile") === "compact";
+      const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+      const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
       return createDocsCacheableResponse({
         request: event.request,
         content,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
           "X-Robots-Tag": "noindex",
           Link: agentManifestLinkHeader,
         },

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -6,6 +6,7 @@ import {
   buildDocsAskAIContext,
   buildDocsSearchFacets,
   buildDocsAgentDiscoverySpec,
+  compactDocsAgentDiscoverySpec,
   buildDocsConfigMap,
   buildDocsDiagnostics,
   createDocsContentChangeFeed,
@@ -1083,27 +1084,26 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
     if (standardsDiscoveryResponse) return standardsDiscoveryResponse;
 
     if (isDocsAgentDiscoveryRequest(url, { apiRoute: discoveryApiRoute })) {
-      const content = `${JSON.stringify(
-        buildDocsAgentDiscoverySpec({
-          ...discoveryOptions,
-          publishedSkills: [
-            await resolveDocsPublishedAgentSkill({
-              preferredDocument: readRootSkillDocument(preloaded, rootDir),
-              fallbackDocument: renderDocsSkillDocument(discoveryOptions),
-            }),
-            ...(await getPublishedAgentSkills()),
-          ],
-          agentCard: config.agent?.a2a,
-        }),
-        null,
-        2,
-      )}\n`;
+      const fullSpec = buildDocsAgentDiscoverySpec({
+        ...discoveryOptions,
+        publishedSkills: [
+          await resolveDocsPublishedAgentSkill({
+            preferredDocument: readRootSkillDocument(preloaded, rootDir),
+            fallbackDocument: renderDocsSkillDocument(discoveryOptions),
+          }),
+          ...(await getPublishedAgentSkills()),
+        ],
+        agentCard: config.agent?.a2a,
+      });
+      const compact = url.searchParams.get("profile") === "compact";
+      const spec = compact ? compactDocsAgentDiscoverySpec(fullSpec) : fullSpec;
+      const content = `${JSON.stringify(spec, null, compact ? undefined : 2)}\n`;
       return createDocsCacheableResponse({
         request: event.request,
         content,
         headers: {
           "Content-Type": "application/json; charset=utf-8",
-          "Cache-Control": "public, max-age=0, s-maxage=3600",
+          "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
           "X-Robots-Tag": "noindex",
           Link: agentManifestLinkHeader,
         },

--- a/website/app/docs/customization/agent-primitive/page.mdx
+++ b/website/app/docs/customization/agent-primitive/page.mdx
@@ -383,10 +383,14 @@ exposes docs, Ask AI, or MCP.
 
 `GET /.well-known/agent.json` is the preferred public discovery URL. It is a Farming Labs
 documentation-discovery extension, not an A2A Agent Card. The document identifies itself with
-`$schema: "https://docs.farming-labs.dev/schema/agent-manifest.v1.json"` and
-`format: "farming-labs-agent-manifest.v1"`. The schema uses JSON Schema Draft 2020-12, and dynamic
+`$schema: "https://docs.farming-labs.dev/schema/agent-manifest.v2.json"` and
+`format: "farming-labs-agent-manifest.v2"`. The schema uses JSON Schema Draft 2020-12, and dynamic
 responses link it with the registered HTTP `describedby` relation. Existing fields and routes remain
 available.
+
+Use `GET /.well-known/agent.json?profile=compact` for a minified first hop without expanded skill
+file inventories. The response retains discovery routes and reports each skill's `fileCount`, so an
+agent can fetch the Agent Skills index only when the task requires those companion files.
 
 `GET /.well-known/agent` is the public fallback, and `GET /api/docs/agent/spec` is the canonical
 framework route. Next.js wires these with `withDocs()`. TanStack Start, SvelteKit, Astro, and Nuxt

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -290,7 +290,7 @@ array of `DocsConfigMapPointer` entries. Sensitive config values are redacted be
 | Header | Value |
 | ------ | ----- |
 | `Content-Type` | `application/json; charset=utf-8` |
-| `Cache-Control` | `public, max-age=0, s-maxage=3600` |
+| `Cache-Control` | `public, max-age=0, s-maxage=3600, stale-while-revalidate=86400` |
 | `X-Robots-Tag` | `noindex` |
 
 ### Agent discovery spec
@@ -299,9 +299,14 @@ The agent discovery spec (`GET /.well-known/agent.json`) now includes:
 
 ```json
 {
-  "$schema": "https://docs.farming-labs.dev/schema/agent-manifest.v1.json",
-  "format": "farming-labs-agent-manifest.v1",
-  "version": "1",
+  "$schema": "https://docs.farming-labs.dev/schema/agent-manifest.v2.json",
+  "format": "farming-labs-agent-manifest.v2",
+  "version": "2",
+  "profile": "full",
+  "profiles": {
+    "full": "/.well-known/agent.json",
+    "compact": "/.well-known/agent.json?profile=compact"
+  },
   "api": {
     "config": "/api/docs?format=config"
   },
@@ -315,11 +320,15 @@ The agent discovery spec (`GET /.well-known/agent.json`) now includes:
 Agents that read the discovery spec can use `spec.config.endpoint` and `spec.config.format` to
 fetch and identify the config map without hard-coding the route.
 
+Agents with a small first-hop budget can request `?profile=compact`. The compact response is
+minified and replaces each published skill's companion-file inventory with `fileCount`; agents can
+then follow `skills.discovery.index` only when they need the expanded catalog.
+
 The root `$schema` and `format` identify this as the Farming Labs manifest extension. Dynamic
 manifest responses keep `Content-Type: application/json` and add:
 
 ```http
-Link: <https://docs.farming-labs.dev/schema/agent-manifest.v1.json>; rel="describedby"; type="application/schema+json"
+Link: <https://docs.farming-labs.dev/schema/agent-manifest.v2.json>; rel="describedby"; type="application/schema+json"
 ```
 
 This is intentionally distinct from the opt-in A2A v1 Agent Card at

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -43,6 +43,7 @@ import { DocsMcpAccess } from "@/components/ui/docs-mcp-access";
 import { GuideCard } from "@/components/ui/guide-card";
 import { MigrationCard } from "@/components/ui/migration-card";
 import { submitDocsFeedback } from "@/lib/submit-docs-feedback";
+import docsPackage from "../packages/docs/package.json";
 
 const algoliaAppId = process.env.ALGOLIA_APP_ID;
 const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME ?? "farming-labs-docs";
@@ -216,6 +217,18 @@ export default defineDocs({
 
   pageActions: {
     copyMarkdown: { enabled: true },
+    connectMcp: {
+      enabled: true,
+      endpoint: "/mcp",
+      providers: ["copy", "claude-code", "cursor", "vscode", "codex"],
+      label: "Connect docs MCP",
+    },
+    installSkills: {
+      enabled: true,
+      index: "/.well-known/agent-skills/index.json",
+      command: "npx skills add farming-labs/docs",
+      label: "Install docs skills",
+    },
     alignment: "right",
     openDocs: {
       enabled: true,
@@ -680,6 +693,7 @@ export default defineDocs({
   mcp: {
     enabled: true,
     name: "@farming-labs/docs",
+    version: docsPackage.version,
     prompts: {
       contracts: true,
       goldenTasks: ["install-existing-nextjs", "create-reusable-theme"],

--- a/website/public/schema/agent-manifest.v2.json
+++ b/website/public/schema/agent-manifest.v2.json
@@ -109,6 +109,19 @@
     "name": {
       "const": "@farming-labs/docs"
     },
+    "profile": {
+      "enum": ["full", "compact"]
+    },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "default": { "const": "full" },
+        "full": { "$ref": "#/$defs/route" },
+        "compact": { "$ref": "#/$defs/route" }
+      },
+      "required": ["default", "full", "compact"]
+    },
     "baseUrl": {
       "$ref": "#/$defs/nonEmptyString",
       "description": "Deployment origin or a relative base used by portable static exports."


### PR DESCRIPTION
## What changed

- publishes full and compact agent-manifest profiles across all framework adapters
- removes expanded skill file inventories from compact first-hop responses while retaining discovery links and file counts
- minifies compact responses and adds stale-while-revalidate caching
- enables Connect MCP and Install Skills actions on the official docs site
- derives the official MCP version from the package manifest instead of reporting 0.0.0
- updates the v2 schema and public documentation

## Why

The official site implemented these capabilities but did not dogfood its setup actions, reported a placeholder MCP version, and required agents to fetch the expanded manifest even when they only needed first-hop routes.

## Impact

The existing full manifest remains the default. Agents can opt into the smaller profile with profile=compact, while readers gain direct MCP and Skills setup actions.

## Validation

- core and all affected adapter type checks passed
- 137 core agent/schema tests passed
- 76 Next/Fumadocs API tests passed
- targeted TanStack Start, Astro, Nuxt, SvelteKit, and Farm.js server tests passed
- website TypeScript check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a compact agent discovery profile with minified responses and stale-while-revalidate caching to reduce first-hop payload size, while keeping the full profile as default. Also update the schema to v2 and enable Connect MCP and Install Skills actions on the docs site with the correct MCP version.

- **New Features - New features added**
  - Expose full and compact agent-manifest profiles across all adapters; add `profile` and `profiles` fields, with full as the default and `?profile=compact` opt-in.
  - Compact profile removes published skill file inventories, keeps discovery links, and reports `fileCount`; responses are minified.
  - Add `Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400` to discovery responses.
  - Docs site: enable Connect MCP and Install Skills actions; derive MCP version from the package; update public docs and `agent-manifest.v2` schema.

<sup>Written for commit 1c452207ecd01d99cc049291c96c6dd54717b33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

