### PR TITLE
feat: add agent page access policies

### DIFF
--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -1014,6 +1014,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             okf: config.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         }
       : null;
   }
@@ -1305,6 +1306,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         origin: markdownOrigin,
         locale: ctx.locale,
         lastModified: representation?.lastModified,
+        access: representation?.access,
         pages: getSearchIndex(ctx),
         sitemap: config.sitemap,
       });

--- a/packages/docs/src/access-surfaces.test.ts
+++ b/packages/docs/src/access-surfaces.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { createDocsMarkdownResponse, renderDocsLlmsTxt } from "./agent.js";
+import { buildDocsContentSnapshot, performDocsSearch } from "./search.js";
+import type { DocsAccessPrincipal, DocsSearchSourcePage } from "./types.js";
+
+const principal: DocsAccessPrincipal = {
+  id: "agent-1",
+  scopes: ["docs:private"],
+  claims: { role: "editor" },
+};
+
+const pages: DocsSearchSourcePage[] = [
+  {
+    title: "Public guide",
+    url: "/docs/public",
+    content: "Public installation guidance.",
+  },
+  {
+    title: "Private runbook",
+    url: "/docs/private",
+    content: "Private sentinel deployment runbook.",
+    agent: {
+      access: {
+        scopes: ["docs:private"],
+        claims: { role: ["admin", "editor"] },
+      },
+    },
+  },
+];
+
+describe("page access across agent surfaces", () => {
+  it("omits protected pages from public llms.txt, search, and content sync", async () => {
+    const llms = renderDocsLlmsTxt(pages);
+    expect(llms.llmsFullTxt).toContain("Public installation guidance");
+    expect(llms.llmsFullTxt).not.toContain("Private sentinel");
+
+    expect(await performDocsSearch({ pages, query: "sentinel" })).toEqual([]);
+    expect(
+      (await buildDocsContentSnapshot({ pages })).documents.map((document) => document.url),
+    ).toEqual(["/docs/public"]);
+  });
+
+  it("includes protected search and sync content for a matching principal", async () => {
+    const results = await performDocsSearch({ pages, query: "sentinel", principal });
+    expect(results[0]?.url).toBe("/docs/private");
+    expect(
+      (await buildDocsContentSnapshot({ pages, principal })).documents.map(
+        (document) => document.url,
+      ),
+    ).toEqual(["/docs/private", "/docs/public"]);
+  });
+
+  it("returns a private, body-free 404 for denied Markdown requests", async () => {
+    const request = new Request("https://docs.example.com/docs/private.md");
+    const denied = createDocsMarkdownResponse({
+      request,
+      requestedPath: "private",
+      document: "Private sentinel deployment runbook.",
+      access: pages[1]!.agent!.access,
+    });
+    expect(denied.status).toBe(404);
+    expect(denied.headers.get("cache-control")).toBe("private, no-store");
+    expect(await denied.text()).not.toContain("sentinel");
+
+    const allowed = createDocsMarkdownResponse({
+      request,
+      requestedPath: "private",
+      document: "Private sentinel deployment runbook.",
+      access: pages[1]!.agent!.access,
+      principal,
+    });
+    expect(allowed.status).toBe(200);
+    expect(await allowed.text()).toContain("Private sentinel");
+  });
+
+  it("does not leak protected pages through Markdown recovery suggestions", async () => {
+    const response = createDocsMarkdownResponse({
+      request: new Request("https://docs.example.com/docs/privat.md"),
+      requestedPath: "privat",
+      document: null,
+      pages,
+    });
+    expect(await response.text()).not.toContain("Private runbook");
+  });
+});

--- a/packages/docs/src/access.test.ts
+++ b/packages/docs/src/access.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterDocsPagesByAccess,
+  isDocsPageAccessAllowed,
+  normalizeDocsPageAccessPolicy,
+} from "./access.js";
+import {
+  getPageAgentFrontmatterIssues,
+  normalizePageAgentFrontmatter,
+  renderPageAgentFrontmatterYamlLines,
+} from "./agent-contract.js";
+
+describe("docs page access policies", () => {
+  it("normalizes bounded declarative policies", () => {
+    expect(
+      normalizeDocsPageAccessPolicy({
+        visibility: "authenticated",
+        scopes: ["docs:read", "docs:read", ""],
+        claims: { role: ["admin", "editor"], plan: "enterprise", ignored: {} },
+      }),
+    ).toEqual({
+      visibility: "authenticated",
+      scopes: ["docs:read"],
+      claims: { role: ["admin", "editor"], plan: "enterprise" },
+    });
+  });
+
+  it("keeps malformed authored access policies fail closed", () => {
+    expect(normalizePageAgentFrontmatter({ access: "private" })).toEqual({
+      access: { visibility: "authenticated" },
+    });
+    expect(normalizePageAgentFrontmatter({ access: {} })).toEqual({
+      access: { visibility: "authenticated" },
+    });
+    expect(getPageAgentFrontmatterIssues({ access: "private" })).toContainEqual({
+      path: "agent.access",
+      message: "must be an object",
+    });
+  });
+
+  it("preserves access policies in normalized agent YAML", () => {
+    const yaml = renderPageAgentFrontmatterYamlLines({
+      access: { scopes: ["docs:private"], claims: { role: ["admin", "editor"] } },
+    }).join("\n");
+    expect(yaml).toContain("access:");
+    expect(yaml).toContain('"role":');
+    expect(yaml).toContain('  - "docs:private"');
+  });
+
+  it("denies protected pages without all scopes and claims", () => {
+    const policy = normalizeDocsPageAccessPolicy({
+      scopes: ["docs:read", "tenant:read"],
+      claims: { role: ["admin", "editor"], tenant: "acme" },
+    });
+    expect(isDocsPageAccessAllowed(policy)).toBe(false);
+    expect(
+      isDocsPageAccessAllowed(policy, {
+        id: "user-1",
+        scopes: ["docs:read", "tenant:read"],
+        claims: { role: "editor", tenant: "acme" },
+      }),
+    ).toBe(true);
+    expect(
+      isDocsPageAccessAllowed(policy, {
+        id: "user-2",
+        scopes: ["docs:read"],
+        claims: { role: "admin", tenant: "acme" },
+      }),
+    ).toBe(false);
+  });
+
+  it("filters protected pages from public corpora", () => {
+    const pages = [
+      { title: "Public", agent: { task: "Read" } },
+      { title: "Private", agent: { access: { scopes: ["docs:private"] } } },
+    ];
+    expect(filterDocsPagesByAccess(pages).map((page) => page.title)).toEqual(["Public"]);
+    expect(
+      filterDocsPagesByAccess(pages, { id: "agent", scopes: ["docs:private"] }).map(
+        (page) => page.title,
+      ),
+    ).toEqual(["Public", "Private"]);
+  });
+});

--- a/packages/docs/src/access.ts
+++ b/packages/docs/src/access.ts
@@ -1,0 +1,97 @@
+import type {
+  DocsAccessClaimValue,
+  DocsAccessPrincipal,
+  DocsPageAccessPolicy,
+  PageAgentFrontmatter,
+} from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = Array.from(
+    new Set(
+      value.flatMap((item) => (typeof item === "string" && item.trim() ? [item.trim()] : [])),
+    ),
+  );
+  return strings.length > 0 ? strings : undefined;
+}
+
+function normalizeClaimValue(value: unknown): DocsAccessClaimValue | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "boolean") return value;
+  return normalizeStrings(value);
+}
+
+export function normalizeDocsPageAccessPolicy(value: unknown): DocsPageAccessPolicy | undefined {
+  if (!isRecord(value)) return undefined;
+  const visibility =
+    value.visibility === "public" || value.visibility === "authenticated"
+      ? value.visibility
+      : undefined;
+  const scopes = normalizeStrings(value.scopes);
+  const rawClaims = isRecord(value.claims) ? value.claims : undefined;
+  const claims = rawClaims
+    ? Object.fromEntries(
+        Object.entries(rawClaims).flatMap(([name, rawValue]) => {
+          const normalizedName = name.trim();
+          const normalizedValue = normalizeClaimValue(rawValue);
+          return normalizedName && normalizedValue !== undefined
+            ? [[normalizedName, normalizedValue]]
+            : [];
+        }),
+      )
+    : undefined;
+  const normalizedClaims = claims && Object.keys(claims).length > 0 ? claims : undefined;
+  if (!visibility && !scopes && !normalizedClaims) return undefined;
+  return {
+    ...(visibility ? { visibility } : {}),
+    ...(scopes ? { scopes } : {}),
+    ...(normalizedClaims ? { claims: normalizedClaims } : {}),
+  };
+}
+
+function claimMatches(expected: DocsAccessClaimValue, actual: unknown): boolean {
+  const expectedValues = Array.isArray(expected) ? expected : [expected];
+  const actualValues = Array.isArray(actual) ? actual : [actual];
+  return expectedValues.some((expectedValue) =>
+    actualValues.some((actualValue) => actualValue === expectedValue),
+  );
+}
+
+export function isDocsPageAccessAllowed(
+  policy: DocsPageAccessPolicy | undefined,
+  principal?: DocsAccessPrincipal,
+): boolean {
+  if (!policy) return true;
+  const requiresPrincipal =
+    policy.visibility !== "public" ||
+    Boolean(policy.scopes?.length) ||
+    Boolean(policy.claims && Object.keys(policy.claims).length > 0);
+  if (!requiresPrincipal) return true;
+  if (!principal) return false;
+
+  const scopes = new Set(principal.scopes ?? []);
+  if (policy.scopes?.some((scope) => !scopes.has(scope))) return false;
+  for (const [name, expected] of Object.entries(policy.claims ?? {})) {
+    if (!claimMatches(expected, principal.claims?.[name])) return false;
+  }
+  return true;
+}
+
+export function isDocsAgentPageAccessible(
+  page: { agent?: PageAgentFrontmatter },
+  principal?: DocsAccessPrincipal,
+): boolean {
+  return isDocsPageAccessAllowed(page.agent?.access, principal);
+}
+
+export function filterDocsPagesByAccess<T extends { agent?: PageAgentFrontmatter }>(
+  pages: readonly T[],
+  principal?: DocsAccessPrincipal,
+): T[] {
+  return pages.filter((page) => isDocsAgentPageAccessible(page, principal));
+}

--- a/packages/docs/src/agent-contract.ts
+++ b/packages/docs/src/agent-contract.ts
@@ -5,6 +5,7 @@ import type {
   PageAgentFrontmatter,
   PageAgentVerification,
 } from "./types.js";
+import { normalizeDocsPageAccessPolicy } from "./access.js";
 
 export interface PageAgentFrontmatterIssue {
   path: string;
@@ -26,10 +27,12 @@ export const PAGE_AGENT_STRUCTURED_CONTRACT_FIELDS = [
 
 export const PAGE_AGENT_CONTRACT_FIELDS = [
   "tokenBudget",
+  "access",
   ...PAGE_AGENT_STRUCTURED_CONTRACT_FIELDS,
 ] as const;
 export const PAGE_AGENT_CONTRACT_FIELD_SCHEMA = {
   tokenBudget: "number",
+  access: "{visibility?,scopes?,claims?}",
   task: "string",
   outcome: "string",
   appliesTo: {
@@ -49,6 +52,7 @@ const APPLIES_TO_FIELDS = ["framework", "version", "package"] as const;
 const COMMAND_FIELDS = ["run", "cwd", "description"] as const;
 const VERIFICATION_FIELDS = ["description", "run", "expect"] as const;
 const FAILURE_MODE_FIELDS = ["symptom", "resolution"] as const;
+const ACCESS_FIELDS = ["visibility", "scopes", "claims"] as const;
 
 export const PAGE_AGENT_CONTRACT_START_MARKER = "<!-- farming-labs:agent-contract:start -->";
 export const PAGE_AGENT_CONTRACT_END_MARKER = "<!-- farming-labs:agent-contract:end -->";
@@ -184,6 +188,12 @@ export function normalizePageAgentFrontmatter(value: unknown): PageAgentFrontmat
   if (!isRecord(value)) return undefined;
 
   const tokenBudget = normalizeTokenBudget(value.tokenBudget);
+  // An authored access rule must never become public because it was malformed.
+  // Preserve fail-closed behavior while diagnostics report the invalid shape.
+  const access =
+    "access" in value
+      ? (normalizeDocsPageAccessPolicy(value.access) ?? { visibility: "authenticated" })
+      : undefined;
   const task = normalizeString(value.task);
   const outcome = normalizeString(value.outcome);
   const appliesTo = normalizeAppliesTo(value.appliesTo);
@@ -197,6 +207,7 @@ export function normalizePageAgentFrontmatter(value: unknown): PageAgentFrontmat
 
   const normalized: PageAgentFrontmatter = {
     ...(tokenBudget !== undefined ? { tokenBudget } : {}),
+    ...(access ? { access } : {}),
     ...(task ? { task } : {}),
     ...(outcome ? { outcome } : {}),
     ...(appliesTo ? { appliesTo } : {}),
@@ -315,6 +326,50 @@ export function getPageAgentFrontmatterIssues(value: unknown): PageAgentFrontmat
       value.tokenBudget <= 0)
   ) {
     issues.push({ path: "agent.tokenBudget", message: "must be a positive finite number" });
+  }
+
+  if ("access" in value) {
+    if (!isRecord(value.access)) {
+      issues.push({ path: "agent.access", message: "must be an object" });
+    } else {
+      addUnknownKeyIssues(issues, value.access, ACCESS_FIELDS, "agent.access");
+      if (
+        "visibility" in value.access &&
+        value.access.visibility !== "public" &&
+        value.access.visibility !== "authenticated"
+      ) {
+        issues.push({
+          path: "agent.access.visibility",
+          message: 'must be "public" or "authenticated"',
+        });
+      }
+      if ("scopes" in value.access && !normalizeStringList(value.access.scopes)) {
+        issues.push({ path: "agent.access.scopes", message: "must be a non-empty string array" });
+      }
+      if ("claims" in value.access) {
+        if (!isRecord(value.access.claims) || Object.keys(value.access.claims).length === 0) {
+          issues.push({ path: "agent.access.claims", message: "must be a non-empty object" });
+        } else {
+          for (const [name, claim] of Object.entries(value.access.claims)) {
+            if (
+              !name.trim() ||
+              normalizeDocsPageAccessPolicy({ claims: { [name]: claim } }) === undefined
+            ) {
+              issues.push({
+                path: `agent.access.claims.${name || "<empty>"}`,
+                message: "must be a string, number, boolean, or non-empty string array",
+              });
+            }
+          }
+        }
+      }
+      if (!normalizeDocsPageAccessPolicy(value.access)) {
+        issues.push({
+          path: "agent.access",
+          message: "must include a valid visibility, scope, or claim",
+        });
+      }
+    }
   }
 
   addStringIssue(issues, value, "task");
@@ -502,6 +557,31 @@ export function renderPageAgentFrontmatterYamlLines(value: unknown, indentation 
   const child = `${indent}  `;
   const lines = [`${indent}agent:`];
   if (agent.tokenBudget !== undefined) lines.push(`${child}tokenBudget: ${agent.tokenBudget}`);
+  if (agent.access) {
+    lines.push(`${child}access:`);
+    const accessIndent = `${child}  `;
+    if (agent.access.visibility) {
+      lines.push(`${accessIndent}visibility: ${agent.access.visibility}`);
+    }
+    if (agent.access.scopes) {
+      renderYamlStringList(lines, accessIndent, "scopes", [...agent.access.scopes]);
+    }
+    if (agent.access.claims) {
+      lines.push(`${accessIndent}claims:`);
+      const claimsIndent = `${accessIndent}  `;
+      for (const [name, claim] of Object.entries(agent.access.claims).sort(([left], [right]) =>
+        left.localeCompare(right),
+      )) {
+        if (Array.isArray(claim)) {
+          renderYamlStringList(lines, claimsIndent, yamlString(name), [...claim]);
+        } else {
+          lines.push(
+            `${claimsIndent}${yamlString(name)}: ${typeof claim === "string" ? yamlString(claim) : claim}`,
+          );
+        }
+      }
+    }
+  }
   if (agent.task) lines.push(`${child}task: ${yamlString(agent.task)}`);
   if (agent.outcome) lines.push(`${child}outcome: ${yamlString(agent.outcome)}`);
   if (agent.appliesTo) {

--- a/packages/docs/src/agent.ts
+++ b/packages/docs/src/agent.ts
@@ -1,5 +1,6 @@
 import type {
   DocsConfig,
+  DocsAccessPrincipal,
   DocsAgentContentChangesConfig,
   DocsOkfConfig,
   DocsOkfTrustMetadata,
@@ -15,8 +16,10 @@ import type {
   LlmsTxtMaxCharsMode,
   LlmsTxtSectionConfig,
   PageAgentFrontmatter,
+  DocsPageAccessPolicy,
   ResolvedDocsRelatedLink,
 } from "./types.js";
+import { filterDocsPagesByAccess, isDocsPageAccessAllowed } from "./access.js";
 import { resolveDocsOkfConfig, resolveDocsOkfTrustMetadata } from "./okf.js";
 import type { ResolvedDocsI18n } from "./i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "./mcp.js";
@@ -640,6 +643,7 @@ export interface DocsLlmsTxtPageInput {
   agentRawContent?: string;
   agentFallbackContent?: string;
   agentFallbackRawContent?: string;
+  agent?: PageAgentFrontmatter;
 }
 
 export interface DocsLlmsTxtGeneratedSection extends DocsLlmsTxtResolvedSection {
@@ -869,6 +873,10 @@ export interface DocsMarkdownResponseOptions extends DocsMarkdownNotFoundOptions
   /** Exact source modification timestamp. Date-only values are intentionally ignored. */
   lastModified?: string | Date | null;
   cacheControl?: string;
+  /** Page policy evaluated before any body or recovery metadata is returned. */
+  access?: DocsPageAccessPolicy;
+  /** Authenticated identity; omitted public requests fail closed for protected pages. */
+  principal?: DocsAccessPrincipal;
 }
 
 const DOCS_MARKDOWN_SECTION_MAX_BUDGET = 1_000_000;
@@ -2169,6 +2177,7 @@ export function renderDocsLlmsTxt(
   pages: DocsLlmsTxtPageInput[],
   options: DocsLlmsDiscoveryConfig = {},
 ): DocsLlmsTxtGeneratedContent {
+  pages = filterDocsPagesByAccess(pages);
   const siteTitle = options.siteTitle ?? "Documentation";
   const siteDescription = options.siteDescription;
   const baseUrl = options.baseUrl ?? "";
@@ -3570,7 +3579,7 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
     entry = "docs",
     requestedPath,
     origin = new URL(request.url).origin,
-    pages,
+    pages: rawPages,
     sitemap,
     locale,
   } = options;
@@ -3588,6 +3597,18 @@ export function createDocsMarkdownResponse(options: DocsMarkdownResponseOptions)
     ...(locale ? { "Content-Language": locale } : {}),
     ...(varyHeader ? { Vary: varyHeader } : {}),
   };
+  const pages = rawPages ? filterDocsPagesByAccess(rawPages, options.principal) : undefined;
+
+  if (!isDocsPageAccessAllowed(options.access, options.principal)) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        ...baseSharedHeaders,
+        "Cache-Control": "private, no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+  }
 
   if (!document) {
     const recovery = resolveDocsMarkdownRecovery({ entry, requestedPath, pages, sitemap });

--- a/packages/docs/src/cli/agent-export.test.ts
+++ b/packages/docs/src/cli/agent-export.test.ts
@@ -306,6 +306,40 @@ pnpm add example
     );
   });
 
+  it("omits access-protected pages from public static agent bundles", async () => {
+    writeProject();
+    writeFileSync(
+      path.join(tmpDir, "docs", "guides", "install", "page.mdx"),
+      `---
+title: "Private install"
+description: "Internal installation runbook"
+agent:
+  access:
+    scopes:
+      - docs:private
+---
+
+# Private install
+
+STATIC PRIVATE SENTINEL
+`,
+      "utf-8",
+    );
+    process.chdir(tmpDir);
+
+    await exportAgentBundle({ public: true });
+
+    expect(existsSync(path.join(tmpDir, "public", "docs", "guides", "install.md"))).toBe(false);
+    expect(readFileSync(path.join(tmpDir, "public", "llms-full.txt"), "utf-8")).not.toContain(
+      "STATIC PRIVATE SENTINEL",
+    );
+    const bundle = readFileSync(
+      path.join(tmpDir, "public", ".well-known", "agent-bundle.json"),
+      "utf-8",
+    );
+    expect(bundle).not.toContain("/docs/guides/install");
+  });
+
   it("uses SvelteKit static and preserves already-public custom policy files", async () => {
     writeProject({ staticExport: false });
     writeFileSync(

--- a/packages/docs/src/cli/agent-export.ts
+++ b/packages/docs/src/cli/agent-export.ts
@@ -44,6 +44,7 @@ import {
   type DocsLlmsDiscoveryConfig,
 } from "../agent.js";
 import { resolveConfiguredAgentSkills } from "../agent-skills-server.js";
+import { isDocsAgentPageAccessible } from "../access.js";
 import { formatDocsContentDigest, resolveDocsHttpDate } from "../http-cache.js";
 import { resolveDocsI18n } from "../i18n.js";
 import type { DocsMcpPage, DocsMcpResolvedConfig } from "../mcp.js";
@@ -1149,7 +1150,8 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   if (localizedPages.length === 0) {
     throw new Error(`No docs content was found under ${contentDir}.`);
   }
-  const pages = localizedPages.map(({ page }) => page);
+  const publishablePages = localizedPages.filter(({ page }) => isDocsAgentPageAccessible(page));
+  const pages = publishablePages.map(({ page }) => page);
   const okfConfig = resolveDocsOkfConfig(config?.agent?.okf);
   const sitemap = resolveDocsSitemapConfig(sitemapInput, { baseUrl });
   const robots = resolveDocsRobotsConfig(robotsInput, {
@@ -1200,7 +1202,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
   let outputs: PlannedOutput[] = [];
   const internalOutputs: PlannedInternalOutput[] = [];
 
-  for (const { page } of localizedPages) {
+  for (const { page } of publishablePages) {
     const output = addOutput(
       outputs,
       publicDir,
@@ -1254,6 +1256,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
         agentRawContent: page.agentRawContent,
         agentFallbackContent: page.agentFallbackContent,
         agentFallbackRawContent: page.agentFallbackRawContent,
+        agent: page.agent,
       })),
       llms,
     );
@@ -1522,7 +1525,7 @@ export async function exportAgentBundle(options: AgentExportOptions = {}): Promi
     internalOutputs,
     orphanedFiles,
     orphanedInternalFiles,
-    pages: localizedPages,
+    pages: publishablePages,
   });
   const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
   const changed = changedOutputs(outputs);

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -9,6 +9,13 @@
 
 import type { DocsConfig } from "./types.js";
 
+export {
+  filterDocsPagesByAccess,
+  isDocsAgentPageAccessible,
+  isDocsPageAccessAllowed,
+  normalizeDocsPageAccessPolicy,
+} from "./access.js";
+
 export { defineDocs } from "./define-docs.js";
 export {
   DOCS_AGENT_TRACE_EVENT_TYPES,
@@ -507,6 +514,9 @@ export type {
   PageTwitter,
   DocsRelatedItem,
   ResolvedDocsRelatedLink,
+  DocsAccessClaimValue,
+  DocsAccessPrincipal,
+  DocsPageAccessPolicy,
   PageAgentAppliesTo,
   PageAgentCommand,
   PageAgentFailureMode,

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -626,6 +626,57 @@ describe("P1 trust and OpenAPI tools", () => {
   });
 });
 
+describe("page access policies", () => {
+  const source = {
+    getPages: () => [
+      { slug: "public", url: "/docs/public", title: "Public", content: "Public content" },
+      {
+        slug: "private",
+        url: "/docs/private",
+        title: "Private",
+        content: "Private MCP sentinel",
+        agent: { access: { scopes: ["docs:private"] } },
+      },
+    ],
+    getNavigation: () => ({
+      name: "Docs",
+      children: [
+        { type: "page" as const, name: "Public", url: "/docs/public" },
+        { type: "page" as const, name: "Private", url: "/docs/private" },
+      ],
+    }),
+  };
+
+  it.each([
+    ["public", undefined, ["/docs/public"]],
+    [
+      "authorized",
+      { transport: "http" as const, auth: { id: "agent", scopes: ["docs:private"] } },
+      ["/docs/private", "/docs/public"],
+    ],
+  ])("filters MCP pages and navigation for %s requests", async (_label, requestContext, urls) => {
+    const server = await createDocsMcpServer({ source, requestContext });
+    const client = new Client({ name: "access-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const listed = await client.callTool({ name: "list_pages", arguments: {} });
+      const navigation = await client.callTool({ name: "get_navigation", arguments: {} });
+      expect(JSON.stringify(listed)).not.toContain("Private MCP sentinel");
+      const listedUrls = JSON.stringify(listed).match(/\/docs\/(?:private|public)/g) ?? [];
+      expect([...new Set(listedUrls)].sort()).toEqual(urls);
+      expect(JSON.stringify(navigation).includes("/docs/private")).toBe(
+        requestContext !== undefined,
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
 describe("MCP contract prompts", () => {
   const contractPage: DocsMcpPage = {
     slug: "installation",

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -32,6 +32,7 @@ import type {
 import * as z from "zod/v4";
 import { stripGeneratedAgentProvenance } from "./agent-provenance.js";
 import { resolveDocsAudienceMdxContent } from "./audience.js";
+import { filterDocsPagesByAccess } from "./access.js";
 import {
   hasStructuredPageAgentContract,
   normalizePageAgentFrontmatter,
@@ -354,6 +355,8 @@ export interface DocsMcpContextResult {
 
 export interface DocsMcpContextOptions {
   pages: readonly DocsMcpPage[];
+  /** Authenticated identity used to retain authorized pages during retrieval. */
+  principal?: DocsMcpAuthPrincipal;
   query: string;
   framework?: string;
   version?: string;
@@ -390,6 +393,23 @@ export type DocsMcpNavigationNode = DocsMcpPageNode | DocsMcpFolderNode;
 export interface DocsMcpNavigationTree {
   name: string;
   children: DocsMcpNavigationNode[];
+}
+
+function filterDocsMcpNavigation(
+  tree: DocsMcpNavigationTree,
+  allowedUrls: ReadonlySet<string>,
+): DocsMcpNavigationTree {
+  const filterNodes = (nodes: readonly DocsMcpNavigationNode[]): DocsMcpNavigationNode[] =>
+    nodes.flatMap((node): DocsMcpNavigationNode[] => {
+      if (node.type === "page") return allowedUrls.has(node.url) ? [node] : [];
+      const children = filterNodes(node.children);
+      const index = node.index && allowedUrls.has(node.index.url) ? node.index : undefined;
+      const { index: _unfilteredIndex, ...folder } = node;
+      return children.length > 0 || index
+        ? [{ ...folder, ...(index ? { index } : {}), children }]
+        : [];
+    });
+  return { ...tree, children: filterNodes(tree.children) };
 }
 
 export interface DocsMcpSource {
@@ -4411,12 +4431,22 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
   };
   const telemetryFramework = options.telemetryFramework ?? "mcp";
 
-  function getSourcePages(locale?: string) {
-    return options.source.getPages(resolveSourceLocale(locale), options.requestContext);
+  async function getSourcePages(locale?: string) {
+    return getResolvedSourcePages(resolveSourceLocale(locale));
   }
 
-  function getSourceNavigation(locale?: string) {
-    return options.source.getNavigation(resolveSourceLocale(locale), options.requestContext);
+  async function getResolvedSourcePages(locale?: string) {
+    const pages = await options.source.getPages(locale, options.requestContext);
+    return filterDocsPagesByAccess(pages, options.requestContext?.auth);
+  }
+
+  async function getSourceNavigation(locale?: string) {
+    const resolvedLocale = resolveSourceLocale(locale);
+    const [tree, pages] = await Promise.all([
+      options.source.getNavigation(resolvedLocale, options.requestContext),
+      getResolvedSourcePages(resolvedLocale),
+    ]);
+    return filterDocsMcpNavigation(tree, new Set(pages.map((page) => page.url)));
   }
 
   function resolveSourceLocale(locale?: string) {
@@ -4734,12 +4764,11 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
       );
     }
     const resolvedLocale = resolveSourceLocale(locale);
-    const pages = dedupePages(
-      await options.source.getPages(resolvedLocale, options.requestContext),
-    );
+    const pages = dedupePages(await getResolvedSourcePages(resolvedLocale));
     try {
       const result = await contentChangeFeed.resolve({
         pages: toSearchSourcePages(pages),
+        principal: options.requestContext?.auth,
         search: options.search,
         audience: "agent",
         locale: resolvedLocale,
@@ -5033,7 +5062,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
 
         try {
           const allPages = toPageSummaries(
-            dedupePages(await options.source.getPages(resolvedLocale, options.requestContext)),
+            dedupePages(await getResolvedSourcePages(resolvedLocale)),
           ).sort(compareDocsMcpPageSummaries);
           const page = paginateDocsMcpItems(allPages, {
             kind: "mcp.tool/list_pages",
@@ -5133,7 +5162,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
 
         try {
           const allDocs = listDocsBySection(
-            dedupePages(await options.source.getPages(resolvedLocale, options.requestContext)),
+            dedupePages(await getResolvedSourcePages(resolvedLocale)),
             {
               section,
               entry: options.source.entry,
@@ -5241,7 +5270,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
 
         try {
           const allTasks = listDocsTasks(
-            dedupePages(await options.source.getPages(resolvedLocale, options.requestContext)),
+            dedupePages(await getResolvedSourcePages(resolvedLocale)),
             {
               query,
               framework,
@@ -5680,11 +5709,10 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(
-            await options.source.getPages(resolvedLocale, options.requestContext),
-          );
+          const pages = dedupePages(await getResolvedSourcePages(resolvedLocale));
           const facets = await buildDocsSearchFacets({
             pages: toSearchSourcePages(pages),
+            principal: options.requestContext?.auth,
             search: toolSearchConfig ?? true,
             audience: resolvedAudience,
             filters,
@@ -5820,11 +5848,10 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(
-            await options.source.getPages(resolvedLocale, options.requestContext),
-          );
+          const pages = dedupePages(await getResolvedSourcePages(resolvedLocale));
           const searchResponse = await performDocsSearchWithMetadata({
             pages: toSearchSourcePages(pages),
+            principal: options.requestContext?.auth,
             query,
             search: toolSearchConfig ?? true,
             audience: resolvedAudience,
@@ -6065,11 +6092,10 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(
-            await options.source.getPages(resolvedLocale, options.requestContext),
-          );
+          const pages = dedupePages(await getResolvedSourcePages(resolvedLocale));
           const result = await buildDocsMcpContext({
             pages,
+            principal: options.requestContext?.auth,
             query,
             framework,
             version,
@@ -6191,9 +6217,7 @@ export async function createDocsMcpServer(options: CreateDocsMcpServerOptions): 
         });
 
         try {
-          const pages = dedupePages(
-            await options.source.getPages(resolvedLocale, options.requestContext),
-          );
+          const pages = dedupePages(await getResolvedSourcePages(resolvedLocale));
           const page = findDocsPage(pages, requestedPath, options.source.entry);
 
           if (!page) {
@@ -6795,9 +6819,12 @@ export function createDocsMcpHttpHandler(options: CreateDocsMcpServerOptions): D
     context: DocsMcpRequestContext,
   ): Promise<DocsMcpContentGenerationState> {
     const locale = options.source.resolveLocale?.(undefined, context);
-    const pages = dedupePages(await options.source.getPages(locale, context));
+    const pages = dedupePages(
+      filterDocsPagesByAccess(await options.source.getPages(locale, context), context.auth),
+    );
     const result = await contentChangeFeed.resolve({
       pages: toSearchSourcePages(pages),
+      principal: context.auth,
       search: options.search,
       audience: "agent",
       locale,
@@ -7057,9 +7084,15 @@ export async function runDocsMcpStdio(options: CreateDocsMcpServerOptions): Prom
 
     const readState = async (): Promise<DocsMcpContentGenerationState> => {
       const locale = options.source.resolveLocale?.(undefined, requestContext);
-      const pages = dedupePages(await options.source.getPages(locale, requestContext));
+      const pages = dedupePages(
+        filterDocsPagesByAccess(
+          await options.source.getPages(locale, requestContext),
+          requestContext.auth,
+        ),
+      );
       const result = await contentChangeFeed.resolve({
         pages: toSearchSourcePages(pages),
+        principal: requestContext.auth,
         search: options.search,
         audience: "agent",
         locale,
@@ -8883,6 +8916,7 @@ export async function buildDocsMcpContext(
   const searchResults = await performDocsSearch({
     pages: scopedPages.map((page) => searchPageBySource.get(page)!),
     generationPages: allSearchPages,
+    principal: options.principal,
     query: options.query,
     search: {
       enabled: true,

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -22,6 +22,7 @@ import type {
   DocsSearchResult,
   DocsSearchSourcePage,
   DocsSearchWarning,
+  DocsAccessPrincipal,
   DocsSearchChunkingConfig,
   DocsContentSnapshot,
   DocsRetrievalSourceProvenance,
@@ -29,6 +30,7 @@ import type {
   McpDocsSearchConfig,
   TypesenseDocsSearchConfig,
 } from "./types.js";
+import { filterDocsPagesByAccess } from "./access.js";
 import { digestDocsRetrievalContent, isDocsRetrievalCanonicalUrl } from "./retrieval-digest.js";
 import {
   createDocsPaginationCursor,
@@ -1442,6 +1444,8 @@ export interface BuildDocsContentSnapshotOptions {
   baseUrl?: string;
   /** @internal Precomputed complete-corpus generation for composed callers. */
   indexGeneration?: string;
+  /** Authenticated identity used to scope protected pages. */
+  principal?: DocsAccessPrincipal;
 }
 
 /**
@@ -1453,12 +1457,13 @@ export interface BuildDocsContentSnapshotOptions {
 export async function buildDocsContentSnapshot(
   options: BuildDocsContentSnapshotOptions,
 ): Promise<DocsContentSnapshot> {
+  const pages = filterDocsPagesByAccess(options.pages, options.principal);
   const audience = resolveDocsSearchAudience(options.audience);
   const search = normalizeDocsSearchConfig(options.search);
   const digestCache = new Map<DocsSearchSourcePage, string>();
   const indexGeneration =
     options.indexGeneration ??
-    (await buildDocsSearchIndexGeneration(options.pages, {
+    (await buildDocsSearchIndexGeneration(pages, {
       audience,
       chunking: search.chunking,
       locale: options.locale,
@@ -1466,7 +1471,7 @@ export async function buildDocsContentSnapshot(
       digestCache,
     }));
   const documents = await Promise.all(
-    options.pages.map(async (page) => {
+    pages.map(async (page) => {
       const localizedPage = localizeDocsSearchPage(page, options.locale);
       const source = await buildDocsRetrievalSource(page, localizedPage.url, {
         audience,
@@ -4505,6 +4510,8 @@ async function maybeSyncSearchIndex(
 
 export interface PerformDocsSearchOptions {
   pages: DocsSearchSourcePage[];
+  /** Authenticated identity used to scope protected pages before local or hosted indexing. */
+  principal?: DocsAccessPrincipal;
   /** @internal Complete corpus used for generation when `pages` is pre-scoped by a caller. */
   generationPages?: DocsSearchSourcePage[];
   /** @internal Precomputed complete-corpus generation for structured callers. */
@@ -4602,7 +4609,12 @@ async function performDocsSearchInternal(
   const audience = resolveDocsSearchAudience(options.audience);
   const filters = normalizeDocsSearchFilters(options.filters);
   const hasFilters = hasDocsSearchFilters(filters);
-  const corpusPages = options.pages.map((page) => localizeDocsSearchPage(page, options.locale));
+  const accessiblePages = filterDocsPagesByAccess(options.pages, options.principal);
+  const accessibleGenerationPages = filterDocsPagesByAccess(
+    options.generationPages ?? options.pages,
+    options.principal,
+  );
+  const corpusPages = accessiblePages.map((page) => localizeDocsSearchPage(page, options.locale));
   const indexBaseUrl =
     options.syncBaseUrl === null ? undefined : (options.syncBaseUrl ?? options.baseUrl);
   const scopedPages = hasFilters
@@ -4653,7 +4665,7 @@ async function performDocsSearchInternal(
   const getCurrentIndexGeneration = () => {
     currentIndexGeneration ??= options.indexGeneration
       ? Promise.resolve(options.indexGeneration)
-      : buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+      : buildDocsSearchIndexGeneration(accessibleGenerationPages, {
           audience,
           chunking: search.chunking,
           locale: options.locale,
@@ -4668,7 +4680,7 @@ async function performDocsSearchInternal(
     hostedIndexGeneration ??=
       audience === "human"
         ? getCurrentIndexGeneration()
-        : buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
+        : buildDocsSearchIndexGeneration(accessibleGenerationPages, {
             audience: "human",
             chunking: search.chunking,
             locale: options.locale,
@@ -5033,6 +5045,8 @@ export interface BuildDocsSearchFacetsOptions {
   limit?: number;
   /** @internal Precomputed complete-corpus generation for composed callers. */
   indexGeneration?: string;
+  /** Authenticated identity used to scope protected pages. */
+  principal?: DocsAccessPrincipal;
 }
 
 function docsSearchPageMatchesFacetFilters(
@@ -5128,12 +5142,13 @@ export async function buildDocsSearchFacets(
   if (options.cursor !== undefined && options.facet === undefined) {
     throw new DocsSearchRequestError("Facet continuation cursors require a `facet` field.");
   }
-  const pages = options.pages
+  const accessiblePages = filterDocsPagesByAccess(options.pages, options.principal);
+  const pages = accessiblePages
     .map((page) => localizeDocsSearchPage(page, options.locale))
     .map((page) => ({ scope: resolveDocsSearchPageScope(page) }));
   const indexGeneration =
     options.indexGeneration ??
-    (await buildDocsSearchIndexGeneration(options.pages, {
+    (await buildDocsSearchIndexGeneration(accessiblePages, {
       audience,
       chunking: search.chunking,
       locale: options.locale,
@@ -5387,12 +5402,15 @@ export async function performDocsSearchWithMetadata(
       : DEFAULT_SEARCH_LIMIT;
   const indexGeneration =
     options.indexGeneration ??
-    (await buildDocsSearchIndexGeneration(options.generationPages ?? options.pages, {
-      audience,
-      chunking: search.chunking,
-      locale: options.locale,
-      baseUrl: options.baseUrl,
-    }));
+    (await buildDocsSearchIndexGeneration(
+      filterDocsPagesByAccess(options.generationPages ?? options.pages, options.principal),
+      {
+        audience,
+        chunking: search.chunking,
+        locale: options.locale,
+        baseUrl: options.baseUrl,
+      },
+    ));
   const normalizedFilters = Object.fromEntries(
     SEARCH_FILTER_FIELDS.flatMap((field) => {
       const values = filters[field];

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -307,12 +307,33 @@ export interface PageAgentFailureMode {
   resolution?: string;
 }
 
+export type DocsAccessClaimValue = string | number | boolean | readonly string[];
+
+/** Declarative, deny-by-default authorization requirements for agent-facing page surfaces. */
+export interface DocsPageAccessPolicy {
+  /** Require an authenticated principal even when no scopes or claims are listed. */
+  visibility?: "public" | "authenticated";
+  /** Every listed scope must be present on the principal. */
+  scopes?: readonly string[];
+  /** Every listed claim must match; arrays match when at least one value overlaps. */
+  claims?: Readonly<Record<string, DocsAccessClaimValue>>;
+}
+
+/** Identity used when evaluating page access outside the MCP transport. */
+export interface DocsAccessPrincipal {
+  id: string;
+  scopes?: readonly string[];
+  claims?: Readonly<Record<string, unknown>>;
+}
+
 export interface PageAgentFrontmatter {
   /**
    * Approximate output token target for machine-readable compaction on this page.
    * Used by `docs agent compact` as a per-page override.
    */
   tokenBudget?: number;
+  /** Authorization requirements shared by Markdown, search, llms.txt, sync, export, and MCP. */
+  access?: DocsPageAccessPolicy;
   /** Concrete task the page helps an agent complete. */
   task?: string;
   /** Observable end state the agent should reach. */
@@ -1494,7 +1515,7 @@ export interface DocsMcpPromptsConfig {
 }
 
 /** Authenticated identity returned by an MCP authentication callback. */
-export interface DocsMcpAuthPrincipal {
+export interface DocsMcpAuthPrincipal extends DocsAccessPrincipal {
   /** Stable identifier for the authenticated user, service, or agent. */
   id: string;
   /** Optional authorization scopes that source adapters can inspect. */

--- a/packages/farmjs/src/server.ts
+++ b/packages/farmjs/src/server.ts
@@ -1164,6 +1164,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             okf: config.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         }
       : null;
   }
@@ -1454,6 +1455,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         origin: markdownOrigin,
         locale: ctx.locale,
         lastModified: representation?.lastModified,
+        access: representation?.access,
         pages: getSearchIndex(ctx),
         sitemap: config.sitemap,
       });

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -4196,6 +4196,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             okf: options?.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         };
       }
     }
@@ -4213,6 +4214,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           okf: options?.agent?.okf,
         }),
         lastModified: resolveDocsRetrievalLastModified(fallbackPage, "agent"),
+        access: fallbackPage.agent?.access,
       };
     }
 
@@ -4228,6 +4230,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
             okf: options?.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         };
       }
     }
@@ -4696,6 +4699,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
           canonicalUrl,
           locale: ctx.locale,
           lastModified: representation?.lastModified,
+          access: representation?.access,
           sitemap: sitemapConfig,
         });
       }

--- a/packages/nuxt/src/server.ts
+++ b/packages/nuxt/src/server.ts
@@ -1004,6 +1004,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             okf: config.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         }
       : null;
   }
@@ -1295,6 +1296,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         origin: markdownOrigin,
         locale: ctx.locale,
         lastModified: representation?.lastModified,
+        access: representation?.access,
         pages: getSearchIndex(ctx),
         sitemap: config.sitemap,
       });

--- a/packages/svelte/src/server.ts
+++ b/packages/svelte/src/server.ts
@@ -1027,6 +1027,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
             okf: config.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         }
       : null;
   }
@@ -1317,6 +1318,7 @@ export function createDocsServer(config: Record<string, any> = {}): DocsServer {
         origin: markdownOrigin,
         locale: ctx.locale,
         lastModified: representation?.lastModified,
+        access: representation?.access,
         pages: getSearchIndex(ctx),
         sitemap: config.sitemap,
       });

--- a/packages/tanstack-start/src/server.ts
+++ b/packages/tanstack-start/src/server.ts
@@ -975,6 +975,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
             okf: config.agent?.okf,
           }),
           lastModified: resolveDocsRetrievalLastModified(page, "agent"),
+          access: page.agent?.access,
         }
       : null;
   }
@@ -1265,6 +1266,7 @@ export function createDocsServer(config: Record<string, any>): DocsServer {
         origin: markdownOrigin,
         locale: ctx.locale,
         lastModified: representation?.lastModified,
+        access: representation?.access,
         pages: getSearchIndex(ctx),
         sitemap: config.sitemap,
       });

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1909,6 +1909,43 @@ Notes:
 See [CLI](/docs/cli) for the command surface and [Token Efficiency](/docs/token-efficiency) for
 when to use compaction instead of writing `agent.md` by hand.
 
+## Protect agent-facing page content
+
+Add `agent.access` to keep a page out of unauthenticated machine-readable surfaces while allowing
+an authenticated MCP principal with the required scopes and claims to read it:
+
+```md title="app/docs/internal-runbook/page.mdx"
+---
+title: "Internal deployment runbook"
+agent:
+  access:
+    visibility: authenticated
+    scopes:
+      - docs:private
+    claims:
+      role:
+        - admin
+        - editor
+      plan: enterprise
+---
+```
+
+The policy is deny by default. Every scope and claim must match; an expected claim array matches
+when the principal has any listed value. The principal comes from `mcp.security.authenticate`, so
+the example requires a principal such as
+`{ id: "agent-1", scopes: ["docs:private"], claims: { role: "editor", plan: "enterprise" } }`.
+
+Protected pages are omitted from public `llms.txt`, search/Ask AI indexes, content-change feeds,
+Markdown recovery suggestions, MCP navigation, and Static Agent Bundles. Default `.md` routes
+return a private, non-cacheable `404` instead of revealing whether the page exists. Invalid authored
+policies also fail closed and are reported by `docs review`.
+
+<Callout type="warning">
+  `agent.access` protects the framework's agent-facing machine surfaces. It does not authenticate
+  your rendered HTML page route; enforce application authorization separately when the human page
+  is also private.
+</Callout>
+
 ## Reusable Agent Skills
 
 Set `agent.skills` to publish every configured skill through standards discovery, Static Agent

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -2532,6 +2532,7 @@ Page-level metadata for machine-readable docs workflows.
 | Property        | Type | Description |
 | --------------- | ---- | ----------- |
 | `tokenBudget`   | `number` | Approximate output token target for `docs agent compact` on this page |
+| `access`        | `DocsPageAccessPolicy` | Deny-by-default scopes and claims for agent-facing page surfaces |
 | `task`          | `string` | Concrete task the page helps an agent complete |
 | `outcome`       | `string` | Observable end state that indicates completion |
 | `appliesTo`     | `{ framework?, version?, package? }` | Applicability values; each accepts a string or string array |
@@ -2549,6 +2550,14 @@ title: "Installation"
 description: "Install the framework"
 agent:
   tokenBudget: 777
+  access:
+    visibility: authenticated
+    scopes:
+      - docs:private
+    claims:
+      role:
+        - admin
+        - editor
   task: Install the framework
   outcome: The docs route renders locally.
   appliesTo:
@@ -2576,6 +2585,11 @@ Notes:
 
 - `agent.tokenBudget` overrides global `agent.compact.maxOutputTokens` defaults and CLI
   `--max-output-tokens` for that one page
+- `agent.access.visibility: authenticated` requires a principal; every listed scope and claim must
+  match, while claim arrays accept any overlapping value
+- protected pages are omitted from public Markdown discovery, `llms.txt`, search/Ask AI, content
+  sync, unauthenticated MCP results, and static agent bundles; application HTML authorization remains
+  the host application's responsibility
 - structured fields are normalized into served Markdown frontmatter, a deterministic
   `## Agent Contract` section, search/Ask AI context, Schema.org `HowTo` JSON-LD, and MCP task tools
 - MCP list-page results contain only `hasContract`, `task`, `outcome`, and `appliesTo`; call


### PR DESCRIPTION
## Summary

- add declarative `agent.access` policies with authenticated visibility, required scopes, and claim matching
- fail closed across Markdown, llms.txt, search and Ask AI, content sync, MCP tools/navigation, and static agent exports
- retain public behavior for pages without a policy and document the separate HTML authorization boundary
- add cross-surface, MCP, export, normalization, and recovery-leak coverage

## Verification

- `pnpm --filter @farming-labs/docs typecheck`
- 400 focused core tests across access, agent, search, content changes, MCP, and agent export
- builds for `@farming-labs/docs`, theme, and Next adapter
- typechecks for TanStack Start, Astro, Nuxt, SvelteKit, Farm.js, and the website
- formatting and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds page-level `agent.access` policies for docs pages to gate machine-readable surfaces by auth, scopes, and claims. Policies are enforced across Markdown, search, llms.txt, content sync, MCP, and static exports; pages without a policy remain public.

- New Features
  - `agent.access` frontmatter with `visibility`, `scopes`, and `claims`; normalized and fail-closed on invalid input
  - Enforcement across llms.txt, search/Ask AI, content snapshots/feeds, MCP pages/navigation/tools, static agent bundles, and Markdown (private 404 with no content leak)
  - Server adapters pass `access` into Markdown rendering; `createDocsMarkdownResponse` now accepts `access` and `principal`
  - New APIs in `@farming-labs/docs`: `normalizeDocsPageAccessPolicy`, `isDocsPageAccessAllowed`, `filterDocsPagesByAccess`, `isDocsAgentPageAccessible`; types `DocsPageAccessPolicy`, `DocsAccessPrincipal`, `DocsAccessClaimValue`
  - Docs updated to explain usage and the separate HTML authorization boundary

- Migration
  - Add `agent.access` to pages you want protected; keep HTML route auth separate
  - Pass an authenticated principal where available: `createDocsMarkdownResponse({ access, principal })`, `performDocsSearch({ principal })`, `buildDocsContentSnapshot({ principal })`, `buildDocsSearchFacets({ principal })`, and via MCP `requestContext.auth`
  - No changes needed for public pages

<sup>Written for commit b13fbeb53911af0cf5019939b5966267457d03d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

