### PR TITLE
feat: add agent maintenance proposal workflows

### DIFF
--- a/packages/docs/src/agent-maintenance.test.ts
+++ b/packages/docs/src/agent-maintenance.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  analyzeDocsAgentMaintenanceSignals,
+  readDocsAgentMaintenanceSignalsFile,
+} from "./agent-maintenance.js";
+
+describe("agent maintenance proposals", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("combines multi-source signals into ranked, review-only drafts", () => {
+    const report = analyzeDocsAgentMaintenanceSignals(
+      [
+        {
+          source: "search",
+          page: "/docs/install",
+          topic: "install existing app",
+          task: "Install in an existing app",
+          summary: "Repeated zero-result query",
+          count: 4,
+          severity: "warning",
+        },
+        {
+          source: "support",
+          page: "/docs/install",
+          topic: "install existing app",
+          summary: "Users miss required peer dependencies",
+          count: 2,
+          severity: "error",
+        },
+        {
+          source: "mcp",
+          page: "/docs/install",
+          topic: "install existing app",
+          summary: "read_page lacks the existing-app example",
+        },
+      ],
+      { generatedAt: "2026-08-12T00:00:00.000Z" },
+    );
+
+    expect(report).toMatchObject({
+      format: "farming-labs-agent-maintenance-proposals.v1",
+      signalCount: 3,
+      representedOccurrences: 7,
+      proposalCount: 1,
+      execution: {
+        mode: "draft-only",
+        writesDocumentation: false,
+        publishesChanges: false,
+        requiresHumanReview: true,
+      },
+    });
+    expect(report.proposals[0]).toMatchObject({
+      page: "/docs/install",
+      occurrenceCount: 7,
+      severity: "error",
+      sources: ["mcp", "search", "support"],
+      goldenTask: { expect: { relevantSources: ["/docs/install"] } },
+    });
+    expect(report.proposals[0]?.recommendedActions.join(" ")).toContain("MCP tool");
+    expect(report.issueDrafts[0]?.body).toContain("untrusted evidence");
+  });
+
+  it("reads generic JSONL, raw feedback, and feedback improvement reports", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "docs-maintenance-"));
+    temporaryDirectories.push(directory);
+    const jsonlPath = path.join(directory, "signals.jsonl");
+    const feedbackPath = path.join(directory, "feedback.json");
+    writeFileSync(
+      jsonlPath,
+      `${JSON.stringify({ source: "issue", summary: "Missing migration steps", page: "/docs/migrate" })}\n${JSON.stringify({ context: { page: "/docs/install" }, payload: { task: "Install", outcome: "blocked" } })}\n`,
+      "utf8",
+    );
+    writeFileSync(
+      feedbackPath,
+      JSON.stringify({
+        format: "farming-labs-agent-feedback-improvements.v1",
+        clusters: [
+          {
+            page: "/docs/install",
+            task: "Install existing app",
+            occurrences: 3,
+            missingContext: ["Peer dependencies"],
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    expect(readDocsAgentMaintenanceSignalsFile(jsonlPath)).toMatchObject([
+      { source: "issue", page: "/docs/migrate" },
+      { source: "agent-feedback", page: "/docs/install", severity: "error" },
+    ]);
+    expect(readDocsAgentMaintenanceSignalsFile(feedbackPath)).toEqual([
+      expect.objectContaining({ source: "agent-feedback", count: 3, summary: "Peer dependencies" }),
+    ]);
+  });
+
+  it("validates signal counts and supported sources", () => {
+    expect(() =>
+      analyzeDocsAgentMaintenanceSignals([{ source: "search", summary: "Bad count", count: 0 }]),
+    ).toThrow("count must be an integer");
+    expect(() =>
+      analyzeDocsAgentMaintenanceSignals([
+        { source: "unknown" as "search", summary: "Unknown source" },
+      ]),
+    ).toThrow("source is not supported");
+  });
+});

--- a/packages/docs/src/agent-maintenance.test.ts
+++ b/packages/docs/src/agent-maintenance.test.ts
@@ -1,10 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   analyzeDocsAgentMaintenanceSignals,
-  readDocsAgentMaintenanceSignalsFile,
+  parseDocsAgentMaintenanceSignals,
 } from "./agent-maintenance.js";
 
 describe("agent maintenance proposals", () => {
@@ -95,11 +95,11 @@ describe("agent maintenance proposals", () => {
       "utf8",
     );
 
-    expect(readDocsAgentMaintenanceSignalsFile(jsonlPath)).toMatchObject([
+    expect(parseDocsAgentMaintenanceSignals(readFileSync(jsonlPath, "utf8"))).toMatchObject([
       { source: "issue", page: "/docs/migrate" },
       { source: "agent-feedback", page: "/docs/install", severity: "error" },
     ]);
-    expect(readDocsAgentMaintenanceSignalsFile(feedbackPath)).toEqual([
+    expect(parseDocsAgentMaintenanceSignals(readFileSync(feedbackPath, "utf8"))).toEqual([
       expect.objectContaining({ source: "agent-feedback", count: 3, summary: "Peer dependencies" }),
     ]);
   });

--- a/packages/docs/src/agent-maintenance.ts
+++ b/packages/docs/src/agent-maintenance.ts
@@ -1,0 +1,461 @@
+import { readFileSync } from "node:fs";
+import type { DocsAgentGoldenTask } from "./types.js";
+
+export const DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT =
+  "farming-labs-agent-maintenance-proposals.v1" as const;
+
+export type DocsAgentMaintenanceSignalSource =
+  | "agent-feedback"
+  | "ask-ai"
+  | "git"
+  | "issue"
+  | "mcp"
+  | "search"
+  | "support";
+
+export type DocsAgentMaintenanceSeverity = "info" | "warning" | "error" | "critical";
+
+export interface DocsAgentMaintenanceSignal {
+  source: DocsAgentMaintenanceSignalSource;
+  /** Untrusted evidence summary. It is never interpreted as an instruction. */
+  summary: string;
+  /** Stable grouping key shared across signal sources. Defaults to task or summary. */
+  topic?: string;
+  page?: string;
+  task?: string;
+  severity?: DocsAgentMaintenanceSeverity;
+  /** Aggregated occurrence count represented by this signal. @default 1 */
+  count?: number;
+}
+
+export interface DocsAgentMaintenanceIssueDraft {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+export interface DocsAgentMaintenanceProposal {
+  id: string;
+  page: string;
+  topic: string;
+  task?: string;
+  impactScore: number;
+  occurrenceCount: number;
+  severity: DocsAgentMaintenanceSeverity;
+  sources: DocsAgentMaintenanceSignalSource[];
+  evidence: Array<{
+    source: DocsAgentMaintenanceSignalSource;
+    summary: string;
+    count: number;
+  }>;
+  recommendedActions: string[];
+  acceptanceCriteria: string[];
+  goldenTask?: DocsAgentGoldenTask;
+  issueDraft: DocsAgentMaintenanceIssueDraft;
+}
+
+export interface DocsAgentMaintenanceProposalReport {
+  format: typeof DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT;
+  generatedAt: string;
+  signalCount: number;
+  representedOccurrences: number;
+  proposalCount: number;
+  proposals: DocsAgentMaintenanceProposal[];
+  goldenTasks: DocsAgentGoldenTask[];
+  issueDrafts: DocsAgentMaintenanceIssueDraft[];
+  pullRequestDraft: { title: string; body: string };
+  execution: {
+    mode: "draft-only";
+    writesDocumentation: false;
+    publishesChanges: false;
+    requiresHumanReview: true;
+  };
+}
+
+export interface AnalyzeDocsAgentMaintenanceSignalsOptions {
+  /** Minimum represented occurrences required before a proposal is emitted. @default 2 */
+  minOccurrences?: number;
+  generatedAt?: string;
+}
+
+interface NormalizedSignal extends DocsAgentMaintenanceSignal {
+  count: number;
+  severity: DocsAgentMaintenanceSeverity;
+  page: string;
+  topic: string;
+}
+
+const SOURCES = new Set<DocsAgentMaintenanceSignalSource>([
+  "agent-feedback",
+  "ask-ai",
+  "git",
+  "issue",
+  "mcp",
+  "search",
+  "support",
+]);
+const SEVERITIES = new Set<DocsAgentMaintenanceSeverity>(["info", "warning", "error", "critical"]);
+const SEVERITY_RANK: Record<DocsAgentMaintenanceSeverity, number> = {
+  info: 1,
+  warning: 2,
+  error: 3,
+  critical: 4,
+};
+const TOPIC_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "docs",
+  "for",
+  "from",
+  "how",
+  "in",
+  "of",
+  "on",
+  "the",
+  "to",
+  "with",
+]);
+
+function cleanString(value: unknown, maxLength = 1_000): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value
+    .split("")
+    .map((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || code === 127 ? " " : character;
+    })
+    .join("")
+    .trim()
+    .replace(/\s+/g, " ");
+  return normalized ? normalized.slice(0, maxLength) : undefined;
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 72) || "docs-maintenance"
+  );
+}
+
+function topicSignature(value: string): string {
+  const tokens = value
+    .toLowerCase()
+    .match(/[a-z0-9][a-z0-9_-]*/g)
+    ?.filter((token) => token.length > 1 && !TOPIC_STOP_WORDS.has(token));
+  return [...new Set(tokens ?? [])].sort().slice(0, 12).join("-") || "unspecified";
+}
+
+function normalizeSignal(value: DocsAgentMaintenanceSignal, index: number): NormalizedSignal {
+  if (!SOURCES.has(value.source)) {
+    throw new Error(`Signal ${index + 1}.source is not supported.`);
+  }
+  const summary = cleanString(value.summary);
+  if (!summary) throw new Error(`Signal ${index + 1}.summary must be a non-empty string.`);
+  const page = cleanString(value.page, 300) ?? "(unknown page)";
+  const task = cleanString(value.task, 500);
+  const topic = cleanString(value.topic, 300) ?? task ?? summary;
+  const count = value.count === undefined ? 1 : Math.floor(value.count);
+  if (!Number.isSafeInteger(count) || count < 1 || count > 1_000_000) {
+    throw new Error(`Signal ${index + 1}.count must be an integer from 1 through 1000000.`);
+  }
+  const severity = value.severity ?? "warning";
+  if (!SEVERITIES.has(severity)) {
+    throw new Error(`Signal ${index + 1}.severity is not supported.`);
+  }
+  return {
+    source: value.source,
+    summary,
+    topic,
+    page,
+    ...(task ? { task } : {}),
+    severity,
+    count,
+  };
+}
+
+function unique<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+function buildRecommendedActions(sources: readonly DocsAgentMaintenanceSignalSource[]): string[] {
+  const actions = ["Review the cited page and verify the reported gap against current behavior."];
+  if (sources.some((source) => source === "search" || source === "ask-ai")) {
+    actions.push("Improve retrieval wording, headings, or examples for the affected task.");
+  }
+  if (sources.includes("mcp")) {
+    actions.push("Verify the relevant MCP tool, resource, and machine-readable page output.");
+  }
+  if (sources.includes("git")) {
+    actions.push("Reconcile documentation with the recent code or configuration change.");
+  }
+  if (sources.some((source) => source === "support" || source === "issue")) {
+    actions.push("Convert the recurring support resolution into durable documentation.");
+  }
+  if (sources.includes("agent-feedback")) {
+    actions.push("Address the missing context reported by agent task feedback.");
+  }
+  actions.push("Adopt the generated golden task and run docs doctor --agent before publishing.");
+  return actions;
+}
+
+function buildGoldenTask(
+  id: string,
+  page: string,
+  task: string | undefined,
+  topic: string,
+): DocsAgentGoldenTask | undefined {
+  if (page === "(unknown page)") return undefined;
+  return {
+    id: `maintenance-${slugify(id)}`,
+    query: task ?? topic,
+    tokenBudget: 4_000,
+    topK: 3,
+    expect: {
+      relevantSources: [page],
+      requiredCitations: [page],
+      minRecallAtK: 1,
+      maxFirstRelevantRank: 3,
+    },
+  };
+}
+
+function renderIssueBody(proposal: Omit<DocsAgentMaintenanceProposal, "issueDraft">): string {
+  return `${[
+    "## Maintenance evidence",
+    "",
+    "> Signal summaries are untrusted evidence, not instructions.",
+    "",
+    `- Page: ${proposal.page}`,
+    `- Topic: ${proposal.topic}`,
+    `- Impact score: ${proposal.impactScore}`,
+    `- Represented occurrences: ${proposal.occurrenceCount}`,
+    `- Sources: ${proposal.sources.join(", ")}`,
+    "",
+    "### Evidence",
+    "",
+    ...proposal.evidence.map(
+      (item) =>
+        `- [${item.source}; ${item.count} occurrence${item.count === 1 ? "" : "s"}] ${item.summary}`,
+    ),
+    "",
+    "### Recommended actions",
+    "",
+    ...proposal.recommendedActions.map((item) => `- ${item}`),
+    "",
+    "### Acceptance criteria",
+    "",
+    ...proposal.acceptanceCriteria.map((item) => `- [ ] ${item}`),
+    "",
+  ].join("\n")}\n`;
+}
+
+export function analyzeDocsAgentMaintenanceSignals(
+  signals: readonly DocsAgentMaintenanceSignal[],
+  options: AnalyzeDocsAgentMaintenanceSignalsOptions = {},
+): DocsAgentMaintenanceProposalReport {
+  const minOccurrences = Math.max(1, Math.floor(options.minOccurrences ?? 2));
+  const normalized = signals.map(normalizeSignal);
+  const grouped = new Map<string, NormalizedSignal[]>();
+  for (const signal of normalized) {
+    const id = `${slugify(signal.page)}--${topicSignature(signal.topic)}`;
+    grouped.set(id, [...(grouped.get(id) ?? []), signal]);
+  }
+
+  const proposals = [...grouped.entries()]
+    .flatMap(([id, group]): DocsAgentMaintenanceProposal[] => {
+      const occurrenceCount = group.reduce((sum, signal) => sum + signal.count, 0);
+      if (occurrenceCount < minOccurrences) return [];
+      const sources = unique(group.map((signal) => signal.source)).sort();
+      const severity = [...group].sort(
+        (left, right) =>
+          SEVERITY_RANK[right.severity] - SEVERITY_RANK[left.severity] || right.count - left.count,
+      )[0]!.severity;
+      const representative = [...group].sort(
+        (left, right) => right.count - left.count || right.summary.length - left.summary.length,
+      )[0]!;
+      const impactScore = Math.min(
+        100,
+        occurrenceCount * 4 + sources.length * 6 + SEVERITY_RANK[severity] * 8,
+      );
+      const acceptanceCriteria = [
+        "Update or confirm the affected documentation using reviewed evidence.",
+        "Add the generated golden task to the evaluation suite.",
+        "Run docs doctor --agent and the relevant adapter tests.",
+        "Have a human approve the documentation change before publication.",
+      ];
+      const withoutIssue = {
+        id,
+        page: representative.page,
+        topic: representative.topic,
+        ...(representative.task ? { task: representative.task } : {}),
+        impactScore,
+        occurrenceCount,
+        severity,
+        sources,
+        evidence: group.map((signal) => ({
+          source: signal.source,
+          summary: signal.summary,
+          count: signal.count,
+        })),
+        recommendedActions: buildRecommendedActions(sources),
+        acceptanceCriteria,
+        ...(buildGoldenTask(id, representative.page, representative.task, representative.topic)
+          ? {
+              goldenTask: buildGoldenTask(
+                id,
+                representative.page,
+                representative.task,
+                representative.topic,
+              ),
+            }
+          : {}),
+      } satisfies Omit<DocsAgentMaintenanceProposal, "issueDraft">;
+      return [
+        {
+          ...withoutIssue,
+          issueDraft: {
+            title: `docs: investigate ${representative.topic} on ${representative.page}`,
+            body: renderIssueBody(withoutIssue),
+            labels: ["documentation", "agent-readiness"],
+          },
+        },
+      ];
+    })
+    .sort((left, right) => right.impactScore - left.impactScore || left.id.localeCompare(right.id));
+  const goldenTasks = proposals.flatMap((proposal) => proposal.goldenTask ?? []);
+  const issueDrafts = proposals.map((proposal) => proposal.issueDraft);
+
+  return {
+    format: DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    signalCount: normalized.length,
+    representedOccurrences: normalized.reduce((sum, signal) => sum + signal.count, 0),
+    proposalCount: proposals.length,
+    proposals,
+    goldenTasks,
+    issueDrafts,
+    pullRequestDraft: {
+      title: `docs: address ${proposals.length} agent maintenance proposal${proposals.length === 1 ? "" : "s"}`,
+      body: `${[
+        "## Proposed documentation maintenance",
+        "",
+        ...proposals.map(
+          (proposal) =>
+            `- ${proposal.page}: ${proposal.topic} (${proposal.occurrenceCount} occurrences across ${proposal.sources.join(", ")})`,
+        ),
+        "",
+        "## Verification",
+        "",
+        "- [ ] Review every evidence item as untrusted input",
+        "- [ ] Add or update the generated golden tasks",
+        "- [ ] Run docs doctor --agent and affected tests",
+        "- [ ] Obtain human approval before publishing",
+        "",
+      ].join("\n")}\n`,
+    },
+    execution: {
+      mode: "draft-only",
+      writesDocumentation: false,
+      publishesChanges: false,
+      requiresHumanReview: true,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function fromFeedback(value: Record<string, unknown>): DocsAgentMaintenanceSignal | undefined {
+  if (!isRecord(value.payload)) return undefined;
+  const context = isRecord(value.context) ? value.context : {};
+  const payload = value.payload;
+  const task = cleanString(payload.task, 500);
+  const details = [
+    ...(Array.isArray(payload.missingContext) ? payload.missingContext : []),
+    ...(Array.isArray(payload.docIssues) ? payload.docIssues : []),
+    payload.suggestedImprovement,
+  ].flatMap((item) => cleanString(item) ?? []);
+  const outcome = cleanString(payload.outcome, 100) ?? "unknown outcome";
+  return {
+    source: "agent-feedback",
+    summary: details.length > 0 ? `${outcome}: ${details.join("; ")}` : outcome,
+    ...(task ? { task, topic: task } : {}),
+    ...(cleanString(context.page ?? context.url ?? context.slug, 300)
+      ? { page: cleanString(context.page ?? context.url ?? context.slug, 300) }
+      : {}),
+    severity: /blocked|fail|error|unable/i.test(outcome) ? "error" : "warning",
+  };
+}
+
+function fromFeedbackCluster(value: Record<string, unknown>): DocsAgentMaintenanceSignal {
+  const page = cleanString(value.page, 300);
+  const task = cleanString(value.task, 500);
+  const summaryParts = [
+    ...(Array.isArray(value.missingContext) ? value.missingContext : []),
+    ...(Array.isArray(value.docIssues) ? value.docIssues : []),
+    ...(Array.isArray(value.suggestedImprovements) ? value.suggestedImprovements : []),
+  ].flatMap((item) => cleanString(item) ?? []);
+  return {
+    source: "agent-feedback",
+    summary: summaryParts.join("; ") || task || "Recurring agent feedback failure",
+    ...(page ? { page } : {}),
+    ...(task ? { task, topic: task } : {}),
+    severity: "error",
+    count:
+      typeof value.occurrences === "number" && Number.isSafeInteger(value.occurrences)
+        ? value.occurrences
+        : 1,
+  };
+}
+
+function parseSignal(value: unknown, label: string): DocsAgentMaintenanceSignal {
+  if (!isRecord(value)) throw new Error(`${label} must be an object.`);
+  const feedback = fromFeedback(value);
+  if (feedback) return feedback;
+  return value as unknown as DocsAgentMaintenanceSignal;
+}
+
+function extractSignals(value: unknown): DocsAgentMaintenanceSignal[] | undefined {
+  if (Array.isArray(value))
+    return value.map((item, index) => parseSignal(item, `Signal ${index + 1}`));
+  if (!isRecord(value)) return undefined;
+  if (Array.isArray(value.clusters)) {
+    return value.clusters.map((item, index) => {
+      if (!isRecord(item)) throw new Error(`Feedback cluster ${index + 1} must be an object.`);
+      return fromFeedbackCluster(item);
+    });
+  }
+  const collection = value.signals ?? value.events ?? value.items;
+  if (Array.isArray(collection)) {
+    return collection.map((item, index) => parseSignal(item, `Signal ${index + 1}`));
+  }
+  return undefined;
+}
+
+export function readDocsAgentMaintenanceSignalsFile(
+  filePath: string,
+): DocsAgentMaintenanceSignal[] {
+  const content = readFileSync(filePath, "utf8").trim();
+  if (!content) return [];
+  try {
+    const extracted = extractSignals(JSON.parse(content));
+    if (extracted) return extracted;
+  } catch {
+    // Fall through to JSON Lines parsing so the line number can be reported.
+  }
+  return content.split(/\r?\n/).map((line, index) => {
+    try {
+      return parseSignal(JSON.parse(line), `Signal line ${index + 1}`);
+    } catch (error) {
+      throw new Error(
+        `Invalid maintenance signal JSON on line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+}

--- a/packages/docs/src/agent-maintenance.ts
+++ b/packages/docs/src/agent-maintenance.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { DocsAgentGoldenTask } from "./types.js";
 
 export const DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT =
@@ -438,10 +437,8 @@ function extractSignals(value: unknown): DocsAgentMaintenanceSignal[] | undefine
   return undefined;
 }
 
-export function readDocsAgentMaintenanceSignalsFile(
-  filePath: string,
-): DocsAgentMaintenanceSignal[] {
-  const content = readFileSync(filePath, "utf8").trim();
+export function parseDocsAgentMaintenanceSignals(content: string): DocsAgentMaintenanceSignal[] {
+  content = content.trim();
   if (!content) return [];
   try {
     const extracted = extractSignals(JSON.parse(content));

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -200,6 +200,18 @@ async function main() {
       return;
     }
     await runAgentFeedbackImprove(feedbackOptions);
+  } else if (parsedCommand.command === "agent" && subcommand === "propose") {
+    const {
+      parseAgentMaintenanceProposeArgs,
+      printAgentMaintenanceProposeHelp,
+      runAgentMaintenancePropose,
+    } = await import("./propose.js");
+    const proposeOptions = parseAgentMaintenanceProposeArgs(args.slice(2));
+    if (proposeOptions.help) {
+      printAgentMaintenanceProposeHelp();
+      return;
+    }
+    await runAgentMaintenancePropose(proposeOptions);
   } else if (parsedCommand.command === "agent" && subcommand === "compact") {
     const { compactAgentDocs, parseAgentCompactArgs, printAgentCompactHelp } =
       await import("./agent.js");
@@ -224,9 +236,11 @@ async function main() {
     const { printAgentCompactHelp } = await import("./agent.js");
     const { printAgentExportHelp } = await import("./agent-export.js");
     const { printAgentFeedbackImproveHelp } = await import("./feedback.js");
+    const { printAgentMaintenanceProposeHelp } = await import("./propose.js");
     printAgentCompactHelp();
     printAgentExportHelp();
     printAgentFeedbackImproveHelp();
+    printAgentMaintenanceProposeHelp();
     process.exit(1);
   } else if (parsedCommand.command === "agents" && subcommand === "generate") {
     const { generateAgents, parseAgentsGenerateArgs, printAgentsGenerateHelp } =
@@ -476,6 +490,14 @@ ${pc.dim("Options for agent feedback:")}
   ${pc.cyan("agent feedback --input <path>")}       Cluster JSON or JSONL agent feedback into improvement drafts
   ${pc.cyan("--min-occurrences <2-100>")}           Recurrence threshold (default: 2)
   ${pc.cyan("--write")}                             Write the report to ${pc.dim(".farming-labs/agent-feedback-improvements.json")}
+  ${pc.cyan("--output <path>")}                     Override the written report path
+  ${pc.cyan("--json")}                              Print JSON while writing
+
+${pc.dim("Options for agent maintenance proposals:")}
+  ${pc.cyan("agent propose --input <path>")}        Combine JSON/JSONL feedback, search, MCP, issue, support, and git signals
+  ${pc.cyan("--input <path>")}                      Repeat to combine multiple signal exports
+  ${pc.cyan("--min-occurrences <1-100>")}           Proposal threshold (default: 2)
+  ${pc.cyan("--write")}                             Write the draft-only report to ${pc.dim(".farming-labs/agent-maintenance-proposals.json")}
   ${pc.cyan("--output <path>")}                     Override the written report path
   ${pc.cyan("--json")}                              Print JSON while writing
 

--- a/packages/docs/src/cli/propose.test.ts
+++ b/packages/docs/src/cli/propose.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseAgentMaintenanceProposeArgs, runAgentMaintenancePropose } from "./propose.js";
+
+describe("agent maintenance proposal CLI", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("parses repeatable inputs and bounded thresholds", () => {
+    expect(
+      parseAgentMaintenanceProposeArgs([
+        "--input",
+        "search.jsonl",
+        "--input",
+        "support.json",
+        "--min-occurrences",
+        "3",
+        "--write",
+        "--output",
+        "proposals.json",
+      ]),
+    ).toEqual({
+      inputs: ["search.jsonl", "support.json"],
+      minOccurrences: 3,
+      write: true,
+      output: "proposals.json",
+    });
+    expect(() => parseAgentMaintenanceProposeArgs(["--min-occurrences", "0"])).toThrow(
+      "1 through 100",
+    );
+  });
+
+  it("writes a proposal artifact without mutating source inputs", async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "docs-propose-cli-"));
+    temporaryDirectories.push(rootDir);
+    const inputPath = path.join(rootDir, "signals.jsonl");
+    const input = `${JSON.stringify({
+      source: "search",
+      page: "/docs/install",
+      topic: "existing install",
+      summary: "Zero results",
+      count: 3,
+    })}\n`;
+    writeFileSync(inputPath, input, "utf8");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const report = await runAgentMaintenancePropose({
+      rootDir,
+      inputs: ["signals.jsonl"],
+      write: true,
+    });
+    expect(report.proposalCount).toBe(1);
+    expect(report.execution.mode).toBe("draft-only");
+    expect(readFileSync(inputPath, "utf8")).toBe(input);
+    const written = JSON.parse(
+      readFileSync(path.join(rootDir, ".farming-labs", "agent-maintenance-proposals.json"), "utf8"),
+    );
+    expect(written.issueDrafts).toHaveLength(1);
+    expect(written.goldenTasks).toHaveLength(1);
+    expect(written.execution.publishesChanges).toBe(false);
+  });
+
+  it("rejects paths outside the project root", async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "docs-propose-path-"));
+    temporaryDirectories.push(rootDir);
+    await expect(
+      runAgentMaintenancePropose({ rootDir, inputs: ["../signals.json"] }),
+    ).rejects.toThrow("stay inside the project root");
+  });
+});

--- a/packages/docs/src/cli/propose.ts
+++ b/packages/docs/src/cli/propose.ts
@@ -1,9 +1,9 @@
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 import {
   analyzeDocsAgentMaintenanceSignals,
-  readDocsAgentMaintenanceSignalsFile,
+  parseDocsAgentMaintenanceSignals,
   type DocsAgentMaintenanceProposalReport,
 } from "../agent-maintenance.js";
 
@@ -76,7 +76,7 @@ export async function runAgentMaintenancePropose(
       ? options.inputs
       : [".farming-labs/agent-feedback-improvements.json"];
   const signals = inputs.flatMap((input) =>
-    readDocsAgentMaintenanceSignalsFile(resolveProjectPath(rootDir, input)),
+    parseDocsAgentMaintenanceSignals(readFileSync(resolveProjectPath(rootDir, input), "utf8")),
   );
   const report = analyzeDocsAgentMaintenanceSignals(signals, {
     minOccurrences: options.minOccurrences,

--- a/packages/docs/src/cli/propose.ts
+++ b/packages/docs/src/cli/propose.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+import {
+  analyzeDocsAgentMaintenanceSignals,
+  readDocsAgentMaintenanceSignalsFile,
+  type DocsAgentMaintenanceProposalReport,
+} from "../agent-maintenance.js";
+
+export interface AgentMaintenanceProposeOptions {
+  inputs?: string[];
+  output?: string;
+  minOccurrences?: number;
+  write?: boolean;
+  json?: boolean;
+  help?: boolean;
+  rootDir?: string;
+}
+
+export function parseAgentMaintenanceProposeArgs(
+  argv: readonly string[],
+): AgentMaintenanceProposeOptions {
+  const options: AgentMaintenanceProposeOptions = { inputs: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]!;
+    if (argument === "--write") options.write = true;
+    else if (argument === "--json") options.json = true;
+    else if (argument === "--help" || argument === "-h") options.help = true;
+    else if (
+      argument === "--input" ||
+      argument === "--output" ||
+      argument === "--min-occurrences"
+    ) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${argument} requires a value.`);
+      index += 1;
+      if (argument === "--input") options.inputs!.push(value);
+      else if (argument === "--output") options.output = value;
+      else {
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+          throw new Error("--min-occurrences must be an integer from 1 through 100.");
+        }
+        options.minOccurrences = parsed;
+      }
+    } else {
+      throw new Error(`Unknown agent propose flag: ${argument}`);
+    }
+  }
+  return options;
+}
+
+function resolveProjectPath(rootDir: string, value: string): string {
+  if (path.isAbsolute(value)) throw new Error("Maintenance paths must be project-relative.");
+  const candidate = path.resolve(rootDir, value);
+  const relative = path.relative(rootDir, candidate);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Maintenance paths must stay inside the project root.");
+  }
+  return candidate;
+}
+
+function writeReport(outputPath: string, report: DocsAgentMaintenanceProposalReport): void {
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+export async function runAgentMaintenancePropose(
+  options: AgentMaintenanceProposeOptions = {},
+): Promise<DocsAgentMaintenanceProposalReport> {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const inputs =
+    options.inputs && options.inputs.length > 0
+      ? options.inputs
+      : [".farming-labs/agent-feedback-improvements.json"];
+  const signals = inputs.flatMap((input) =>
+    readDocsAgentMaintenanceSignalsFile(resolveProjectPath(rootDir, input)),
+  );
+  const report = analyzeDocsAgentMaintenanceSignals(signals, {
+    minOccurrences: options.minOccurrences,
+  });
+
+  if (options.write) {
+    const outputPath = resolveProjectPath(
+      rootDir,
+      options.output ?? ".farming-labs/agent-maintenance-proposals.json",
+    );
+    writeReport(outputPath, report);
+    if (!options.json) {
+      console.log(
+        pc.green(
+          `Wrote ${path.relative(rootDir, outputPath)} with ${report.proposalCount} reviewable proposal${report.proposalCount === 1 ? "" : "s"}.`,
+        ),
+      );
+    }
+  }
+  if (options.json || !options.write) console.log(JSON.stringify(report, null, 2));
+  return report;
+}
+
+export function printAgentMaintenanceProposeHelp(): void {
+  console.log(`${pc.bold("docs agent propose")} — turn recurring signals into reviewable maintenance drafts
+
+${pc.dim("Usage:")}
+  docs agent propose --input .farming-labs/agent-feedback-improvements.json
+  docs agent propose --input search-signals.jsonl --input support-signals.json --write
+
+${pc.dim("Options:")}
+  ${pc.cyan("--input <path>")}             Repeatable JSON/JSONL signal or feedback report
+  ${pc.cyan("--min-occurrences <1-100>")} Proposal threshold (default: 2)
+  ${pc.cyan("--write")}                    Write the draft-only proposal report
+  ${pc.cyan("--output <path>")}            Output path (default: .farming-labs/agent-maintenance-proposals.json)
+  ${pc.cyan("--json")}                     Print JSON when writing
+
+Signal sources: agent-feedback, ask-ai, git, issue, mcp, search, support.
+The command never edits documentation, creates issues, publishes branches, or merges changes.
+`);
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -84,6 +84,20 @@ export {
 } from "./agent-contract.js";
 export type { PageAgentFrontmatterIssue } from "./agent-contract.js";
 export {
+  analyzeDocsAgentMaintenanceSignals,
+  DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT,
+  readDocsAgentMaintenanceSignalsFile,
+} from "./agent-maintenance.js";
+export type {
+  AnalyzeDocsAgentMaintenanceSignalsOptions,
+  DocsAgentMaintenanceIssueDraft,
+  DocsAgentMaintenanceProposal,
+  DocsAgentMaintenanceProposalReport,
+  DocsAgentMaintenanceSeverity,
+  DocsAgentMaintenanceSignal,
+  DocsAgentMaintenanceSignalSource,
+} from "./agent-maintenance.js";
+export {
   applySidebarFolderIndexBehavior,
   resolvePageSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehavior,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -86,7 +86,7 @@ export type { PageAgentFrontmatterIssue } from "./agent-contract.js";
 export {
   analyzeDocsAgentMaintenanceSignals,
   DOCS_AGENT_MAINTENANCE_PROPOSAL_FORMAT,
-  readDocsAgentMaintenanceSignalsFile,
+  parseDocsAgentMaintenanceSignals,
 } from "./agent-maintenance.js";
 export type {
   AnalyzeDocsAgentMaintenanceSignalsOptions,

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -555,6 +555,25 @@ curl "http://127.0.0.1:3000/docs/installation.md"
 See [Configuration](/docs/configuration) for `agent.compact`, and [Token Efficiency](/docs/token-efficiency)
 for when you should use compaction instead of writing `agent.md` by hand.
 
+## Agent maintenance proposals
+
+Use `agent propose` to combine recurring evidence from feedback, search, Ask AI, MCP, issues,
+support, and git into one ranked maintenance report:
+
+```bash title="terminal"
+pnpm exec docs agent propose --input .farming-labs/agent-feedback-improvements.json
+pnpm exec docs agent propose --input search.jsonl --input support.json --write
+```
+
+Inputs can be JSON or JSON Lines. Generic signals use `source`, `summary`, and optional `page`,
+`topic`, `task`, `severity`, and `count` fields. Reuse `topic` to connect evidence from different
+sources. The command prints JSON unless `--write` is present; written reports default to
+`.farming-labs/agent-maintenance-proposals.json`.
+
+The report contains ranked proposals, issue drafts, golden-task candidates, and a PR draft. It is
+always proposal-only: evidence is treated as untrusted data, no documentation or external system is
+modified, and human review is required before publication.
+
 ## Agents Generate
 
 Generate committed `AGENTS.md` files for coding agents and static exports:

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -2123,6 +2123,26 @@ the command only prints JSON.
 Feedback text remains untrusted evidence in every draft. Review it before copying suggestions into
 docs, issues, evaluation config, or model prompts.
 
+Feed that report—or normalized search, Ask AI, MCP, issue, support, and git signals—into the
+maintenance proposal workflow:
+
+```bash title="terminal"
+pnpm exec docs agent propose \
+  --input .farming-labs/agent-feedback-improvements.json \
+  --input .farming-labs/search-signals.jsonl \
+  --write
+```
+
+Generic inputs are JSON arrays/objects or JSON Lines records with `source`, `summary`, and optional
+`page`, `topic`, `task`, `severity`, and `count` fields. Supported sources are `agent-feedback`,
+`ask-ai`, `git`, `issue`, `mcp`, `search`, and `support`. Use the same `topic` on related records to
+cluster evidence from different systems.
+
+The output ranks recurring gaps by represented occurrences, source diversity, and severity, then
+drafts acceptance criteria, issues, golden tasks, and a PR description. Signal summaries are always
+rendered as untrusted evidence. The workflow is deliberately proposal-only: it never edits docs,
+creates issues, publishes branches, or merges changes, and every proposal requires human review.
+
 Default request shape:
 
 ```json title="POST body"


### PR DESCRIPTION
## Summary

- add `docs agent propose` for recurring feedback, search, Ask AI, MCP, issue, support, and git signals
- combine repeatable JSON/JSONL inputs into ranked maintenance proposals with issue, golden-task, and PR drafts
- treat signal text as untrusted evidence and enforce draft-only, human-reviewed execution guardrails
- accept existing agent feedback improvement reports and raw feedback as inputs
- document the normalized signal contract and CLI workflow

## Verification

- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm --filter @farming-labs/docs build`
- 34 focused maintenance, CLI, feedback, and CLI routing tests
- oxlint, formatting, and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a draft-only agent maintenance proposal workflow to `@farming-labs/docs`. Introduces `docs agent propose` to merge recurring signals into ranked proposals with issue, golden-task, and PR drafts without changing docs.

- **New Features**
  - New CLI `docs agent propose`: combine JSON/JSONL signals from `agent-feedback`, `search`, `ask-ai`, `mcp`, `issue`, `support`, and `git`; repeatable `--input`; `--min-occurrences` threshold; defaults to `.farming-labs/agent-feedback-improvements.json`; writes to `.farming-labs/agent-maintenance-proposals.json` with `--write`; supports `--output`, `--json`, and project-root path safety.
  - Proposal engine: groups by page+topic, ranks by occurrences/source diversity/severity, treats text as untrusted, and emits issue drafts, golden tasks, and a PR draft; execution is draft-only and requires human review.
  - Exposes `analyzeDocsAgentMaintenanceSignals`, `parseDocsAgentMaintenanceSignals`, related constants, and types from `@farming-labs/docs`; CLI and config docs updated.

- **Bug Fixes**
  - Made maintenance signal parsing browser-safe.

<sup>Written for commit 3dd8e8bf8dfa43cd840235944308bb12b134cd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

