### PR TITLE
feat: add feedback-derived evaluation workflows

### DIFF
--- a/packages/docs/src/agent-feedback-evaluations-node.ts
+++ b/packages/docs/src/agent-feedback-evaluations-node.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import type { DocsGoldenTasksReport } from "./agent-evals.js";
+import type { DocsAgentFeedbackImprovementReport } from "./agent-feedback-loop.js";
+import {
+  DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT,
+  type DocsAgentFeedbackEvaluationBaseline,
+} from "./agent-feedback-evaluations.js";
+import type { DocsAgentGoldenTask } from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+export function readDocsAgentFeedbackImprovementReport(
+  filePath: string,
+): DocsAgentFeedbackImprovementReport {
+  const value = readJsonFile(filePath);
+  if (
+    !isRecord(value) ||
+    value.format !== "farming-labs-agent-feedback-improvements.v1" ||
+    !Array.isArray(value.clusters) ||
+    typeof value.feedbackCount !== "number" ||
+    typeof value.recurringClusterCount !== "number"
+  ) {
+    throw new Error("Input is not a supported agent feedback improvement report.");
+  }
+  return value as unknown as DocsAgentFeedbackImprovementReport;
+}
+
+export function readDocsAgentEvaluationTasksFile(filePath: string): DocsAgentGoldenTask[] {
+  const value = readJsonFile(filePath);
+  if (Array.isArray(value)) return value as DocsAgentGoldenTask[];
+  if (!isRecord(value)) {
+    throw new Error("Existing evaluation tasks must be a JSON object or array.");
+  }
+  if (Array.isArray(value.candidates)) {
+    return value.candidates.flatMap((candidate) =>
+      isRecord(candidate) && isRecord(candidate.task)
+        ? [candidate.task as unknown as DocsAgentGoldenTask]
+        : [],
+    );
+  }
+  if (Array.isArray(value.tasks)) return value.tasks as DocsAgentGoldenTask[];
+  if (
+    isRecord(value.agent) &&
+    isRecord(value.agent.evaluations) &&
+    Array.isArray(value.agent.evaluations.tasks)
+  ) {
+    return value.agent.evaluations.tasks as DocsAgentGoldenTask[];
+  }
+  throw new Error("Could not find evaluation tasks in the existing JSON file.");
+}
+
+export function readDocsGoldenTasksReportFile(filePath: string): DocsGoldenTasksReport {
+  const value = readJsonFile(filePath);
+  const report = isRecord(value) && isRecord(value.evaluations) ? value.evaluations : value;
+  if (
+    !isRecord(report) ||
+    !Array.isArray(report.tasks) ||
+    typeof report.taskCount !== "number" ||
+    !(typeof report.score === "number" || report.score === null)
+  ) {
+    throw new Error("Input does not contain a golden-task evaluation report.");
+  }
+  return report as unknown as DocsGoldenTasksReport;
+}
+
+export function readDocsAgentFeedbackEvaluationBaseline(
+  filePath: string,
+): DocsAgentFeedbackEvaluationBaseline {
+  const value = readJsonFile(filePath);
+  if (
+    !isRecord(value) ||
+    value.format !== DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT ||
+    typeof value.score !== "number" ||
+    !Array.isArray(value.tasks)
+  ) {
+    throw new Error("Evaluation baseline format is not supported.");
+  }
+  return value as unknown as DocsAgentFeedbackEvaluationBaseline;
+}

--- a/packages/docs/src/agent-feedback-evaluations.test.ts
+++ b/packages/docs/src/agent-feedback-evaluations.test.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DocsGoldenTasksReport } from "./agent-evals.js";
+import type { DocsAgentFeedbackImprovementReport } from "./agent-feedback-loop.js";
+import {
+  buildDocsAgentFeedbackEvaluationCandidates,
+  compareDocsAgentFeedbackEvaluationBaseline,
+  createDocsAgentFeedbackEvaluationBaseline,
+  readDocsGoldenTasksReportFile,
+} from "./agent-feedback-evaluations.js";
+
+function feedbackReport(): DocsAgentFeedbackImprovementReport {
+  const goldenTask = {
+    id: "feedback-install",
+    query: "Install with sk-secretToken123456 for person@example.com",
+    tokenBudget: 4_000,
+    topK: 3,
+    expect: {
+      relevantSources: ["/docs/install?token=private-value"],
+      requiredCitations: ["/docs/install?token=private-value"],
+      minRecallAtK: 1,
+      maxFirstRelevantRank: 3,
+    },
+  };
+  return {
+    format: "farming-labs-agent-feedback-improvements.v1",
+    generatedAt: "2026-08-12T00:00:00.000Z",
+    feedbackCount: 3,
+    failureCount: 3,
+    recurringClusterCount: 2,
+    clusters: [
+      {
+        id: "install",
+        page: "/docs/install",
+        task: "Install package",
+        occurrences: 2,
+        outcomes: ["blocked"],
+        missingContext: [],
+        docIssues: [],
+        suggestedImprovements: [],
+        goldenTask,
+        issue: { title: "Install", body: "", labels: [] },
+      },
+      {
+        id: "install-duplicate",
+        page: "/docs/install",
+        task: "Install package",
+        occurrences: 1,
+        outcomes: ["failed"],
+        missingContext: [],
+        docIssues: [],
+        suggestedImprovements: [],
+        goldenTask: { ...goldenTask, id: "another-id" },
+        issue: { title: "Install", body: "", labels: [] },
+      },
+    ],
+    goldenTasks: [goldenTask],
+    issueDrafts: [],
+    pullRequestDraft: { title: "Draft", body: "" },
+  };
+}
+
+function evaluationReport(
+  tasks: Array<{ id: string; passed: boolean; score: number }>,
+  score: number,
+): DocsGoldenTasksReport {
+  return {
+    status: tasks.every((task) => task.passed) ? "passed" : "failed",
+    passed: tasks.every((task) => task.passed),
+    score,
+    taskCount: tasks.length,
+    passedTaskCount: tasks.filter((task) => task.passed).length,
+    failedTaskCount: tasks.filter((task) => !task.passed).length,
+    quality: {} as DocsGoldenTasksReport["quality"],
+    coverage: {} as DocsGoldenTasksReport["coverage"],
+    tasks: tasks as unknown as DocsGoldenTasksReport["tasks"],
+  };
+}
+
+describe("feedback-derived evaluation candidates", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("redacts sensitive feedback, deduplicates tasks, and requires review", () => {
+    const registry = buildDocsAgentFeedbackEvaluationCandidates(feedbackReport(), {
+      generatedAt: "2026-08-12T00:00:00.000Z",
+    });
+
+    expect(registry).toMatchObject({
+      format: "farming-labs-agent-feedback-evaluation-candidates.v1",
+      sourceClusterCount: 2,
+      candidateCount: 1,
+      duplicateCount: 1,
+      promotion: {
+        mode: "review-required",
+        automaticallyUpdatesConfig: false,
+        automaticallyPublishes: false,
+      },
+    });
+    expect(registry.redactionCount).toBeGreaterThanOrEqual(3);
+    expect(JSON.stringify(registry)).not.toContain("secretToken");
+    expect(JSON.stringify(registry)).not.toContain("person@example.com");
+    expect(JSON.stringify(registry)).not.toContain("private-value");
+    expect(registry.candidates[0]).toMatchObject({
+      state: "candidate",
+      promotion: { target: "agent.evaluations.tasks", requiresHumanReview: true },
+    });
+    expect(registry.duplicates[0]?.reason).toBe("duplicate-candidate");
+  });
+
+  it("deduplicates candidates against existing task ids and fingerprints", () => {
+    const first = buildDocsAgentFeedbackEvaluationCandidates(feedbackReport());
+    const registry = buildDocsAgentFeedbackEvaluationCandidates(feedbackReport(), {
+      existingTasks: [first.candidates[0]!.task],
+    });
+    expect(registry.candidateCount).toBe(0);
+    expect(registry.duplicates.map((duplicate) => duplicate.reason)).toContain("existing-id");
+  });
+
+  it("creates baselines and detects pass, score, missing, and new-task regressions", () => {
+    const baseline = createDocsAgentFeedbackEvaluationBaseline(
+      evaluationReport(
+        [
+          { id: "install", passed: true, score: 100 },
+          { id: "theme", passed: true, score: 90 },
+        ],
+        95,
+      ),
+      "2026-08-12T00:00:00.000Z",
+    );
+    const comparison = compareDocsAgentFeedbackEvaluationBaseline(
+      evaluationReport(
+        [
+          { id: "install", passed: false, score: 70 },
+          { id: "new-task", passed: false, score: 50 },
+        ],
+        60,
+      ),
+      baseline,
+    );
+
+    expect(comparison.passed).toBe(false);
+    expect(comparison.regressions.map((regression) => regression.kind)).toEqual(
+      expect.arrayContaining([
+        "suite-score-drop",
+        "pass-to-fail",
+        "score-drop",
+        "missing-task",
+        "new-failure",
+      ]),
+    );
+    expect(
+      compareDocsAgentFeedbackEvaluationBaseline(
+        evaluationReport(
+          [
+            { id: "install", passed: true, score: 100 },
+            { id: "theme", passed: true, score: 90 },
+          ],
+          95,
+        ),
+        baseline,
+      ).passed,
+    ).toBe(true);
+  });
+
+  it("reads evaluation data from doctor JSON reports", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "docs-feedback-evals-"));
+    temporaryDirectories.push(directory);
+    const filePath = path.join(directory, "doctor.json");
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        mode: "agent",
+        evaluations: evaluationReport([{ id: "a", passed: true, score: 100 }], 100),
+      }),
+      "utf8",
+    );
+    expect(readDocsGoldenTasksReportFile(filePath)).toMatchObject({ score: 100, taskCount: 1 });
+  });
+});

--- a/packages/docs/src/agent-feedback-evaluations.test.ts
+++ b/packages/docs/src/agent-feedback-evaluations.test.ts
@@ -8,8 +8,8 @@ import {
   buildDocsAgentFeedbackEvaluationCandidates,
   compareDocsAgentFeedbackEvaluationBaseline,
   createDocsAgentFeedbackEvaluationBaseline,
-  readDocsGoldenTasksReportFile,
 } from "./agent-feedback-evaluations.js";
+import { readDocsGoldenTasksReportFile } from "./agent-feedback-evaluations-node.js";
 
 function feedbackReport(): DocsAgentFeedbackImprovementReport {
   const goldenTask = {

--- a/packages/docs/src/agent-feedback-evaluations.ts
+++ b/packages/docs/src/agent-feedback-evaluations.ts
@@ -1,10 +1,9 @@
-import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
 import type {
   DocsAgentFeedbackCluster,
   DocsAgentFeedbackImprovementReport,
 } from "./agent-feedback-loop.js";
 import type { DocsGoldenTasksReport } from "./agent-evals.js";
+import { sha256DocsContent } from "./retrieval-digest.js";
 import type { DocsAgentGoldenTask } from "./types.js";
 
 export const DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT =
@@ -176,15 +175,13 @@ function slugify(value: string): string {
 
 function fingerprintTask(task: DocsAgentGoldenTask): string {
   const sources = [...(task.expect.relevantSources ?? [])].sort();
-  return `sha256:${createHash("sha256")
-    .update(
-      JSON.stringify({
-        query: task.query.trim().toLowerCase(),
-        sources,
-        filters: task.filters ?? null,
-      }),
-    )
-    .digest("hex")}`;
+  return `sha256:${sha256DocsContent(
+    JSON.stringify({
+      query: task.query.trim().toLowerCase(),
+      sources,
+      filters: task.filters ?? null,
+    }),
+  )}`;
 }
 
 function sanitizeClusterTask(cluster: DocsAgentFeedbackCluster): {
@@ -398,76 +395,4 @@ export function compareDocsAgentFeedbackEvaluationBaseline(
     maxScoreDrop,
     regressions,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-export function readDocsAgentFeedbackImprovementReport(
-  filePath: string,
-): DocsAgentFeedbackImprovementReport {
-  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
-  if (
-    !isRecord(value) ||
-    value.format !== "farming-labs-agent-feedback-improvements.v1" ||
-    !Array.isArray(value.clusters) ||
-    typeof value.feedbackCount !== "number" ||
-    typeof value.recurringClusterCount !== "number"
-  ) {
-    throw new Error("Input is not a supported agent feedback improvement report.");
-  }
-  return value as unknown as DocsAgentFeedbackImprovementReport;
-}
-
-export function readDocsAgentEvaluationTasksFile(filePath: string): DocsAgentGoldenTask[] {
-  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
-  if (Array.isArray(value)) return value as DocsAgentGoldenTask[];
-  if (!isRecord(value))
-    throw new Error("Existing evaluation tasks must be a JSON object or array.");
-  if (Array.isArray(value.candidates)) {
-    return value.candidates.flatMap((candidate) =>
-      isRecord(candidate) && isRecord(candidate.task)
-        ? [candidate.task as unknown as DocsAgentGoldenTask]
-        : [],
-    );
-  }
-  if (Array.isArray(value.tasks)) return value.tasks as DocsAgentGoldenTask[];
-  if (
-    isRecord(value.agent) &&
-    isRecord(value.agent.evaluations) &&
-    Array.isArray(value.agent.evaluations.tasks)
-  ) {
-    return value.agent.evaluations.tasks as DocsAgentGoldenTask[];
-  }
-  throw new Error("Could not find evaluation tasks in the existing JSON file.");
-}
-
-export function readDocsGoldenTasksReportFile(filePath: string): DocsGoldenTasksReport {
-  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
-  const report = isRecord(value) && isRecord(value.evaluations) ? value.evaluations : value;
-  if (
-    !isRecord(report) ||
-    !Array.isArray(report.tasks) ||
-    typeof report.taskCount !== "number" ||
-    !(typeof report.score === "number" || report.score === null)
-  ) {
-    throw new Error("Input does not contain a golden-task evaluation report.");
-  }
-  return report as unknown as DocsGoldenTasksReport;
-}
-
-export function readDocsAgentFeedbackEvaluationBaseline(
-  filePath: string,
-): DocsAgentFeedbackEvaluationBaseline {
-  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
-  if (
-    !isRecord(value) ||
-    value.format !== DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT ||
-    typeof value.score !== "number" ||
-    !Array.isArray(value.tasks)
-  ) {
-    throw new Error("Evaluation baseline format is not supported.");
-  }
-  return value as unknown as DocsAgentFeedbackEvaluationBaseline;
 }

--- a/packages/docs/src/agent-feedback-evaluations.ts
+++ b/packages/docs/src/agent-feedback-evaluations.ts
@@ -1,0 +1,473 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type {
+  DocsAgentFeedbackCluster,
+  DocsAgentFeedbackImprovementReport,
+} from "./agent-feedback-loop.js";
+import type { DocsGoldenTasksReport } from "./agent-evals.js";
+import type { DocsAgentGoldenTask } from "./types.js";
+
+export const DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT =
+  "farming-labs-agent-feedback-evaluation-candidates.v1" as const;
+export const DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT =
+  "farming-labs-agent-feedback-evaluation-baseline.v1" as const;
+export const DOCS_AGENT_FEEDBACK_EVALUATION_REGRESSION_FORMAT =
+  "farming-labs-agent-feedback-evaluation-regression.v1" as const;
+
+export interface DocsAgentFeedbackEvaluationCandidate {
+  id: string;
+  fingerprint: string;
+  state: "candidate";
+  task: DocsAgentGoldenTask;
+  evidence: {
+    clusterId: string;
+    page: string;
+    occurrences: number;
+    outcomes: string[];
+  };
+  sanitization: { redactionCount: number };
+  promotion: {
+    target: "agent.evaluations.tasks";
+    requiresHumanReview: true;
+  };
+}
+
+export interface DocsAgentFeedbackEvaluationDuplicate {
+  clusterId: string;
+  taskId: string;
+  fingerprint: string;
+  reason: "existing-id" | "existing-fingerprint" | "duplicate-candidate";
+}
+
+export interface DocsAgentFeedbackEvaluationCandidateRegistry {
+  format: typeof DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT;
+  generatedAt: string;
+  sourceFeedbackCount: number;
+  sourceClusterCount: number;
+  candidateCount: number;
+  duplicateCount: number;
+  redactionCount: number;
+  candidates: DocsAgentFeedbackEvaluationCandidate[];
+  duplicates: DocsAgentFeedbackEvaluationDuplicate[];
+  promotion: {
+    mode: "review-required";
+    automaticallyUpdatesConfig: false;
+    automaticallyPublishes: false;
+  };
+}
+
+export interface BuildDocsAgentFeedbackEvaluationCandidatesOptions {
+  generatedAt?: string;
+  existingTasks?: readonly DocsAgentGoldenTask[];
+}
+
+export interface DocsAgentFeedbackEvaluationTaskBaseline {
+  id: string;
+  passed: boolean;
+  score: number;
+}
+
+export interface DocsAgentFeedbackEvaluationBaseline {
+  format: typeof DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT;
+  generatedAt: string;
+  score: number;
+  taskCount: number;
+  passedTaskCount: number;
+  tasks: DocsAgentFeedbackEvaluationTaskBaseline[];
+}
+
+export interface DocsAgentFeedbackEvaluationRegression {
+  kind: "missing-task" | "new-failure" | "pass-to-fail" | "score-drop" | "suite-score-drop";
+  taskId?: string;
+  message: string;
+}
+
+export interface DocsAgentFeedbackEvaluationRegressionReport {
+  format: typeof DOCS_AGENT_FEEDBACK_EVALUATION_REGRESSION_FORMAT;
+  passed: boolean;
+  baselineScore: number;
+  currentScore: number;
+  scoreDelta: number;
+  maxScoreDrop: number;
+  regressions: DocsAgentFeedbackEvaluationRegression[];
+}
+
+export interface CompareDocsAgentFeedbackEvaluationOptions {
+  /** Maximum allowed score decrease for the suite and each task. @default 0 */
+  maxScoreDrop?: number;
+  /** Treat newly added failing tasks as regressions. @default true */
+  failOnNewFailures?: boolean;
+}
+
+const SECRET_PATTERNS: Array<{
+  pattern: RegExp;
+  replacement: string | ((match: string) => string);
+}> = [
+  {
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gu,
+    replacement: "[redacted-private-key]",
+  },
+  {
+    pattern:
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{12,})\b/gu,
+    replacement: "[redacted-token]",
+  },
+  {
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b/giu,
+    replacement: "Bearer [redacted-token]",
+  },
+  {
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu,
+    replacement: "[redacted-email]",
+  },
+  {
+    pattern: /([?&](?:api[_-]?key|password|secret|signature|token)=)[^&#\s]+/giu,
+    replacement: (match) => `${match.slice(0, match.indexOf("=") + 1)}[redacted]`,
+  },
+];
+
+function sanitizeText(value: unknown, maxLength: number): { value?: string; redactions: number } {
+  if (typeof value !== "string") return { redactions: 0 };
+  let output = value
+    .split("")
+    .map((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || code === 127 ? " " : character;
+    })
+    .join("")
+    .trim()
+    .replace(/\s+/g, " ");
+  let redactions = 0;
+  for (const { pattern, replacement } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    output = output.replace(pattern, (match) => {
+      redactions += 1;
+      return typeof replacement === "function" ? replacement(match) : replacement;
+    });
+  }
+  return output ? { value: output.slice(0, maxLength), redactions } : { redactions };
+}
+
+function sanitizeStringList(
+  value: unknown,
+  maxItems: number,
+  maxLength: number,
+): { values: string[]; redactions: number } {
+  if (!Array.isArray(value)) return { values: [], redactions: 0 };
+  const values: string[] = [];
+  let redactions = 0;
+  for (const item of value.slice(0, maxItems)) {
+    const sanitized = sanitizeText(item, maxLength);
+    redactions += sanitized.redactions;
+    if (sanitized.value && !values.includes(sanitized.value)) values.push(sanitized.value);
+  }
+  return { values, redactions };
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 96) || "feedback-evaluation"
+  );
+}
+
+function fingerprintTask(task: DocsAgentGoldenTask): string {
+  const sources = [...(task.expect.relevantSources ?? [])].sort();
+  return `sha256:${createHash("sha256")
+    .update(
+      JSON.stringify({
+        query: task.query.trim().toLowerCase(),
+        sources,
+        filters: task.filters ?? null,
+      }),
+    )
+    .digest("hex")}`;
+}
+
+function sanitizeClusterTask(cluster: DocsAgentFeedbackCluster): {
+  task?: DocsAgentGoldenTask;
+  redactions: number;
+} {
+  const rawTask = cluster.goldenTask;
+  if (!rawTask) return { redactions: 0 };
+  const query = sanitizeText(rawTask.query, 500);
+  const relevant = sanitizeStringList(rawTask.expect?.relevantSources, 20, 500);
+  const citations = sanitizeStringList(rawTask.expect?.requiredCitations, 20, 500);
+  const id = sanitizeText(rawTask.id, 120);
+  const redactions = query.redactions + relevant.redactions + citations.redactions + id.redactions;
+  if (!query.value || relevant.values.length === 0) return { redactions };
+  const taskId = slugify(id.value ?? `feedback-${cluster.id}`);
+  const topK =
+    typeof rawTask.topK === "number" && Number.isFinite(rawTask.topK)
+      ? Math.min(100, Math.max(1, Math.floor(rawTask.topK)))
+      : 3;
+  return {
+    redactions,
+    task: {
+      id: taskId,
+      query: query.value,
+      tokenBudget:
+        typeof rawTask.tokenBudget === "number" && Number.isFinite(rawTask.tokenBudget)
+          ? Math.min(1_000_000, Math.max(1, Math.floor(rawTask.tokenBudget)))
+          : 4_000,
+      topK,
+      expect: {
+        relevantSources: relevant.values,
+        requiredCitations: citations.values.length > 0 ? citations.values : relevant.values,
+        minRecallAtK: 1,
+        maxFirstRelevantRank: topK,
+      },
+    },
+  };
+}
+
+export function buildDocsAgentFeedbackEvaluationCandidates(
+  report: DocsAgentFeedbackImprovementReport,
+  options: BuildDocsAgentFeedbackEvaluationCandidatesOptions = {},
+): DocsAgentFeedbackEvaluationCandidateRegistry {
+  if (report.format !== "farming-labs-agent-feedback-improvements.v1") {
+    throw new Error("Input is not a supported agent feedback improvement report.");
+  }
+  const existingTasks = options.existingTasks ?? [];
+  const existingIds = new Set(existingTasks.map((task) => task.id));
+  const existingFingerprints = new Set(existingTasks.map(fingerprintTask));
+  const candidateFingerprints = new Set<string>();
+  const candidates: DocsAgentFeedbackEvaluationCandidate[] = [];
+  const duplicates: DocsAgentFeedbackEvaluationDuplicate[] = [];
+  let redactionCount = 0;
+
+  for (const cluster of report.clusters) {
+    const clusterId = sanitizeText(cluster.id, 200);
+    const sanitized = sanitizeClusterTask(cluster);
+    redactionCount += clusterId.redactions + sanitized.redactions;
+    if (!sanitized.task) continue;
+    const fingerprint = fingerprintTask(sanitized.task);
+    const reason = existingIds.has(sanitized.task.id)
+      ? "existing-id"
+      : existingFingerprints.has(fingerprint)
+        ? "existing-fingerprint"
+        : candidateFingerprints.has(fingerprint)
+          ? "duplicate-candidate"
+          : undefined;
+    if (reason) {
+      duplicates.push({
+        clusterId: slugify(clusterId.value ?? "feedback"),
+        taskId: sanitized.task.id,
+        fingerprint,
+        reason,
+      });
+      continue;
+    }
+    candidateFingerprints.add(fingerprint);
+    const page = sanitizeText(cluster.page, 500);
+    const outcomes = sanitizeStringList(cluster.outcomes, 20, 200);
+    redactionCount += page.redactions + outcomes.redactions;
+    candidates.push({
+      id: `candidate-${slugify(clusterId.value ?? "feedback")}`,
+      fingerprint,
+      state: "candidate",
+      task: sanitized.task,
+      evidence: {
+        clusterId: slugify(clusterId.value ?? "feedback"),
+        page: page.value ?? "(unknown page)",
+        occurrences: Math.max(1, Math.floor(cluster.occurrences)),
+        outcomes: outcomes.values,
+      },
+      sanitization: {
+        redactionCount:
+          sanitized.redactions + clusterId.redactions + page.redactions + outcomes.redactions,
+      },
+      promotion: {
+        target: "agent.evaluations.tasks",
+        requiresHumanReview: true,
+      },
+    });
+  }
+
+  candidates.sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    format: DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    sourceFeedbackCount: report.feedbackCount,
+    sourceClusterCount: report.recurringClusterCount,
+    candidateCount: candidates.length,
+    duplicateCount: duplicates.length,
+    redactionCount,
+    candidates,
+    duplicates,
+    promotion: {
+      mode: "review-required",
+      automaticallyUpdatesConfig: false,
+      automaticallyPublishes: false,
+    },
+  };
+}
+
+export function createDocsAgentFeedbackEvaluationBaseline(
+  report: DocsGoldenTasksReport,
+  generatedAt = new Date().toISOString(),
+): DocsAgentFeedbackEvaluationBaseline {
+  if (report.score === null || report.taskCount === 0) {
+    throw new Error("Cannot create a baseline from an unmeasured evaluation report.");
+  }
+  return {
+    format: DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT,
+    generatedAt,
+    score: report.score,
+    taskCount: report.taskCount,
+    passedTaskCount: report.passedTaskCount,
+    tasks: report.tasks
+      .map((task) => ({ id: task.id, passed: task.passed, score: task.score }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function compareDocsAgentFeedbackEvaluationBaseline(
+  current: DocsGoldenTasksReport,
+  baseline: DocsAgentFeedbackEvaluationBaseline,
+  options: CompareDocsAgentFeedbackEvaluationOptions = {},
+): DocsAgentFeedbackEvaluationRegressionReport {
+  if (current.score === null) throw new Error("Current evaluation report is unmeasured.");
+  if (baseline.format !== DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT) {
+    throw new Error("Evaluation baseline format is not supported.");
+  }
+  const requestedScoreDrop = options.maxScoreDrop ?? 0;
+  if (!Number.isFinite(requestedScoreDrop) || requestedScoreDrop < 0 || requestedScoreDrop > 100) {
+    throw new Error("maxScoreDrop must be a number from 0 through 100.");
+  }
+  const maxScoreDrop = requestedScoreDrop;
+  const regressions: DocsAgentFeedbackEvaluationRegression[] = [];
+  const scoreDelta = round(current.score - baseline.score);
+  if (scoreDelta < -maxScoreDrop) {
+    regressions.push({
+      kind: "suite-score-drop",
+      message: `Suite score dropped from ${baseline.score} to ${current.score}.`,
+    });
+  }
+  const currentById = new Map(current.tasks.map((task) => [task.id, task]));
+  const baselineIds = new Set(baseline.tasks.map((task) => task.id));
+  for (const expected of baseline.tasks) {
+    const actual = currentById.get(expected.id);
+    if (!actual) {
+      regressions.push({
+        kind: "missing-task",
+        taskId: expected.id,
+        message: `Baseline task ${expected.id} is missing from the current report.`,
+      });
+      continue;
+    }
+    if (expected.passed && !actual.passed) {
+      regressions.push({
+        kind: "pass-to-fail",
+        taskId: expected.id,
+        message: `Task ${expected.id} changed from passing to failing.`,
+      });
+    }
+    if (actual.score < expected.score - maxScoreDrop) {
+      regressions.push({
+        kind: "score-drop",
+        taskId: expected.id,
+        message: `Task ${expected.id} score dropped from ${expected.score} to ${actual.score}.`,
+      });
+    }
+  }
+  if (options.failOnNewFailures !== false) {
+    for (const task of current.tasks) {
+      if (!baselineIds.has(task.id) && !task.passed) {
+        regressions.push({
+          kind: "new-failure",
+          taskId: task.id,
+          message: `New task ${task.id} is failing.`,
+        });
+      }
+    }
+  }
+  return {
+    format: DOCS_AGENT_FEEDBACK_EVALUATION_REGRESSION_FORMAT,
+    passed: regressions.length === 0,
+    baselineScore: baseline.score,
+    currentScore: current.score,
+    scoreDelta,
+    maxScoreDrop,
+    regressions,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function readDocsAgentFeedbackImprovementReport(
+  filePath: string,
+): DocsAgentFeedbackImprovementReport {
+  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  if (
+    !isRecord(value) ||
+    value.format !== "farming-labs-agent-feedback-improvements.v1" ||
+    !Array.isArray(value.clusters) ||
+    typeof value.feedbackCount !== "number" ||
+    typeof value.recurringClusterCount !== "number"
+  ) {
+    throw new Error("Input is not a supported agent feedback improvement report.");
+  }
+  return value as unknown as DocsAgentFeedbackImprovementReport;
+}
+
+export function readDocsAgentEvaluationTasksFile(filePath: string): DocsAgentGoldenTask[] {
+  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  if (Array.isArray(value)) return value as DocsAgentGoldenTask[];
+  if (!isRecord(value))
+    throw new Error("Existing evaluation tasks must be a JSON object or array.");
+  if (Array.isArray(value.candidates)) {
+    return value.candidates.flatMap((candidate) =>
+      isRecord(candidate) && isRecord(candidate.task)
+        ? [candidate.task as unknown as DocsAgentGoldenTask]
+        : [],
+    );
+  }
+  if (Array.isArray(value.tasks)) return value.tasks as DocsAgentGoldenTask[];
+  if (
+    isRecord(value.agent) &&
+    isRecord(value.agent.evaluations) &&
+    Array.isArray(value.agent.evaluations.tasks)
+  ) {
+    return value.agent.evaluations.tasks as DocsAgentGoldenTask[];
+  }
+  throw new Error("Could not find evaluation tasks in the existing JSON file.");
+}
+
+export function readDocsGoldenTasksReportFile(filePath: string): DocsGoldenTasksReport {
+  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  const report = isRecord(value) && isRecord(value.evaluations) ? value.evaluations : value;
+  if (
+    !isRecord(report) ||
+    !Array.isArray(report.tasks) ||
+    typeof report.taskCount !== "number" ||
+    !(typeof report.score === "number" || report.score === null)
+  ) {
+    throw new Error("Input does not contain a golden-task evaluation report.");
+  }
+  return report as unknown as DocsGoldenTasksReport;
+}
+
+export function readDocsAgentFeedbackEvaluationBaseline(
+  filePath: string,
+): DocsAgentFeedbackEvaluationBaseline {
+  const value = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  if (
+    !isRecord(value) ||
+    value.format !== DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT ||
+    typeof value.score !== "number" ||
+    !Array.isArray(value.tasks)
+  ) {
+    throw new Error("Evaluation baseline format is not supported.");
+  }
+  return value as unknown as DocsAgentFeedbackEvaluationBaseline;
+}

--- a/packages/docs/src/cli/feedback-evals.test.ts
+++ b/packages/docs/src/cli/feedback-evals.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DocsAgentFeedbackImprovementReport } from "../agent-feedback-loop.js";
+import type { DocsGoldenTasksReport } from "../agent-evals.js";
+import {
+  parseAgentFeedbackEvaluationsArgs,
+  runAgentFeedbackEvaluations,
+} from "./feedback-evals.js";
+
+function feedbackReport(): DocsAgentFeedbackImprovementReport {
+  const goldenTask = {
+    id: "feedback-install",
+    query: "Install existing app",
+    expect: {
+      relevantSources: ["/docs/install"],
+      requiredCitations: ["/docs/install"],
+    },
+  };
+  return {
+    format: "farming-labs-agent-feedback-improvements.v1",
+    generatedAt: "2026-08-12T00:00:00.000Z",
+    feedbackCount: 2,
+    failureCount: 2,
+    recurringClusterCount: 1,
+    clusters: [
+      {
+        id: "install",
+        page: "/docs/install",
+        task: "Install existing app",
+        occurrences: 2,
+        outcomes: ["blocked"],
+        missingContext: [],
+        docIssues: [],
+        suggestedImprovements: [],
+        goldenTask,
+        issue: { title: "Install", body: "", labels: [] },
+      },
+    ],
+    goldenTasks: [goldenTask],
+    issueDrafts: [],
+    pullRequestDraft: { title: "Draft", body: "" },
+  };
+}
+
+function results(passed: boolean, score: number): DocsGoldenTasksReport {
+  return {
+    status: passed ? "passed" : "failed",
+    passed,
+    score,
+    taskCount: 1,
+    passedTaskCount: passed ? 1 : 0,
+    failedTaskCount: passed ? 0 : 1,
+    quality: {} as DocsGoldenTasksReport["quality"],
+    coverage: {} as DocsGoldenTasksReport["coverage"],
+    tasks: [{ id: "feedback-install", passed, score }] as DocsGoldenTasksReport["tasks"],
+  };
+}
+
+describe("agent feedback evaluations CLI", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("parses candidate and regression flags", () => {
+    expect(
+      parseAgentFeedbackEvaluationsArgs([
+        "--input",
+        "feedback.json",
+        "--existing",
+        "tasks.json",
+        "--write",
+      ]),
+    ).toEqual({
+      existing: ["tasks.json"],
+      input: "feedback.json",
+      write: true,
+    });
+    expect(
+      parseAgentFeedbackEvaluationsArgs([
+        "--results",
+        "doctor.json",
+        "--baseline",
+        "baseline.json",
+        "--check",
+        "--max-score-drop",
+        "2.5",
+      ]),
+    ).toEqual({
+      existing: [],
+      results: "doctor.json",
+      baseline: "baseline.json",
+      check: true,
+      maxScoreDrop: 2.5,
+    });
+  });
+
+  it("writes review-required candidates", async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "docs-feedback-evals-cli-"));
+    temporaryDirectories.push(rootDir);
+    writeFileSync(path.join(rootDir, "feedback.json"), JSON.stringify(feedbackReport()), "utf8");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await runAgentFeedbackEvaluations({ rootDir, input: "feedback.json", write: true });
+    const registry = JSON.parse(
+      readFileSync(path.join(rootDir, ".farming-labs", "agent-evaluation-candidates.json"), "utf8"),
+    );
+    expect(registry.candidateCount).toBe(1);
+    expect(registry.promotion.mode).toBe("review-required");
+  });
+
+  it("writes a baseline and fails checks on regressions", async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "docs-feedback-regression-cli-"));
+    temporaryDirectories.push(rootDir);
+    writeFileSync(path.join(rootDir, "results.json"), JSON.stringify(results(true, 100)), "utf8");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await runAgentFeedbackEvaluations({
+      rootDir,
+      results: "results.json",
+      baseline: "baseline.json",
+      writeBaseline: true,
+    });
+    expect(JSON.parse(readFileSync(path.join(rootDir, "baseline.json"), "utf8")).score).toBe(100);
+
+    writeFileSync(path.join(rootDir, "results.json"), JSON.stringify(results(false, 60)), "utf8");
+    await expect(
+      runAgentFeedbackEvaluations({
+        rootDir,
+        results: "results.json",
+        baseline: "baseline.json",
+        check: true,
+      }),
+    ).rejects.toThrow("regression check failed");
+  });
+
+  it("rejects paths outside the project", async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "docs-feedback-evals-path-"));
+    temporaryDirectories.push(rootDir);
+    await expect(
+      runAgentFeedbackEvaluations({ rootDir, input: "../feedback.json" }),
+    ).rejects.toThrow("stay inside the project root");
+  });
+});

--- a/packages/docs/src/cli/feedback-evals.ts
+++ b/packages/docs/src/cli/feedback-evals.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+import {
+  buildDocsAgentFeedbackEvaluationCandidates,
+  compareDocsAgentFeedbackEvaluationBaseline,
+  createDocsAgentFeedbackEvaluationBaseline,
+  readDocsAgentEvaluationTasksFile,
+  readDocsAgentFeedbackEvaluationBaseline,
+  readDocsAgentFeedbackImprovementReport,
+  readDocsGoldenTasksReportFile,
+  type DocsAgentFeedbackEvaluationCandidateRegistry,
+  type DocsAgentFeedbackEvaluationRegressionReport,
+} from "../agent-feedback-evaluations.js";
+
+export interface AgentFeedbackEvaluationsOptions {
+  input?: string;
+  existing?: string[];
+  output?: string;
+  write?: boolean;
+  results?: string;
+  baseline?: string;
+  writeBaseline?: boolean;
+  check?: boolean;
+  maxScoreDrop?: number;
+  allowNewFailures?: boolean;
+  json?: boolean;
+  help?: boolean;
+  rootDir?: string;
+}
+
+export function parseAgentFeedbackEvaluationsArgs(
+  argv: readonly string[],
+): AgentFeedbackEvaluationsOptions {
+  const options: AgentFeedbackEvaluationsOptions = { existing: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]!;
+    if (argument === "--write") options.write = true;
+    else if (argument === "--write-baseline") options.writeBaseline = true;
+    else if (argument === "--check") options.check = true;
+    else if (argument === "--allow-new-failures") options.allowNewFailures = true;
+    else if (argument === "--json") options.json = true;
+    else if (argument === "--help" || argument === "-h") options.help = true;
+    else if (
+      argument === "--input" ||
+      argument === "--existing" ||
+      argument === "--output" ||
+      argument === "--results" ||
+      argument === "--baseline" ||
+      argument === "--max-score-drop"
+    ) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${argument} requires a value.`);
+      index += 1;
+      if (argument === "--input") options.input = value;
+      else if (argument === "--existing") options.existing!.push(value);
+      else if (argument === "--output") options.output = value;
+      else if (argument === "--results") options.results = value;
+      else if (argument === "--baseline") options.baseline = value;
+      else {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+          throw new Error("--max-score-drop must be a number from 0 through 100.");
+        }
+        options.maxScoreDrop = parsed;
+      }
+    } else {
+      throw new Error(`Unknown agent feedback-evals flag: ${argument}`);
+    }
+  }
+  return options;
+}
+
+function resolveProjectPath(rootDir: string, value: string): string {
+  if (path.isAbsolute(value)) throw new Error("Evaluation paths must be project-relative.");
+  const candidate = path.resolve(rootDir, value);
+  const relative = path.relative(rootDir, candidate);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Evaluation paths must stay inside the project root.");
+  }
+  return candidate;
+}
+
+function writeJson(outputPath: string, value: unknown): void {
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  const temporaryPath = `${outputPath}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  renameSync(temporaryPath, outputPath);
+}
+
+async function runCandidateMode(
+  rootDir: string,
+  options: AgentFeedbackEvaluationsOptions,
+): Promise<DocsAgentFeedbackEvaluationCandidateRegistry> {
+  const report = readDocsAgentFeedbackImprovementReport(
+    resolveProjectPath(rootDir, options.input ?? ".farming-labs/agent-feedback-improvements.json"),
+  );
+  const existingTasks = (options.existing ?? []).flatMap((filePath) =>
+    readDocsAgentEvaluationTasksFile(resolveProjectPath(rootDir, filePath)),
+  );
+  const registry = buildDocsAgentFeedbackEvaluationCandidates(report, { existingTasks });
+  if (options.write) {
+    const outputPath = resolveProjectPath(
+      rootDir,
+      options.output ?? ".farming-labs/agent-evaluation-candidates.json",
+    );
+    writeJson(outputPath, registry);
+    if (!options.json) {
+      console.log(
+        pc.green(
+          `Wrote ${path.relative(rootDir, outputPath)} with ${registry.candidateCount} review-required candidate${registry.candidateCount === 1 ? "" : "s"}.`,
+        ),
+      );
+    }
+  }
+  if (options.json || !options.write) console.log(JSON.stringify(registry, null, 2));
+  return registry;
+}
+
+async function runRegressionMode(
+  rootDir: string,
+  options: AgentFeedbackEvaluationsOptions,
+): Promise<DocsAgentFeedbackEvaluationRegressionReport | undefined> {
+  if (!options.results || !options.baseline) {
+    throw new Error("--results and --baseline are required for baseline or regression mode.");
+  }
+  const results = readDocsGoldenTasksReportFile(resolveProjectPath(rootDir, options.results));
+  const baselinePath = resolveProjectPath(rootDir, options.baseline);
+  if (options.writeBaseline) {
+    const baseline = createDocsAgentFeedbackEvaluationBaseline(results);
+    writeJson(baselinePath, baseline);
+    if (!options.json) console.log(pc.green(`Wrote ${path.relative(rootDir, baselinePath)}.`));
+    if (options.json) console.log(JSON.stringify(baseline, null, 2));
+    return undefined;
+  }
+  const baseline = readDocsAgentFeedbackEvaluationBaseline(baselinePath);
+  const comparison = compareDocsAgentFeedbackEvaluationBaseline(results, baseline, {
+    maxScoreDrop: options.maxScoreDrop,
+    failOnNewFailures: options.allowNewFailures !== true,
+  });
+  console.log(JSON.stringify(comparison, null, 2));
+  if (options.check && !comparison.passed) {
+    throw new Error(
+      `Agent evaluation regression check failed with ${comparison.regressions.length} regression(s).`,
+    );
+  }
+  return comparison;
+}
+
+export async function runAgentFeedbackEvaluations(
+  options: AgentFeedbackEvaluationsOptions = {},
+): Promise<
+  | DocsAgentFeedbackEvaluationCandidateRegistry
+  | DocsAgentFeedbackEvaluationRegressionReport
+  | undefined
+> {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  if (options.writeBaseline && options.check) {
+    throw new Error("--write-baseline and --check are separate operations.");
+  }
+  const regressionMode =
+    options.results !== undefined ||
+    options.baseline !== undefined ||
+    options.writeBaseline === true ||
+    options.check === true;
+  if (regressionMode) return runRegressionMode(rootDir, options);
+  return runCandidateMode(rootDir, options);
+}
+
+export function printAgentFeedbackEvaluationsHelp(): void {
+  console.log(`${pc.bold("docs agent feedback-evals")} — promote feedback into reviewed evaluations and guard regressions
+
+${pc.dim("Candidate usage:")}
+  docs agent feedback-evals --input .farming-labs/agent-feedback-improvements.json
+  docs agent feedback-evals --existing docs-evaluations.json --write
+
+${pc.dim("Regression usage:")}
+  docs agent feedback-evals --results doctor.json --baseline .farming-labs/agent-evaluation-baseline.json --write-baseline
+  docs agent feedback-evals --results doctor.json --baseline .farming-labs/agent-evaluation-baseline.json --check
+
+${pc.dim("Options:")}
+  ${pc.cyan("--input <path>")}             Feedback improvement report
+  ${pc.cyan("--existing <path>")}          Repeatable registry/config/task JSON used for deduplication
+  ${pc.cyan("--write")}                    Write sanitized candidates
+  ${pc.cyan("--output <path>")}            Candidate output (default: .farming-labs/agent-evaluation-candidates.json)
+  ${pc.cyan("--results <path>")}           Golden-task or doctor JSON evaluation results
+  ${pc.cyan("--baseline <path>")}          Baseline JSON path
+  ${pc.cyan("--write-baseline")}           Create or replace the baseline from --results
+  ${pc.cyan("--check")}                    Fail when results regress from the baseline
+  ${pc.cyan("--max-score-drop <0-100>")}   Allowed suite/task score decrease (default: 0)
+  ${pc.cyan("--allow-new-failures")}        Do not fail only because a newly added task fails
+  ${pc.cyan("--json")}                     Print written candidate/baseline JSON
+
+Candidates are redacted, deduplicated, and never added to docs.config without human review.
+`);
+}

--- a/packages/docs/src/cli/feedback-evals.ts
+++ b/packages/docs/src/cli/feedback-evals.ts
@@ -5,13 +5,15 @@ import {
   buildDocsAgentFeedbackEvaluationCandidates,
   compareDocsAgentFeedbackEvaluationBaseline,
   createDocsAgentFeedbackEvaluationBaseline,
+  type DocsAgentFeedbackEvaluationCandidateRegistry,
+  type DocsAgentFeedbackEvaluationRegressionReport,
+} from "../agent-feedback-evaluations.js";
+import {
   readDocsAgentEvaluationTasksFile,
   readDocsAgentFeedbackEvaluationBaseline,
   readDocsAgentFeedbackImprovementReport,
   readDocsGoldenTasksReportFile,
-  type DocsAgentFeedbackEvaluationCandidateRegistry,
-  type DocsAgentFeedbackEvaluationRegressionReport,
-} from "../agent-feedback-evaluations.js";
+} from "../agent-feedback-evaluations-node.js";
 
 export interface AgentFeedbackEvaluationsOptions {
   input?: string;

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -200,6 +200,18 @@ async function main() {
       return;
     }
     await runAgentFeedbackImprove(feedbackOptions);
+  } else if (parsedCommand.command === "agent" && subcommand === "feedback-evals") {
+    const {
+      parseAgentFeedbackEvaluationsArgs,
+      printAgentFeedbackEvaluationsHelp,
+      runAgentFeedbackEvaluations,
+    } = await import("./feedback-evals.js");
+    const evaluationOptions = parseAgentFeedbackEvaluationsArgs(args.slice(2));
+    if (evaluationOptions.help) {
+      printAgentFeedbackEvaluationsHelp();
+      return;
+    }
+    await runAgentFeedbackEvaluations(evaluationOptions);
   } else if (parsedCommand.command === "agent" && subcommand === "compact") {
     const { compactAgentDocs, parseAgentCompactArgs, printAgentCompactHelp } =
       await import("./agent.js");
@@ -224,9 +236,11 @@ async function main() {
     const { printAgentCompactHelp } = await import("./agent.js");
     const { printAgentExportHelp } = await import("./agent-export.js");
     const { printAgentFeedbackImproveHelp } = await import("./feedback.js");
+    const { printAgentFeedbackEvaluationsHelp } = await import("./feedback-evals.js");
     printAgentCompactHelp();
     printAgentExportHelp();
     printAgentFeedbackImproveHelp();
+    printAgentFeedbackEvaluationsHelp();
     process.exit(1);
   } else if (parsedCommand.command === "agents" && subcommand === "generate") {
     const { generateAgents, parseAgentsGenerateArgs, printAgentsGenerateHelp } =
@@ -478,6 +492,14 @@ ${pc.dim("Options for agent feedback:")}
   ${pc.cyan("--write")}                             Write the report to ${pc.dim(".farming-labs/agent-feedback-improvements.json")}
   ${pc.cyan("--output <path>")}                     Override the written report path
   ${pc.cyan("--json")}                              Print JSON while writing
+
+${pc.dim("Options for feedback-derived evaluations:")}
+  ${pc.cyan("agent feedback-evals --write")}        Sanitize and deduplicate feedback-derived golden-task candidates
+  ${pc.cyan("--existing <path>")}                   Compare against an existing candidate registry, task list, or config JSON
+  ${pc.cyan("--results <path> --baseline <path>")} Read golden-task or doctor JSON for baseline comparison
+  ${pc.cyan("--write-baseline")}                    Create or replace an explicit evaluation baseline
+  ${pc.cyan("--check")}                             Fail CI when suite/task results regress
+  ${pc.cyan("--max-score-drop <0-100>")}            Allow a bounded suite/task score decrease
 
 ${pc.dim("Options for skills scaffold:")}
   ${pc.cyan("skills scaffold [name]")}              Compile page agent contracts into a compact ${pc.dim("SKILL.md")} router and focused references

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -84,6 +84,29 @@ export {
 } from "./agent-contract.js";
 export type { PageAgentFrontmatterIssue } from "./agent-contract.js";
 export {
+  buildDocsAgentFeedbackEvaluationCandidates,
+  compareDocsAgentFeedbackEvaluationBaseline,
+  createDocsAgentFeedbackEvaluationBaseline,
+  DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT,
+  DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT,
+  DOCS_AGENT_FEEDBACK_EVALUATION_REGRESSION_FORMAT,
+  readDocsAgentEvaluationTasksFile,
+  readDocsAgentFeedbackEvaluationBaseline,
+  readDocsAgentFeedbackImprovementReport,
+  readDocsGoldenTasksReportFile,
+} from "./agent-feedback-evaluations.js";
+export type {
+  BuildDocsAgentFeedbackEvaluationCandidatesOptions,
+  CompareDocsAgentFeedbackEvaluationOptions,
+  DocsAgentFeedbackEvaluationBaseline,
+  DocsAgentFeedbackEvaluationCandidate,
+  DocsAgentFeedbackEvaluationCandidateRegistry,
+  DocsAgentFeedbackEvaluationDuplicate,
+  DocsAgentFeedbackEvaluationRegression,
+  DocsAgentFeedbackEvaluationRegressionReport,
+  DocsAgentFeedbackEvaluationTaskBaseline,
+} from "./agent-feedback-evaluations.js";
+export {
   applySidebarFolderIndexBehavior,
   resolvePageSidebarFolderIndexBehavior,
   resolveSidebarFolderIndexBehavior,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -90,10 +90,6 @@ export {
   DOCS_AGENT_FEEDBACK_EVALUATION_BASELINE_FORMAT,
   DOCS_AGENT_FEEDBACK_EVALUATION_CANDIDATES_FORMAT,
   DOCS_AGENT_FEEDBACK_EVALUATION_REGRESSION_FORMAT,
-  readDocsAgentEvaluationTasksFile,
-  readDocsAgentFeedbackEvaluationBaseline,
-  readDocsAgentFeedbackImprovementReport,
-  readDocsGoldenTasksReportFile,
 } from "./agent-feedback-evaluations.js";
 export type {
   BuildDocsAgentFeedbackEvaluationCandidatesOptions,

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -555,6 +555,30 @@ curl "http://127.0.0.1:3000/docs/installation.md"
 See [Configuration](/docs/configuration) for `agent.compact`, and [Token Efficiency](/docs/token-efficiency)
 for when you should use compaction instead of writing `agent.md` by hand.
 
+## Feedback-derived evaluations
+
+Use `agent feedback-evals` after `agent feedback` to create review-required golden-task candidates:
+
+```bash title="terminal"
+pnpm exec docs agent feedback-evals --write
+pnpm exec docs agent feedback-evals --existing existing-tasks.json --write
+```
+
+The command sanitizes feedback text, deduplicates candidates, and writes
+`.farming-labs/agent-evaluation-candidates.json`. It never changes `docs.config` or publishes the
+candidates automatically.
+
+The same command can create an explicit baseline from `docs doctor --agent --json-output` results
+and enforce it in CI:
+
+```bash title="terminal"
+pnpm exec docs agent feedback-evals --results doctor.json --baseline baseline.json --write-baseline
+pnpm exec docs agent feedback-evals --results doctor.json --baseline baseline.json --check
+```
+
+`--check` fails for suite/task score regressions, pass-to-fail changes, missing baseline tasks, and
+new failing tasks. `--max-score-drop` provides an optional numeric tolerance.
+
 ## Agents Generate
 
 Generate committed `AGENTS.md` files for coding agents and static exports:

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -2123,6 +2123,42 @@ the command only prints JSON.
 Feedback text remains untrusted evidence in every draft. Review it before copying suggestions into
 docs, issues, evaluation config, or model prompts.
 
+### Promote feedback into evaluation candidates
+
+Turn the feedback report's draft golden tasks into a sanitized candidate registry:
+
+```bash title="terminal"
+pnpm exec docs agent feedback-evals \
+  --input .farming-labs/agent-feedback-improvements.json \
+  --write
+```
+
+The command redacts common credentials, secret query parameters, private keys, and email addresses;
+normalizes task budgets and retrieval expectations; and deduplicates by task ID and a stable
+query/source fingerprint. Candidates remain in `state: "candidate"` and are never inserted into
+`agent.evaluations.tasks` automatically. Review the original evidence and the sanitized task before
+promoting it.
+
+After running `docs doctor --agent --json-output doctor.json`, create an explicit baseline and use
+it as a CI regression gate:
+
+```bash title="terminal"
+pnpm exec docs agent feedback-evals \
+  --results doctor.json \
+  --baseline .farming-labs/agent-evaluation-baseline.json \
+  --write-baseline
+
+pnpm exec docs agent feedback-evals \
+  --results doctor.json \
+  --baseline .farming-labs/agent-evaluation-baseline.json \
+  --check
+```
+
+The check catches suite score drops, per-task score drops, pass-to-fail changes, removed baseline
+tasks, and newly added failing tasks. Use `--max-score-drop` only for an intentional bounded
+tolerance, and `--allow-new-failures` only when newly introduced tasks are expected to start red.
+Baseline replacement is always explicit through `--write-baseline`.
+
 Default request shape:
 
 ```json title="POST body"


### PR DESCRIPTION
## Summary

- add `docs agent feedback-evals` to sanitize and deduplicate feedback-derived golden-task candidates
- redact common tokens, private keys, secret query parameters, and email addresses before candidate storage
- keep promotion review-required and never mutate docs config or publish candidates automatically
- add explicit evaluation baselines and CI regression checks for suite/task score drops, pass-to-fail changes, missing tasks, and new failures
- accept direct golden-task results or `docs doctor --agent --json-output` reports

## Verification

- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm --filter @farming-labs/docs build`
- 105 focused feedback, CLI, golden-evaluation, and routing tests
- compiled CLI help smoke test
- oxlint, formatting, and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `docs agent feedback-evals` workflow in `@farming-labs/docs` to turn agent feedback into review-required golden-task candidates and to create/compare explicit baselines for CI regression checks. Keeps browser builds safe by isolating Node-only file I/O so browser bundles don’t pull in `fs`.

- **New Features**
  - Generate sanitized, deduplicated candidate tasks; write `.farming-labs/agent-evaluation-candidates.json` with review-required promotion.
  - Deduplicate by task ID and stable query/source fingerprint; supports `--existing` JSON for cross-file checks.
  - Redact private keys, tokens, emails, and secret query params; normalize budgets/topK/expectations.
  - Baselines/regression: use `--results` (golden-task or `docs doctor --agent --json-output`), `--write-baseline`, and `--check` with `--max-score-drop` and `--allow-new-failures`.
  - Safe, project-relative paths and atomic JSON writes; CLI wired into `docs agent` with help and docs updated.
  - Export builders, formats, and types for programmatic use from `@farming-labs/docs`.

- **Bug Fixes**
  - Keep feedback evaluations browser-safe by moving JSON readers to `agent-feedback-evaluations-node.ts` and importing them only in the CLI; core helpers remain browser-safe.

<sup>Written for commit 8a2fbb5d88c13e1dc634c589d2a9a689b3fe75c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

