### PR TITLE
feat: devtools editor & advanced mdx collocations

### DIFF
--- a/examples/next/app/docs/page.mdx
+++ b/examples/next/app/docs/page.mdx
@@ -5,28 +5,30 @@ description: A comprehensive authentication and authorization framework for Type
 icon: book
 ---
 
-# Introduction
+# Introduction intro
 
-Better Auth is a framework-agnostic, universal authentication and authorization framework for TypeScript. It provides a comprehensive set of features out of the box and includes a plugin ecosystem that simplifies adding advanced functionalities.
+<Agent>
+You are reading the example docs entry page as an implementation agent.
+
+Before implementing from this docs site, fetch `/api/docs/agent/spec` from the same origin. Use the
+returned markdown route pattern, search endpoint, MCP endpoint, `llms.txt` routes, skills metadata,
+locale config, and feedback endpoints instead of hard-coding defaults.
+
+Prefer markdown reads over HTML scraping. For Next.js, `/docs.md`, `/docs/<slug>.md`,
+`Accept: text/markdown` on `/docs/<slug>`, and `Signature-Agent` on `/docs/<slug>` are the
+page-level machine-readable entry points when reported by the spec.
+</Agent>
 
 ## Features
 
-- **Framework Agnostic** — Support for most popular frameworks
-- **Email & Password** — Built-in support for secure email and password authentication
-- **Account & Session Management** — Manage user accounts and sessions with ease
-- **Built-In Rate Limiter** — Built-in rate limiter with custom rules
-- **Automatic Database Management** — Automatic database management and migrations
-- **Social Sign-on** — Multiple social sign-on providers
-- **Plugin Ecosystem** — Even more capabilities with plugins
+Better Auth is a framework-agnostic, universal authentication and authorization framework for TypeScript. It provides a comprehensive set of features out of the box and includes a plugin ecosystem that simplifies adding advanced functionalities. **lets do it.** someone here.
 
 ---
-
-## Quick Start
 
 Get up and running in under 5 minutes:
 
 ```bash title="terminal"
-npm install better-auth
+npm install demo - hello world
 ```
 
 ```ts title="auth.ts"
@@ -34,7 +36,7 @@ import { betterAuth } from "better-auth";
 
 export const auth = betterAuth({
   database: {
-    provider: "postgresql",
+    provider: "psg",
     url: process.env.DATABASE_URL,
   },
   emailAndPassword: {
@@ -45,8 +47,38 @@ export const auth = betterAuth({
 
 ---
 
-## Next Steps
+## Next Steps:
 
 - Read the [Installation](/docs/installation) guide
 - Follow the [Get Started](/docs/getting-started) guide
 - Explore [Concepts](/docs/concepts)
+
+<HoverLink href="/docs" title="Related guide" description="A useful related documentation page.">
+  Read the related guide
+</HoverLink>
+
+<Prompt title="Try this prompt">
+Use this docs page to implement the feature.
+</Prompt>
+
+<Callout type="note" title="hello world">
+Write a helpful callout.
+</Callout>
+
+<Tabs items={["npm", "pnpm", "drag.ts"]}>
+  <Tab value="npm">
+    ```bash
+                        npm install my-package
+                        ```
+  </Tab>
+
+  <Tab value="pnpm">
+    ```bash
+                        pnpm add my-package
+                        ```
+  </Tab>
+
+  <Tab value="drag.ts">
+    Content
+  </Tab>
+</Tabs>

--- a/examples/next/docs.config.tsx
+++ b/examples/next/docs.config.tsx
@@ -76,6 +76,7 @@ const searchConfig: DocsSearchConfig | undefined =
 
 export default defineDocs({
   entry: "docs",
+  devTools: true,
   ...(searchConfig ? { search: searchConfig } : {}),
   observability: {
     console: "debug",

--- a/packages/docs/src/define-docs.ts
+++ b/packages/docs/src/define-docs.ts
@@ -35,6 +35,7 @@ export function defineDocs(config: DocsConfig): DocsConfig {
     ai: config.ai,
     ordering: config.ordering,
     metadata: config.metadata,
+    devTools: config.devTools,
     og: config.og,
     changelog: config.changelog,
     apiReference: config.apiReference,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -542,6 +542,7 @@ export type {
   DocsNav,
   DocsTheme,
   DocsMetadata,
+  DevToolsConfig,
   OGConfig,
   OpenGraphImage,
   PageOpenGraph,

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -238,6 +238,19 @@ export interface DocsMetadata {
   twitterCard?: "summary" | "summary_large_image";
 }
 
+export interface DevToolsConfig {
+  /**
+   * Enables the built-in visual docs editor in development.
+   *
+   * When enabled, the docs UI renders a floating action button that can edit
+   * the current MDX page and apply changes back to the source file through the
+   * local docs API.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+}
+
 export interface OGConfig {
   enabled?: boolean;
   type?: "static" | "dynamic";
@@ -4563,6 +4576,13 @@ export interface DocsConfig {
   review?: boolean | DocsReviewConfig;
   /** SEO metadata - separate from theme */
   metadata?: DocsMetadata;
+  /**
+   * Built-in visual docs editor.
+   *
+   * Use `devTools: true` during local development to edit MDX pages with the
+   * floating docs editor and write changes back to the page source file.
+   */
+  devTools?: boolean | DevToolsConfig;
   /** Open Graph image handling */
   og?: OGConfig;
 }

--- a/packages/fumadocs/src/colorful/index.ts
+++ b/packages/fumadocs/src/colorful/index.ts
@@ -37,7 +37,6 @@ const ColorfulUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/command-grid/index.ts
+++ b/packages/fumadocs/src/command-grid/index.ts
@@ -41,7 +41,6 @@ const CommandGridUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" as const },
   },
 };
 

--- a/packages/fumadocs/src/concrete/index.ts
+++ b/packages/fumadocs/src/concrete/index.ts
@@ -41,7 +41,6 @@ const ConcreteUIDefaults = {
     Callout: { variant: "outline", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "View doc", showIndicator: false },
-    Tabs: { style: "default" as const },
   },
 };
 

--- a/packages/fumadocs/src/darkbold/index.ts
+++ b/packages/fumadocs/src/darkbold/index.ts
@@ -37,7 +37,6 @@ const DarkBoldUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/darksharp/index.ts
+++ b/packages/fumadocs/src/darksharp/index.ts
@@ -56,7 +56,6 @@ const DarksharpUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/default/index.ts
+++ b/packages/fumadocs/src/default/index.ts
@@ -55,7 +55,6 @@ const DefaultUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/devtools.tsx
+++ b/packages/fumadocs/src/devtools.tsx
@@ -1,0 +1,4289 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type MdxBlock =
+  | { id: string; type: "heading"; level: number; text: string }
+  | { id: string; type: "paragraph"; content: string }
+  | { id: string; type: "callout"; variant: string; title: string; content: string }
+  | { id: string; type: "code"; language: string; title: string; code: string }
+  | { id: string; type: "tabs"; tabs: Array<{ label: string; content: string }> }
+  | {
+      id: string;
+      type: "hoverlink";
+      href: string;
+      title: string;
+      description: string;
+      label: string;
+    }
+  | { id: string; type: "prompt"; title: string; content: string }
+  | { id: string; type: "raw"; content: string };
+
+interface ParsedMdxDocument {
+  prefix: string;
+  blocks: MdxBlock[];
+}
+
+interface DevToolsPagePayload {
+  requestedPath: string;
+  relativePath: string;
+  content: string;
+  lastModified: string;
+}
+
+interface DocsDevToolsProps {
+  api: string;
+  pathname: string;
+}
+
+// ─── ID generation ────────────────────────────────────────────────────────────
+
+let idCounter = 0;
+function createId(prefix = "block"): string {
+  idCounter += 1;
+  return `${prefix}-${Date.now().toString(36)}-${idCounter.toString(36)}`;
+}
+
+// ─── Parse utilities ──────────────────────────────────────────────────────────
+
+function normalizeSource(s: string) {
+  return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function splitPrefix(source: string): { prefix: string; body: string } {
+  const lines = normalizeSource(source).split("\n");
+  const pre: string[] = [];
+  let i = 0;
+  if (lines[i]?.trim() === "---") {
+    pre.push(lines[i]);
+    i++;
+    while (i < lines.length) {
+      pre.push(lines[i]);
+      const done = lines[i]?.trim() === "---";
+      i++;
+      if (done) break;
+    }
+  }
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    const t = line.trim();
+    if (t === "") {
+      pre.push(line);
+      i++;
+      continue;
+    }
+    if (/^(import|export)\b/.test(t)) {
+      pre.push(line);
+      i++;
+      while (
+        i < lines.length &&
+        lines[i]?.trim() !== "" &&
+        !/[;}]$/.test(lines[i - 1]?.trim() ?? "")
+      ) {
+        pre.push(lines[i] ?? "");
+        i++;
+      }
+      continue;
+    }
+    break;
+  }
+  return { prefix: pre.join("\n").trimEnd(), body: lines.slice(i).join("\n").trim() };
+}
+
+function getAttribute(src: string, name: string): string {
+  const m = src.match(new RegExp(`${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`));
+  return m?.[1] ?? m?.[2] ?? "";
+}
+
+function parseStringArray(src: string) {
+  return src
+    .split(",")
+    .map((v) => v.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}
+
+function captureUntil(lines: string[], start: number, closing: RegExp) {
+  const out: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    out.push(lines[i] ?? "");
+    if (closing.test(lines[i] ?? "")) return { content: out.join("\n"), end: i + 1 };
+  }
+  return { content: out.join("\n"), end: lines.length };
+}
+
+function isSpecialStart(line: string) {
+  const t = line.trim();
+  return /^#{1,6}\s+/.test(t) || t.startsWith("```") || /^<[A-Z][\w.:-]*(\s|>|\/>)/.test(t);
+}
+
+function parseCodeBlock(lines: string[], start: number): { block: MdxBlock; end: number } {
+  const opening = lines[start]?.trim() ?? "```";
+  const info = opening.replace(/^```/, "").trim();
+  const title = getAttribute(info, "title");
+  const language = info.split(/\s+/, 1)[0]?.replace(/title=.*/, "") ?? "";
+  const content: string[] = [];
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if ((lines[i] ?? "").trim().startsWith("```")) {
+      end = i + 1;
+      break;
+    }
+    content.push(lines[i] ?? "");
+  }
+  return {
+    block: { id: createId("code"), type: "code", language, title, code: content.join("\n") },
+    end,
+  };
+}
+
+function parseCalloutBlock(raw: string): MdxBlock {
+  const op = raw.split("\n", 1)[0] ?? "";
+  const inner = raw
+    .replace(/^<Callout\b[^>]*>\s*/s, "")
+    .replace(/\s*<\/Callout>\s*$/s, "")
+    .trim();
+  return {
+    id: createId("callout"),
+    type: "callout",
+    variant: getAttribute(op, "type") || "info",
+    title: getAttribute(op, "title"),
+    content: inner || "Write the callout content here.",
+  };
+}
+
+function parsePromptBlock(raw: string): MdxBlock {
+  const op = raw.split("\n", 1)[0] ?? "";
+  const inner = raw
+    .replace(/^<Prompt\b[^>]*>\s*/s, "")
+    .replace(/\s*<\/Prompt>\s*$/s, "")
+    .trim();
+  return {
+    id: createId("prompt"),
+    type: "prompt",
+    title: getAttribute(op, "title") || "Prompt",
+    content: inner || getAttribute(op, "prompt") || "Write the prompt here.",
+  };
+}
+
+function parseHoverLinkBlock(raw: string): MdxBlock {
+  const op = raw.split("\n", 1)[0] ?? "";
+  const label = raw
+    .replace(/^<HoverLink\b[^>]*>\s*/s, "")
+    .replace(/\s*<\/HoverLink>\s*$/s, "")
+    .trim();
+  return {
+    id: createId("hoverlink"),
+    type: "hoverlink",
+    href: getAttribute(op, "href") || "#",
+    title: getAttribute(op, "title") || "Linked page",
+    description: getAttribute(op, "description") || "Describe the linked page.",
+    label: label || "Open the linked page",
+  };
+}
+
+function parseTabsBlock(raw: string): MdxBlock {
+  const op = raw.split("\n", 1)[0] ?? "";
+  const im = op.match(/items\s*=\s*\{\s*\[([^\]]*)\]\s*\}/);
+  const items = im ? parseStringArray(im[1] ?? "") : [];
+  const tabs: Array<{ label: string; content: string }> = [];
+  const tp = /<Tab\s+value=["']([^"']+)["'][^>]*>([\s\S]*?)<\/Tab>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tp.exec(raw)) !== null)
+    tabs.push({ label: m[1] ?? "Tab", content: (m[2] ?? "").trim() || "Tab content" });
+  if (tabs.length === 0)
+    for (const item of items.length > 0 ? items : ["First", "Second"])
+      tabs.push({ label: item, content: "Tab content" });
+  return { id: createId("tabs"), type: "tabs", tabs };
+}
+
+function parseRawJsxBlock(lines: string[], start: number): { block: MdxBlock; end: number } {
+  const firstLine = lines[start] ?? "";
+  if (firstLine.trim().endsWith("/>"))
+    return { block: { id: createId("raw"), type: "raw", content: firstLine }, end: start + 1 };
+  const tag = firstLine.trim().match(/^<([A-Z][\w.:-]*)\b/)?.[1];
+  if (tag) {
+    const closing = new RegExp(`</${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}>`);
+    const cap = captureUntil(lines, start, closing);
+    return { block: { id: createId("raw"), type: "raw", content: cap.content }, end: cap.end };
+  }
+  return { block: { id: createId("raw"), type: "raw", content: firstLine }, end: start + 1 };
+}
+
+function parseMdxDocument(source: string): ParsedMdxDocument {
+  const { prefix, body } = splitPrefix(source);
+  const lines = body.split("\n");
+  const blocks: MdxBlock[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    const t = line.trim();
+    if (t === "") {
+      i++;
+      continue;
+    }
+    const h = t.match(/^(#{1,6})\s+(.+)$/);
+    if (h) {
+      blocks.push({
+        id: createId("heading"),
+        type: "heading",
+        level: h[1]?.length ?? 2,
+        text: h[2] ?? "Heading",
+      });
+      i++;
+      continue;
+    }
+    if (t.startsWith("```")) {
+      const p = parseCodeBlock(lines, i);
+      blocks.push(p.block);
+      i = p.end;
+      continue;
+    }
+    if (t.startsWith("<Callout")) {
+      const c = captureUntil(lines, i, /<\/Callout>/);
+      blocks.push(parseCalloutBlock(c.content));
+      i = c.end;
+      continue;
+    }
+    if (t.startsWith("<Tabs")) {
+      const c = captureUntil(lines, i, /<\/Tabs>/);
+      blocks.push(parseTabsBlock(c.content));
+      i = c.end;
+      continue;
+    }
+    if (t.startsWith("<Prompt")) {
+      const c = captureUntil(lines, i, /<\/Prompt>/);
+      blocks.push(parsePromptBlock(c.content));
+      i = c.end;
+      continue;
+    }
+    if (t.startsWith("<HoverLink")) {
+      const c = captureUntil(lines, i, /<\/HoverLink>/);
+      blocks.push(parseHoverLinkBlock(c.content));
+      i = c.end;
+      continue;
+    }
+    if (/^<[A-Z][\w.:-]*(\s|>|\/>)/.test(t)) {
+      const p = parseRawJsxBlock(lines, i);
+      blocks.push(p.block);
+      i = p.end;
+      continue;
+    }
+    const para: string[] = [line];
+    i++;
+    while (i < lines.length) {
+      const next = lines[i] ?? "";
+      if (next.trim() === "" || isSpecialStart(next)) break;
+      para.push(next);
+      i++;
+    }
+    blocks.push({ id: createId("paragraph"), type: "paragraph", content: para.join("\n").trim() });
+  }
+  if (blocks.length === 0)
+    blocks.push({ id: createId("paragraph"), type: "paragraph", content: "Start writing…" });
+  return { prefix, blocks };
+}
+
+// ─── Serialize ────────────────────────────────────────────────────────────────
+
+function q(v: string) {
+  return v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+function ind(v: string, n = 2) {
+  const p = " ".repeat(n);
+  return v
+    .split("\n")
+    .map((l) => (l.trim() ? `${p}${l}` : l))
+    .join("\n");
+}
+
+function serializeBlock(block: MdxBlock): string {
+  if (block.type === "heading")
+    return `${"#".repeat(Math.min(6, Math.max(1, block.level)))} ${block.text.trim() || "Heading"}`;
+  if (block.type === "paragraph") return block.content.trim();
+  if (block.type === "callout") {
+    const t = block.title.trim() ? ` title="${q(block.title.trim())}"` : "";
+    return `<Callout type="${q(block.variant || "info")}"${t}>\n${block.content.trim()}\n</Callout>`;
+  }
+  if (block.type === "code") {
+    const t = block.title.trim() ? ` title="${q(block.title.trim())}"` : "";
+    return `\`\`\`${block.language.trim()}${t}\n${block.code.replace(/\s+$/g, "")}\n\`\`\``;
+  }
+  if (block.type === "tabs") {
+    const tabs = block.tabs.length > 0 ? block.tabs : [{ label: "First", content: "Tab content" }];
+    const items = tabs.map((t) => `"${q(t.label || "Tab")}"`).join(", ");
+    const rendered = tabs
+      .map(
+        (t) =>
+          `  <Tab value="${q(t.label || "Tab")}">\n${ind(t.content.trim() || "Tab content", 4)}\n  </Tab>`,
+      )
+      .join("\n\n");
+    return `<Tabs items={[${items}]}>\n${rendered}\n</Tabs>`;
+  }
+  if (block.type === "hoverlink")
+    return `<HoverLink href="${q(block.href || "#")}" title="${q(block.title || "Linked page")}" description="${q(block.description || "")}">\n${ind(block.label || "Open the linked page", 2)}\n</HoverLink>`;
+  if (block.type === "prompt") {
+    const t = block.title.trim() ? ` title="${q(block.title.trim())}"` : "";
+    return `<Prompt${t}>\n${block.content.trim() || "Write the prompt here."}\n</Prompt>`;
+  }
+  return block.content.trim();
+}
+
+function serializeMdxDocument(doc: ParsedMdxDocument): string {
+  const body = doc.blocks.map(serializeBlock).filter(Boolean).join("\n\n");
+  return [doc.prefix.trim(), body.trim()].filter(Boolean).join("\n\n").trimEnd() + "\n";
+}
+
+function createBlock(type: MdxBlock["type"]): MdxBlock {
+  if (type === "heading") return { id: createId("heading"), type, level: 2, text: "New heading" };
+  if (type === "callout")
+    return {
+      id: createId("callout"),
+      type,
+      variant: "note",
+      title: "",
+      content: "Write a helpful callout.",
+    };
+  if (type === "code")
+    return {
+      id: createId("code"),
+      type,
+      language: "ts",
+      title: "example.ts",
+      code: "export const value = true;",
+    };
+  if (type === "tabs")
+    return {
+      id: createId("tabs"),
+      type,
+      tabs: [
+        { label: "npm", content: "```bash\nnpm install my-package\n```" },
+        { label: "pnpm", content: "```bash\npnpm add my-package\n```" },
+      ],
+    };
+  if (type === "hoverlink")
+    return {
+      id: createId("hoverlink"),
+      type,
+      href: "/docs",
+      title: "Related guide",
+      description: "A useful related documentation page.",
+      label: "Read the related guide",
+    };
+  if (type === "prompt")
+    return {
+      id: createId("prompt"),
+      type,
+      title: "Try this prompt",
+      content: "Use this docs page to implement the feature.",
+    };
+  if (type === "raw") return { id: createId("raw"), type, content: "<CustomComponent />" };
+  return { id: createId("paragraph"), type: "paragraph", content: "Write a paragraph." };
+}
+
+function createDevToolsUrl(
+  api: string,
+  mode: "page" | "publish" | "theme" | "nav-item",
+  pathname: string,
+) {
+  const url = new URL(api, window.location.origin);
+  url.searchParams.set("devtools", mode);
+  if (mode === "page") url.searchParams.set("path", pathname);
+  return `${url.pathname}${url.search}`;
+}
+
+// ─── DOM → block-id map ──────────────────────────────────────────────────────
+// Built once after the MDX doc is loaded. Each direct child of [data-dt-content]
+// is assigned to exactly one parsed block id. We use per-type cursors so that:
+//   • h1-h6 elements → heading blocks (text match preferred, cursor fallback)
+//   • p / ul / ol / hr / blockquote → paragraph blocks  (our parser treats all
+//     of these as paragraphs — lists, HR, blockquotes are all parsed as paragraph)
+//   • figure → code blocks
+//   • div/aside/section → callout / tabs / prompt / hoverlink / raw
+//     identified by DOM attributes/classes, never by position alone
+
+function paragraphRenderedElementCount(content: string): number {
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  let count = 0;
+  let prev: "normal" | "ul" | "ol" | "blockquote" | "hr" | null = null;
+
+  for (const line of lines) {
+    const kind = /^[-*+]\s+/.test(line)
+      ? "ul"
+      : /^\d+[.)]\s+/.test(line)
+        ? "ol"
+        : /^>\s?/.test(line)
+          ? "blockquote"
+          : /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/.test(line)
+            ? "hr"
+            : "normal";
+
+    if (kind !== prev || kind === "hr") count += 1;
+    prev = kind;
+  }
+
+  return Math.max(1, count);
+}
+
+function buildDomBlockMap(contentEl: HTMLElement, blocks: MdxBlock[]): Map<HTMLElement, string> {
+  const children = Array.from(contentEl.children) as HTMLElement[];
+  const map = new Map<HTMLElement, string>();
+
+  // Group parser blocks by type, keeping their parsed order.
+  const byType: Record<string, MdxBlock[]> = {};
+  blocks.forEach((block) => {
+    (byType[block.type] ??= []).push(block);
+  });
+
+  const cursors: Record<string, number> = {};
+  const paragraphDomIds = blocks.flatMap((block) =>
+    block.type === "paragraph"
+      ? Array.from({ length: paragraphRenderedElementCount(block.content) }, () => block.id)
+      : [],
+  );
+  let paragraphDomCursor = 0;
+
+  function nextParagraph(): string | null {
+    const id = paragraphDomIds[paragraphDomCursor];
+    paragraphDomCursor += 1;
+    return id ?? null;
+  }
+
+  function next(type: string): string | null {
+    const list = byType[type];
+    if (!list) return null;
+    const c = cursors[type] ?? 0;
+    if (c >= list.length) return null;
+    cursors[type] = c + 1;
+    return list[c]!.id;
+  }
+
+  for (const el of children) {
+    const tag = el.tagName.toLowerCase();
+    let blockId: string | null = null;
+
+    if (/^h[1-6]$/.test(tag)) {
+      // Prefer text match so invisible-render components (Agent etc.) don't shift indices
+      const headings = byType["heading"];
+      const c = cursors["heading"] ?? 0;
+      const elText = (el.textContent ?? "").trim();
+      const ahead = headings?.slice(c) ?? [];
+      const matchOff = ahead.findIndex(
+        (block) => (block as Extract<MdxBlock, { type: "heading" }>).text.trim() === elText,
+      );
+      if (matchOff >= 0) {
+        blockId = ahead[matchOff]!.id;
+        cursors["heading"] = c + matchOff + 1;
+      } else {
+        blockId = next("heading");
+      }
+    } else if (
+      tag === "p" ||
+      tag === "ul" ||
+      tag === "ol" ||
+      tag === "hr" ||
+      tag === "blockquote"
+    ) {
+      // All rendered as paragraph blocks by our parser
+      blockId = nextParagraph();
+    } else if (tag === "figure") {
+      blockId = next("code");
+    } else if (tag === "div" || tag === "aside" || tag === "section" || tag === "nav") {
+      // Detect component type from DOM shape
+      const role = el.getAttribute("role") ?? "";
+      const cls = el.className ?? "";
+      if (role === "note" || cls.includes("callout")) {
+        blockId = next("callout");
+      } else if (el.querySelector("[role=tablist], [data-radix-collection-item]")) {
+        blockId = next("tabs");
+      } else if (el.querySelector(".fd-prompt-header") || cls.includes("fd-prompt")) {
+        blockId = next("prompt");
+      } else if (
+        el.querySelector("a[href]") &&
+        (byType["hoverlink"]?.length ?? 0) > (cursors["hoverlink"] ?? 0)
+      ) {
+        blockId = next("hoverlink");
+      } else {
+        blockId = next("raw");
+      }
+    }
+
+    if (blockId !== null) map.set(el, blockId);
+  }
+
+  return map;
+}
+
+// ─── Catalogues ───────────────────────────────────────────────────────────────
+
+const BLOCK_CATALOGUE: Array<{
+  type: MdxBlock["type"];
+  label: string;
+  icon: string;
+  accent: string;
+  desc: string;
+}> = [
+  { type: "paragraph", label: "Paragraph", icon: "¶", accent: "#6366f1", desc: "Plain text" },
+  { type: "heading", label: "Heading", icon: "H", accent: "#7c3aed", desc: "H1 – H6" },
+  { type: "callout", label: "Callout", icon: "◈", accent: "#f59e0b", desc: "Note / warning" },
+  { type: "code", label: "Code", icon: "</>", accent: "#10b981", desc: "Fenced block" },
+  { type: "tabs", label: "Tabs", icon: "⊟", accent: "#3b82f6", desc: "Tabbed content" },
+  { type: "hoverlink", label: "HoverLink", icon: "↗", accent: "#ec4899", desc: "Card link" },
+  { type: "prompt", label: "Prompt", icon: "◉", accent: "#06b6d4", desc: "Copyable prompt" },
+  { type: "raw", label: "Raw MDX", icon: "{}", accent: "#64748b", desc: "Custom component" },
+];
+
+interface ThemeDef {
+  id: string;
+  label: string;
+  accent: string;
+  bg: string;
+  fg: string;
+  border: string;
+  muted: string;
+  dark: boolean;
+}
+
+const THEMES: ThemeDef[] = [
+  {
+    id: "default",
+    label: "Default",
+    accent: "#6366f1",
+    bg: "#ffffff",
+    fg: "#0f172a",
+    border: "#e2e8f0",
+    muted: "#f1f5f9",
+    dark: false,
+  },
+  {
+    id: "darksharp",
+    label: "Dark Sharp",
+    accent: "#e2e8f0",
+    bg: "#0a0a0a",
+    fg: "#f8fafc",
+    border: "#1e293b",
+    muted: "#111827",
+    dark: true,
+  },
+  {
+    id: "ledger",
+    label: "Ledger",
+    accent: "#5f6cf6",
+    bg: "#f6f8fb",
+    fg: "#30364a",
+    border: "#dbe3ef",
+    muted: "#eef3fb",
+    dark: false,
+  },
+  {
+    id: "concrete",
+    label: "Concrete",
+    accent: "#171717",
+    bg: "#f5f5f4",
+    fg: "#171717",
+    border: "#d4d0cb",
+    muted: "#e7e5e4",
+    dark: false,
+  },
+  {
+    id: "hardline",
+    label: "Hardline",
+    accent: "#ef4444",
+    bg: "#fafaf9",
+    fg: "#0c0a09",
+    border: "#e7e5e4",
+    muted: "#f5f5f4",
+    dark: false,
+  },
+  {
+    id: "greentree",
+    label: "Green Tree",
+    accent: "#22c55e",
+    bg: "#f0fdf4",
+    fg: "#052e16",
+    border: "#bbf7d0",
+    muted: "#dcfce7",
+    dark: false,
+  },
+  {
+    id: "shiny",
+    label: "Shiny",
+    accent: "#ec4899",
+    bg: "#0f0a1a",
+    fg: "#f0e6ff",
+    border: "#3b1f5e",
+    muted: "#1a0e30",
+    dark: true,
+  },
+  {
+    id: "colorful",
+    label: "Colorful",
+    accent: "#f59e0b",
+    bg: "#fffbeb",
+    fg: "#1c1917",
+    border: "#fde68a",
+    muted: "#fef3c7",
+    dark: false,
+  },
+  {
+    id: "pixel-border",
+    label: "Pixel Border",
+    accent: "#3b82f6",
+    bg: "#0f172a",
+    fg: "#f1f5f9",
+    border: "#1e3a5f",
+    muted: "#1e293b",
+    dark: true,
+  },
+  {
+    id: "command-grid",
+    label: "Command Grid",
+    accent: "#8b5cf6",
+    bg: "#fafafa",
+    fg: "#18181b",
+    border: "#e4e4e7",
+    muted: "#f4f4f5",
+    dark: false,
+  },
+  {
+    id: "darkbold",
+    label: "Dark Bold",
+    accent: "#ffffff",
+    bg: "#0a0a0a",
+    fg: "#ededed",
+    border: "#333333",
+    muted: "#1a1a1a",
+    dark: true,
+  },
+];
+
+// Matches the actual Callout component variant styles exactly
+const CALLOUT_VARIANTS: Record<
+  string,
+  {
+    iconEl: () => React.ReactElement;
+    iconClass: string;
+    titleClass: string;
+    border: string;
+    bg: string;
+    label: string;
+  }
+> = {
+  note: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 16v-4" />
+        <path d="M12 8h.01" />
+      </svg>
+    ),
+    iconClass: "text-black/50 dark:text-white/50",
+    titleClass: "text-black/70 dark:text-white/70",
+    border:
+      "border-black/10 dark:border-white/10 border-l-4 border-l-black/25 dark:border-l-white/25",
+    bg: "bg-black/[0.03] dark:bg-white/[0.025]",
+    label: "Note",
+  },
+  warning: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </svg>
+    ),
+    iconClass: "text-black/55 dark:text-white/55",
+    titleClass: "text-black/75 dark:text-white/75",
+    border:
+      "border-black/10 dark:border-white/10 border-l-4 border-l-black/35 dark:border-l-white/35",
+    bg: "bg-black/[0.04] dark:bg-white/[0.035]",
+    label: "Warning",
+  },
+  tip: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+        <path d="M9 18h6" />
+        <path d="M10 22h4" />
+      </svg>
+    ),
+    iconClass: "text-black/50 dark:text-white/50",
+    titleClass: "text-black/70 dark:text-white/70",
+    border:
+      "border-black/10 dark:border-white/10 border-l-4 border-l-black/30 dark:border-l-white/30",
+    bg: "bg-black/[0.03] dark:bg-white/[0.025]",
+    label: "Tip",
+  },
+  important: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      </svg>
+    ),
+    iconClass: "text-black/55 dark:text-white/55",
+    titleClass: "text-black/75 dark:text-white/75",
+    border:
+      "border-black/10 dark:border-white/10 border-l-4 border-l-black/35 dark:border-l-white/35",
+    bg: "bg-black/[0.04] dark:bg-white/[0.035]",
+    label: "Important",
+  },
+  caution: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+    ),
+    iconClass: "text-black/60 dark:text-white/60",
+    titleClass: "text-black/80 dark:text-white/80",
+    border:
+      "border-black/15 dark:border-white/15 border-l-4 border-l-black/40 dark:border-l-white/40",
+    bg: "bg-black/[0.05] dark:bg-white/[0.045]",
+    label: "Caution",
+  },
+  // parser aliases
+  info: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 16v-4" />
+        <path d="M12 8h.01" />
+      </svg>
+    ),
+    iconClass: "text-black/50 dark:text-white/50",
+    titleClass: "text-black/70 dark:text-white/70",
+    border:
+      "border-black/10 dark:border-white/10 border-l-4 border-l-black/25 dark:border-l-white/25",
+    bg: "bg-black/[0.03] dark:bg-white/[0.025]",
+    label: "Info",
+  },
+  error: {
+    iconEl: () => (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+    ),
+    iconClass: "text-black/60 dark:text-white/60",
+    titleClass: "text-black/80 dark:text-white/80",
+    border:
+      "border-black/15 dark:border-white/15 border-l-4 border-l-black/40 dark:border-l-white/40",
+    bg: "bg-black/[0.05] dark:bg-white/[0.045]",
+    label: "Error",
+  },
+};
+
+// ─── CSS ──────────────────────────────────────────────────────────────────────
+
+const CSS = `
+nextjs-portal{pointer-events:none!important}
+
+/* ─ reset inside devtools ─ */
+.dt,.dt *{box-sizing:border-box;-webkit-font-smoothing:antialiased}
+.dt button,.dt input,.dt select,.dt textarea{font-family:inherit}
+
+/* ─ trigger ─ */
+.dt-trigger{
+  position:fixed;left:16px;bottom:16px;z-index:2147483000;
+  height:34px;padding:0 13px 0 10px;
+  border:1px solid rgba(255,255,255,0.13);border-radius:999px;
+  background:rgba(12,12,16,0.93);color:#fff;
+  box-shadow:0 8px 28px rgba(0,0,0,0.45);backdrop-filter:blur(16px);
+  display:inline-flex;align-items:center;gap:7px;
+  font-size:12px;font-weight:700;cursor:pointer;
+  transition:transform .12s,box-shadow .12s;
+}
+.dt-trigger:hover{transform:translateY(-1px);box-shadow:0 12px 36px rgba(0,0,0,0.55)}
+.dt-dot{
+  width:7px;height:7px;border-radius:50%;
+  background:var(--color-fd-primary,#6366f1);
+  box-shadow:0 0 0 3px color-mix(in srgb,var(--color-fd-primary,#6366f1) 22%,transparent);
+  animation:dtpulse 2.4s ease-in-out infinite;
+}
+@keyframes dtpulse{0%,100%{opacity:1}50%{opacity:.45}}
+
+/* ─ toolbar ─ */
+.dt-bar{
+  position:fixed;top:0;left:0;right:0;height:50px;z-index:2147483002;
+  border-bottom:1px solid rgba(255,255,255,0.07);
+  background:rgba(9,9,13,0.95);backdrop-filter:blur(20px);
+  display:flex;align-items:center;gap:0;pointer-events:auto;
+}
+.dt-bar-logo{
+  display:flex;align-items:center;gap:8px;
+  padding:0 14px;height:100%;
+  border-right:1px solid rgba(255,255,255,0.07);flex-shrink:0;
+}
+.dt-bar-emblem{
+  width:22px;height:22px;border-radius:5px;
+  background:linear-gradient(135deg,#6366f1,#8b5cf6);
+  display:grid;place-items:center;font-size:10px;font-weight:900;color:#fff;
+}
+.dt-bar-wordmark{font-size:12.5px;font-weight:750;color:#fff;white-space:nowrap}
+.dt-bar-file{
+  flex:1;min-width:0;padding:0 14px;
+  display:flex;flex-direction:column;gap:1px;
+}
+.dt-bar-path{font-size:11.5px;color:rgba(255,255,255,0.45);font-family:ui-monospace,monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dt-bar-status{font-size:10.5px;color:rgba(255,255,255,0.28);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dt-bar-actions{
+  display:flex;align-items:center;gap:5px;
+  padding:0 10px;height:100%;
+  border-left:1px solid rgba(255,255,255,0.07);flex-shrink:0;
+}
+
+/* ─ toolbar buttons ─ */
+.dt-btn{
+  height:28px;padding:0 10px;
+  border:1px solid rgba(255,255,255,0.11);border-radius:6px;
+  background:rgba(255,255,255,0.06);color:rgba(255,255,255,0.8);
+  font-size:11.5px;font-weight:650;cursor:pointer;
+  display:inline-flex;align-items:center;gap:5px;
+  transition:border-color .12s,background .12s,color .12s;white-space:nowrap;
+}
+.dt-btn:hover{border-color:rgba(255,255,255,0.22);background:rgba(255,255,255,0.11);color:#fff}
+.dt-btn:disabled{opacity:.32;cursor:not-allowed}
+.dt-btn[data-primary]{background:var(--color-fd-primary,#6366f1);border-color:var(--color-fd-primary,#6366f1);color:#fff}
+.dt-btn[data-primary]:hover{filter:brightness(1.1)}
+.dt-btn[data-active]{background:rgba(255,255,255,0.13);border-color:rgba(255,255,255,0.2);color:#fff}
+.dt-btn-sep{width:1px;height:18px;background:rgba(255,255,255,0.08);margin:0 2px;flex-shrink:0}
+
+/* ─ theme popover ─ */
+.dt-theme-pop{
+  position:fixed;top:54px;right:10px;z-index:2147483003;
+  width:220px;
+  border:1px solid rgba(255,255,255,0.1);border-radius:10px;
+  background:rgba(10,10,14,0.97);backdrop-filter:blur(20px);
+  padding:6px;
+  box-shadow:0 16px 48px rgba(0,0,0,0.55);
+}
+.dt-theme-item{
+  display:flex;align-items:center;gap:9px;
+  padding:7px 9px;border-radius:7px;cursor:pointer;
+  transition:background .1s;
+}
+.dt-theme-item:hover{background:rgba(255,255,255,0.07)}
+.dt-theme-item[data-active]{background:rgba(255,255,255,0.1)}
+.dt-theme-dots{display:flex;gap:3px;flex-shrink:0}
+.dt-theme-dot{width:10px;height:10px;border-radius:50%}
+.dt-theme-name{font-size:12px;font-weight:600;color:rgba(255,255,255,0.8);flex:1}
+.dt-theme-tick{color:#6366f1;font-size:12px;flex-shrink:0}
+
+/* ─ article editing mode — only outlines, zero layout change ─ */
+/* Uses html attribute (not article attribute) to avoid React reconciliation mismatch */
+html[data-docs-devtools-open="true"] [data-dt-content] > *:not([data-dt-ui]){
+  cursor:pointer;
+  outline:2px dashed transparent;
+  outline-offset:5px;
+  transition:outline-color .12s;
+}
+html[data-docs-devtools-open="true"] [data-dt-content] > *:not([data-dt-ui]):hover{
+  outline-color:color-mix(in srgb,var(--color-fd-primary,#6366f1) 38%,transparent);
+}
+html[data-docs-devtools-open="true"] [data-dt-content] > [data-dt-deleted="true"]{
+  display:none!important;
+}
+
+/* ─ inline mini toolbar (appears above heading / paragraph editors) ─ */
+.dt-inline-toolbar{
+  position:fixed;z-index:2147483002;
+  display:inline-flex;align-items:center;gap:4px;
+  background:color-mix(in srgb,var(--color-fd-background,#fff) 94%,#0f172a 6%);
+  color:var(--color-fd-foreground,#0f172a);
+  backdrop-filter:blur(16px);
+  border:1px solid color-mix(in srgb,var(--color-fd-border,#e2e8f0) 75%,transparent);
+  border-radius:10px;
+  padding:4px;
+  box-shadow:0 18px 42px rgba(15,23,42,0.18),0 1px 0 rgba(255,255,255,0.55) inset;
+}
+.dark .dt-inline-toolbar{
+  background:rgba(9,9,13,0.94);
+  color:#fff;
+  border-color:rgba(255,255,255,0.12);
+  box-shadow:0 18px 42px rgba(0,0,0,0.42),0 1px 0 rgba(255,255,255,0.08) inset;
+}
+.dt-inline-toolbar-group{display:inline-flex;align-items:center;gap:3px}
+.dt-inline-tb-btn{
+  min-width:28px;height:26px;padding:0 7px;
+  border:1px solid transparent;
+  background:transparent;
+  color:var(--color-fd-muted-foreground,#64748b);
+  font-size:11px;font-weight:750;cursor:pointer;
+  display:grid;place-items:center;border-radius:7px;
+  transition:color .1s,background .1s,border-color .1s,transform .1s;
+}
+.dt-inline-tb-btn:hover{
+  color:var(--color-fd-foreground,#0f172a);
+  background:color-mix(in srgb,var(--color-fd-primary,#6366f1) 9%,transparent);
+  border-color:color-mix(in srgb,var(--color-fd-primary,#6366f1) 28%,transparent);
+}
+.dark .dt-inline-tb-btn{color:rgba(255,255,255,0.76)}
+.dark .dt-inline-tb-btn:hover{color:#fff;background:rgba(255,255,255,0.1);border-color:rgba(255,255,255,0.12)}
+.dt-inline-tb-btn:disabled{opacity:.25;cursor:not-allowed}
+.dt-inline-tb-btn[data-active]{background:var(--color-fd-primary,#6366f1);color:#fff}
+.dt-inline-tb-btn[data-danger]:hover{color:#ef4444;background:rgba(239,68,68,0.12)}
+.dt-inline-tb-sep{width:1px;height:18px;background:var(--color-fd-border,#e2e8f0);margin:0 2px;flex-shrink:0}
+.dark .dt-inline-tb-sep{background:rgba(255,255,255,0.12)}
+.dt-inline-save-btn{
+  display:inline-flex;align-items:center;gap:5px;
+  height:26px;padding:0 9px;
+}
+.dt-inline-save-btn span{font-size:11px;font-weight:750}
+
+/* ─ sidebar editing mode ─ */
+html[data-docs-devtools-open="true"] #nd-sidebar a{
+  cursor:pointer;
+  position:relative;
+}
+html[data-docs-devtools-open="true"] #nd-sidebar a::after{
+  content:"✎";
+  position:absolute;
+  right:4px;
+  top:50%;
+  transform:translateY(-50%);
+  font-size:10px;
+  opacity:0;
+  transition:opacity .1s;
+  color:var(--color-fd-primary,#6366f1);
+}
+html[data-docs-devtools-open="true"] #nd-sidebar a:hover::after{
+  opacity:0.5;
+}
+/* Active block highlight rendered as a React-controlled fixed overlay (no DOM mutation) */
+.dt-active-highlight{
+  position:fixed;pointer-events:none;z-index:2147483000;
+  outline:2px dashed var(--color-fd-primary,#6366f1);
+  outline-offset:5px;border-radius:3px;
+}
+
+/* Inline editor overlay — sits over the original block for direct text editing */
+.dt-inline-cover{
+  position:fixed;z-index:2147483001;
+  background:var(--color-fd-background,#fff);
+  box-sizing:border-box;
+  border-radius:6px;
+  box-shadow:0 0 0 6px var(--color-fd-background,#fff);
+}
+.dt-inline-input,.dt-inline-ta{
+  display:block;width:100%;background:transparent;
+  border:none;outline:none;resize:none;
+  padding:0;margin:0;
+  font:inherit;color:inherit;
+}
+/* WYSIWYG inline formatting inside the paragraph overlay */
+.dt-inline-cover strong{font-weight:bold}
+.dt-inline-cover em{font-style:italic}
+.dt-inline-cover code{
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+  font-size:0.875em;
+  background:rgba(0,0,0,0.07);
+  padding:0.1em 0.3em;border-radius:3px;
+}
+.dt-inline-cover a,.dt-editable a{
+  color:var(--color-fd-primary,#6366f1);
+  text-decoration:underline;
+  text-underline-offset:2px;
+  cursor:pointer;
+}
+.dt-inline-cover p,.dt-editable p{margin:0}
+.dt-inline-cover ul,.dt-inline-cover ol,.dt-editable ul,.dt-editable ol{
+  margin:.35em 0 0;
+  padding-left:1.35em;
+}
+.dt-inline-cover li,.dt-editable li{margin:.15em 0}
+/* Remove figure margin when CodeRenderer is placed inside the inline cover */
+.dt-inline-cover .dt-code-fig{margin:0!important}
+
+/* ─ floating block editor (appears near clicked block) ─ */
+.dt-float-editor{
+  position:fixed;z-index:2147483003;
+  background:var(--color-fd-background,#fff);
+  border:1px solid color-mix(in srgb,var(--color-fd-border,#e2e8f0) 86%,transparent);
+  border-radius:10px;
+  box-shadow:0 22px 60px rgba(15,23,42,0.18),0 2px 10px rgba(15,23,42,0.08);
+  width:min(480px,90vw);
+  max-height:72vh;
+  overflow-y:auto;
+  display:flex;flex-direction:column;
+}
+.dt-float-editor-hdr{
+  display:flex;align-items:center;gap:4px;
+  padding:9px 10px 7px;
+  border-bottom:1px solid var(--color-fd-border,#e2e8f0);
+  flex-shrink:0;
+  position:sticky;top:0;
+  background:var(--color-fd-background,#fff);
+  z-index:1;
+}
+.dt-float-editor-type{
+  font-size:10px;font-weight:850;text-transform:uppercase;letter-spacing:0;
+  display:inline-flex;align-items:center;gap:3px;flex-shrink:0;
+}
+.dt-float-editor-body{padding:12px 14px}
+
+/* ─ separator ─ */
+.dt-float-sep{width:1px;height:14px;background:var(--color-fd-border,#e2e8f0);margin:0 2px;flex-shrink:0}
+
+/* ─ float action button ─ */
+.dt-float-btn{
+  width:26px;height:24px;border:1px solid transparent;background:transparent;
+  color:var(--color-fd-muted-foreground,#64748b);cursor:pointer;
+  display:grid;place-items:center;border-radius:7px;
+  transition:color .1s,background .1s,border-color .1s;
+}
+.dt-float-btn:hover{
+  color:var(--color-fd-foreground,#0f172a);
+  background:var(--color-fd-muted,#f1f5f9);
+  border-color:var(--color-fd-border,#e2e8f0);
+}
+.dt-float-btn:disabled{opacity:.25;cursor:not-allowed}
+.dt-float-btn[data-danger]:hover{color:#ef4444;background:rgba(239,68,68,0.08)}
+.dt-float-save-btn{
+  height:24px;padding:0 10px;
+  border:1px solid var(--color-fd-primary,#6366f1);
+  background:var(--color-fd-primary,#6366f1);
+  color:#fff;border-radius:7px;
+  font-size:11px;font-weight:750;
+  display:inline-flex;align-items:center;gap:5px;cursor:pointer;
+  transition:filter .1s,opacity .1s;
+}
+.dt-float-save-btn:hover{filter:brightness(1.06)}
+.dt-float-save-btn:disabled{opacity:.45;cursor:not-allowed;filter:none}
+
+/* ─ insert (+) button ─ */
+.dt-insert-btn{
+  width:20px;height:20px;border-radius:50%;
+  border:1.5px solid var(--color-fd-border,#e2e8f0);
+  background:var(--color-fd-background,#fff);
+  color:var(--color-fd-muted-foreground,#94a3b8);
+  cursor:pointer;
+  display:grid;place-items:center;
+  transition:border-color .12s,color .12s,transform .12s,box-shadow .12s;
+}
+.dt-insert-btn:hover{
+  border-color:var(--color-fd-primary,#6366f1);
+  color:var(--color-fd-primary,#6366f1);
+  transform:scale(1.15);
+  box-shadow:0 0 0 4px color-mix(in srgb,var(--color-fd-primary,#6366f1) 12%,transparent);
+}
+
+/* ─ insert menu palette ─ */
+.dt-palette{
+  position:fixed;z-index:2147483004;
+  width:260px;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  border-radius:10px;
+  background:var(--color-fd-background,#fff);
+  box-shadow:0 12px 40px rgba(0,0,0,0.15);
+  padding:6px;overflow:hidden;
+}
+.dt-palette-title{
+  font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:.08em;
+  color:var(--color-fd-muted-foreground,#64748b);
+  padding:4px 8px 6px;
+}
+.dt-palette-grid{display:grid;grid-template-columns:1fr 1fr;gap:3px}
+.dt-palette-item{
+  display:flex;align-items:center;gap:8px;
+  padding:8px 9px;border-radius:7px;
+  cursor:pointer;border:none;background:transparent;text-align:left;
+  transition:background .1s;width:100%;
+}
+.dt-palette-item:hover{background:var(--color-fd-muted,#f1f5f9)}
+.dt-palette-icon{
+  width:26px;height:26px;border-radius:6px;
+  display:grid;place-items:center;font-size:11px;font-weight:900;
+  flex-shrink:0;
+}
+.dt-palette-label{font-size:11.5px;font-weight:650;color:var(--color-fd-foreground,#0f172a);line-height:1.2}
+.dt-palette-desc{font-size:10px;color:var(--color-fd-muted-foreground,#64748b);margin-top:1px}
+
+/* ─ contenteditable prose ─ */
+.dt-editable{
+  outline:none;white-space:pre-wrap;overflow-wrap:anywhere;
+  caret-color:var(--color-fd-primary,#6366f1);
+  margin:0;
+}
+.dt-editable:empty::before{
+  content:attr(data-ph);
+  color:color-mix(in srgb,var(--color-fd-muted-foreground,#94a3b8) 55%,transparent);
+  pointer-events:none;
+}
+.dt-editable::selection{background:color-mix(in srgb,var(--color-fd-primary,#6366f1) 20%,transparent)}
+
+/* ─ formatting mini-bar ─ */
+.dt-fmt-bar{
+  display:flex;gap:3px;margin-bottom:8px;
+  opacity:0;transition:opacity .13s,height .13s;padding:0;height:0;overflow:hidden;
+  pointer-events:none;
+}
+.dt-float-editor-body .dt-fmt-bar{
+  opacity:1;height:auto;pointer-events:auto;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  border-radius:8px;
+  padding:4px;
+  background:color-mix(in srgb,var(--color-fd-muted,#f1f5f9) 58%,transparent);
+}
+.dt-fmt-btn{
+  height:26px;min-width:28px;padding:0 8px;
+  border:1px solid transparent;border-radius:6px;
+  background:transparent;color:var(--color-fd-muted-foreground,#64748b);
+  font-size:11px;font-weight:780;cursor:pointer;
+  transition:color .1s,border-color .1s,background .1s;
+}
+.dt-fmt-btn:hover{
+  color:var(--color-fd-foreground,#0f172a);
+  border-color:var(--color-fd-primary,#6366f1);
+  background:color-mix(in srgb,var(--color-fd-primary,#6366f1) 6%,transparent);
+}
+
+/* ─ heading level row ─ */
+.dt-level-row{display:flex;gap:3px;margin-bottom:6px;opacity:0;transition:opacity .13s;pointer-events:none;height:0;overflow:hidden}
+.dt-float-editor-body .dt-level-row{opacity:1;pointer-events:auto;height:auto}
+.dt-level-btn{
+  width:26px;height:21px;border-radius:4px;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  background:transparent;color:var(--color-fd-muted-foreground,#64748b);
+  font-size:10px;font-weight:800;cursor:pointer;
+  display:grid;place-items:center;
+  transition:color .1s,background .1s,border-color .1s;
+}
+.dt-level-btn:hover,.dt-level-btn[data-active]{
+  color:var(--color-fd-primary,#6366f1);
+  border-color:var(--color-fd-primary,#6366f1);
+  background:color-mix(in srgb,var(--color-fd-primary,#6366f1) 8%,transparent);
+}
+
+/* ─ callout variant selector ─ */
+.dt-variant-row{display:flex;gap:3px;margin-bottom:7px;opacity:0;pointer-events:none;height:0;overflow:hidden;transition:opacity .13s}
+.dt-float-editor-body .dt-variant-row{opacity:1;pointer-events:auto;height:auto}
+.dt-variant-btn{
+  height:20px;padding:0 7px;border-radius:4px;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  background:transparent;color:var(--color-fd-muted-foreground,#64748b);
+  font-size:10px;font-weight:700;cursor:pointer;
+  transition:color .1s,background .1s,border-color .1s;
+}
+.dt-variant-btn[data-active],.dt-variant-btn:hover{
+  color:var(--color-fd-foreground,#0f172a);
+  border-color:var(--color-fd-border,#e2e8f0);
+  background:var(--color-fd-muted,#f1f5f9);
+}
+
+/* ─ hoverlink (inline dashed-link + hover metadata panel) ─ */
+.dt-hl-trigger{
+  display:inline;border:none;background:transparent;padding:0;margin:0;
+  color:var(--color-fd-foreground,currentColor);cursor:text;
+  text-decoration:underline;text-decoration-style:dashed;
+  text-decoration-thickness:0.08em;text-underline-offset:0.22em;
+  text-decoration-color:color-mix(in srgb,var(--color-fd-foreground,currentColor) 46%,transparent);
+  font:inherit;line-height:inherit;appearance:none;
+}
+.dt-hl-meta{
+  display:none;flex-direction:column;gap:4px;
+  margin-top:8px;padding:7px 10px;
+  border-radius:6px;border:1px solid var(--color-fd-border,#e2e8f0);
+  background:var(--color-fd-muted,#f1f5f9);
+}
+.dt-float-editor-body .dt-hl-meta{display:flex}
+.dt-hl-row{display:flex;align-items:center;gap:7px}
+.dt-hl-lbl{font-size:9.5px;font-weight:800;text-transform:uppercase;letter-spacing:.07em;color:var(--color-fd-muted-foreground,#64748b);width:52px;flex-shrink:0}
+.dt-hl-inp{background:transparent;border:none;outline:none;font-size:11.5px;color:var(--color-fd-foreground,#0f172a);flex:1;font-family:inherit}
+
+/* ─ prompt (uses fd-prompt classes from base.css, just override editable inputs) ─ */
+.fd-prompt input.fd-prompt-title-edit,.fd-prompt textarea.fd-prompt-body-edit{
+  background:transparent;border:none;outline:none;font:inherit;color:inherit;
+  width:100%;resize:none;padding:0;margin:0;
+}
+
+/* ─ raw block ─ */
+.dt-raw-shell{
+  border-radius:8px;
+  border:1.5px dashed color-mix(in srgb,var(--color-fd-border,#e2e8f0) 80%,transparent);
+  padding:10px 12px;
+  background:color-mix(in srgb,var(--color-fd-muted,#f1f5f9) 40%,transparent);
+}
+
+/* ─ code block (matches fumadocs CodeBlock <figure>) ─ */
+.dt-code-fig{
+  margin:1rem 0;
+  background:var(--color-fd-card,#f8fafc);
+  border-radius:0.75rem;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  box-shadow:0 1px 2px rgba(0,0,0,0.06);
+  overflow:hidden;
+  font-size:0.875rem;
+  position:relative;
+}
+.dt-code-hdr{
+  display:flex;align-items:center;gap:0.5rem;
+  height:2.375rem;
+  border-bottom:1px solid var(--color-fd-border,#e2e8f0);
+  padding:0 1rem;
+  color:var(--color-fd-muted-foreground,#64748b);
+}
+.dt-code-lang{
+  background:transparent;border:none;outline:none;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+  font-size:0.75rem;font-weight:600;
+  color:var(--color-fd-muted-foreground,#64748b);
+  width:52px;flex-shrink:0;
+}
+.dt-code-sep-v{width:1px;height:0.75rem;background:var(--color-fd-border,#e2e8f0);flex-shrink:0}
+.dt-code-file{
+  background:transparent;border:none;outline:none;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+  font-size:0.75rem;
+  color:var(--color-fd-muted-foreground,#64748b);
+  flex:1;min-width:0;
+}
+.dt-code-body{padding:1rem}
+.dt-code-fig figcaption{margin-top:0!important;font-size:inherit!important;color:inherit!important;line-height:inherit!important}
+.dt-code-ta{
+  width:100%;min-height:80px;resize:vertical;
+  background:transparent;border:none;outline:none;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+  font-size:0.875rem;line-height:1.65;
+  color:var(--color-fd-foreground,#0f172a);
+  display:block;
+}
+
+/* ─ source textarea ─ */
+.dt-source-ta{
+  width:100%;min-height:200px;
+  border:1px solid var(--color-fd-border,#e2e8f0);border-radius:9px;
+  padding:16px;outline:none;resize:vertical;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+  font-size:13px;line-height:1.65;
+  background:color-mix(in srgb,var(--color-fd-muted,#f1f5f9) 50%,var(--color-fd-background,#fff));
+  color:var(--color-fd-foreground,#0f172a);
+}
+
+/* ─ empty state ─ */
+.dt-empty{
+  padding:32px 24px;text-align:center;
+  border:1.5px dashed color-mix(in srgb,var(--color-fd-border,#e2e8f0) 70%,transparent);
+  border-radius:12px;
+}
+.dt-empty-title{font-size:14px;font-weight:700;color:var(--color-fd-muted-foreground,#64748b);margin-bottom:4px}
+.dt-empty-sub{font-size:12px;color:color-mix(in srgb,var(--color-fd-muted-foreground,#94a3b8) 75%,transparent)}
+
+@media(max-width:780px){
+  .dt-bar-wordmark{display:none}
+  .dt-btn span{display:none}
+}
+
+/* ─ selection toolbar (shows above selected text in any contentEditable) ─ */
+.dt-sel-toolbar{
+  position:fixed;z-index:2147483010;
+  display:inline-flex;align-items:center;gap:1px;
+  background:rgba(9,9,13,0.97);backdrop-filter:blur(18px);
+  border:1px solid rgba(255,255,255,0.14);border-radius:9px;
+  padding:3px 5px;
+  box-shadow:0 6px 24px rgba(0,0,0,0.55);
+  transform:translateX(-50%);
+  pointer-events:auto;
+  white-space:nowrap;
+}
+/* small arrow pointing down */
+.dt-sel-toolbar::after{
+  content:"";
+  position:absolute;top:100%;left:50%;transform:translateX(-50%);
+  border:5px solid transparent;
+  border-top-color:rgba(9,9,13,0.97);
+}
+.dt-sel-btn{
+  height:26px;padding:0 8px;
+  border:none;background:transparent;color:rgba(255,255,255,0.82);
+  font-size:12.5px;font-weight:700;cursor:pointer;
+  border-radius:6px;
+  display:inline-flex;align-items:center;gap:3px;
+  transition:color .1s,background .1s;
+  font-family:inherit;
+}
+.dt-sel-btn:hover{color:#fff;background:rgba(255,255,255,0.13)}
+.dt-sel-btn[data-active]{background:var(--color-fd-primary,#6366f1);color:#fff}
+.dt-sel-sep{width:1px;height:15px;background:rgba(255,255,255,0.14);margin:0 3px;flex-shrink:0}
+
+/* ─ link editor popover ─ */
+.dt-link-pop{
+  position:fixed;z-index:2147483011;
+  width:min(320px,calc(100vw - 24px));
+  border:1px solid color-mix(in srgb,var(--color-fd-border,#e2e8f0) 86%,transparent);
+  border-radius:10px;
+  background:var(--color-fd-background,#fff);
+  box-shadow:0 20px 54px rgba(15,23,42,0.22),0 2px 10px rgba(15,23,42,0.08);
+  padding:10px;
+}
+.dt-link-pop-row{display:grid;gap:4px;margin-bottom:8px}
+.dt-link-pop-label{font-size:10px;font-weight:750;color:var(--color-fd-muted-foreground,#64748b)}
+.dt-link-pop-input{
+  height:30px;width:100%;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  border-radius:7px;
+  background:var(--color-fd-background,#fff);
+  color:var(--color-fd-foreground,#0f172a);
+  padding:0 9px;font:inherit;font-size:12px;outline:none;
+}
+.dt-link-pop-input:focus{
+  border-color:var(--color-fd-primary,#6366f1);
+  box-shadow:0 0 0 3px color-mix(in srgb,var(--color-fd-primary,#6366f1) 14%,transparent);
+}
+.dt-link-pop-actions{display:flex;align-items:center;justify-content:flex-end;gap:6px}
+.dt-link-pop-btn{
+  height:28px;padding:0 10px;border-radius:7px;
+  border:1px solid var(--color-fd-border,#e2e8f0);
+  background:transparent;color:var(--color-fd-foreground,#0f172a);
+  font-size:12px;font-weight:700;cursor:pointer;
+}
+.dt-link-pop-btn:hover{background:var(--color-fd-muted,#f1f5f9)}
+.dt-link-pop-btn[data-primary]{background:var(--color-fd-primary,#6366f1);border-color:var(--color-fd-primary,#6366f1);color:#fff}
+`;
+
+// ─── ContentEditable helper ───────────────────────────────────────────────────
+
+function getEditText(el: HTMLElement) {
+  return el.innerText.replace(/\n\n$/g, "").replace(/ /g, " ");
+}
+
+function getEditSel(el: HTMLElement, fallback: number): { start: number; end: number } {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return { start: fallback, end: fallback };
+  if (!el.contains(sel.anchorNode) || !el.contains(sel.focusNode))
+    return { start: fallback, end: fallback };
+  const range = sel.getRangeAt(0);
+  const before = range.cloneRange();
+  before.selectNodeContents(el);
+  before.setEnd(range.startContainer, range.startOffset);
+  const start = before.toString().length;
+  return { start, end: start + range.toString().length };
+}
+
+function setEditSel(el: HTMLElement, start: number, end: number) {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  let sn: Text | null = null;
+  let en: Text | null = null;
+  let so = 0;
+  let eo = 0;
+  let node = walker.nextNode() as Text | null;
+  while (node) {
+    const len = (node.textContent ?? "").length;
+    const next = offset + len;
+    if (!sn && start <= next) {
+      sn = node;
+      so = Math.max(0, start - offset);
+    }
+    if (!en && end <= next) {
+      en = node;
+      eo = Math.max(0, end - offset);
+      break;
+    }
+    offset = next;
+    node = walker.nextNode() as Text | null;
+  }
+  if (!sn || !en) return;
+  const range = document.createRange();
+  range.setStart(sn, so);
+  range.setEnd(en, eo);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+}
+
+function syncEditable(el: HTMLElement) {
+  el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "formatSetBlockText" }));
+}
+
+function syncActiveEditable() {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && active.isContentEditable) {
+    syncEditable(active);
+  }
+}
+
+function execRichTextCommand(command: string, value?: string) {
+  document.execCommand(command, false, value);
+  syncActiveEditable();
+}
+
+type LinkEditorRequest = {
+  host: HTMLElement;
+  range: Range;
+  anchor: HTMLAnchorElement | null;
+  label: string;
+  url: string;
+  rect: DOMRect;
+};
+
+let closeActiveLinkEditor: (() => void) | null = null;
+
+function getContentEditableHost(node: Node | null): HTMLElement | null {
+  const el = node instanceof Element ? node : node?.parentElement;
+  const host = el?.closest("[contenteditable]");
+  return host instanceof HTMLElement ? host : null;
+}
+
+function getClosestAnchor(node: Node | null): HTMLAnchorElement | null {
+  const el = node instanceof Element ? node : node?.parentElement;
+  const anchor = el?.closest("a[href]");
+  return anchor instanceof HTMLAnchorElement ? anchor : null;
+}
+
+function fallbackRectFor(el: HTMLElement): DOMRect {
+  const rect = el.getBoundingClientRect();
+  if (rect.width || rect.height) return rect;
+  return new DOMRect(16, 72, 280, 32);
+}
+
+function rangeBelongsToHost(range: Range, host: HTMLElement) {
+  return host.contains(range.startContainer) && host.contains(range.endContainer);
+}
+
+function fallbackRangeFor(host: HTMLElement) {
+  const fallback = document.createRange();
+  fallback.selectNodeContents(host);
+  fallback.collapse(false);
+  return fallback;
+}
+
+function requestRichTextLink(anchorRect?: DOMRect, fallbackHost?: HTMLElement | null) {
+  const sel = window.getSelection();
+  const active = document.activeElement;
+  const activeHost = active instanceof HTMLElement && active.isContentEditable ? active : null;
+  const host =
+    getContentEditableHost(sel?.anchorNode ?? null) ??
+    getContentEditableHost(sel?.focusNode ?? null) ??
+    fallbackHost ??
+    activeHost;
+  if (!host) return;
+
+  const selectedRange = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
+  const range =
+    selectedRange && rangeBelongsToHost(selectedRange, host)
+      ? selectedRange
+      : fallbackRangeFor(host);
+
+  const anchor =
+    getClosestAnchor(sel?.anchorNode ?? null) ?? getClosestAnchor(sel?.focusNode ?? null);
+  const hostAnchor = anchor && host.contains(anchor) ? anchor : null;
+  const label = hostAnchor?.textContent ?? sel?.toString() ?? "";
+  const url = hostAnchor?.getAttribute("href") ?? "";
+  const selectionRect = range.getBoundingClientRect();
+  const rect =
+    anchorRect ??
+    (hostAnchor ? fallbackRectFor(hostAnchor) : null) ??
+    (selectionRect.width || selectionRect.height ? selectionRect : fallbackRectFor(host));
+
+  const request = { host, range, anchor: hostAnchor, label, url, rect };
+  showLinkEditorPopover(request);
+}
+
+function insertRichTextLink(host: HTMLElement, range: Range, url: string, selectedText: string) {
+  const href = url.trim();
+  if (!href) return;
+  const label = selectedText.trim() || href;
+
+  host.focus();
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.textContent = label;
+  range.deleteContents();
+  range.insertNode(anchor);
+  range.setStartAfter(anchor);
+  range.setEndAfter(anchor);
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  syncActiveEditable();
+}
+
+function closeLinkEditorPopover() {
+  closeActiveLinkEditor?.();
+  closeActiveLinkEditor = null;
+}
+
+function placeLinkEditorPopover(pop: HTMLElement, rect: DOMRect) {
+  const gap = 8;
+  const width = pop.offsetWidth || 320;
+  const height = pop.offsetHeight || 132;
+  const left = Math.max(
+    12,
+    Math.min(window.innerWidth - width - 12, rect.left + rect.width / 2 - width / 2),
+  );
+  const aboveTop = rect.top - height - gap;
+  const belowTop = rect.bottom + gap;
+  const top =
+    aboveTop >= 12 ? aboveTop : Math.min(Math.max(12, belowTop), window.innerHeight - height - 12);
+
+  pop.style.top = `${top}px`;
+  pop.style.left = `${left}px`;
+}
+
+function showLinkEditorPopover(request: LinkEditorRequest) {
+  closeLinkEditorPopover();
+
+  const pop = document.createElement("div");
+  pop.className = "dt dt-link-pop";
+  pop.style.visibility = "hidden";
+
+  const labelRow = document.createElement("label");
+  labelRow.className = "dt-link-pop-row";
+  const labelText = document.createElement("span");
+  labelText.className = "dt-link-pop-label";
+  labelText.textContent = "Label";
+  const labelInput = document.createElement("input");
+  labelInput.className = "dt-link-pop-input";
+  labelInput.placeholder = "Link text";
+  labelInput.value = request.label;
+  labelRow.append(labelText, labelInput);
+
+  const urlRow = document.createElement("label");
+  urlRow.className = "dt-link-pop-row";
+  const urlText = document.createElement("span");
+  urlText.className = "dt-link-pop-label";
+  urlText.textContent = "URL";
+  const urlInput = document.createElement("input");
+  urlInput.className = "dt-link-pop-input";
+  urlInput.placeholder = "https://example.com";
+  urlInput.value = request.url;
+  urlRow.append(urlText, urlInput);
+
+  const actions = document.createElement("div");
+  actions.className = "dt-link-pop-actions";
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.className = "dt-link-pop-btn";
+  cancel.textContent = "Cancel";
+  const apply = document.createElement("button");
+  apply.type = "button";
+  apply.className = "dt-link-pop-btn";
+  apply.dataset.primary = "";
+  apply.textContent = "Apply";
+  actions.append(cancel, apply);
+  pop.append(labelRow, urlRow, actions);
+
+  function cleanup() {
+    pop.remove();
+    document.removeEventListener("mousedown", outside);
+    document.removeEventListener("keydown", key);
+    closeActiveLinkEditor = null;
+  }
+
+  function save() {
+    const href = urlInput.value.trim();
+    if (!href) return;
+
+    if (request.anchor && request.host.contains(request.anchor)) {
+      request.anchor.href = href;
+      request.anchor.textContent = labelInput.value.trim() || href;
+      syncEditable(request.host);
+    } else {
+      insertRichTextLink(request.host, request.range, href, labelInput.value || request.label);
+    }
+    cleanup();
+  }
+
+  function outside(e: MouseEvent) {
+    if (pop.contains(e.target as Node)) return;
+    cleanup();
+  }
+
+  function key(e: KeyboardEvent) {
+    if (e.key === "Escape") cleanup();
+    if (e.key === "Enter" && document.activeElement === urlInput) {
+      e.preventDefault();
+      save();
+    }
+  }
+
+  cancel.addEventListener("click", cleanup);
+  apply.addEventListener("click", save);
+  document.body.appendChild(pop);
+  placeLinkEditorPopover(pop, request.rect);
+  pop.style.visibility = "";
+  closeActiveLinkEditor = cleanup;
+  window.setTimeout(() => {
+    document.addEventListener("mousedown", outside);
+    document.addEventListener("keydown", key);
+    labelInput.focus();
+    labelInput.select();
+  }, 0);
+}
+
+// ─── ProseEditor (contentEditable with formatting) ────────────────────────────
+
+function ProseEditor({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || document.activeElement === el) return;
+    if (html2md(el.innerHTML) !== value) el.innerHTML = md2html(value);
+  }, [value]);
+
+  function focusEditor() {
+    const el = ref.current;
+    if (!el) return;
+    el.focus();
+  }
+
+  function wrapCode() {
+    focusEditor();
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !sel.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    const code = document.createElement("code");
+    try {
+      range.surroundContents(code);
+      syncActiveEditable();
+    } catch {
+      execRichTextCommand("insertText", `\`${sel.toString()}\``);
+    }
+  }
+
+  return (
+    <div>
+      <div className="dt-fmt-bar" aria-label="Markdown formatting">
+        {(
+          [
+            ["B", "bold", () => execRichTextCommand("bold")],
+            ["I", "italic", () => execRichTextCommand("italic")],
+            ["`", "code", wrapCode],
+            ["↗", "link", () => requestRichTextLink(undefined, ref.current)],
+            ["—", "item", () => execRichTextCommand("insertText", "- ")],
+          ] as const
+        ).map(([label, title, action]) => (
+          <button
+            key={label}
+            type="button"
+            className="dt-fmt-btn"
+            title={title}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              focusEditor();
+              action();
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div
+        ref={ref}
+        className="dt-editable"
+        contentEditable
+        suppressContentEditableWarning
+        data-ph={placeholder}
+        dangerouslySetInnerHTML={{ __html: md2html(value) }}
+        onInput={(e) => onChange(html2md(e.currentTarget.innerHTML))}
+        onClick={(e) => {
+          const anchor = (e.target as HTMLElement).closest("a[href]");
+          if (!anchor || !ref.current?.contains(anchor)) return;
+          e.preventDefault();
+          e.stopPropagation();
+          const range = document.createRange();
+          range.selectNodeContents(anchor);
+          const sel = window.getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
+          requestRichTextLink(anchor.getBoundingClientRect(), ref.current);
+        }}
+        onPaste={(e) => {
+          e.preventDefault();
+          document.execCommand("insertText", false, e.clipboardData.getData("text/plain"));
+        }}
+      />
+    </div>
+  );
+}
+
+// ─── md2html / html2md (minimal inline markdown → HTML conversion) ───────────
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/'/g, "&#39;");
+}
+
+function inlineMdToHtml(md: string): string {
+  const links: string[] = [];
+  const withLinkTokens = md.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_m, label: string, href: string) => {
+      const token = `\uE000${links.length}\uE001`;
+      links.push(`<a href="${escapeAttr(href)}">${inlineMdToHtml(label)}</a>`);
+      return token;
+    },
+  );
+
+  let s = escapeHtml(withLinkTokens);
+  s = s
+    .replace(/\*\*(.+?)\*\*/gs, "<strong>$1</strong>")
+    .replace(/__(.+?)__/gs, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/gs, "<em>$1</em>")
+    .replace(/_(.+?)_/gs, "<em>$1</em>")
+    .replace(/`(.+?)`/g, "<code>$1</code>");
+  links.forEach((html, index) => {
+    s = s.replace(`\uE000${index}\uE001`, html);
+  });
+  return s;
+}
+
+function md2html(md: string): string {
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let normal: string[] = [];
+  let list: Array<{ ordered: boolean; text: string }> = [];
+
+  function flushNormal() {
+    if (normal.length === 0) return;
+    out.push(`<p>${inlineMdToHtml(normal.join("\n")).replace(/\n/g, "<br>")}</p>`);
+    normal = [];
+  }
+
+  function flushList() {
+    if (list.length === 0) return;
+    const ordered = list[0]?.ordered ?? false;
+    const tag = ordered ? "ol" : "ul";
+    out.push(
+      `<${tag}>${list.map((item) => `<li>${inlineMdToHtml(item.text)}</li>`).join("")}</${tag}>`,
+    );
+    list = [];
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    const unordered = line.match(/^[-*+]\s+(.+)$/);
+    const ordered = line.match(/^\d+[.)]\s+(.+)$/);
+
+    if (unordered || ordered) {
+      flushNormal();
+      const isOrdered = Boolean(ordered);
+      if (list.length > 0 && list[0]?.ordered !== isOrdered) flushList();
+      list.push({ ordered: isOrdered, text: unordered?.[1] ?? ordered?.[1] ?? "" });
+      continue;
+    }
+
+    flushList();
+    normal.push(rawLine);
+  }
+
+  flushNormal();
+  flushList();
+  return out.join("") || "<p><br></p>";
+}
+
+function html2md(html: string): string {
+  if (typeof document === "undefined") return html;
+
+  const root = document.createElement("div");
+  root.innerHTML = html;
+
+  function inline(nodes: NodeListOf<ChildNode> | ChildNode[]): string {
+    return Array.from(nodes)
+      .map((node) => {
+        if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+        if (!(node instanceof HTMLElement)) return "";
+
+        const tag = node.tagName.toLowerCase();
+        if (tag === "br") return "\n";
+        if (tag === "strong" || tag === "b") return `**${inline(node.childNodes)}**`;
+        if (tag === "em" || tag === "i") return `_${inline(node.childNodes)}_`;
+        if (tag === "code") return `\`${node.textContent ?? ""}\``;
+        if (tag === "a") {
+          const href = node.getAttribute("href") ?? "";
+          const label = inline(node.childNodes).trim() || href;
+          return href ? `[${label}](${href})` : label;
+        }
+        if (tag === "li") return inline(node.childNodes);
+        return inline(node.childNodes);
+      })
+      .join("");
+  }
+
+  function block(node: ChildNode): string {
+    if (node.nodeType === Node.TEXT_NODE) return (node.textContent ?? "").trim();
+    if (!(node instanceof HTMLElement)) return "";
+
+    const tag = node.tagName.toLowerCase();
+    if (tag === "ul" || tag === "ol") {
+      return Array.from(node.children)
+        .filter((child): child is HTMLElement => child instanceof HTMLElement)
+        .map((li, index) => {
+          const prefix = tag === "ol" ? `${index + 1}. ` : "- ";
+          return `${prefix}${inline(li.childNodes).trim()}`;
+        })
+        .join("\n");
+    }
+    if (tag === "blockquote") {
+      return inline(node.childNodes)
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    }
+    if (tag === "hr") return "---";
+    return inline(node.childNodes).trim();
+  }
+
+  return Array.from(root.childNodes)
+    .map(block)
+    .filter(Boolean)
+    .join("\n")
+    .replace(/\u00a0/g, " ")
+    .trim();
+}
+
+// ─── WYSIWYG Paragraph Editor (contentEditable, renders bold/italic/code) ────
+
+function WysiwygParagraphEditor({
+  initialContent,
+  style,
+  onChange,
+  onClose,
+}: {
+  initialContent: string;
+  style: React.CSSProperties;
+  onChange: (md: string) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  // Set innerHTML only on mount — never overwrite while the user types
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.innerHTML = md2html(initialContent);
+    el.focus();
+    // Move caret to end
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div
+      ref={ref}
+      contentEditable
+      suppressContentEditableWarning
+      style={{
+        ...style,
+        outline: "none",
+        minHeight: "1em",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+      }}
+      onInput={(e) => onChange(html2md(e.currentTarget.innerHTML))}
+      onClick={(e) => {
+        const anchor = (e.target as HTMLElement).closest("a[href]");
+        if (!anchor || !ref.current?.contains(anchor)) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const range = document.createRange();
+        range.selectNodeContents(anchor);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        requestRichTextLink(anchor.getBoundingClientRect(), ref.current);
+      }}
+      onPaste={(e) => {
+        e.preventDefault();
+        // Paste as plain text to avoid pasting HTML tags
+        document.execCommand("insertText", false, e.clipboardData.getData("text/plain"));
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          onClose();
+        }
+      }}
+    />
+  );
+}
+
+// ─── Inline-editable input ────────────────────────────────────────────────────
+
+function InlineInput({
+  value,
+  onChange,
+  className,
+  placeholder,
+  style,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  className?: string;
+  placeholder?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <input
+      className={className}
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+      placeholder={placeholder}
+      style={style}
+    />
+  );
+}
+
+// ─── Block renderer components ────────────────────────────────────────────────
+
+function HeadingRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "heading" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  const level = Math.min(6, Math.max(1, block.level));
+  const hRef = (el: HTMLHeadingElement | null) => {
+    if (el && document.activeElement !== el && el.innerText !== block.text)
+      el.innerText = block.text;
+  };
+  const hProps = {
+    className: "dt-editable",
+    contentEditable: true as const,
+    suppressContentEditableWarning: true,
+    "data-ph": `Heading ${level}`,
+    onInput: (e: React.FormEvent<HTMLHeadingElement>) =>
+      onChange({ ...block, text: getEditText(e.currentTarget) }),
+    onPaste: (e: React.ClipboardEvent<HTMLHeadingElement>) => {
+      e.preventDefault();
+      document.execCommand("insertText", false, e.clipboardData.getData("text/plain"));
+    },
+  };
+  return (
+    <div>
+      <div className="dt-level-row" aria-label="Heading level">
+        {[1, 2, 3, 4, 5, 6].map((l) => (
+          <button
+            key={l}
+            type="button"
+            className="dt-level-btn"
+            data-active={level === l ? "" : undefined}
+            onClick={() => onChange({ ...block, level: l })}
+          >
+            H{l}
+          </button>
+        ))}
+      </div>
+      {level === 1 && <h1 ref={hRef} {...hProps} />}
+      {level === 2 && <h2 ref={hRef} {...hProps} />}
+      {level === 3 && <h3 ref={hRef} {...hProps} />}
+      {level === 4 && <h4 ref={hRef} {...hProps} />}
+      {level === 5 && <h5 ref={hRef} {...hProps} />}
+      {level === 6 && <h6 ref={hRef} {...hProps} />}
+    </div>
+  );
+}
+
+function ParagraphRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "paragraph" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  return (
+    <ProseEditor
+      value={block.content}
+      onChange={(content) => onChange({ ...block, content })}
+      placeholder="Write a paragraph…"
+    />
+  );
+}
+
+function CalloutRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "callout" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  const v = CALLOUT_VARIANTS[block.variant] ?? CALLOUT_VARIANTS.note!;
+  const Icon = v.iconEl;
+  const primaryVariants = ["note", "warning", "tip", "important", "caution"] as const;
+  return (
+    <div>
+      {/* Variant selector — hidden by default, shows on block hover */}
+      <div className="dt-variant-row" aria-label="Callout variant">
+        {primaryVariants.map((k) => {
+          const cv = CALLOUT_VARIANTS[k]!;
+          return (
+            <button
+              key={k}
+              type="button"
+              className="dt-variant-btn"
+              data-active={block.variant === k ? "" : undefined}
+              onClick={() => onChange({ ...block, variant: k })}
+            >
+              {cv.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Exact same structure as website/components/ui/callout.tsx */}
+      <div
+        role="note"
+        className={`callout-custom my-4 flex gap-0 overflow-x-hidden rounded-none border p-4 font-mono ${v.border} ${v.bg}`}
+        style={{ fontSize: "9px" }}
+      >
+        <div className={`shrink-0 -mt-1 ${v.iconClass}`} aria-hidden="true">
+          <Icon />
+        </div>
+        <div className="min-w-0 -mt-6 ml-2 flex-1 space-y-1">
+          <input
+            className={`font-mono uppercase tracking-tight bg-transparent border-none outline-none w-full p-0 ${v.titleClass}`}
+            style={{ fontSize: "9px" }}
+            value={block.title}
+            onChange={(e) => onChange({ ...block, title: e.currentTarget.value })}
+            placeholder="Optional title…"
+          />
+          <div className="h-px w-[calc(100%+10rem)] -mt-2 mx-auto ml-[-5rem] bg-black/10 dark:bg-white/10" />
+          <div className="text-black/80 pt-2 font-sans dark:text-white/80 [&>p:last-child]:mb-0 [&>p]:my-0">
+            <ProseEditor
+              value={block.content}
+              onChange={(content) => onChange({ ...block, content })}
+              placeholder="Callout body…"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CodeRenderer({
+  block,
+  onChange,
+  autoFocusCode = false,
+}: {
+  block: Extract<MdxBlock, { type: "code" }>;
+  onChange: (b: MdxBlock) => void;
+  autoFocusCode?: boolean;
+}) {
+  const codeRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (!autoFocusCode) return;
+    const el = codeRef.current;
+    if (!el) return;
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+  }, [autoFocusCode]);
+
+  return (
+    <figure className="dt-code-fig not-prose">
+      <div className="dt-code-hdr">
+        <input
+          className="dt-code-lang"
+          value={block.language}
+          onChange={(e) => onChange({ ...block, language: e.currentTarget.value })}
+          placeholder="ts"
+        />
+        <div className="dt-code-sep-v" />
+        <figcaption style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+          <input
+            className="dt-code-file"
+            value={block.title}
+            onChange={(e) => onChange({ ...block, title: e.currentTarget.value })}
+            placeholder="filename.ts"
+          />
+        </figcaption>
+      </div>
+      <div className="dt-code-body">
+        <textarea
+          ref={codeRef}
+          className="dt-code-ta"
+          value={block.code}
+          onChange={(e) => onChange({ ...block, code: e.currentTarget.value })}
+          spellCheck={false}
+          rows={Math.max(4, block.code.split("\n").length + 1)}
+        />
+      </div>
+    </figure>
+  );
+}
+
+function TabsRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "tabs" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  const [activeTab, setActiveTab] = useState(0);
+  const tab = block.tabs[activeTab] ?? block.tabs[0];
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-xl border bg-fd-secondary my-4 not-prose">
+      <div className="flex items-center overflow-x-auto border-b px-1">
+        {block.tabs.map((t, i) => (
+          <div
+            key={i}
+            className={`flex items-center gap-1 px-3 h-9 cursor-pointer shrink-0 border-b-2 transition-colors ${activeTab === i ? "border-fd-primary text-fd-foreground" : "border-transparent text-fd-muted-foreground"}`}
+            style={{ marginBottom: "-1px" }}
+            onClick={() => setActiveTab(i)}
+          >
+            <input
+              className="bg-transparent border-none outline-none text-xs font-medium cursor-text"
+              value={t.label}
+              onClick={(e) => {
+                e.stopPropagation();
+                setActiveTab(i);
+              }}
+              onChange={(e) => {
+                const tabs = [...block.tabs];
+                tabs[i] = { ...t, label: e.currentTarget.value };
+                onChange({ ...block, tabs });
+              }}
+              style={{ width: `${Math.max(30, t.label.length * 7.5)}px` }}
+            />
+            <button
+              type="button"
+              className="w-4 h-4 rounded flex items-center justify-center text-xs text-fd-muted-foreground hover:text-red-500"
+              onClick={(e) => {
+                e.stopPropagation();
+                const tabs = block.tabs.filter((_, idx) => idx !== i);
+                onChange({ ...block, tabs });
+                if (activeTab >= tabs.length) setActiveTab(Math.max(0, tabs.length - 1));
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className="h-7 px-2 mx-1 my-1 text-xs text-fd-muted-foreground border border-dashed border-fd-border rounded shrink-0 hover:border-fd-primary hover:text-fd-primary transition-colors"
+          onClick={() => {
+            const tabs = [...block.tabs, { label: "New", content: "Content" }];
+            onChange({ ...block, tabs });
+            setActiveTab(tabs.length - 1);
+          }}
+        >
+          + Add
+        </button>
+      </div>
+      {tab && (
+        <div className="p-4 prose">
+          <ProseEditor
+            key={activeTab}
+            value={tab.content}
+            onChange={(content) => {
+              const tabs = [...block.tabs];
+              tabs[activeTab] = { ...tab, content };
+              onChange({ ...block, tabs });
+            }}
+            placeholder="Tab content…"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HoverLinkRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "hoverlink" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  return (
+    <div>
+      {/* Looks like the actual rendered HoverLink — an inline dashed-underline link */}
+      <p style={{ margin: 0 }}>
+        <input
+          className="dt-hl-trigger"
+          value={block.label}
+          onChange={(e) => onChange({ ...block, label: e.currentTarget.value })}
+          placeholder="Link label text…"
+          style={{ width: `${Math.max(120, block.label.length * 8)}px` }}
+        />
+      </p>
+      {/* Metadata fields — hidden by default, slide in on hover via dt-hl-meta CSS */}
+      <div className="dt-hl-meta">
+        <div className="dt-hl-row">
+          <span className="dt-hl-lbl">href</span>
+          <input
+            className="dt-hl-inp"
+            value={block.href}
+            onChange={(e) => onChange({ ...block, href: e.currentTarget.value })}
+            placeholder="/docs/page"
+          />
+        </div>
+        <div className="dt-hl-row">
+          <span className="dt-hl-lbl">title</span>
+          <input
+            className="dt-hl-inp"
+            value={block.title}
+            onChange={(e) => onChange({ ...block, title: e.currentTarget.value })}
+            placeholder="Hover card title"
+          />
+        </div>
+        <div className="dt-hl-row">
+          <span className="dt-hl-lbl">desc</span>
+          <input
+            className="dt-hl-inp"
+            value={block.description}
+            onChange={(e) => onChange({ ...block, description: e.currentTarget.value })}
+            placeholder="Hover card description"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PromptRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "prompt" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  return (
+    // Uses the real fd-prompt CSS classes from packages/fumadocs/styles/base.css
+    <div className="fd-prompt not-prose">
+      <div className="fd-prompt-header">
+        <div className="fd-prompt-copy">
+          <input
+            className="fd-prompt-title"
+            style={{
+              background: "transparent",
+              border: "none",
+              outline: "none",
+              width: "100%",
+              padding: 0,
+              margin: 0,
+              font: "inherit",
+              color: "inherit",
+            }}
+            value={block.title}
+            onChange={(e) => onChange({ ...block, title: e.currentTarget.value })}
+            placeholder="Prompt title…"
+          />
+        </div>
+      </div>
+      <div className="fd-prompt-body">
+        <textarea
+          className="fd-prompt-code"
+          style={{
+            width: "100%",
+            resize: "vertical",
+            background: "transparent",
+            border: "none",
+            outline: "none",
+            font: "inherit",
+            color: "inherit",
+            padding: 0,
+          }}
+          value={block.content}
+          onChange={(e) => onChange({ ...block, content: e.currentTarget.value })}
+          rows={Math.max(3, block.content.split("\n").length + 1)}
+          placeholder="Prompt text…"
+          spellCheck={false}
+        />
+      </div>
+      <div className="fd-prompt-actions" style={{ justifyContent: "flex-start" }}>
+        <button
+          type="button"
+          className="fd-prompt-action-btn"
+          style={{ pointerEvents: "none", opacity: 0.5 }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+          <span>Copy prompt</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RawRenderer({
+  block,
+  onChange,
+}: {
+  block: Extract<MdxBlock, { type: "raw" }>;
+  onChange: (b: MdxBlock) => void;
+}) {
+  return (
+    <div className="dt-raw-shell">
+      <textarea
+        className="dt-code-ta"
+        value={block.content}
+        onChange={(e) => onChange({ ...block, content: e.currentTarget.value })}
+        spellCheck={false}
+        rows={Math.max(2, block.content.split("\n").length)}
+        placeholder="<CustomComponent />"
+      />
+    </div>
+  );
+}
+
+function BlockContent({ block, onChange }: { block: MdxBlock; onChange: (b: MdxBlock) => void }) {
+  if (block.type === "heading") return <HeadingRenderer block={block} onChange={onChange} />;
+  if (block.type === "paragraph") return <ParagraphRenderer block={block} onChange={onChange} />;
+  if (block.type === "callout") return <CalloutRenderer block={block} onChange={onChange} />;
+  if (block.type === "code") return <CodeRenderer block={block} onChange={onChange} />;
+  if (block.type === "tabs") return <TabsRenderer block={block} onChange={onChange} />;
+  if (block.type === "hoverlink") return <HoverLinkRenderer block={block} onChange={onChange} />;
+  if (block.type === "prompt") return <PromptRenderer block={block} onChange={onChange} />;
+  if (block.type === "raw") return <RawRenderer block={block} onChange={onChange} />;
+  return null;
+}
+
+// ─── SVG icons ────────────────────────────────────────────────────────────────
+
+function ChevUp() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  );
+}
+function ChevDown() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+function Trash() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+    </svg>
+  );
+}
+function Copy() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+function SaveIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z" />
+      <path d="M7 3v6h10" />
+      <path d="M7 21v-7h10v7" />
+    </svg>
+  );
+}
+function Plus() {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+// ─── Insert palette ───────────────────────────────────────────────────────────
+
+function InsertPalette({
+  x,
+  y,
+  onInsert,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  onInsert: (t: MdxBlock["type"]) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function keyHandler(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", keyHandler);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", keyHandler);
+    };
+  }, [onClose]);
+
+  const style: React.CSSProperties = {
+    left: Math.min(x, window.innerWidth - 280),
+    top: Math.min(y, window.innerHeight - 320),
+  };
+
+  return (
+    <div ref={ref} className="dt-palette dt" style={style} role="menu" aria-label="Insert block">
+      <div className="dt-palette-title">Insert block</div>
+      <div className="dt-palette-grid">
+        {BLOCK_CATALOGUE.map(({ type, label, icon, accent, desc }) => (
+          <button
+            key={type}
+            type="button"
+            className="dt-palette-item"
+            role="menuitem"
+            onClick={() => {
+              onInsert(type);
+              onClose();
+            }}
+          >
+            <div className="dt-palette-icon" style={{ background: `${accent}20`, color: accent }}>
+              {icon}
+            </div>
+            <div>
+              <div className="dt-palette-label">{label}</div>
+              <div className="dt-palette-desc">{desc}</div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Inline block editor (overlays directly on heading / paragraph blocks) ────
+
+function InlineBlockEditor({
+  block,
+  rect,
+  el,
+  onChange,
+  onClose,
+  onMove,
+  onDuplicate,
+  onDelete,
+  onSave,
+  saving,
+  index,
+  total,
+}: {
+  block: Extract<MdxBlock, { type: "heading" | "paragraph" }>;
+  rect: DOMRect;
+  el: HTMLElement;
+  onChange: (b: MdxBlock) => void;
+  onClose: () => void;
+  onMove: (dir: -1 | 1) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onSave: () => void;
+  saving: boolean;
+  index: number;
+  total: number;
+}) {
+  const cs = window.getComputedStyle(el);
+
+  // Cover style: fixed, same bounding box, opaque background so original is hidden
+  const cover: React.CSSProperties = {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    // grow with content, start at the element's natural height
+    minHeight: rect.height,
+    // Copy padding so text sits in the same position
+    paddingTop: cs.paddingTop || 0,
+    paddingBottom: cs.paddingBottom || 0,
+    paddingLeft: cs.paddingLeft || 0,
+    paddingRight: cs.paddingRight || 0,
+  };
+
+  // Shared text style cloned from the real element
+  const text: React.CSSProperties = {
+    fontSize: cs.fontSize,
+    fontWeight: cs.fontWeight,
+    lineHeight: cs.lineHeight,
+    letterSpacing: cs.letterSpacing,
+    fontFamily: cs.fontFamily,
+    color: cs.color,
+    textDecoration: "none",
+    margin: 0,
+    padding: 0,
+  };
+
+  // Mini action toolbar — appears above the cover
+  const toolbarTop = Math.max(54, rect.top - 36);
+
+  return createPortal(
+    <>
+      {/* Opaque cover that hides the original text and hosts the editor */}
+      <div className="dt-inline-cover dt" style={cover}>
+        {block.type === "heading" ? (
+          <input
+            autoFocus
+            className="dt-inline-input"
+            style={text}
+            value={block.text}
+            onChange={(e) => onChange({ ...block, text: e.target.value })}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") onClose();
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onClose();
+              }
+            }}
+          />
+        ) : (
+          <WysiwygParagraphEditor
+            initialContent={block.content}
+            style={{ ...text, minHeight: Math.max(rect.height, 48) }}
+            onChange={(content) => onChange({ ...block, content } as MdxBlock)}
+            onClose={onClose}
+          />
+        )}
+      </div>
+
+      {/* Mini toolbar above the block */}
+      <div className="dt dt-inline-toolbar" style={{ top: toolbarTop, left: rect.left }}>
+        {block.type === "heading" && (
+          <span className="dt-inline-toolbar-group">
+            {([1, 2, 3, 4, 5, 6] as const).map((l) => (
+              <button
+                key={l}
+                type="button"
+                className="dt-inline-tb-btn"
+                data-active={block.level === l ? "" : undefined}
+                onClick={() => onChange({ ...block, level: l })}
+              >
+                H{l}
+              </button>
+            ))}
+            <span className="dt-inline-tb-sep" />
+          </span>
+        )}
+        {block.type === "paragraph" && (
+          <span className="dt-inline-toolbar-group">
+            {(
+              [
+                ["B", "bold", () => execRichTextCommand("bold")],
+                ["I", "italic", () => execRichTextCommand("italic")],
+                [
+                  "`",
+                  "code",
+                  () => {
+                    // Wrap selection in <code> via execCommand insertHTML, or surroundContents
+                    const sel = window.getSelection();
+                    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return;
+                    const range = sel.getRangeAt(0);
+                    const code = document.createElement("code");
+                    try {
+                      range.surroundContents(code);
+                      syncActiveEditable();
+                    } catch {
+                      execRichTextCommand("insertText", `\`${sel.toString()}\``);
+                    }
+                  },
+                ],
+                [
+                  "↗",
+                  "link",
+                  () => {
+                    const active = document.activeElement;
+                    const host =
+                      active instanceof HTMLElement && active.isContentEditable
+                        ? active
+                        : document.querySelector<HTMLElement>(
+                            ".dt-inline-cover [contenteditable='true']",
+                          );
+                    requestRichTextLink(undefined, host);
+                  },
+                ],
+              ] as const
+            ).map(([lbl, title, fn]) => (
+              <button
+                key={lbl}
+                type="button"
+                className="dt-inline-tb-btn"
+                title={title}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  fn();
+                }}
+              >
+                {lbl}
+              </button>
+            ))}
+            <span className="dt-inline-tb-sep" />
+          </span>
+        )}
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          disabled={index === 0}
+          onClick={() => onMove(-1)}
+          title="Move up"
+        >
+          <ChevUp />
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          disabled={index === total - 1}
+          onClick={() => onMove(1)}
+          title="Move down"
+        >
+          <ChevDown />
+        </button>
+        <span className="dt-inline-tb-sep" />
+        <button type="button" className="dt-inline-tb-btn" onClick={onDuplicate} title="Duplicate">
+          <Copy />
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn dt-inline-save-btn"
+          onClick={() => {
+            syncActiveEditable();
+            onSave();
+          }}
+          disabled={saving}
+          title="Save block"
+        >
+          <SaveIcon />
+          <span>{saving ? "Saving" : "Save"}</span>
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          data-danger=""
+          onClick={() => {
+            onDelete();
+            onClose();
+          }}
+          title="Delete"
+        >
+          <Trash />
+        </button>
+        <span className="dt-inline-tb-sep" />
+        <button type="button" className="dt-inline-tb-btn" onClick={onClose} title="Done">
+          ✓
+        </button>
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+// ─── Floating block editor (appears near the clicked block) ───────────────────
+
+function FloatingBlockEditor({
+  block,
+  rect,
+  index,
+  total,
+  onClose,
+  onChange,
+  onMove,
+  onDuplicate,
+  onDelete,
+  onSave,
+  saving,
+  onInsertAfter,
+}: {
+  block: MdxBlock;
+  rect: DOMRect;
+  index: number;
+  total: number;
+  onClose: () => void;
+  onChange: (b: MdxBlock) => void;
+  onMove: (dir: -1 | 1) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onSave: () => void;
+  saving: boolean;
+  onInsertAfter: (type: MdxBlock["type"]) => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [palette, setPalette] = useState<{ x: number; y: number } | null>(null);
+  const meta = BLOCK_CATALOGUE.find((b) => b.type === block.type);
+
+  // Position: prefer below the block, fall back to above
+  const editorH = 420;
+  const editorW = Math.min(480, window.innerWidth * 0.9);
+  let top = rect.bottom + 10;
+  if (top + editorH > window.innerHeight - 16) top = Math.max(16, rect.top - editorH - 10);
+  let left = rect.left;
+  if (left + editorW > window.innerWidth - 10)
+    left = Math.max(10, window.innerWidth - editorW - 10);
+
+  useEffect(() => {
+    // Delay attaching the outside-click listener so the very click that opened
+    // this editor doesn't immediately close it.
+    let cleanup: (() => void) | undefined;
+    const tid = window.setTimeout(() => {
+      function outside(e: MouseEvent) {
+        const t = e.target as HTMLElement;
+        if (ref.current?.contains(t)) return;
+        if (t.closest(".dt-palette")) return;
+        onClose();
+      }
+      function key(e: KeyboardEvent) {
+        if (e.key === "Escape") onClose();
+      }
+      document.addEventListener("mousedown", outside);
+      document.addEventListener("keydown", key);
+      cleanup = () => {
+        document.removeEventListener("mousedown", outside);
+        document.removeEventListener("keydown", key);
+      };
+    }, 120);
+    return () => {
+      window.clearTimeout(tid);
+      cleanup?.();
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div ref={ref} className="dt-float-editor dt" style={{ top, left }}>
+      <div className="dt-float-editor-hdr">
+        <span className="dt-float-editor-type" style={{ color: meta?.accent }}>
+          {meta?.icon} {meta?.label ?? block.type}
+        </span>
+        <div style={{ flex: 1 }} />
+        <button
+          type="button"
+          className="dt-float-btn"
+          disabled={index === 0}
+          onClick={() => onMove(-1)}
+          title="Move up"
+        >
+          <ChevUp />
+        </button>
+        <button
+          type="button"
+          className="dt-float-btn"
+          disabled={index === total - 1}
+          onClick={() => onMove(1)}
+          title="Move down"
+        >
+          <ChevDown />
+        </button>
+        <span className="dt-float-sep" />
+        <button
+          type="button"
+          className="dt-float-save-btn"
+          onClick={() => {
+            syncActiveEditable();
+            onSave();
+          }}
+          disabled={saving}
+          title="Save block"
+        >
+          <SaveIcon />
+          {saving ? "Saving" : "Save"}
+        </button>
+        <span className="dt-float-sep" />
+        <button type="button" className="dt-float-btn" onClick={onDuplicate} title="Duplicate">
+          <Copy />
+        </button>
+        <button
+          type="button"
+          className="dt-float-btn"
+          data-danger=""
+          onClick={() => {
+            onDelete();
+            onClose();
+          }}
+          title="Delete"
+        >
+          <Trash />
+        </button>
+        <button
+          type="button"
+          className="dt-float-btn"
+          title="Insert block after"
+          onClick={() => {
+            const r = ref.current?.getBoundingClientRect();
+            if (r) setPalette({ x: r.left, y: r.bottom + 4 });
+          }}
+        >
+          <Plus />
+        </button>
+        <span className="dt-float-sep" />
+        <button
+          type="button"
+          className="dt-float-btn"
+          onClick={onClose}
+          title="Close"
+          style={{ fontSize: 13 }}
+        >
+          ✕
+        </button>
+      </div>
+      <div className="dt-float-editor-body">
+        <BlockContent block={block} onChange={onChange} />
+      </div>
+      {palette &&
+        createPortal(
+          <InsertPalette
+            x={palette.x}
+            y={palette.y}
+            onInsert={(type) => {
+              onInsertAfter(type);
+              setPalette(null);
+            }}
+            onClose={() => setPalette(null)}
+          />,
+          document.body,
+        )}
+    </div>,
+    document.body,
+  );
+}
+
+// ─── SelectionToolbar ────────────────────────────────────────────────────────
+// Global component — appears above any selected text inside a contentEditable
+// within the devtools. Shows B / I / S / ` / Link formatting buttons.
+
+function SelectionToolbar() {
+  const [pos, setPos] = useState<{ top: number; centerX: number } | null>(null);
+
+  useEffect(() => {
+    function onSel() {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        setPos(null);
+        return;
+      }
+      // Only activate when the selection is anchored inside a contentEditable
+      const anchor = sel.anchorNode;
+      const host = (
+        anchor?.nodeType === Node.TEXT_NODE ? anchor.parentElement : (anchor as Element | null)
+      )?.closest("[contenteditable]");
+      if (!host) {
+        setPos(null);
+        return;
+      }
+      // Inline page-block editors have their own fixed toolbar. Showing the
+      // global selection bubble there can sit over B/I controls and eat clicks.
+      if (host.closest(".dt-inline-cover")) {
+        setPos(null);
+        return;
+      }
+      const r = sel.getRangeAt(0).getBoundingClientRect();
+      if (!r.width && !r.height) {
+        setPos(null);
+        return;
+      }
+      setPos({ top: r.top - 48, centerX: r.left + r.width / 2 });
+    }
+    document.addEventListener("selectionchange", onSel);
+    return () => document.removeEventListener("selectionchange", onSel);
+  }, []);
+
+  if (!pos) return null;
+
+  const top = Math.max(58, pos.top);
+  const left = Math.max(
+    60,
+    Math.min((typeof window !== "undefined" ? window.innerWidth : 1200) - 200, pos.centerX),
+  );
+
+  function fmt(cmd: string) {
+    execRichTextCommand(cmd);
+  }
+
+  function wrapCode() {
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !sel.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    const code = document.createElement("code");
+    try {
+      range.surroundContents(code);
+      syncActiveEditable();
+    } catch {
+      execRichTextCommand("insertText", `\`${sel.toString()}\``);
+    }
+  }
+
+  function wrapLink() {
+    requestRichTextLink();
+  }
+
+  return createPortal(
+    <div className="dt dt-sel-toolbar" style={{ top, left }}>
+      <button
+        type="button"
+        className="dt-sel-btn"
+        title="Bold"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          fmt("bold");
+        }}
+      >
+        <strong>B</strong>
+      </button>
+      <button
+        type="button"
+        className="dt-sel-btn"
+        title="Italic"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          fmt("italic");
+        }}
+      >
+        <em style={{ fontStyle: "italic" }}>I</em>
+      </button>
+      <button
+        type="button"
+        className="dt-sel-btn"
+        title="Strikethrough"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          fmt("strikeThrough");
+        }}
+      >
+        <s>S</s>
+      </button>
+      <div className="dt-sel-sep" />
+      <button
+        type="button"
+        className="dt-sel-btn"
+        title="Inline code"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          wrapCode();
+        }}
+        style={{ fontFamily: "ui-monospace,monospace", letterSpacing: 0 }}
+      >
+        {"</>"}
+      </button>
+      <button
+        type="button"
+        className="dt-sel-btn"
+        title="Link"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          wrapLink();
+        }}
+      >
+        ↗
+      </button>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── InlineCodeEditor ─────────────────────────────────────────────────────────
+// Covers the clicked code block with an editable version of the same UI.
+
+function InlineCodeEditor({
+  block,
+  rect,
+  onChange,
+  onClose,
+  onMove,
+  onDuplicate,
+  onDelete,
+  onSave,
+  saving,
+  index,
+  total,
+}: {
+  block: Extract<MdxBlock, { type: "code" }>;
+  rect: DOMRect;
+  onChange: (b: MdxBlock) => void;
+  onClose: () => void;
+  onMove: (dir: -1 | 1) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onSave: () => void;
+  saving: boolean;
+  index: number;
+  total: number;
+}) {
+  const toolbarTop = Math.max(54, rect.top - 36);
+
+  const cover: React.CSSProperties = {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    minHeight: rect.height,
+  };
+
+  return createPortal(
+    <>
+      {/* Opaque cover exactly over the code block */}
+      <div className="dt-inline-cover dt" style={cover}>
+        {/* Re-use the existing CodeRenderer — it renders an editable figure */}
+        <div style={{ margin: 0 }}>
+          <CodeRenderer block={block} onChange={onChange} autoFocusCode />
+        </div>
+      </div>
+
+      {/* Mini toolbar floating above */}
+      <div className="dt dt-inline-toolbar" style={{ top: toolbarTop, left: rect.left }}>
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          disabled={index === 0}
+          onClick={() => onMove(-1)}
+          title="Move up"
+        >
+          <ChevUp />
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          disabled={index === total - 1}
+          onClick={() => onMove(1)}
+          title="Move down"
+        >
+          <ChevDown />
+        </button>
+        <span className="dt-inline-tb-sep" />
+        <button type="button" className="dt-inline-tb-btn" onClick={onDuplicate} title="Duplicate">
+          <Copy />
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn dt-inline-save-btn"
+          onClick={() => onSave()}
+          disabled={saving}
+          title="Save block"
+        >
+          <SaveIcon />
+          <span>{saving ? "Saving" : "Save"}</span>
+        </button>
+        <button
+          type="button"
+          className="dt-inline-tb-btn"
+          data-danger=""
+          onClick={() => {
+            onDelete();
+            onClose();
+          }}
+          title="Delete"
+        >
+          <Trash />
+        </button>
+        <span className="dt-inline-tb-sep" />
+        <button type="button" className="dt-inline-tb-btn" onClick={onClose} title="Done">
+          ✓
+        </button>
+      </div>
+    </>,
+    document.body,
+  );
+}
+
+// ─── Theme popover ────────────────────────────────────────────────────────────
+
+function ThemePopover({
+  active,
+  onSelect,
+  onClose,
+}: {
+  active: string;
+  onSelect: (t: ThemeDef) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    function h(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function k(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", h);
+    document.addEventListener("keydown", k);
+    return () => {
+      document.removeEventListener("mousedown", h);
+      document.removeEventListener("keydown", k);
+    };
+  }, [onClose]);
+
+  return (
+    <div ref={ref} className="dt-theme-pop dt" role="menu" aria-label="Choose theme">
+      {THEMES.map((t) => (
+        <div
+          key={t.id}
+          className="dt-theme-item"
+          data-active={active === t.id ? "" : undefined}
+          role="menuitem"
+          tabIndex={0}
+          onClick={() => onSelect(t)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") onSelect(t);
+          }}
+        >
+          <div className="dt-theme-dots">
+            <div
+              className="dt-theme-dot"
+              style={{ background: t.bg, border: `1px solid ${t.border}` }}
+            />
+            <div className="dt-theme-dot" style={{ background: t.accent }} />
+            <div
+              className="dt-theme-dot"
+              style={{ background: t.muted, border: `1px solid ${t.border}` }}
+            />
+          </div>
+          <span className="dt-theme-name">{t.label}</span>
+          {active === t.id && <span className="dt-theme-tick">✓</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Floating sidebar editor ──────────────────────────────────────────────────
+
+function FloatingSidebarEditor({
+  item,
+  api,
+  onClose,
+}: {
+  item: { href: string; label: string; rect: DOMRect };
+  api: string;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [title, setTitle] = useState(item.label);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("");
+
+  // Position near the sidebar item
+  const top = Math.min(item.rect.bottom + 6, window.innerHeight - 180);
+  const left = item.rect.right + 8;
+  const adjustedLeft = left + 300 > window.innerWidth ? Math.max(8, item.rect.left - 316) : left;
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    const tid = window.setTimeout(() => {
+      function outside(e: MouseEvent) {
+        if (ref.current?.contains(e.target as Node)) return;
+        onClose();
+      }
+      function key(e: KeyboardEvent) {
+        if (e.key === "Escape") onClose();
+      }
+      document.addEventListener("mousedown", outside);
+      document.addEventListener("keydown", key);
+      cleanup = () => {
+        document.removeEventListener("mousedown", outside);
+        document.removeEventListener("keydown", key);
+      };
+    }, 120);
+    return () => {
+      window.clearTimeout(tid);
+      cleanup?.();
+    };
+  }, [onClose]);
+
+  async function save() {
+    setSaving(true);
+    setStatus("Saving…");
+    try {
+      const res = await fetch(createDevToolsUrl(api, "nav-item", item.href), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ href: item.href, title }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !payload.ok)
+        throw new Error("error" in payload && payload.error ? payload.error : "Could not save.");
+      setStatus("Saved!");
+      setTimeout(() => onClose(), 700);
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : "Could not save.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="dt-float-editor dt"
+      style={{
+        top: adjustedLeft === left ? item.rect.top : top,
+        left: adjustedLeft,
+        width: 300,
+        maxHeight: "auto",
+      }}
+    >
+      <div className="dt-float-editor-hdr">
+        <span className="dt-float-editor-type" style={{ color: "#6366f1" }}>
+          ≡ Sidebar item
+        </span>
+        <div style={{ flex: 1 }} />
+        <a
+          href={item.href}
+          style={{
+            fontSize: 11,
+            color: "var(--color-fd-muted-foreground,#64748b)",
+            textDecoration: "none",
+            marginRight: 6,
+          }}
+        >
+          Go to page ↗
+        </a>
+        <button type="button" className="dt-float-btn" onClick={onClose} style={{ fontSize: 13 }}>
+          ✕
+        </button>
+      </div>
+      <div className="dt-float-editor-body">
+        <div style={{ marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: ".06em",
+              color: "var(--color-fd-muted-foreground,#64748b)",
+              marginBottom: 4,
+            }}
+          >
+            Title
+          </div>
+          <input
+            style={{
+              width: "100%",
+              padding: "6px 8px",
+              border: "1px solid var(--color-fd-border,#e2e8f0)",
+              borderRadius: 6,
+              fontSize: 13,
+              background: "var(--color-fd-background,#fff)",
+              color: "var(--color-fd-foreground,#0f172a)",
+              outline: "none",
+              fontFamily: "inherit",
+            }}
+            value={title}
+            onChange={(e) => setTitle(e.currentTarget.value)}
+            placeholder="Page title"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void save();
+              }
+            }}
+          />
+        </div>
+        {status && (
+          <div
+            style={{
+              fontSize: 11,
+              color: status.startsWith("Could")
+                ? "#ef4444"
+                : "var(--color-fd-muted-foreground,#64748b)",
+              marginBottom: 6,
+            }}
+          >
+            {status}
+          </div>
+        )}
+        <button
+          type="button"
+          className="dt-btn"
+          data-primary=""
+          style={{ width: "100%", justifyContent: "center" }}
+          onClick={save}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save title"}
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function DocsDevTools({ api, pathname }: DocsDevToolsProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [page, setPage] = useState<DevToolsPagePayload | null>(null);
+  const [doc, setDoc] = useState<ParsedMdxDocument | null>(null);
+  const [draft, setDraft] = useState("");
+  const [status, setStatus] = useState("");
+  // Which block is currently selected for editing, and where the editor floats
+  const [activeBlockId, setActiveBlockId] = useState<string | null>(null);
+  const [activeRect, setActiveRect] = useState<DOMRect | null>(null);
+  const [themeId, setThemeId] = useState("default");
+  const [savedThemeId, setSavedThemeId] = useState("default");
+  const [themeVars, setThemeVars] = useState<Record<string, string>>({});
+  const [showThemes, setShowThemes] = useState(false);
+  const [showSource, setShowSource] = useState(false);
+  const [addPalette, setAddPalette] = useState<{ x: number; y: number } | null>(null);
+  const [sidebarItem, setSidebarItem] = useState<{
+    href: string;
+    label: string;
+    rect: DOMRect;
+  } | null>(null);
+  const addBtnRef = useRef<HTMLButtonElement | null>(null);
+  const themeStyleRef = useRef<HTMLStyleElement | null>(null);
+  // Always-fresh reference to doc so article click handler never captures stale closure
+  const docRef = useRef<ParsedMdxDocument | null>(null);
+  docRef.current = doc;
+  const mappedDocRef = useRef<ParsedMdxDocument | null>(null);
+  // Reference to the active DOM element — used for scroll-tracking rect updates
+  const activeElRef = useRef<HTMLElement | null>(null);
+  // Pre-built DOM element → loaded block id map.
+  const domBlockMapRef = useRef<Map<HTMLElement, string>>(new Map());
+  const hiddenDraftBlockElsRef = useRef<Set<HTMLElement>>(new Set());
+
+  // serialized is always derived from the visual doc state
+  const serialized = useMemo(() => (doc ? serializeMdxDocument(doc) : draft), [doc, draft]);
+
+  function renderedBlockElements(id: string): HTMLElement[] {
+    return Array.from(domBlockMapRef.current.entries())
+      .filter(([el, blockId]) => blockId === id && el.dataset.dtDeleted !== "true")
+      .map(([el]) => el);
+  }
+
+  function rectFromElements(elements: HTMLElement[]): DOMRect | null {
+    const rects = elements
+      .map((el) => el.getBoundingClientRect())
+      .filter((rect) => rect.width > 0 || rect.height > 0);
+    const first = rects[0];
+    if (!first) return null;
+
+    let top = first.top;
+    let left = first.left;
+    let right = first.right;
+    let bottom = first.bottom;
+
+    for (const rect of rects.slice(1)) {
+      top = Math.min(top, rect.top);
+      left = Math.min(left, rect.left);
+      right = Math.max(right, rect.right);
+      bottom = Math.max(bottom, rect.bottom);
+    }
+
+    return new DOMRect(left, top, right - left, bottom - top);
+  }
+
+  function renderedBlockRect(id: string, fallback?: HTMLElement | null): DOMRect | null {
+    return rectFromElements(renderedBlockElements(id)) ?? fallback?.getBoundingClientRect() ?? null;
+  }
+
+  async function loadPage() {
+    setLoading(true);
+    setStatus("");
+    try {
+      const res = await fetch(createDevToolsUrl(api, "page", pathname), {
+        headers: { Accept: "application/json" },
+      });
+      const payload = (await res.json()) as DevToolsPagePayload | { error?: string };
+      if (!res.ok || !("content" in payload))
+        throw new Error(
+          "error" in payload && payload.error ? payload.error : "Could not load page.",
+        );
+      const parsed = parseMdxDocument(payload.content);
+      setPage(payload);
+      setDoc(parsed);
+      docRef.current = parsed;
+      setDraft(payload.content);
+      mappedDocRef.current = parsed;
+      domBlockMapRef.current = new Map();
+      clearHiddenDraftBlocks();
+      closeEditor();
+      setStatus(`Loaded ${payload.relativePath}`);
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : "Could not load page.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    void loadPage();
+  }, [open, pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Rebuild DOM→block map only when a page is loaded ──
+  useEffect(() => {
+    if (!page || !open) return;
+    // Small delay so React can flush and the DOM matches the newly loaded page
+    const tid = window.setTimeout(() => {
+      const contentEl = document.querySelector<HTMLElement>("[data-dt-content]");
+      const mappedDoc = mappedDocRef.current;
+      if (contentEl && mappedDoc)
+        domBlockMapRef.current = buildDomBlockMap(contentEl, mappedDoc.blocks);
+    }, 50);
+    return () => window.clearTimeout(tid);
+  }, [open, page?.lastModified, page?.relativePath]);
+
+  // ── Set html attribute + wire up content click overlay ──
+  useEffect(() => {
+    if (!open) return;
+
+    window.document.documentElement.dataset.docsDevtoolsOpen = "true";
+
+    const contentEl = document.querySelector<HTMLElement>("[data-dt-content]");
+    if (contentEl) {
+      const contentRoot = contentEl;
+
+      function findContentBlock(target: EventTarget | null): HTMLElement | null {
+        const node = target instanceof Node ? target : null;
+        let el = node instanceof Element ? node : node?.parentElement;
+        if (!el || el.closest(".dt,[data-dt-ui]")) return null;
+
+        while (el && el.parentElement !== contentRoot) el = el.parentElement;
+        return el instanceof HTMLElement ? el : null;
+      }
+
+      function selectContentBlock(el: HTMLElement) {
+        if (el.dataset.dtUi) return false;
+
+        // Lazily build the map the first time (doc might not have loaded yet
+        // when the click effect fires, so we rebuild defensively).
+        if (domBlockMapRef.current.size === 0 && mappedDocRef.current) {
+          domBlockMapRef.current = buildDomBlockMap(contentRoot, mappedDocRef.current.blocks);
+        }
+
+        // Look up the block id from the map.
+        // Fall back to positional if the element isn't mapped (e.g. doc not loaded).
+        const mappedId = domBlockMapRef.current.get(el);
+        const d = docRef.current;
+        if (!d) return false;
+        let blockIdx = mappedId ? d.blocks.findIndex((block) => block.id === mappedId) : -1;
+
+        if (mappedId && blockIdx < 0) {
+          closeEditor();
+          setStatus(
+            "That rendered block was removed from the draft. Save or reload to refresh it.",
+          );
+          return true;
+        }
+
+        if (!mappedId) {
+          const domIdx = Array.from(contentRoot.children).indexOf(el);
+          blockIdx = Math.min(Math.max(0, domIdx), d.blocks.length - 1);
+        }
+
+        const block = d.blocks[blockIdx];
+        if (!block) return false;
+
+        const blockEls = mappedId ? renderedBlockElements(block.id) : [];
+        activeElRef.current = blockEls[0] ?? el;
+        setActiveBlockId(block.id);
+        setActiveRect(rectFromElements(blockEls) ?? el.getBoundingClientRect());
+        return true;
+      }
+
+      // Single delegated handler.
+      // Block id is read directly from the pre-built map so selection survives edits.
+      function handleContentPointerDown(e: PointerEvent) {
+        const el = findContentBlock(e.target);
+        if (!el || !selectContentBlock(el)) return;
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      function handleContentClick(e: MouseEvent) {
+        const el = findContentBlock(e.target);
+        if (!el) return;
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      contentEl.addEventListener("pointerdown", handleContentPointerDown, true);
+      contentEl.addEventListener("click", handleContentClick, true);
+
+      return () => {
+        contentEl.removeEventListener("pointerdown", handleContentPointerDown, true);
+        contentEl.removeEventListener("click", handleContentClick, true);
+        delete window.document.documentElement.dataset.docsDevtoolsOpen;
+        themeStyleRef.current?.remove();
+        themeStyleRef.current = null;
+      };
+    }
+
+    return () => {
+      delete window.document.documentElement.dataset.docsDevtoolsOpen;
+      themeStyleRef.current?.remove();
+      themeStyleRef.current = null;
+    };
+  }, [open, pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Sidebar click interception ──
+  useEffect(() => {
+    if (!open) return;
+    const sidebar = document.getElementById("nd-sidebar");
+    if (!sidebar) return;
+
+    function handleSidebarClick(e: MouseEvent) {
+      const anchor = (e.target as HTMLElement).closest("a");
+      if (!anchor) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setSidebarItem({
+        href: anchor.getAttribute("href") ?? "",
+        label: anchor.textContent?.trim() ?? "",
+        rect: anchor.getBoundingClientRect(),
+      });
+    }
+
+    sidebar.addEventListener("click", handleSidebarClick, true);
+    return () => sidebar.removeEventListener("click", handleSidebarClick, true);
+  }, [open]);
+
+  // ── Scroll / resize → keep active highlight rect in sync with the block ──
+  useEffect(() => {
+    if (!activeBlockId) return;
+    const selectedBlockId = activeBlockId;
+    function refresh() {
+      setActiveRect(renderedBlockRect(selectedBlockId, activeElRef.current));
+    }
+    // capture:true catches scroll events on any ancestor, not just window
+    window.addEventListener("scroll", refresh, { passive: true, capture: true });
+    window.addEventListener("resize", refresh, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", refresh, true);
+      window.removeEventListener("resize", refresh);
+    };
+  }, [activeBlockId]);
+
+  // ── block mutations ──
+
+  function virtualBlockRect(anchor?: DOMRect | null): DOMRect {
+    if (anchor)
+      return new DOMRect(anchor.left, anchor.top, anchor.width || 360, anchor.height || 56);
+
+    const width = Math.min(420, Math.max(280, window.innerWidth - 24));
+    const height = 72;
+    return new DOMRect(
+      Math.max(12, window.innerWidth - width - 16),
+      Math.min(92, Math.max(58, window.innerHeight - height - 16)),
+      width,
+      height,
+    );
+  }
+
+  function selectVirtualBlock(id: string, anchor?: DOMRect | null) {
+    activeElRef.current = null;
+    setActiveBlockId(id);
+    setActiveRect(virtualBlockRect(anchor));
+  }
+
+  function clearHiddenDraftBlocks() {
+    hiddenDraftBlockElsRef.current.forEach((el) => {
+      delete el.dataset.dtDeleted;
+    });
+    hiddenDraftBlockElsRef.current.clear();
+  }
+
+  function hideRenderedBlock(id: string) {
+    const directEl = activeBlockId === id && activeElRef.current ? activeElRef.current : null;
+    const mappedEls = renderedBlockElements(id);
+    const targets = mappedEls.length > 0 ? mappedEls : directEl ? [directEl] : [];
+
+    targets.forEach((el) => {
+      el.dataset.dtDeleted = "true";
+      hiddenDraftBlockElsRef.current.add(el);
+    });
+  }
+
+  function mutateDoc(fn: (blocks: MdxBlock[]) => MdxBlock[]): ParsedMdxDocument | null {
+    const cur = docRef.current;
+    if (!cur) return null;
+    const next = { ...cur, blocks: fn(cur.blocks) };
+    docRef.current = next;
+    setDoc(next);
+    return next;
+  }
+
+  function updateBlock(id: string, next: MdxBlock) {
+    mutateDoc((bs) => bs.map((b) => (b.id === id ? next : b)));
+  }
+  function deleteBlock(id: string, options?: { persist?: boolean }) {
+    hideRenderedBlock(id);
+    const nextDoc = mutateDoc((bs) => bs.filter((b) => b.id !== id));
+    if (activeBlockId === id) closeEditor();
+    setStatus(options?.persist ? "Deleting block…" : "Removed block from draft");
+    if (options?.persist && nextDoc) void applyChanges(nextDoc);
+  }
+  function duplicateBlock(block: MdxBlock) {
+    const copy = { ...block, id: createId(block.type) } as MdxBlock;
+    mutateDoc((bs) => {
+      const i = bs.findIndex((b) => b.id === block.id);
+      if (i < 0) return bs;
+      const next = [...bs];
+      next.splice(i + 1, 0, copy);
+      return next;
+    });
+    selectVirtualBlock(copy.id, activeRect);
+    setStatus("Duplicated block in draft");
+  }
+
+  function moveBlock(id: string, dir: -1 | 1) {
+    mutateDoc((bs) => {
+      const i = bs.findIndex((b) => b.id === id);
+      const ni = i + dir;
+      if (i < 0 || ni < 0 || ni >= bs.length) return bs;
+      const next = [...bs];
+      const [b] = next.splice(i, 1);
+      if (!b) return bs;
+      next.splice(ni, 0, b);
+      return next;
+    });
+    setStatus("Moved block in draft");
+  }
+
+  function addBlockAt(type: MdxBlock["type"], atIndex: number) {
+    const block = createBlock(type);
+    mutateDoc((bs) => {
+      const next = [...bs];
+      next.splice(Math.min(Math.max(0, atIndex), next.length), 0, block);
+      return next;
+    });
+    selectVirtualBlock(block.id, activeRect);
+    setStatus("Added block in draft");
+  }
+
+  function appendBlock(type: MdxBlock["type"], anchor?: DOMRect | null) {
+    const block = createBlock(type);
+    mutateDoc((bs) => [...bs, block]);
+    selectVirtualBlock(block.id, anchor);
+    setStatus("Added block in draft");
+  }
+
+  function closeEditor() {
+    activeElRef.current = null;
+    setActiveBlockId(null);
+    setActiveRect(null);
+    closeLinkEditorPopover();
+  }
+
+  // ── persist ──
+
+  async function saveThemeToConfig(newThemeId: string) {
+    await fetch(createDevToolsUrl(api, "theme", pathname), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ themeId: newThemeId }),
+    });
+  }
+
+  async function applyChanges(docOverride?: ParsedMdxDocument | null) {
+    setSaving(true);
+    setStatus("Saving…");
+    try {
+      const content = docOverride
+        ? serializeMdxDocument(docOverride)
+        : docRef.current
+          ? serializeMdxDocument(docRef.current)
+          : draft;
+      const res = await fetch(createDevToolsUrl(api, "page", pathname), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      const payload = (await res.json()) as { ok?: boolean; error?: string; relativePath?: string };
+      if (!res.ok || !payload.ok) throw new Error(payload.error || "Could not save.");
+      // Also save theme if it changed
+      if (themeId !== savedThemeId) {
+        await saveThemeToConfig(themeId);
+        setSavedThemeId(themeId);
+      }
+      setStatus(`Saved ${payload.relativePath ?? page?.relativePath ?? "page.mdx"}`);
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : "Could not save.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function publishPreview() {
+    setStatus("Publishing…");
+    try {
+      const res = await fetch(createDevToolsUrl(api, "publish", pathname), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ path: pathname, file: page?.relativePath, content: serialized }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      if (!res.ok) throw new Error(payload.error || "Could not publish.");
+      setStatus(payload.url ? `Preview: ${payload.url}` : "Preview published.");
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : "Could not publish.");
+    }
+  }
+
+  // ── theme ──
+
+  function applyTheme(t: ThemeDef) {
+    setThemeId(t.id);
+    setThemeVars({
+      "--color-fd-primary": t.accent,
+      "--color-fd-background": t.bg,
+      "--color-fd-foreground": t.fg,
+      "--color-fd-border": t.border,
+      "--color-fd-muted": t.muted,
+      "--color-fd-muted-foreground": t.dark ? "rgba(255,255,255,0.5)" : "rgba(0,0,0,0.5)",
+    });
+    setShowThemes(false);
+    themeStyleRef.current?.remove();
+    themeStyleRef.current = null;
+    fetch(`/themes/${t.id}.css`)
+      .then((r) => (r.ok ? r.text() : Promise.reject()))
+      .then((css) => {
+        const el = document.createElement("style");
+        el.dataset.dtTheme = t.id;
+        el.textContent = css;
+        document.head.appendChild(el);
+        themeStyleRef.current = el;
+      })
+      .catch(() => {});
+  }
+
+  useEffect(() => {
+    if (!open || Object.keys(themeVars).length === 0) return;
+    const html = document.documentElement;
+    const prev: Record<string, string> = {};
+    const wasDark = html.classList.contains("dark");
+    for (const [key, value] of Object.entries(themeVars)) {
+      prev[key] = html.style.getPropertyValue(key);
+      html.style.setProperty(key, value);
+    }
+    const theme = THEMES.find((t) => t.id === themeId);
+    if (theme?.dark) html.classList.add("dark");
+    else html.classList.remove("dark");
+    return () => {
+      for (const [key, p] of Object.entries(prev)) {
+        if (p) html.style.setProperty(key, p);
+        else html.style.removeProperty(key);
+      }
+      if (wasDark) html.classList.add("dark");
+      else html.classList.remove("dark");
+    };
+  }, [open, themeVars, themeId]);
+
+  // ── active block ──
+  const activeIndex = useMemo(
+    () => (doc && activeBlockId ? doc.blocks.findIndex((block) => block.id === activeBlockId) : -1),
+    [doc, activeBlockId],
+  );
+  const activeBlock = doc && activeIndex >= 0 ? (doc.blocks[activeIndex] ?? null) : null;
+
+  // Classify the clicked DOM element so we route to the right editor:
+  //   h1-h6 / p → InlineBlockEditor  (opaque text overlay)
+  //   figure    → InlineCodeEditor   (opaque code overlay with editable fields)
+  //   anything else → FloatingBlockEditor (floating panel beside the block)
+  const domTag = (activeElRef.current?.tagName ?? "").toLowerCase();
+  const domIsTextBlock =
+    activeBlock?.type === "paragraph" ||
+    (activeBlock?.type === "heading" && /^h[1-6]$/.test(domTag));
+  const domIsCodeBlock = domTag === "figure";
+  const domIsInline = domIsTextBlock || domIsCodeBlock;
+
+  // ── render ──
+
+  return (
+    <>
+      <style>{CSS}</style>
+
+      {!open && (
+        <button
+          type="button"
+          className="dt-trigger dt"
+          aria-label="Open Docs DevTools"
+          onClick={() => setOpen(true)}
+        >
+          <span className="dt-dot" aria-hidden="true" />
+          Edit page
+        </button>
+      )}
+
+      {open && (
+        <>
+          {/* ── Top toolbar ── */}
+          <div role="banner" aria-label="Docs DevTools" className="dt-bar dt">
+            <div className="dt-bar-logo">
+              <div className="dt-bar-emblem" aria-hidden="true">
+                DT
+              </div>
+              <span className="dt-bar-wordmark">DevTools</span>
+            </div>
+            <div className="dt-bar-file">
+              <div className="dt-bar-path">{page?.relativePath ?? pathname}</div>
+              {status && <div className="dt-bar-status">{status}</div>}
+            </div>
+            <div className="dt-bar-actions">
+              {/* Theme switcher */}
+              <div style={{ position: "relative" }}>
+                <button
+                  type="button"
+                  className="dt-btn"
+                  data-active={showThemes ? "" : undefined}
+                  onClick={() => setShowThemes((s) => !s)}
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.2"
+                    strokeLinecap="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+                  </svg>
+                  <span>Theme</span>
+                </button>
+                {showThemes && (
+                  <ThemePopover
+                    active={themeId}
+                    onSelect={applyTheme}
+                    onClose={() => setShowThemes(false)}
+                  />
+                )}
+              </div>
+
+              <div className="dt-btn-sep" />
+
+              {/* Source editor button */}
+              <button
+                type="button"
+                className="dt-btn"
+                onClick={() => {
+                  setDraft(serialized);
+                  setShowSource((s) => !s);
+                }}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="16 18 22 12 16 6" />
+                  <polyline points="8 6 2 12 8 18" />
+                </svg>
+                <span>Source</span>
+              </button>
+
+              {/* Add block */}
+              <button
+                ref={addBtnRef}
+                type="button"
+                className="dt-btn"
+                disabled={!doc || loading}
+                onClick={() => {
+                  const rect = addBtnRef.current?.getBoundingClientRect();
+                  if (rect) setAddPalette({ x: Math.max(6, rect.left - 130), y: rect.bottom + 6 });
+                }}
+              >
+                <Plus />
+                <span>Add</span>
+              </button>
+
+              <div className="dt-btn-sep" />
+              <button type="button" className="dt-btn" onClick={loadPage} disabled={loading}>
+                {loading ? "Loading…" : "Reload"}
+              </button>
+              <button
+                type="button"
+                className="dt-btn"
+                onClick={publishPreview}
+                disabled={saving || loading}
+              >
+                Preview
+              </button>
+              <button
+                type="button"
+                className="dt-btn"
+                data-primary=""
+                onClick={() => void applyChanges()}
+                disabled={saving || loading || (!doc && !draft)}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <div className="dt-btn-sep" />
+              <button
+                type="button"
+                className="dt-btn"
+                onClick={() => {
+                  closeEditor();
+                  setOpen(false);
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+
+          {/* ── Selection toolbar — appears above any selected text in a contentEditable ── */}
+          <SelectionToolbar />
+
+          {/* ── Active block highlight — dashed rect, tracks scroll ──
+               Hidden only when an inline opaque cover is showing (InlineBlockEditor
+               or InlineCodeEditor), since those already visually replace the block. ── */}
+          {activeRect && !domIsInline && (
+            <div
+              className="dt-active-highlight dt"
+              style={{
+                top: activeRect.top - 5,
+                left: activeRect.left - 5,
+                width: activeRect.width + 10,
+                height: activeRect.height + 10,
+              }}
+            />
+          )}
+
+          {/* ── InlineBlockEditor — opaque overlay for heading / paragraph ── */}
+          {activeBlock &&
+            activeRect &&
+            activeElRef.current &&
+            domIsTextBlock &&
+            (activeBlock.type === "heading" || activeBlock.type === "paragraph") && (
+              <InlineBlockEditor
+                key={activeBlock.id}
+                block={activeBlock as Extract<MdxBlock, { type: "heading" | "paragraph" }>}
+                rect={activeRect}
+                el={activeElRef.current}
+                index={activeIndex!}
+                total={doc!.blocks.length}
+                onChange={(next) => updateBlock(activeBlock.id, next)}
+                onClose={closeEditor}
+                onMove={(dir) => moveBlock(activeBlock.id, dir)}
+                onDuplicate={() => duplicateBlock(activeBlock)}
+                onSave={() => void applyChanges()}
+                saving={saving}
+                onDelete={() => {
+                  deleteBlock(activeBlock.id, { persist: true });
+                  closeEditor();
+                }}
+              />
+            )}
+
+          {/* ── InlineCodeEditor — opaque overlay for code blocks (figure) ── */}
+          {activeBlock &&
+            activeRect &&
+            activeElRef.current &&
+            domIsCodeBlock &&
+            activeBlock.type === "code" && (
+              <InlineCodeEditor
+                key={activeBlock.id}
+                block={activeBlock as Extract<MdxBlock, { type: "code" }>}
+                rect={activeRect}
+                index={activeIndex!}
+                total={doc!.blocks.length}
+                onChange={(next) => updateBlock(activeBlock.id, next)}
+                onClose={closeEditor}
+                onMove={(dir) => moveBlock(activeBlock.id, dir)}
+                onDuplicate={() => duplicateBlock(activeBlock)}
+                onSave={() => void applyChanges()}
+                saving={saving}
+                onDelete={() => {
+                  deleteBlock(activeBlock.id, { persist: true });
+                  closeEditor();
+                }}
+              />
+            )}
+
+          {/* ── FloatingBlockEditor — for callout / tabs / hoverlink / prompt / raw
+               and any DOM element we couldn't classify as inline               ── */}
+          {activeBlock && activeRect && !domIsInline && (
+            <FloatingBlockEditor
+              key={activeBlock.id}
+              block={activeBlock}
+              rect={activeRect}
+              index={activeIndex!}
+              total={doc!.blocks.length}
+              onClose={closeEditor}
+              onChange={(next) => updateBlock(activeBlock.id, next)}
+              onMove={(dir) => moveBlock(activeBlock.id, dir)}
+              onDuplicate={() => duplicateBlock(activeBlock)}
+              onSave={() => void applyChanges()}
+              saving={saving}
+              onDelete={() => {
+                deleteBlock(activeBlock.id, { persist: true });
+                closeEditor();
+              }}
+              onInsertAfter={(type) => {
+                addBlockAt(type, activeIndex! + 1);
+              }}
+            />
+          )}
+
+          {/* ── Source modal ── */}
+          {showSource &&
+            createPortal(
+              <div
+                className="dt-float-editor dt"
+                style={{
+                  top: 70,
+                  left: "50%",
+                  transform: "translateX(-50%)",
+                  width: "min(720px,95vw)",
+                  maxHeight: "80vh",
+                }}
+              >
+                <div className="dt-float-editor-hdr">
+                  <span className="dt-float-editor-type">Source MDX</span>
+                  <div style={{ flex: 1 }} />
+                  <button
+                    type="button"
+                    className="dt-btn"
+                    data-primary=""
+                    onClick={() => {
+                      const parsed = parseMdxDocument(draft);
+                      setDoc(parsed);
+                      docRef.current = parsed;
+                      mappedDocRef.current = parsed;
+                      domBlockMapRef.current = new Map();
+                      clearHiddenDraftBlocks();
+                      closeEditor();
+                      setStatus("Applied source");
+                      setShowSource(false);
+                    }}
+                  >
+                    Apply
+                  </button>
+                  <button
+                    type="button"
+                    className="dt-float-btn"
+                    onClick={() => setShowSource(false)}
+                    style={{ fontSize: 13 }}
+                  >
+                    ✕
+                  </button>
+                </div>
+                <div className="dt-float-editor-body" style={{ padding: "10px" }}>
+                  <textarea
+                    className="dt-source-ta"
+                    style={{ minHeight: "60vh" }}
+                    value={draft}
+                    onChange={(e) => setDraft(e.currentTarget.value)}
+                    spellCheck={false}
+                  />
+                </div>
+              </div>,
+              document.body,
+            )}
+
+          {/* ── Add block palette ── */}
+          {addPalette &&
+            createPortal(
+              <InsertPalette
+                x={addPalette.x}
+                y={addPalette.y}
+                onInsert={(type) => {
+                  appendBlock(type, addBtnRef.current?.getBoundingClientRect());
+                  setAddPalette(null);
+                }}
+                onClose={() => setAddPalette(null)}
+              />,
+              document.body,
+            )}
+
+          {/* Loading indicator when no blocks yet */}
+          {loading &&
+            createPortal(
+              <div
+                className="dt"
+                style={{
+                  position: "fixed",
+                  bottom: 16,
+                  left: "50%",
+                  transform: "translateX(-50%)",
+                  background: "rgba(9,9,13,0.92)",
+                  color: "#fff",
+                  borderRadius: 8,
+                  padding: "8px 16px",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  zIndex: 2147483003,
+                  backdropFilter: "blur(12px)",
+                }}
+              >
+                Loading editor…
+              </div>,
+              document.body,
+            )}
+
+          {/* ── Sidebar item editor ── */}
+          {sidebarItem && (
+            <FloatingSidebarEditor
+              item={sidebarItem}
+              api={api}
+              onClose={() => setSidebarItem(null)}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/fumadocs/src/docs-api.test.ts
+++ b/packages/fumadocs/src/docs-api.test.ts
@@ -2,7 +2,15 @@ import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
-import fs, { chmodSync, mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import fs, {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type {
@@ -856,6 +864,154 @@ Install and configure the docs framework.
       type: "heading",
     });
     expect(payload[0]?.content).toContain("Quickstart");
+  });
+
+  it("reads and writes MDX pages through DevTools when enabled", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-devtools-route-"));
+    tempDirs.push(rootDir);
+
+    const pagePath = join(rootDir, "app", "docs", "guide", "page.mdx");
+    mkdirSync(join(rootDir, "app", "docs", "guide"), { recursive: true });
+    writeFileSync(
+      pagePath,
+      `---
+title: "Guide"
+---
+
+# Guide
+
+Original content.
+`,
+    );
+
+    const { GET, POST } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      devTools: true,
+    });
+
+    const readResponse = await GET(
+      new Request("http://localhost/api/docs?devtools=page&path=/docs/guide"),
+    );
+    expect(readResponse.status).toBe(200);
+    const readPayload = (await readResponse.json()) as {
+      relativePath?: string;
+      content?: string;
+    };
+    expect(readPayload.relativePath).toBe("app/docs/guide/page.mdx");
+    expect(readPayload.content).toContain("Original content.");
+
+    const nextContent = `---
+title: "Guide"
+---
+
+# Guide
+
+Updated from DevTools.
+`;
+    const writeResponse = await POST(
+      new Request("http://localhost/api/docs?devtools=page&path=/docs/guide", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: nextContent }),
+      }),
+    );
+
+    expect(writeResponse.status).toBe(200);
+    expect(await writeResponse.json()).toMatchObject({
+      ok: true,
+      relativePath: "app/docs/guide/page.mdx",
+    });
+    expect(readFileSync(pagePath, "utf-8")).toBe(nextContent);
+  });
+
+  it("maps custom public docs paths back to source files for DevTools writes", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-devtools-public-path-"));
+    tempDirs.push(rootDir);
+
+    const pagePath = join(rootDir, "app", "docs", "guide", "page.mdx");
+    mkdirSync(join(rootDir, "app", "docs", "guide"), { recursive: true });
+    writeFileSync(pagePath, "# Guide\n\nOriginal public path content.\n");
+
+    const { POST } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+      docsPath: "learn",
+      devTools: true,
+    });
+
+    const writeResponse = await POST(
+      new Request("http://localhost/api/docs?devtools=page&path=/learn/guide", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "# Guide\n\nUpdated through /learn.\n" }),
+      }),
+    );
+
+    expect(writeResponse.status).toBe(200);
+    expect(readFileSync(pagePath, "utf-8")).toBe("# Guide\n\nUpdated through /learn.\n");
+  });
+
+  it("keeps DevTools API disabled unless the config enables it", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-devtools-disabled-"));
+    tempDirs.push(rootDir);
+
+    mkdirSync(join(rootDir, "app", "docs"), { recursive: true });
+    writeFileSync(join(rootDir, "app", "docs", "page.mdx"), "# Home\n");
+
+    const { GET } = createDocsAPI({
+      rootDir,
+      entry: "docs",
+    });
+
+    const response = await GET(new Request("http://localhost/api/docs?devtools=page&path=/docs"));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: expect.stringContaining("devTools: true"),
+    });
+  });
+
+  it("requires cloud credentials before DevTools can publish a preview", async () => {
+    const previousCloudKey = process.env.FARMING_CLOUD_API_KEY;
+    const previousApiKey = process.env.FARMING_API_KEY;
+    delete process.env.FARMING_CLOUD_API_KEY;
+    delete process.env.FARMING_API_KEY;
+
+    try {
+      const rootDir = mkdtempSync(join(tmpdir(), "fumadocs-devtools-publish-"));
+      tempDirs.push(rootDir);
+
+      const { POST } = createDocsAPI({
+        rootDir,
+        entry: "docs",
+        devTools: true,
+      });
+
+      const response = await POST(
+        new Request("http://localhost/api/docs?devtools=publish", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: "/docs" }),
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({
+        error: expect.stringContaining("FARMING_CLOUD_API_KEY"),
+      });
+    } finally {
+      if (previousCloudKey === undefined) {
+        delete process.env.FARMING_CLOUD_API_KEY;
+      } else {
+        process.env.FARMING_CLOUD_API_KEY = previousCloudKey;
+      }
+
+      if (previousApiKey === undefined) {
+        delete process.env.FARMING_API_KEY;
+      } else {
+        process.env.FARMING_API_KEY = previousApiKey;
+      }
+    }
   });
 
   it("filters regular docs metadata and returns opt-in structured agent warnings", async () => {

--- a/packages/fumadocs/src/docs-api.ts
+++ b/packages/fumadocs/src/docs-api.ts
@@ -94,6 +94,7 @@ import type {
   DocsAgentFeedbackContext,
   DocsAgentFeedbackData,
   DocsConfig,
+  DevToolsConfig,
   DocsI18nConfig,
   LlmsTxtConfig,
   DocsObservabilityConfig,
@@ -221,6 +222,8 @@ interface DocsAPIOptions {
   apiReference?: DocsConfig["apiReference"];
   /** Metadata used in generated OpenAPI documents. */
   metadata?: DocsConfig["metadata"];
+  /** Visual docs editor configuration. */
+  devTools?: boolean | DevToolsConfig;
   /** Reusable skill publication and optional real A2A service metadata. */
   agent?: DocsConfig["agent"];
   /** @internal Build-time Agent Skills snapshot supplied by framework adapters. */
@@ -2091,6 +2094,320 @@ function resolvePublicMarkdownRequest(
   return null;
 }
 
+type DevToolsRequest = "page" | "publish" | "theme" | "nav-item";
+
+interface EditableDocsPage {
+  requestedPath: string;
+  filePath: string;
+  relativePath: string;
+  content: string;
+  lastModified: string;
+}
+
+function resolveDevToolsEnabled(devTools?: boolean | DevToolsConfig): boolean {
+  if (devTools === undefined) return false;
+  if (typeof devTools === "boolean") return devTools;
+  return devTools.enabled !== false;
+}
+
+function resolveDevToolsRequest(url: URL): DevToolsRequest | null {
+  const value = url.searchParams.get("devtools")?.trim().toLowerCase();
+  if (value === "page" || value === "publish" || value === "theme" || value === "nav-item")
+    return value;
+  return null;
+}
+
+function isLocalDevToolsRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  const host = url.hostname.toLowerCase();
+
+  return (
+    process.env.NODE_ENV !== "production" ||
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]"
+  );
+}
+
+function createDevToolsUnavailableResponse(status = 404): Response {
+  return Response.json(
+    {
+      error:
+        "Docs DevTools are not available. Set `devTools: true` and use a local development server.",
+    },
+    { status },
+  );
+}
+
+function getDevToolsRequestedPath(url: URL, request: Request): string {
+  const explicit = url.searchParams.get("path")?.trim();
+  if (explicit) return explicit;
+
+  const referrer = request.headers.get("referer") ?? request.headers.get("referrer");
+  if (referrer) {
+    try {
+      return new URL(referrer).pathname;
+    } catch {
+      // fall through
+    }
+  }
+
+  return "";
+}
+
+function isPathWithinDir(candidate: string, target: string): boolean {
+  const relative = path.relative(target, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function getEditableDocsPage(
+  ctx: {
+    entryPath: string;
+    publicPath: string;
+    docsDirs: string[];
+  },
+  requestedPath: string,
+  rootDir: string,
+): EditableDocsPage | null {
+  const normalizedEntry = `/${normalizePathSegment(ctx.entryPath)}`;
+  const normalizedPublicPath = ctx.publicPath ? normalizeUrlPath(ctx.publicPath) : "";
+  const normalizedRequestedPath = normalizeRequestedMarkdownPath(ctx.entryPath, requestedPath);
+  let normalizedRequest = normalizedRequestedPath;
+
+  if (normalizedPublicPath && normalizedPublicPath !== normalizedEntry) {
+    const normalizedPublicRequest = normalizeUrlPath(
+      requestedPath.trim().replace(/\.md$/i, "").startsWith("/")
+        ? requestedPath.trim().replace(/\.md$/i, "")
+        : `/${requestedPath.trim().replace(/\.md$/i, "")}`,
+    );
+
+    if (normalizedPublicRequest === normalizedPublicPath) {
+      normalizedRequest = normalizedEntry;
+    } else if (normalizedPublicRequest.startsWith(`${normalizedPublicPath}/`)) {
+      normalizedRequest = publicDocsRoute(
+        normalizedEntry,
+        normalizedPublicRequest
+          .slice(normalizedPublicPath.length + 1)
+          .split("/")
+          .filter(Boolean),
+      );
+    }
+  }
+
+  const relativeSlug =
+    normalizedRequest === normalizedEntry
+      ? ""
+      : normalizedRequest.slice(normalizedEntry.length).replace(/^\/+/, "");
+  const slugParts = relativeSlug.split("/").filter(Boolean);
+
+  for (const docsDir of ctx.docsDirs) {
+    const resolvedDocsDir = path.resolve(docsDir);
+    const candidateDir =
+      slugParts.length > 0 ? path.join(resolvedDocsDir, ...slugParts) : resolvedDocsDir;
+    const source = resolveDocsSearchPageSource(candidateDir);
+    if (!source) continue;
+
+    const resolvedSource = path.resolve(source);
+    if (!isPathWithinDir(resolvedSource, resolvedDocsDir)) continue;
+
+    try {
+      const stat = fs.statSync(resolvedSource);
+      if (!stat.isFile()) continue;
+
+      return {
+        requestedPath: normalizedRequest,
+        filePath: resolvedSource,
+        relativePath: path.relative(rootDir, resolvedSource).replace(/\\/g, "/"),
+        content: fs.readFileSync(resolvedSource, "utf-8"),
+        lastModified: stat.mtime.toISOString(),
+      };
+    } catch {
+      // try the next candidate
+    }
+  }
+
+  return null;
+}
+
+async function parseDevToolsWriteBody(
+  request: Request,
+): Promise<{ ok: true; content: string } | { ok: false; response: Response }> {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: Response.json({ error: "DevTools write body must be valid JSON" }, { status: 400 }),
+    };
+  }
+
+  if (!isPlainObject(body) || typeof body.content !== "string") {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: "DevTools write body must include a string `content` field" },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (body.content.length > 5_000_000) {
+    return {
+      ok: false,
+      response: Response.json({ error: "DevTools content is too large to write" }, { status: 413 }),
+    };
+  }
+
+  return { ok: true, content: body.content };
+}
+
+function toCamelCase(id: string): string {
+  return id.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+async function handleDevToolsThemeRequest(request: Request, rootDir: string): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as Record<string, unknown>).themeId !== "string"
+  ) {
+    return Response.json({ error: "Body must include a string `themeId` field" }, { status: 400 });
+  }
+  const themeId = ((body as Record<string, unknown>).themeId as string).trim();
+  const themeFn = toCamelCase(themeId);
+
+  // Update app/global.css
+  const cssPath = path.join(rootDir, "app", "global.css");
+  try {
+    const cssContent = fs.readFileSync(cssPath, "utf-8");
+    const updatedCss = cssContent.replace(
+      /@import\s+"@farming-labs\/theme\/[^/]+\/css";/,
+      `@import "@farming-labs/theme/${themeId}/css";`,
+    );
+    fs.writeFileSync(cssPath, updatedCss);
+  } catch {
+    return Response.json(
+      { error: `Could not update ${path.relative(rootDir, cssPath)}` },
+      { status: 500 },
+    );
+  }
+
+  // Update docs.config.tsx
+  const configPath = path.join(rootDir, "docs.config.tsx");
+  try {
+    const configContent = fs.readFileSync(configPath, "utf-8");
+    // Replace: import { anyName } from "@farming-labs/theme/anyTheme"
+    const updatedImport = configContent.replace(
+      /import\s*\{\s*\w+\s*\}\s*from\s*"@farming-labs\/theme\/\w[\w-]*"/,
+      `import { ${themeFn} } from "@farming-labs/theme/${themeId}"`,
+    );
+    // Replace: theme: someName({...}) — update the function name
+    const updatedConfig = updatedImport.replace(/\btheme\s*:\s*\w+\s*\(/, `theme: ${themeFn}(`);
+    fs.writeFileSync(configPath, updatedConfig);
+  } catch {
+    return Response.json(
+      { error: `Could not update ${path.relative(rootDir, configPath)}` },
+      { status: 500 },
+    );
+  }
+
+  return Response.json({ ok: true, themeId }, { headers: { "Cache-Control": "no-store" } });
+}
+
+async function handleDevToolsNavItemRequest(
+  request: Request,
+  ctx: { entryPath: string; publicPath: string; docsDirs: string[] },
+  rootDir: string,
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return Response.json({ error: "Invalid body" }, { status: 400 });
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.href !== "string" || typeof b.title !== "string") {
+    return Response.json(
+      { error: "Body must include string `href` and `title` fields" },
+      { status: 400 },
+    );
+  }
+
+  const href = b.href.trim();
+  const title = b.title.trim();
+
+  const page = getEditableDocsPage(ctx, href, rootDir);
+  if (!page) {
+    return Response.json({ error: "Could not find an MDX page for that path." }, { status: 404 });
+  }
+
+  // Update the frontmatter title
+  const parsed = matter(page.content);
+  parsed.data.title = title;
+  const updated = matter.stringify(parsed.content, parsed.data);
+  fs.writeFileSync(page.filePath, updated);
+
+  return Response.json(
+    { ok: true, relativePath: page.relativePath },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+async function handleDevToolsPublishRequest(request: Request): Promise<Response> {
+  const apiKey = process.env.FARMING_CLOUD_API_KEY ?? process.env.FARMING_API_KEY;
+  const endpoint =
+    process.env.FARMING_CLOUD_API_URL ?? "https://api.farming-labs.dev/v1/docs/previews";
+
+  if (!apiKey) {
+    return Response.json(
+      {
+        error:
+          "Cloud publishing is not logged in. Set FARMING_CLOUD_API_KEY or run the Farming Cloud login flow before publishing a preview.",
+      },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(isPlainObject(body) ? body : {}),
+  });
+
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") ?? "application/json; charset=utf-8";
+
+  return new Response(text, {
+    status: response.status,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
 function renderMarkdownDocument(
   page: DocsMcpPage | DocsSearchSourcePage,
   options: {
@@ -3937,6 +4254,7 @@ export function createDocsAPI(options?: DocsAPIOptions) {
     robots: robotsConfig,
   } as DocsConfig);
   const apiReferenceConfig = options?.apiReference ?? readApiReferenceConfig(root);
+  const devToolsEnabled = resolveDevToolsEnabled(options?.devTools);
   const apiReferenceDocsConfig = {
     ...options,
     entry,
@@ -4359,6 +4677,39 @@ export function createDocsAPI(options?: DocsAPIOptions) {
         return Response.json(buildDocsConfigMap(docsConfigMapInput), {
           headers: {
             "Cache-Control": "public, max-age=0, s-maxage=3600",
+            "X-Robots-Tag": "noindex",
+          },
+        });
+      }
+
+      const devToolsRequest = resolveDevToolsRequest(url);
+      if (devToolsRequest) {
+        if (!devToolsEnabled || !isLocalDevToolsRequest(request)) {
+          return createDevToolsUnavailableResponse();
+        }
+
+        if (devToolsRequest !== "page") {
+          return Response.json(
+            { error: "Method Not Allowed" },
+            {
+              status: 405,
+              headers: { Allow: "POST" },
+            },
+          );
+        }
+
+        const requestedPath = getDevToolsRequestedPath(url, request);
+        const page = getEditableDocsPage(ctx, requestedPath, root);
+        if (!page) {
+          return Response.json(
+            { error: "Could not find an editable MDX page for this route." },
+            { status: 404 },
+          );
+        }
+
+        return Response.json(page, {
+          headers: {
+            "Cache-Control": "no-store",
             "X-Robots-Tag": "noindex",
           },
         });
@@ -4875,6 +5226,60 @@ export function createDocsAPI(options?: DocsAPIOptions) {
       const requestAnalyticsProperties = getRequestAnalyticsProperties(request);
       const standardsResponse = await resolveStandardsResponse(request, url);
       if (standardsResponse) return standardsResponse;
+
+      const devToolsRequest = resolveDevToolsRequest(url);
+      if (devToolsRequest) {
+        if (!devToolsEnabled || !isLocalDevToolsRequest(request)) {
+          return createDevToolsUnavailableResponse();
+        }
+
+        if (devToolsRequest === "publish") {
+          return handleDevToolsPublishRequest(request);
+        }
+
+        if (devToolsRequest === "theme") {
+          return handleDevToolsThemeRequest(request, root);
+        }
+
+        const ctx = resolveContextFromRequest(request);
+
+        if (devToolsRequest === "nav-item") {
+          return handleDevToolsNavItemRequest(request, ctx, root);
+        }
+
+        const requestedPath = getDevToolsRequestedPath(url, request);
+        const page = getEditableDocsPage(ctx, requestedPath, root);
+        if (!page) {
+          return Response.json(
+            { error: "Could not find an editable MDX page for this route." },
+            { status: 404 },
+          );
+        }
+
+        const parsed = await parseDevToolsWriteBody(request);
+        if (!parsed.ok) return parsed.response;
+
+        const content = parsed.content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        fs.writeFileSync(page.filePath, content.endsWith("\n") ? content : `${content}\n`);
+        indexesByLocale.clear();
+        markdownSourcesByLocale.clear();
+
+        const stat = fs.statSync(page.filePath);
+        return Response.json(
+          {
+            ok: true,
+            requestedPath: page.requestedPath,
+            relativePath: page.relativePath,
+            lastModified: stat.mtime.toISOString(),
+          },
+          {
+            headers: {
+              "Cache-Control": "no-store",
+              "X-Robots-Tag": "noindex",
+            },
+          },
+        );
+      }
 
       const agentFeedbackRequest = resolveAgentFeedbackRequest(url, agentFeedbackConfig);
 

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -1101,6 +1101,10 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
 
   // When staticExport is true (e.g. Cloudflare Pages), no server → disable search and AI
   const staticExport = !!(config as { staticExport?: boolean }).staticExport;
+  const devToolsEnabled =
+    !staticExport &&
+    (config.devTools === true ||
+      (typeof config.devTools === "object" && config.devTools.enabled !== false));
   // AI features — resolved from config, rendered automatically
   const aiConfig = config.ai as AIConfig | undefined;
   const aiEnabled = !staticExport && !!aiConfig?.enabled;
@@ -1275,6 +1279,8 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
             readingTimeMap={readingTimeMap}
             structuredDataMap={structuredDataMap}
             llmsTxtEnabled={llmsTxtEnabled}
+            devToolsEnabled={devToolsEnabled}
+            docsApiUrl={docsApiUrl}
             generatedTitleMap={generatedTitleMap}
             descriptionMap={descriptionMap}
             feedbackEnabled={feedbackConfig.enabled}

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -17,6 +17,7 @@ import { DocsFeedback } from "./docs-feedback.js";
 import { resolveClientLocale, withLangInUrl } from "./i18n.js";
 import { emitClientAnalyticsEvent } from "./client-analytics.js";
 import { escapeJsonLdForScript } from "./json-ld.js";
+import { DocsDevTools } from "./devtools.js";
 
 const agentLlmsDirectiveStyle: CSSProperties = {
   position: "absolute",
@@ -117,6 +118,10 @@ interface DocsPageClientProps {
   lastUpdatedPosition?: "footer" | "below-title";
   /** Whether llms.txt is enabled — shows links in footer */
   llmsTxtEnabled?: boolean;
+  /** Whether to show the local visual MDX editor. */
+  devToolsEnabled?: boolean;
+  /** Unified docs API route used by the visual MDX editor. */
+  docsApiUrl?: string;
   /** Frontmatter titles for pages whose MDX body does not author an h1 */
   generatedTitleMap?: Record<string, string>;
   /** Map of pathname → frontmatter description */
@@ -554,6 +559,8 @@ export function DocsPageClient({
   lastUpdatedLabel = "Last updated",
   lastUpdatedPosition = "footer",
   llmsTxtEnabled = false,
+  devToolsEnabled = false,
+  docsApiUrl = "/api/docs",
   generatedTitleMap,
   descriptionMap,
   description,
@@ -1075,7 +1082,7 @@ export function DocsPageClient({
           style={{ display: "flex", flexDirection: "column" }}
         >
           {generatedPageHeader}
-          <div key="content" className="fd-docs-content" style={{ flex: 1 }}>
+          <div key="content" className="fd-docs-content" style={{ flex: 1 }} data-dt-content="">
             {renderedChildren}
           </div>
           {!generatedPageHeader && titleDecorationsFallback}
@@ -1184,6 +1191,7 @@ export function DocsPageClient({
           )}
         </DocsBody>
       </DocsPage>
+      {devToolsEnabled && <DocsDevTools api={docsApiUrl} pathname={normalizedPath} />}
     </>
   );
 }

--- a/packages/fumadocs/src/greentree/index.ts
+++ b/packages/fumadocs/src/greentree/index.ts
@@ -37,7 +37,6 @@ const GreenTreeUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/hardline/index.ts
+++ b/packages/fumadocs/src/hardline/index.ts
@@ -41,7 +41,6 @@ const HardlineUIDefaults = {
     Callout: { variant: "outline", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: true },
-    Tabs: { style: "underline" as const },
   },
 };
 

--- a/packages/fumadocs/src/index.ts
+++ b/packages/fumadocs/src/index.ts
@@ -89,6 +89,7 @@ export { DocsLayout } from "fumadocs-ui/layouts/docs";
 export { DocsPageClient } from "./docs-page-client.js";
 export { DocsClientHooks } from "./docs-client-hooks.js";
 export { DocsFeedback } from "./docs-feedback.js";
+export { DocsDevTools } from "./devtools.js";
 
 // ─── Page action buttons (Copy Markdown, Open in LLM) ─────────────────
 export { PageActions } from "./page-actions.js";
@@ -109,6 +110,7 @@ export type {
   TypographyConfig,
   DocsNav,
   DocsMetadata,
+  DevToolsConfig,
   OGConfig,
   PageFrontmatter,
   PageAgentAppliesTo,

--- a/packages/fumadocs/src/ledger/index.ts
+++ b/packages/fumadocs/src/ledger/index.ts
@@ -55,7 +55,6 @@ const LedgerUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/shadcn/index.test.ts
+++ b/packages/fumadocs/src/shadcn/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { hardline } from "../hardline/index.js";
+import { threadline } from "../threadline/index.js";
 import { shadcn } from "./index.js";
 
 describe("shadcn theme", () => {
@@ -9,5 +11,11 @@ describe("shadcn theme", () => {
       theme: "github-light-default",
       darkTheme: "vesper",
     });
+  });
+
+  it("does not forward theme variants through React's reserved style prop", () => {
+    for (const theme of [hardline(), shadcn(), threadline()]) {
+      expect(theme.ui?.components?.Tabs).toBeUndefined();
+    }
   });
 });

--- a/packages/fumadocs/src/shadcn/index.ts
+++ b/packages/fumadocs/src/shadcn/index.ts
@@ -61,7 +61,6 @@ const ShadcnUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "underline" as const },
   },
 };
 

--- a/packages/fumadocs/src/shiny/index.ts
+++ b/packages/fumadocs/src/shiny/index.ts
@@ -37,7 +37,6 @@ const ShinyUIDefaults = {
     Callout: { variant: "soft", icon: true },
     CodeBlock: { showCopyButton: true },
     HoverLink: { linkLabel: "Open page", showIndicator: false },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/src/threadline/index.ts
+++ b/packages/fumadocs/src/threadline/index.ts
@@ -64,7 +64,6 @@ const ThreadlineUIDefaults = {
       copiedIcon: "check",
       openIcon: "arrowUpRight",
     },
-    Tabs: { style: "default" },
   },
 };
 

--- a/packages/fumadocs/tsdown.config.ts
+++ b/packages/fumadocs/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     "src/code-block-copy-wrapper.tsx",
     "src/docs-ai-features.tsx",
     "src/docs-command-search.tsx",
+    "src/devtools.tsx",
     "src/docs-layout.tsx",
     "src/docs-page-client.tsx",
     "src/mdx-img.tsx",

--- a/skills/farming-labs/configuration/references/core-options.md
+++ b/skills/farming-labs/configuration/references/core-options.md
@@ -36,6 +36,7 @@ export, and reader-facing UI configuration.
 | `agent` | unset | Compaction, evaluations, published skills, and A2A |
 | `review` | `true` | Review scoring, CI workflow, and severities |
 | `pageActions` | unset | Copy Markdown and Open in LLM actions |
+| `devTools` | `false` | Local visual MDX editor with apply and preview actions |
 | `ai` | unset | Ask AI configuration |
 | `search` | `true` | Simple, Typesense, Algolia, MCP, or custom search |
 | `cloud` | unset | Hosted preview/publish defaults |
@@ -165,6 +166,22 @@ export default defineDocs({
 - Publish the API catalog separately with host routing when static hosting must expose it.
 
 ## Reader-facing options
+
+### DevTools
+
+```ts
+devTools: true,
+
+// or
+devTools: {
+  enabled: true,
+},
+```
+
+The built-in DevTools editor is local-development only. It loads and writes the current MDX page
+through `/api/docs?devtools=page`, supports block and source editing, and can publish a preview
+through `/api/docs?devtools=publish` when `FARMING_CLOUD_API_KEY` or `FARMING_API_KEY` is available.
+It is hidden for `staticExport: true`, and its API rejects production or non-local requests.
 
 ### Reading time
 

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -168,6 +168,7 @@ All configuration lives in a single `docs.config.ts` file.
 | `review`      | `boolean \| DocsReviewConfig`  | `true`          | Docs Review CI workflow generation, scoring, and rule severity |
 | `readingTime` | `boolean \| ReadingTimeConfig` | `false`         | Opt-in estimated read-time label with optional per-page overrides |
 | `pageActions` | `PageActionsConfig`            | —               | Copy Markdown, Open in LLM buttons                 |
+| `devTools`    | `boolean \| DevToolsConfig`    | `false`         | Local visual MDX editor with Apply Changes and Publish Preview actions |
 | `ai`          | `AIConfig`                     | —               | RAG-powered AI chat                                |
 | `search`      | `boolean \| DocsSearchConfig`  | `true`          | Built-in simple search, Typesense, Algolia, or a custom adapter |
 | `cloud`       | `DocsCloudConfig`              | —               | Docs Cloud API key env, deploy, and publish defaults mirrored into `docs.json` |
@@ -593,6 +594,28 @@ export default defineDocs({
 ```
 
 Use this when you deploy to a static host and don’t run a server. Search and AI require a server; with `staticExport: true` they are hidden so the site works without one.
+
+## DevTools
+
+Set `devTools: true` while developing locally to render the built-in visual MDX editor. It adds a
+floating DevTools button on docs pages, loads the current page source from the docs API, replaces the
+page body with an inline editing canvas, lets you edit/reorder MDX blocks, and writes the result back
+to the source file when you click Apply Changes.
+
+```ts title="docs.config.ts"
+export default defineDocs({
+  entry: "docs",
+  devTools: true,
+  theme: fumadocs(),
+});
+```
+
+DevTools are local-development only. The docs API refuses DevTools requests unless the feature is
+enabled and the request is local or the app is running outside production. With `staticExport: true`,
+the floating editor is hidden because there is no server route to write files.
+
+Publish Preview uses the same local DevTools toolbar and forwards to Farming Cloud with
+`FARMING_CLOUD_API_KEY` or `FARMING_API_KEY`.
 
 ## Search
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -141,6 +141,7 @@ Top-level configuration object passed to `defineDocs()`.
 | `review`      | `boolean \| DocsReviewConfig`                   | `true`           | Docs Review scoring, rule severity, and GitHub Actions workflow generation           |
 | `readingTime` | `boolean \| ReadingTimeConfig`                  | `false`          | Opt-in estimated reading-time label with per-page overrides                          |
 | `pageActions` | `PageActionsConfig`                             | —                | "Copy Markdown" and "Open in LLM" buttons                                            |
+| `devTools`    | `boolean \| DevToolsConfig`                     | `false`          | Local visual MDX editor with Apply Changes and Publish Preview actions               |
 | `ai`          | `AIConfig`                                      | —                | RAG-powered AI chat                                                                  |
 | `search`      | `boolean \| DocsSearchConfig`                   | `true`           | Built-in simple search, Typesense, Algolia, or a custom adapter                     |
 | `mcp`         | `boolean \| DocsMcpConfig`                      | enabled          | Built-in MCP server over stdio, `/mcp`, and `/.well-known/mcp`                       |
@@ -407,6 +408,34 @@ In both cases the adapter-owned MDX transform is prepended before any plugins yo
 ---
 
 `components` is merged into the default MDX component map, so you can both add your own components and replace built-ins such as `Callout`, `Tabs`, `HoverLink`, or `Prompt`. For built-in defaults like `theme.ui.components.HoverLink` and `theme.ui.components.Prompt`, see [Creating themes](/docs/themes/creating-themes). For usage examples and a live demo, see [Components](/docs/customization/components).
+
+---
+
+## `devTools` and `DevToolsConfig`
+
+Local visual MDX editor for docs authors.
+
+| Option    | Type      | Default | Description                                    |
+| --------- | --------- | ------- | ---------------------------------------------- |
+| `enabled` | `boolean` | `true`  | Set `false` when using object form to opt out. |
+
+```ts title="docs.config.ts"
+devTools: true,
+
+// or
+devTools: {
+  enabled: true,
+},
+```
+
+When enabled, docs pages render a floating DevTools button in local development. Opening it replaces
+the page body with an inline MDX editing canvas, so authors can edit the current page as blocks or
+raw source, apply changes back to the page file through `/api/docs?devtools=page`, and publish
+previews through `/api/docs?devtools=publish` when `FARMING_CLOUD_API_KEY` or `FARMING_API_KEY` is
+available.
+
+DevTools are hidden when `staticExport: true` and API requests are rejected unless the feature is
+enabled and the request is local or the app is running outside production.
 
 ---
 


### PR DESCRIPTION
## Status

Draft. This restores the work from the original PR #200 so it can continue being developed and reviewed before merging again.

## Scope

- Devtools editor support.
- Advanced MDX collocations.
- Related docs, examples, exports, and tests from the original change.

## History

The original PR was reverted by #474 because it was not ready to ship. This branch reproduces the original PR tree exactly, without unrelated changes.

## Next steps

Continue refining and testing this work here. The runtime theme tweaks are maintained as a separate draft stacked on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local DevTools visual editor for MDX docs and the API endpoints it needs, gated behind a new `devTools` config. Themes no longer inject a Tabs style default to avoid leaking into React’s reserved `style` prop.

- Opt-in: set `devTools: true` in `defineDocs()`; hidden when `staticExport: true`. The API rejects DevTools requests unless enabled and the request is local or not in production.
- Endpoints:
  - `/api/docs?devtools=page` GET returns `{ relativePath, content }` for the current route; POST writes file changes and invalidates indexes. Resolves custom `docsPath` back to `app/docs/**/page.mdx`.
  - `/api/docs?devtools=theme` POST rewrites `app/global.css` and `docs.config.tsx` imports/initializer to switch `@farming-labs/theme/*`.
  - `/api/docs?devtools=nav-item` POST updates frontmatter (e.g., `title`) of the target page.
  - `/api/docs?devtools=publish` POST forwards to Cloud; requires `FARMING_CLOUD_API_KEY` or `FARMING_API_KEY`.
- Safeguards: path resolution constrained to docs dirs, content size limit, local-only, and “unavailable” responses when disabled.
- UI: `DocsPageClient` mounts `<DocsDevTools>` and marks the content region (`data-dt-content`) when enabled.
- Themes: removed `ui.components.Tabs` defaults across presets to avoid React `style` prop conflicts; pass tab style where you render Tabs if you relied on theme defaults.
- Docs: added `devTools` to `DocsConfig` types and public docs; examples updated to demonstrate block-level MDX editing.

<sup>Written for commit 0b97114f2aa69b0beb6e5e2701570e1b903d97a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

