### PR TITLE
feat: model agent evaluation applicability

### DIFF
--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -134,24 +134,32 @@ describe("runDocsGoldenTasks", () => {
       coverage: {
         status: "unmeasured",
         measuredTaskDimensions: 0,
+        applicableTaskDimensions: 0,
+        notApplicableTaskDimensions: 0,
         totalTaskDimensions: 0,
         coveragePercent: 0,
         dimensions: {
           safety: {
             status: "unmeasured",
             measuredTaskCount: 0,
+            applicableTaskCount: 0,
+            notApplicableTaskCount: 0,
             totalTaskCount: 0,
             coveragePercent: 0,
           },
           answerQuality: {
             status: "unmeasured",
             measuredTaskCount: 0,
+            applicableTaskCount: 0,
+            notApplicableTaskCount: 0,
             totalTaskCount: 0,
             coveragePercent: 0,
           },
           executableExamples: {
             status: "unmeasured",
             measuredTaskCount: 0,
+            applicableTaskCount: 0,
+            notApplicableTaskCount: 0,
             totalTaskCount: 0,
             coveragePercent: 0,
           },
@@ -176,6 +184,8 @@ describe("runDocsGoldenTasks", () => {
     expect(report.coverage).toMatchObject({
       status: "unmeasured",
       measuredTaskDimensions: 0,
+      applicableTaskDimensions: 3,
+      notApplicableTaskDimensions: 0,
       totalTaskDimensions: 3,
       dimensions: {
         safety: { status: "unmeasured", measuredTaskCount: 0 },
@@ -226,6 +236,66 @@ describe("runDocsGoldenTasks", () => {
     expect(result.usage.conservativeTokenUpperBound).toBe(result.usage.usedUtf8Bytes);
     expect(result.usage.usedUtf8Bytes).toBeLessThanOrEqual(result.usage.tokenBudget);
     expect(result.score).toBe(100);
+  });
+
+  it("excludes explicitly not-applicable runtime execution from coverage", async () => {
+    const report = await runDocsGoldenTasks(pages, [
+      {
+        ...passingTask,
+        id: "documentation-only-example",
+        expect: {
+          ...passingTask.expect,
+          coverage: { executableExamples: "not-applicable" },
+        },
+      },
+    ]);
+
+    expect(report.status).toBe("passed");
+    expect(report.coverage).toMatchObject({
+      status: "unmeasured",
+      measuredTaskDimensions: 0,
+      applicableTaskDimensions: 2,
+      notApplicableTaskDimensions: 1,
+      totalTaskDimensions: 3,
+      coveragePercent: 0,
+      dimensions: {
+        executableExamples: {
+          status: "not-applicable",
+          measuredTaskCount: 0,
+          applicableTaskCount: 0,
+          notApplicableTaskCount: 1,
+          totalTaskCount: 1,
+          coveragePercent: 100,
+        },
+      },
+    });
+    expect(report.tasks[0].coverageApplicability.executableExamples).toBe("not-applicable");
+  });
+
+  it("rejects execute expectations declared not applicable", async () => {
+    const report = await runDocsGoldenTasks(pages, [
+      {
+        ...passingTask,
+        id: "conflicting-example-applicability",
+        expect: {
+          ...passingTask.expect,
+          examples: passingTask.expect.examples?.map((example) => ({
+            ...example,
+            verification: "execute" as const,
+          })),
+          coverage: { executableExamples: "not-applicable" },
+        },
+      },
+    ]);
+
+    expect(report.status).toBe("failed");
+    expect(report.tasks[0].issues).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "coverage.executableExamples cannot be not-applicable when an example uses verification: execute",
+        ),
+      ]),
+    );
   });
 
   it("keeps an empty safety declaration unmeasured", async () => {

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -42,6 +42,8 @@ import type {
   DocsAgentEvaluationAnswerResult,
   DocsAgentEvaluationSurface,
   DocsAgentGoldenAnswerExpectation,
+  DocsAgentGoldenCoverageApplicability,
+  DocsAgentGoldenCoverageExpectation,
   DocsAgentGoldenAuthenticatedContentExpectation,
   DocsAgentGoldenExpectedExample,
   DocsAgentGoldenFreshnessExpectation,
@@ -82,7 +84,11 @@ const EXECUTABLE_LANGUAGES = new Set([
 ]);
 
 export type DocsGoldenEvaluationStatus = "unmeasured" | "passed" | "failed";
-export type DocsGoldenEvaluationCoverageStatus = "measured" | "partially-measured" | "unmeasured";
+export type DocsGoldenEvaluationCoverageStatus =
+  | "measured"
+  | "partially-measured"
+  | "unmeasured"
+  | "not-applicable";
 
 export type DocsGoldenTaskFilters = DocsAgentGoldenTaskFilters;
 export type DocsGoldenExpectedExample = DocsAgentGoldenExpectedExample;
@@ -250,6 +256,9 @@ export interface DocsGoldenTaskReport {
   selection: DocsGoldenSelectionMetrics;
   examples: DocsGoldenExampleMetrics;
   usage: DocsGoldenUsageMetrics;
+  coverageApplicability: {
+    executableExamples: DocsAgentGoldenCoverageApplicability;
+  };
   issues: string[];
 }
 
@@ -280,6 +289,8 @@ export interface DocsGoldenEvaluationQuality {
 export interface DocsGoldenEvaluationDimensionCoverage {
   status: DocsGoldenEvaluationCoverageStatus;
   measuredTaskCount: number;
+  applicableTaskCount: number;
+  notApplicableTaskCount: number;
   totalTaskCount: number;
   coveragePercent: number;
 }
@@ -287,6 +298,8 @@ export interface DocsGoldenEvaluationDimensionCoverage {
 export interface DocsGoldenEvaluationCoverage {
   status: DocsGoldenEvaluationCoverageStatus;
   measuredTaskDimensions: number;
+  applicableTaskDimensions: number;
+  notApplicableTaskDimensions: number;
   totalTaskDimensions: number;
   coveragePercent: number;
   dimensions: {
@@ -781,6 +794,27 @@ function normalizeRuntimeExamples(
   });
 }
 
+function normalizeRuntimeCoverageExpectation(
+  value: unknown,
+  path: string,
+  issues: string[],
+): DocsAgentGoldenCoverageExpectation | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    issues.push(`${path} must be an object.`);
+    return {};
+  }
+
+  return {
+    executableExamples: normalizeRuntimeEnum(
+      value.executableExamples,
+      `${path}.executableExamples`,
+      issues,
+      ["applicable", "not-applicable"] as const,
+    ),
+  };
+}
+
 function normalizeGoldenTaskInput(
   value: unknown,
   index: number,
@@ -853,6 +887,11 @@ function normalizeGoldenTaskInput(
     { minimum: 0, maximum: 1 },
   );
   const examples = normalizeRuntimeExamples(expectation.examples, `${expectPath}.examples`, issues);
+  const coverage = normalizeRuntimeCoverageExpectation(
+    expectation.coverage,
+    `${expectPath}.coverage`,
+    issues,
+  );
   const scope = normalizeRuntimeFilters(expectation.scope, `${expectPath}.scope`, issues);
   const answer = normalizeRuntimeAnswerExpectation(
     expectation.answer,
@@ -864,6 +903,14 @@ function normalizeGoldenTaskInput(
     `${expectPath}.safety`,
     issues,
   );
+  if (
+    coverage?.executableExamples === "not-applicable" &&
+    examples?.some((example) => resolveExampleVerification(example) === "execute")
+  ) {
+    issues.push(
+      `${expectPath}.coverage.executableExamples cannot be not-applicable when an example uses verification: execute.`,
+    );
+  }
 
   const forbidden = forbiddenSources ?? [];
   for (const [name, sources] of [
@@ -901,6 +948,7 @@ function normalizeGoldenTaskInput(
         maxFirstRelevantRank,
         minUsefulByteRatio,
         examples,
+        coverage,
         scope,
         answer,
         safety,
@@ -3419,6 +3467,9 @@ async function evaluateTask(
     selection,
     examples,
     usage,
+    coverageApplicability: {
+      executableExamples: task.expect.coverage?.executableExamples ?? "applicable",
+    },
     issues,
   };
 }
@@ -3432,17 +3483,29 @@ function buildGoldenEvaluationCoverage(
   tasks: readonly DocsGoldenTaskReport[],
 ): DocsGoldenEvaluationCoverage {
   const totalTaskCount = tasks.length;
-  const dimension = (measuredTaskCount: number): DocsGoldenEvaluationDimensionCoverage => {
+  const dimension = (
+    measuredTaskCount: number,
+    notApplicableTaskCount = 0,
+  ): DocsGoldenEvaluationDimensionCoverage => {
+    const applicableTaskCount = totalTaskCount - notApplicableTaskCount;
     const coveragePercent =
-      totalTaskCount === 0 ? 0 : Math.round((measuredTaskCount / totalTaskCount) * 100);
+      totalTaskCount === 0
+        ? 0
+        : applicableTaskCount === 0
+          ? 100
+          : Math.round((measuredTaskCount / applicableTaskCount) * 100);
     return {
       status:
-        measuredTaskCount === 0
-          ? "unmeasured"
-          : measuredTaskCount === totalTaskCount
-            ? "measured"
-            : "partially-measured",
+        totalTaskCount > 0 && applicableTaskCount === 0
+          ? "not-applicable"
+          : measuredTaskCount === 0
+            ? "unmeasured"
+            : measuredTaskCount === applicableTaskCount
+              ? "measured"
+              : "partially-measured",
       measuredTaskCount,
+      applicableTaskCount,
+      notApplicableTaskCount,
       totalTaskCount,
       coveragePercent,
     };
@@ -3457,6 +3520,8 @@ function buildGoldenEvaluationCoverage(
       tasks.filter((task) =>
         task.examples.results.some((result) => result.verification === "execute"),
       ).length,
+      tasks.filter((task) => task.coverageApplicability.executableExamples === "not-applicable")
+        .length,
     ),
   };
   const dimensionValues = Object.values(dimensions);
@@ -3464,20 +3529,34 @@ function buildGoldenEvaluationCoverage(
     (total, value) => total + value.measuredTaskCount,
     0,
   );
+  const applicableTaskDimensions = dimensionValues.reduce(
+    (total, value) => total + value.applicableTaskCount,
+    0,
+  );
+  const notApplicableTaskDimensions = dimensionValues.reduce(
+    (total, value) => total + value.notApplicableTaskCount,
+    0,
+  );
   const totalTaskDimensions = totalTaskCount * dimensionValues.length;
   const coveragePercent =
     totalTaskDimensions === 0
       ? 0
-      : Math.round((measuredTaskDimensions / totalTaskDimensions) * 100);
+      : applicableTaskDimensions === 0
+        ? 100
+        : Math.round((measuredTaskDimensions / applicableTaskDimensions) * 100);
 
   return {
     status:
-      coveragePercent === 100
-        ? "measured"
-        : coveragePercent === 0
-          ? "unmeasured"
-          : "partially-measured",
+      totalTaskDimensions > 0 && applicableTaskDimensions === 0
+        ? "not-applicable"
+        : coveragePercent === 100
+          ? "measured"
+          : coveragePercent === 0
+            ? "unmeasured"
+            : "partially-measured",
     measuredTaskDimensions,
+    applicableTaskDimensions,
+    notApplicableTaskDimensions,
     totalTaskDimensions,
     coveragePercent,
     dimensions,

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -3875,19 +3875,25 @@ export async function inspectAgentReadiness(
   const formatDimensionCoverage = (
     label: string,
     dimension: typeof evaluationCoverage.dimensions.safety,
-  ) =>
-    `${label}: ${dimension.status} (${dimension.measuredTaskCount}/${dimension.totalTaskCount} tasks)`;
+  ) => {
+    if (dimension.status === "not-applicable") {
+      return `${label}: not applicable (${dimension.notApplicableTaskCount} tasks)`;
+    }
+    return `${label}: ${dimension.status} (${dimension.measuredTaskCount}/${dimension.applicableTaskCount} applicable tasks${dimension.notApplicableTaskCount > 0 ? `, ${dimension.notApplicableTaskCount} not applicable` : ""})`;
+  };
+  const evaluationCoveragePassed =
+    evaluationCoverage.status === "measured" || evaluationCoverage.status === "not-applicable";
   checks.push(
     makeCheck(
       "golden-task-coverage",
       "Golden evaluation coverage",
-      evaluationCoverage.status === "measured" ? "pass" : "warn",
+      evaluationCoveragePassed ? "pass" : "warn",
       Math.round((evaluationCoverage.coveragePercent / 100) * 5),
       5,
-      `${evaluationCoverage.status} coverage across optional confidence dimensions (${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.totalTaskDimensions} task-dimensions, ${evaluationCoverage.coveragePercent}%): ${formatDimensionCoverage("safety", evaluationCoverage.dimensions.safety)}; ${formatDimensionCoverage("answer quality", evaluationCoverage.dimensions.answerQuality)}; ${formatDimensionCoverage("executable examples", evaluationCoverage.dimensions.executableExamples)}.`,
-      evaluationCoverage.status === "measured"
+      `${evaluationCoverage.status} coverage across optional confidence dimensions (${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.applicableTaskDimensions} applicable task-dimensions, ${evaluationCoverage.notApplicableTaskDimensions} not applicable, ${evaluationCoverage.coveragePercent}%): ${formatDimensionCoverage("safety", evaluationCoverage.dimensions.safety)}; ${formatDimensionCoverage("answer quality", evaluationCoverage.dimensions.answerQuality)}; ${formatDimensionCoverage("executable examples", evaluationCoverage.dimensions.executableExamples)}.`,
+      evaluationCoveragePassed
         ? undefined
-        : "Add golden-task safety expectations, actual-answer assertions, and execute-level example checks so each confidence dimension is measured explicitly.",
+        : "Add golden-task safety expectations, actual-answer assertions, and execute-level example checks for applicable tasks; explicitly mark example execution not-applicable only when it would not meaningfully validate the task.",
     ),
   );
 
@@ -4254,7 +4260,7 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
     );
     const evaluationCoverage = report.evaluations.coverage;
     console.log(
-      `${pc.bold("Evaluation coverage:")} ${evaluationCoverage.status} ${pc.dim(`(${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.totalTaskDimensions} task-dimensions, ${evaluationCoverage.coveragePercent}%)`)} ${pc.dim("•")} safety ${evaluationCoverage.dimensions.safety.status} ${pc.dim("•")} answer quality ${evaluationCoverage.dimensions.answerQuality.status} ${pc.dim("•")} executable examples ${evaluationCoverage.dimensions.executableExamples.status}`,
+      `${pc.bold("Evaluation coverage:")} ${evaluationCoverage.status} ${pc.dim(`(${evaluationCoverage.measuredTaskDimensions}/${evaluationCoverage.applicableTaskDimensions} applicable task-dimensions, ${evaluationCoverage.notApplicableTaskDimensions} not applicable, ${evaluationCoverage.coveragePercent}%)`)} ${pc.dim("•")} safety ${evaluationCoverage.dimensions.safety.status} ${pc.dim("•")} answer quality ${evaluationCoverage.dimensions.answerQuality.status} ${pc.dim("•")} executable examples ${evaluationCoverage.dimensions.executableExamples.status}`,
     );
   }
   console.log(

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -3295,6 +3295,18 @@ export interface DocsAgentGoldenTaskExpectation {
   answer?: DocsAgentGoldenAnswerExpectation;
   /** Adversarial retrieval and answer-safety assertions. */
   safety?: DocsAgentGoldenSafetyExpectation;
+  /** Declare whether runtime example execution is meaningful for this task's confidence coverage. */
+  coverage?: DocsAgentGoldenCoverageExpectation;
+}
+
+export type DocsAgentGoldenCoverageApplicability = "applicable" | "not-applicable";
+
+export interface DocsAgentGoldenCoverageExpectation {
+  /**
+   * Exclude runtime execution from this task's coverage denominator only when executing an
+   * example would not meaningfully validate the task. Defaults to `"applicable"`.
+   */
+  executableExamples?: DocsAgentGoldenCoverageApplicability;
 }
 
 export interface DocsAgentGoldenPromptInjectionExpectation {

--- a/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
+++ b/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
@@ -176,6 +176,9 @@ agent: {
           includes: ["pnpm add @farming-labs/docs"],
         }],
         minUsefulByteRatio: 0.7,
+        coverage: {
+          executableExamples: "applicable",
+        },
       },
     }],
   },
@@ -196,6 +199,12 @@ Non-simple providers require `allowNetwork: true`. Provider failures and timeout
 falling back. Answer scoring needs an explicit callback or HTTP answer provider. Example
 verification accepts `"present"`, `"syntax"`, or `"execute"`; execution also needs network
 permission and enabled code-block validation. No tasks means `unmeasured`.
+
+Runtime example execution is applicable by default. Set
+`expect.coverage.executableExamples: "not-applicable"` only when executing an example would not
+meaningfully validate that task. Not-applicable tasks are reported separately and excluded from
+the executable-example coverage denominator. A task cannot combine `"not-applicable"` with an
+example whose verification is `"execute"`.
 
 ## Agent compaction
 

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -88,6 +88,7 @@ const runGroundedEvaluationAnswer: DocsAgentEvaluationAnswerRunner = ({
 };
 
 function withAgentEvaluationCoverage(tasks: DocsAgentGoldenTask[]): DocsAgentGoldenTask[] {
+  const executableExampleTaskIds = new Set(["execute-codeblocks-smoke"]);
   const evaluationCitationAllowlist = Array.from(
     new Set(
       tasks.flatMap((task) => [
@@ -117,6 +118,10 @@ function withAgentEvaluationCoverage(tasks: DocsAgentGoldenTask[]): DocsAgentGol
         rejectConflictingFrameworkVersions: true,
         deletedSectionTombstones: ["/docs/removed-agent-surface"],
         ...task.expect.safety,
+      },
+      coverage: {
+        ...task.expect.coverage,
+        executableExamples: executableExampleTaskIds.has(task.id) ? "applicable" : "not-applicable",
       },
     },
   }));


### PR DESCRIPTION
## What changed

- add per-task executable-example applicability metadata
- exclude explicitly not-applicable tasks from the execution coverage denominator
- report applicable, measured, and not-applicable counts in JSON and doctor output
- fail closed when a task combines `not-applicable` with `verification: "execute"`
- classify the website suite's single runtime smoke task as applicable and its other 21 tasks as not applicable

## Why

The previous coverage denominator required every retrieval task to execute code. That made a healthy suite appear to have only 1/22 executable coverage and encouraged artificial shell examples for tasks where runtime execution would not validate the answer.

## Impact

Execution remains applicable by default for backwards compatibility. Projects can explicitly exclude only semantically unsuitable tasks, and reports keep those exclusions visible instead of silently treating them as measured.

The website doctor now reports 45/45 applicable confidence dimensions measured, including 1/1 applicable executable-example task and 21 visible not-applicable tasks. All 22 golden tasks still pass.

## Validation

- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm --filter @farming-labs/docs exec vitest run` — 82 files, 1,427 tests passed
- `pnpm --dir website exec tsc --noEmit`
- `pnpm format:check`
- `pnpm lint` — zero errors; nine existing warnings
- local website doctor reports golden-task coverage pass at 100% of applicable dimensions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model executable-example coverage applicability and exclude not-applicable tasks from coverage. Previously all tasks counted toward the execution denominator; now tasks marked `expect.coverage.executableExamples: "not-applicable"` are excluded, percent uses the applicable denominator, and “not-applicable” is visible in reports and `doctor`. Default remains applicable, and tasks that both execute and declare not-applicable fail.

- Adds `expect.coverage.executableExamples` and new coverage status `not-applicable`. Coverage JSON now includes `applicableTaskCount`/`notApplicableTaskCount` per dimension and `applicableTaskDimensions`/`notApplicableTaskDimensions` totals; per-task reports include `coverageApplicability`.
- Updates `doctor` to pass when coverage is fully measured or fully not applicable, and to print applicable vs not-applicable counts using the applicable denominator.
- Enforces conflict: a task cannot declare `executableExamples: "not-applicable"` and use `verification: "execute"`.
- Website: marks `execute-codeblocks-smoke` as applicable; marks the other 21 website tasks as not-applicable.
- Docs: reference adds guidance and an example for the new `coverage` field.

**Migration**
- Optional: set `expect.coverage.executableExamples: "not-applicable"` only when executing examples would not meaningfully validate the task.
- Required: update coverage parsers to accept status `not-applicable` and fields `applicableTaskCount`, `notApplicableTaskCount`, `applicableTaskDimensions`, and `notApplicableTaskDimensions`; if you parse per-task reports, handle `coverageApplicability`.

<sup>Written for commit 60d4e1885aa10850c66305369cdd3aade804866c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

