### PR TITLE
fix: harden hosted agent probes

### DIFF
--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -171,9 +171,20 @@ describe("parseDoctorArgs", () => {
   });
 
   it("parses hosted URL probes", () => {
-    expect(parseDoctorArgs(["--agent", "--url", "https://docs.example.com"])).toEqual({
+    expect(
+      parseDoctorArgs([
+        "--agent",
+        "--url",
+        "https://docs.example.com",
+        "--timeout",
+        "20000",
+        "--retries=2",
+      ]),
+    ).toEqual({
       mode: "agent",
       url: "https://docs.example.com",
+      hostedTimeoutMs: 20000,
+      hostedRetries: 2,
     });
     expect(parseDoctorArgs(["--url=https://docs.example.com", "--json"])).toEqual({
       mode: "agent",
@@ -202,6 +213,18 @@ describe("parseDoctorArgs", () => {
   it("rejects missing URL values", () => {
     expect(() => parseDoctorArgs(["--url"])).toThrow("Missing value for --url.");
     expect(() => parseDoctorArgs(["--url="])).toThrow("Missing value for --url.");
+  });
+
+  it("rejects invalid hosted probe controls", () => {
+    expect(() => parseDoctorArgs(["--timeout", "99"])).toThrow(
+      "Invalid value for --timeout. Expected a value between 100 and 120000.",
+    );
+    expect(() => parseDoctorArgs(["--retries=6"])).toThrow(
+      "Invalid value for --retries. Expected a value between 0 and 5.",
+    );
+    expect(() => parseDoctorArgs(["--retries", "eventually"])).toThrow(
+      "Invalid value for --retries. Expected an integer.",
+    );
   });
 
   it("rejects invalid only mode values", () => {
@@ -1582,6 +1605,7 @@ Use MCP and markdown routes.
     let serveInvalidSkillUtf8 = false;
     let serveArchiveSkill = false;
     let initializedNotifications = 0;
+    let llmsTxtRequests = 0;
 
     const server = createServer(async (req, res) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -1768,6 +1792,14 @@ Use MCP and markdown routes.
         }
 
         if (url.pathname === "/llms.txt" || url.pathname === "/llms-full.txt") {
+          if (url.pathname === "/llms.txt") {
+            llmsTxtRequests += 1;
+            if (llmsTxtRequests === 1) {
+              res.writeHead(503, { "Content-Type": "text/plain" });
+              res.end("warming up");
+              return;
+            }
+          }
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end(`# Docs\n\n${url.pathname}`);
           return;
@@ -1953,6 +1985,7 @@ Use MCP and markdown routes.
         "docs digest verified",
       );
       expect(report.checks.find((check) => check.id === "hosted-llms")?.status).toBe("pass");
+      expect(llmsTxtRequests).toBeGreaterThanOrEqual(2);
       expect(report.checks.find((check) => check.id === "hosted-sitemap")?.status).toBe("pass");
       expect(report.checks.find((check) => check.id === "hosted-robots")?.status).toBe("pass");
       expect(report.checks.find((check) => check.id === "hosted-skill")?.status).toBe("pass");

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -1445,10 +1445,7 @@ function toMarkdownRoute(pageUrl?: string): string | undefined {
   return normalized.endsWith(".md") ? normalized : `${normalized}.md`;
 }
 
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit = {},
-): Promise<Response> {
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
   const options = hostedProbeOptions.getStore();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_HOSTED_TIMEOUT_MS;
   const retries = options?.retries ?? DEFAULT_HOSTED_RETRIES;

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -7,6 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { gunzipSync } from "node:zlib";
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/server";
@@ -109,6 +110,13 @@ type HumanDoctorGrade = "Human-optimized" | "Reader-ready" | "Promising" | "Need
 type DoctorMode = "agent" | "human";
 type DoctorFailOn = "warn" | "fail";
 
+const DEFAULT_HOSTED_TIMEOUT_MS = 15_000;
+const DEFAULT_HOSTED_RETRIES = 1;
+const hostedProbeOptions = new AsyncLocalStorage<{
+  timeoutMs: number;
+  retries: number;
+}>();
+
 export interface DoctorOptions {
   configPath?: string;
   mode?: DoctorMode;
@@ -120,6 +128,10 @@ export interface DoctorOptions {
   strict?: boolean;
   failOn?: DoctorFailOn;
   url?: string;
+  /** Timeout for each hosted HTTP probe. */
+  hostedTimeoutMs?: number;
+  /** Retry count for safe hosted GET and HEAD probes. */
+  hostedRetries?: number;
   fix?: boolean;
   dryRun?: boolean;
 }
@@ -261,6 +273,25 @@ function parseDoctorFailOn(value: string): DoctorFailOn {
   throw new Error("Invalid value for --fail-on. Expected warn or fail.");
 }
 
+function parseDoctorInteger(
+  flag: "--timeout" | "--retries",
+  value: string,
+  bounds: { min: number; max: number },
+): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid value for ${flag}. Expected an integer.`);
+  }
+
+  const parsed = Number(value);
+  if (parsed < bounds.min || parsed > bounds.max) {
+    throw new Error(
+      `Invalid value for ${flag}. Expected a value between ${bounds.min} and ${bounds.max}.`,
+    );
+  }
+
+  return parsed;
+}
+
 export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
   const parsed: ParsedDoctorArgs = {};
 
@@ -392,6 +423,50 @@ export function parseDoctorArgs(argv: string[]): ParsedDoctorArgs {
       continue;
     }
 
+    if (arg.startsWith("--timeout=")) {
+      const value = parseInlineFlag(arg).value;
+      if (!value) {
+        throw new Error("Missing value for --timeout.");
+      }
+      parsed.hostedTimeoutMs = parseDoctorInteger("--timeout", value, {
+        min: 100,
+        max: 120_000,
+      });
+      continue;
+    }
+
+    if (arg === "--timeout") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("Missing value for --timeout.");
+      }
+      parsed.hostedTimeoutMs = parseDoctorInteger("--timeout", value, {
+        min: 100,
+        max: 120_000,
+      });
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--retries=")) {
+      const value = parseInlineFlag(arg).value;
+      if (value === undefined || value === "") {
+        throw new Error("Missing value for --retries.");
+      }
+      parsed.hostedRetries = parseDoctorInteger("--retries", value, { min: 0, max: 5 });
+      continue;
+    }
+
+    if (arg === "--retries") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("Missing value for --retries.");
+      }
+      parsed.hostedRetries = parseDoctorInteger("--retries", value, { min: 0, max: 5 });
+      index += 1;
+      continue;
+    }
+
     if (arg === "--config") {
       const value = argv[index + 1];
       if (!value || value.startsWith("--")) {
@@ -443,6 +518,8 @@ ${pc.dim("Options:")}
   ${pc.cyan("--dry-run")}          With ${pc.cyan("--fix")}, report the compaction command without writing files
   ${pc.cyan("--fail-on <level>")}  Exit with failure on ${pc.cyan("warn")} or only on ${pc.cyan("fail")}
   ${pc.cyan("--url <url>")}        Probe hosted agent surfaces, e.g. ${pc.dim("https://docs.example.com")}
+  ${pc.cyan("--timeout <ms>")}     Set each hosted probe timeout (default: ${pc.dim(String(DEFAULT_HOSTED_TIMEOUT_MS))})
+  ${pc.cyan("--retries <count>")}  Retry safe hosted GET/HEAD probes (default: ${pc.dim(String(DEFAULT_HOSTED_RETRIES))})
   ${pc.cyan("--config <path>")}    Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
   ${pc.cyan("-h, --help")}         Show this help message
 `);
@@ -1371,18 +1448,39 @@ function toMarkdownRoute(pageUrl?: string): string | undefined {
 async function fetchWithTimeout(
   url: string,
   init: RequestInit = {},
-  timeoutMs = 8000,
 ): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const options = hostedProbeOptions.getStore();
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_HOSTED_TIMEOUT_MS;
+  const retries = options?.retries ?? DEFAULT_HOSTED_RETRIES;
+  const method = init.method?.toUpperCase() ?? "GET";
+  const retryableMethod = method === "GET" || method === "HEAD";
 
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: controller.signal,
-    });
-  } finally {
-    clearTimeout(timeout);
+  for (let attempt = 0; ; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: controller.signal,
+      });
+      const retryableStatus =
+        response.status === 408 ||
+        response.status === 425 ||
+        response.status === 429 ||
+        response.status >= 500;
+
+      if (retryableMethod && retryableStatus && attempt < retries) {
+        await response.body?.cancel().catch(() => undefined);
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      if (!retryableMethod || attempt >= retries) throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 }
 
@@ -3913,7 +4011,15 @@ export async function inspectAgentReadiness(
     ),
   );
 
-  const hosted = options.url ? await buildHostedAgentChecks(options.url, pages) : undefined;
+  const hosted = options.url
+    ? await hostedProbeOptions.run(
+        {
+          timeoutMs: options.hostedTimeoutMs ?? DEFAULT_HOSTED_TIMEOUT_MS,
+          retries: options.hostedRetries ?? DEFAULT_HOSTED_RETRIES,
+        },
+        () => buildHostedAgentChecks(options.url!, pages),
+      )
+    : undefined;
   if (hosted) {
     checks.push(...hosted.checks);
   }

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -558,6 +558,8 @@ ${pc.dim("Options for doctor:")}
   ${pc.cyan("doctor --agent --fix")}                Refresh stale generated ${pc.dim("agent.md")} files and token-budget missing outputs
   ${pc.cyan("doctor --agent --fix --dry-run")}      Report the fix command without writing generated ${pc.dim("agent.md")} files
   ${pc.cyan("doctor --fail-on warn|fail")}          Choose whether warnings or only failures fail CI
+  ${pc.cyan("doctor --timeout <ms>")}               Set each hosted probe timeout (default: ${pc.dim("15000")})
+  ${pc.cyan("doctor --retries <0-5>")}              Retry safe hosted GET/HEAD probes (default: ${pc.dim("1")})
   ${pc.cyan("doctor agent")}                        Subcommand alias for agent scoring
   ${pc.cyan("doctor site")}                         Subcommand alias for reader-facing scoring
   ${pc.cyan("doctor human")}                        Legacy alias for reader-facing scoring

--- a/packages/docs/src/sitemap.test.ts
+++ b/packages/docs/src/sitemap.test.ts
@@ -84,6 +84,9 @@ describe("docs sitemap helpers", () => {
     });
 
     expect(response?.headers.get("content-type")).toContain("application/xml");
+    expect(response?.headers.get("cache-control")).toBe(
+      "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    );
     expect(response?.headers.get("etag")).toBeTruthy();
     expect(await response?.text()).toContain("<urlset");
   });

--- a/packages/docs/src/sitemap.ts
+++ b/packages/docs/src/sitemap.ts
@@ -442,7 +442,7 @@ export function createDocsSitemapResponse({
   const headers = new Headers({
     "Content-Type":
       format === "xml" ? "application/xml; charset=utf-8" : "text/markdown; charset=utf-8",
-    "Cache-Control": "public, max-age=0, must-revalidate",
+    "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
     ETag: hashString(body),
   });
   const lastModified = newestLastmod(nextManifest.pages);

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -21,6 +21,7 @@ pnpm exec docs doctor --agent --json
 pnpm exec docs doctor --agent --ci --json-output .farming-labs/doctor.json
 pnpm exec docs doctor --agent --config docs.config.tsx
 pnpm exec docs doctor --agent --url https://docs.example.com
+pnpm exec docs doctor --agent --url https://docs.example.com --timeout 20000 --retries 2
 pnpm exec docs doctor --agent --url https://docs.example.com --json
 ```
 
@@ -69,6 +70,10 @@ With `--url`, doctor additionally checks:
 - root and well-known `skill.md`
 - a representative `.md` page
 - `/mcp`, `/.well-known/mcp`, and hosted MCP subdomain aliases
+
+Hosted probes allow 15 seconds per request and retry one failed safe `GET` or `HEAD` request by
+default. Use `--timeout <milliseconds>` for slower cold starts and `--retries <0-5>` to tune safe
+probe retries. Mutating MCP requests are never retried automatically.
 
 For MCP, doctor initializes Streamable HTTP, checks session behavior, lists tools, and expects the
 core docs tools. Hosted evidence adds checks without changing the normalized 100-point scale.


### PR DESCRIPTION
## What changed

- increase the default hosted doctor timeout from 8 seconds to 15 seconds
- add `doctor --timeout <ms>` and `doctor --retries <0-5>` controls
- retry transient failures only for safe GET and HEAD probes
- allow sitemap responses to be cached by shared CDNs with stale-while-revalidate
- document the new controls in the CLI skill reference

## Why

Cold production requests for `llms.txt` and the well-known sitemap could exceed the previous fixed timeout. The doctor reported those healthy routes as unavailable, while the sitemap response also forced every CDN request through revalidation.

## Impact

Hosted readiness checks now tolerate ordinary cold starts without retrying mutating MCP requests. Sitemap aliases can be served from shared cache while retaining ETag and Last-Modified validators.

## Validation

- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm --filter @farming-labs/docs exec vitest run` — 82 files, 1,426 tests passed
- built CLI help exposes `--timeout` and `--retries`
- production doctor run: hosted llms and all advertised sitemap routes passed; no hosted failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens hosted agent probes to reduce cold-start false negatives and enables CDN-friendly sitemap caching. Previously probes used an 8s timeout with no retries; now they default to 15s with a single retry for safe GET/HEAD requests, and sitemap responses support stale-while-revalidate.

- Adds `doctor --timeout <ms>` (100–120000) and `doctor --retries <0-5>`; invalid or missing values fail fast. Settings drive a per-probe fetch helper with abort-based timeouts; CLI help updated.
- Retries apply only to GET/HEAD on transient statuses (408, 425, 429, 5xx); mutating MCP requests are never retried.
- Changes sitemap Cache-Control to `public, max-age=0, s-maxage=3600, stale-while-revalidate=86400` while keeping ETag and Last-Modified.
- Updates docs and tests to cover flags, validation, transient 503 warmup retry, and sitemap caching headers.

<sup>Written for commit 7ee7940a7baf445189dea39ef5aea0cb423e17fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

