### PR TITLE
feat: add reviewed compaction state

### DIFF
--- a/.github/agent-freshness-exceptions.md
+++ b/.github/agent-freshness-exceptions.md
@@ -22,5 +22,12 @@ provenance was refreshed without accepting the lower-quality text. The final cor
 | `/docs/customization/agent-primitive` | Unknown / hand-authored | Preserve | This is the canonical audience-projection, discovery, feedback, and Agent Skills operating guide. |
 | `/docs/customization/sidebar` | Unknown / hand-authored | Preserve | This is a concise, intentionally scoped sidebar answer guide rather than generated page compression. |
 
-The CI freshness check allows reviewed modified and unknown files, but fails when a
-provenance-generated file is stale or when a token-budget page is missing its required `agent.md`.
+These decisions are now recorded in the machine-readable
+`website/.farming-labs/agent-compaction-reviews.json` manifest. Each entry binds the decision to
+the resolved page source, compaction settings, and preserved `agent.md` body hashes, plus the
+reviewer, timestamp, and rationale.
+
+The CI freshness check accepts matching reviewed entries, but fails when any reviewed hash drifts,
+a manifest entry becomes orphaned, a provenance-generated file is stale, or a token-budget page is
+missing its required `agent.md`. Re-review requires an explicit route, reviewer, and rationale; it
+never rewrites the preserved `agent.md`.

--- a/.github/workflows/agent-freshness.yml
+++ b/.github/workflows/agent-freshness.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/agent-freshness.yml"
+      - "website/.farming-labs/agent-compaction-reviews.json"
       - "packages/docs/src/cli/agent.ts"
       - "packages/docs/src/cli/agent.test.ts"
       - "website/app/docs/**"
@@ -13,6 +14,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/agent-freshness.yml"
+      - "website/.farming-labs/agent-compaction-reviews.json"
       - "packages/docs/src/cli/agent.ts"
       - "packages/docs/src/cli/agent.test.ts"
       - "website/app/docs/**"

--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -86,6 +86,26 @@ describe("parseAgentCompactArgs", () => {
     });
   });
 
+  it("parses hash-bound review metadata", () => {
+    expect(
+      parseAgentCompactArgs([
+        "--review",
+        "--reviewed-by",
+        "docs-team",
+        "--reason=Preserve operator guidance",
+        "--review-manifest",
+        ".farming-labs/reviews.json",
+        "/docs/configuration",
+      ]),
+    ).toEqual({
+      review: true,
+      reviewedBy: "docs-team",
+      reviewReason: "Preserve operator guidance",
+      reviewManifestPath: ".farming-labs/reviews.json",
+      pages: ["/docs/configuration"],
+    });
+  });
+
   it("parses changed compaction flags", () => {
     expect(parseAgentCompactArgs(["--changed", "installation"])).toEqual({
       changed: true,
@@ -1185,7 +1205,7 @@ First body.
     expect(
       logs.some((line) =>
         line.includes(
-          "Agent compaction freshness check passed: 1 fresh, 0 stale, 0 modified, 0 unknown, 0 required missing, and 0 optional missing.",
+          "Agent compaction freshness check passed: 1 fresh, 0 reviewed, 0 invalid reviews, 0 orphaned reviews, 0 stale, 0 modified, 0 unknown, 0 required missing, and 0 optional missing.",
         ),
       ),
     ).toBe(true);
@@ -1207,8 +1227,94 @@ Updated body.
     );
 
     await expect(compactAgentDocs({ check: true })).rejects.toThrow(
-      "Agent compaction freshness check failed: 0 fresh, 1 stale",
+      "Agent compaction freshness check failed: 0 fresh, 0 reviewed, 0 invalid reviews, 0 orphaned reviews, 1 stale",
     );
+  });
+
+  it("records reviewed agent.md hashes and fails when reviewed content or source drifts", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs", agent: { compact: { model: "docs-cloud-compress-v1" } } };`,
+      "utf-8",
+    );
+    const pageDir = path.join(tmpDir, "app", "docs", "operations");
+    mkdirSync(pageDir, { recursive: true });
+    const pagePath = path.join(pageDir, "page.mdx");
+    const agentPath = path.join(pageDir, "agent.md");
+    writeFileSync(
+      pagePath,
+      `---
+title: "Operations"
+description: "Operate the docs service"
+---
+
+# Operations
+
+Original source guidance.
+`,
+      "utf-8",
+    );
+    writeFileSync(
+      agentPath,
+      "# Operations for agents\n\nPreserve the safe operator workflow.\n",
+      "utf-8",
+    );
+
+    process.chdir(tmpDir);
+    await expect(
+      compactAgentDocs({
+        review: true,
+        reviewedBy: "docs-team",
+        reviewReason: "Preserve reviewed operator safety guidance.",
+        pages: ["operations"],
+      }),
+    ).resolves.toBeUndefined();
+
+    const manifest = JSON.parse(
+      readFileSync(path.join(tmpDir, ".farming-labs", "agent-compaction-reviews.json"), "utf-8"),
+    ) as {
+      version: number;
+      reviews: Array<Record<string, string>>;
+    };
+    expect(manifest.version).toBe(1);
+    expect(manifest.reviews).toEqual([
+      expect.objectContaining({
+        route: "/docs/operations",
+        reviewedBy: "docs-team",
+        reason: "Preserve reviewed operator safety guidance.",
+        sourceHash: expect.stringMatching(/^fnv1a64:/),
+        settingsHash: expect.stringMatching(/^fnv1a64:/),
+        outputHash: expect.stringMatching(/^fnv1a64:/),
+      }),
+    ]);
+
+    await expect(compactAgentDocs({ check: true })).resolves.toBeUndefined();
+    expect(
+      logs.some((line) =>
+        line.includes(
+          "Agent compaction freshness check passed: 0 fresh, 1 reviewed, 0 invalid reviews",
+        ),
+      ),
+    ).toBe(true);
+
+    writeFileSync(agentPath, "# Operations for agents\n\nChanged after review.\n", "utf-8");
+    await expect(compactAgentDocs({ check: true })).rejects.toThrow("1 invalid reviews");
+
+    await compactAgentDocs({
+      review: true,
+      reviewedBy: "docs-team",
+      reviewReason: "Re-reviewed the intentional agent guidance update.",
+      pages: ["operations"],
+    });
+    writeFileSync(
+      pagePath,
+      readFileSync(pagePath, "utf-8").replace(
+        "Original source guidance.",
+        "Source guidance changed after review.",
+      ),
+      "utf-8",
+    );
+    await expect(compactAgentDocs({ check: true })).rejects.toThrow("1 invalid reviews");
   });
 
   it("skips modified generated agent.md files during --stale runs", async () => {

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import matter from "gray-matter";
@@ -39,6 +48,24 @@ const DEFAULT_COMPRESSION_AGGRESSIVENESS = 0.3;
 const DEFAULT_DOCS_CLOUD_API_KEY_ENV = "DOCS_CLOUD_API_KEY";
 const MAX_COMPRESSION_INPUT_CHARACTERS = 200_000;
 const INDEX_PAGE_BASENAMES = new Set(["index", "page", "+page"]);
+export const DEFAULT_AGENT_COMPACTION_REVIEW_MANIFEST_PATH =
+  ".farming-labs/agent-compaction-reviews.json";
+export const AGENT_COMPACTION_REVIEW_MANIFEST_VERSION = 1;
+
+export interface AgentCompactionReview {
+  route: string;
+  sourceHash: string;
+  settingsHash: string;
+  outputHash: string;
+  reviewedAt: string;
+  reviewedBy: string;
+  reason: string;
+}
+
+export interface AgentCompactionReviewManifest {
+  version: number;
+  reviews: AgentCompactionReview[];
+}
 
 export interface AgentCompactOptions {
   configPath?: string;
@@ -57,6 +84,12 @@ export interface AgentCompactOptions {
   includeMissing?: boolean;
   dryRun?: boolean;
   check?: boolean;
+  review?: boolean;
+  reviewedBy?: string;
+  reviewReason?: string;
+  reviewManifestPath?: string;
+  /** Resolved review records used internally by doctor and compaction inspection. */
+  reviewRecords?: AgentCompactionReview[];
 }
 
 export interface ParsedAgentCompactArgs extends AgentCompactOptions {
@@ -77,6 +110,8 @@ export type AgentCompactionStateKind =
   | "stale"
   | "modified"
   | "stale-modified"
+  | "reviewed"
+  | "review-invalid"
   | "missing"
   | "unknown";
 
@@ -86,6 +121,8 @@ export interface AgentCompactionState {
   pageOptions: AgentCompactOptions;
   sourceDocument: string;
   provenance?: GeneratedAgentProvenance;
+  review?: AgentCompactionReview;
+  reviewMismatches?: Array<"source" | "settings" | "output">;
   tokenBudget?: number;
 }
 
@@ -142,6 +179,11 @@ export function parseAgentCompactArgs(argv: string[]): ParsedAgentCompactArgs {
 
     if (arg === "--check") {
       parsed.check = true;
+      continue;
+    }
+
+    if (arg === "--review") {
+      parsed.review = true;
       continue;
     }
 
@@ -220,6 +262,15 @@ export function parseAgentCompactArgs(argv: string[]): ParsedAgentCompactArgs {
       case "protect-json":
         parsed.protectJson = parseBooleanFlag(value);
         break;
+      case "reviewed-by":
+        parsed.reviewedBy = value;
+        break;
+      case "reason":
+        parsed.reviewReason = value;
+        break;
+      case "review-manifest":
+        parsed.reviewManifestPath = value;
+        break;
       default:
         throw new Error(`Unknown agent compact flag: --${key}.`);
     }
@@ -236,6 +287,121 @@ function normalizeUrlPath(value: string): string {
   const normalized = value.replace(/\/+/g, "/");
   if (normalized === "/") return normalized;
   return normalized.replace(/\/+$/, "");
+}
+
+function resolveReviewManifestPath(rootDir: string, configuredPath?: string): string {
+  const relativePath = configuredPath?.trim() || DEFAULT_AGENT_COMPACTION_REVIEW_MANIFEST_PATH;
+  if (path.isAbsolute(relativePath)) {
+    throw new Error("Agent compaction reviewManifestPath must be project-relative.");
+  }
+
+  const resolved = path.resolve(rootDir, relativePath);
+  const relative = path.relative(rootDir, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Agent compaction reviewManifestPath must stay inside the project root.");
+  }
+  return resolved;
+}
+
+function normalizeReviewRecord(value: unknown, index: number): AgentCompactionReview {
+  const pathLabel = `reviews[${index}]`;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${pathLabel} must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  const readString = (key: keyof AgentCompactionReview): string => {
+    const field = record[key];
+    if (typeof field !== "string" || !field.trim()) {
+      throw new Error(`${pathLabel}.${key} must be a non-empty string.`);
+    }
+    return field.trim();
+  };
+  const route = normalizeUrlPath(readString("route"));
+  if (!route.startsWith("/") || route.includes("?") || route.includes("#")) {
+    throw new Error(`${pathLabel}.route must be an absolute docs route without query or hash.`);
+  }
+  const sourceHash = readString("sourceHash");
+  const settingsHash = readString("settingsHash");
+  const outputHash = readString("outputHash");
+  for (const [key, hash] of Object.entries({ sourceHash, settingsHash, outputHash })) {
+    if (!/^fnv1a64:[0-9a-f]{16}$/u.test(hash)) {
+      throw new Error(`${pathLabel}.${key} must be an fnv1a64 content hash.`);
+    }
+  }
+  const reviewedAt = readString("reviewedAt");
+  if (!Number.isFinite(Date.parse(reviewedAt))) {
+    throw new Error(`${pathLabel}.reviewedAt must be an ISO-compatible timestamp.`);
+  }
+
+  return {
+    route,
+    sourceHash,
+    settingsHash,
+    outputHash,
+    reviewedAt,
+    reviewedBy: readString("reviewedBy"),
+    reason: readString("reason"),
+  };
+}
+
+export function loadAgentCompactionReviews(
+  rootDir: string,
+  configuredPath?: string,
+): AgentCompactionReview[] {
+  const manifestPath = resolveReviewManifestPath(rootDir, configuredPath);
+  if (!existsSync(manifestPath)) return [];
+  const manifestStat = lstatSync(manifestPath);
+  if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
+    throw new Error("Agent compaction review manifest must be a regular non-symlink file.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  } catch (error) {
+    throw new Error(
+      `Could not parse agent compaction review manifest ${path.relative(rootDir, manifestPath)}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Agent compaction review manifest must be a JSON object.");
+  }
+  const manifest = parsed as Record<string, unknown>;
+  if (manifest.version !== AGENT_COMPACTION_REVIEW_MANIFEST_VERSION) {
+    throw new Error(
+      `Agent compaction review manifest version must be ${AGENT_COMPACTION_REVIEW_MANIFEST_VERSION}.`,
+    );
+  }
+  if (!Array.isArray(manifest.reviews)) {
+    throw new Error("Agent compaction review manifest reviews must be an array.");
+  }
+
+  const reviews = manifest.reviews.map(normalizeReviewRecord);
+  const routes = new Set<string>();
+  for (const review of reviews) {
+    if (routes.has(review.route)) {
+      throw new Error(`Agent compaction review route is duplicated: ${review.route}.`);
+    }
+    routes.add(review.route);
+  }
+  return reviews;
+}
+
+function writeAgentCompactionReviews(
+  rootDir: string,
+  configuredPath: string | undefined,
+  reviews: AgentCompactionReview[],
+): string {
+  const manifestPath = resolveReviewManifestPath(rootDir, configuredPath);
+  const manifest: AgentCompactionReviewManifest = {
+    version: AGENT_COMPACTION_REVIEW_MANIFEST_VERSION,
+    reviews: [...reviews].sort((left, right) => left.route.localeCompare(right.route)),
+  };
+  mkdirSync(path.dirname(manifestPath), { recursive: true });
+  const temporaryPath = `${manifestPath}.tmp-${process.pid}`;
+  writeFileSync(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+  renameSync(temporaryPath, manifestPath);
+  return manifestPath;
 }
 
 function normalizeRequestedPage(entry: string, rawValue: string): string {
@@ -439,6 +605,7 @@ function readAgentCompactConfig(content: string): AgentCompactOptions {
     maxOutputTokens: readNumberProperty(compactBlock, "maxOutputTokens"),
     minOutputTokens: readNumberProperty(compactBlock, "minOutputTokens"),
     protectJson: readBooleanProperty(compactBlock, "protectJson"),
+    reviewManifestPath: readStringProperty(compactBlock, "reviewManifestPath"),
   };
 }
 
@@ -463,6 +630,7 @@ function readAgentCompactConfigFromModule(config: DocsConfig): AgentCompactOptio
     maxOutputTokens: compact.maxOutputTokens,
     minOutputTokens: compact.minOutputTokens,
     protectJson: compact.protectJson,
+    reviewManifestPath: compact.reviewManifestPath,
   };
 }
 
@@ -604,6 +772,33 @@ export function inspectAgentCompactionState(
 
   const sourceKind = resolveSourceKindForCompaction(target, currentDocument);
   const sourceDocument = buildSourceDocumentForCompaction(page, sourceKind);
+  const review = defaults.reviewRecords?.find(
+    (candidate) => normalizeUrlPath(candidate.route) === normalizeUrlPath(target.url),
+  );
+
+  if (review) {
+    const reviewMismatches: Array<"source" | "settings" | "output"> = [];
+    if (hashGeneratedAgentContent(buildResolvedPageSourceDocument(page)) !== review.sourceHash) {
+      reviewMismatches.push("source");
+    }
+    if (buildCompactionSettingsHash(pageOptions) !== review.settingsHash) {
+      reviewMismatches.push("settings");
+    }
+    if (hashGeneratedAgentContent(currentDocument.content) !== review.outputHash) {
+      reviewMismatches.push("output");
+    }
+
+    return {
+      status: reviewMismatches.length === 0 ? "reviewed" : "review-invalid",
+      sourceKind,
+      pageOptions,
+      sourceDocument,
+      provenance: currentDocument.provenance,
+      review,
+      reviewMismatches,
+      tokenBudget,
+    };
+  }
 
   if (!currentDocument.provenance) {
     return {
@@ -839,6 +1034,10 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   );
   const configDefaults = mergeAgentCompactOptions(cloudApiKeyDefaults, compactDefaults);
   const resolvedOptions = mergeAgentCompactOptions(configDefaults, options);
+  resolvedOptions.reviewRecords = loadAgentCompactionReviews(
+    rootDir,
+    resolvedOptions.reviewManifestPath,
+  );
   const entry =
     normalizePathSegment(
       loadedConfigModule?.config.entry ??
@@ -860,6 +1059,12 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
   if (resolvedOptions.includeMissing && !resolvedOptions.stale) {
     throw new Error("Use --include-missing together with --stale.");
   }
+  if (
+    (resolvedOptions.reviewedBy || resolvedOptions.reviewReason) &&
+    resolvedOptions.review !== true
+  ) {
+    throw new Error("Use --reviewed-by and --reason together with --review.");
+  }
 
   const requestedPages = resolvedOptions.pages?.filter((value) => value.trim().length > 0) ?? [];
   if (
@@ -868,6 +1073,7 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
       resolvedOptions.stale ||
       resolvedOptions.changed ||
       resolvedOptions.includeMissing ||
+      resolvedOptions.review ||
       resolvedOptions.dryRun ||
       requestedPages.length > 0)
   ) {
@@ -876,11 +1082,31 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
     );
   }
   if (
+    resolvedOptions.review &&
+    (resolvedOptions.all ||
+      resolvedOptions.stale ||
+      resolvedOptions.changed ||
+      resolvedOptions.includeMissing ||
+      resolvedOptions.check)
+  ) {
+    throw new Error("Use --review with explicit page arguments, not selection or check flags.");
+  }
+  if (resolvedOptions.review && requestedPages.length === 0) {
+    throw new Error("Pass at least one explicit docs page with --review.");
+  }
+  if (resolvedOptions.review && !resolvedOptions.reviewedBy?.trim()) {
+    throw new Error("Pass --reviewed-by <name> with --review.");
+  }
+  if (resolvedOptions.review && !resolvedOptions.reviewReason?.trim()) {
+    throw new Error("Pass --reason <text> with --review.");
+  }
+  if (
     !resolvedOptions.all &&
     requestedPages.length === 0 &&
     !resolvedOptions.stale &&
     !resolvedOptions.changed &&
-    !resolvedOptions.check
+    !resolvedOptions.check &&
+    !resolvedOptions.review
   ) {
     throw new Error(
       "Pass --all, --changed, --stale, or at least one docs page slug/path to compact.",
@@ -918,8 +1144,50 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
     throw new Error("No compactable docs pages matched the request.");
   }
 
+  if (resolvedOptions.review) {
+    const reviewsByRoute = new Map(
+      (resolvedOptions.reviewRecords ?? []).map((review) => [review.route, review] as const),
+    );
+    for (const { page, target } of filteredPages) {
+      const currentDocument = readCurrentAgentDocument(target);
+      if (!currentDocument) {
+        throw new Error(`Cannot review ${page.url}: ${target.agentPath} does not exist.`);
+      }
+      reviewsByRoute.set(page.url, {
+        route: page.url,
+        sourceHash: hashGeneratedAgentContent(buildResolvedPageSourceDocument(page)),
+        settingsHash: buildCompactionSettingsHash(
+          buildPageOptions(resolvedOptions, target.pagePath).pageOptions,
+        ),
+        outputHash: hashGeneratedAgentContent(currentDocument.content),
+        reviewedAt: new Date().toISOString(),
+        reviewedBy: resolvedOptions.reviewedBy!.trim(),
+        reason: resolvedOptions.reviewReason!.trim(),
+      });
+    }
+    if (resolvedOptions.dryRun) {
+      console.log(
+        pc.green(
+          `Dry run: would record ${filteredPages.length} reviewed agent.md page${filteredPages.length === 1 ? "" : "s"}.`,
+        ),
+      );
+      return;
+    }
+    const manifestPath = writeAgentCompactionReviews(rootDir, resolvedOptions.reviewManifestPath, [
+      ...reviewsByRoute.values(),
+    ]);
+    console.log(
+      pc.green(
+        `Recorded ${filteredPages.length} reviewed agent.md page${filteredPages.length === 1 ? "" : "s"} in ${path.relative(rootDir, manifestPath)}.`,
+      ),
+    );
+    return;
+  }
+
   if (resolvedOptions.check) {
     let fresh = 0;
+    let reviewed = 0;
+    let reviewInvalid = 0;
     let stale = 0;
     let modified = 0;
     let unknown = 0;
@@ -929,6 +1197,8 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
     for (const { page, target } of filteredPages) {
       const state = inspectAgentCompactionState(page, target, resolvedOptions);
       if (state.status === "fresh") fresh += 1;
+      else if (state.status === "reviewed") reviewed += 1;
+      else if (state.status === "review-invalid") reviewInvalid += 1;
       else if (state.status === "stale") stale += 1;
       else if (state.status === "modified" || state.status === "stale-modified") modified += 1;
       else if (state.status === "unknown") unknown += 1;
@@ -936,10 +1206,15 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
       else optionalMissing += 1;
     }
 
-    const summary = `${fresh} fresh, ${stale} stale, ${modified} modified, ${unknown} unknown, ${requiredMissing} required missing, and ${optionalMissing} optional missing`;
-    if (stale > 0 || requiredMissing > 0) {
+    const targetRoutes = new Set(filteredPages.map(({ target }) => normalizeUrlPath(target.url)));
+    const orphanedReviews = (resolvedOptions.reviewRecords ?? []).filter(
+      (review) => !targetRoutes.has(normalizeUrlPath(review.route)),
+    ).length;
+
+    const summary = `${fresh} fresh, ${reviewed} reviewed, ${reviewInvalid} invalid reviews, ${orphanedReviews} orphaned reviews, ${stale} stale, ${modified} modified, ${unknown} unknown, ${requiredMissing} required missing, and ${optionalMissing} optional missing`;
+    if (reviewInvalid > 0 || orphanedReviews > 0 || stale > 0 || requiredMissing > 0) {
       throw new Error(
-        `Agent compaction freshness check failed: ${summary}. Run docs agent compact --stale --include-missing, then review generated changes.`,
+        `Agent compaction freshness check failed: ${summary}. Refresh stale output, or re-review intentional agent.md content after inspecting every changed hash.`,
       );
     }
 
@@ -962,6 +1237,16 @@ export async function compactAgentDocs(options: AgentCompactOptions = {}): Promi
     if (resolvedOptions.stale) {
       if (state.status === "fresh") {
         skippedFresh += 1;
+        continue;
+      }
+
+      if (state.status === "reviewed") {
+        skippedFresh += 1;
+        continue;
+      }
+
+      if (state.status === "review-invalid") {
+        skippedModified += 1;
         continue;
       }
 
@@ -1065,6 +1350,7 @@ ${pc.dim("Examples:")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --stale")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --stale --include-missing")}
   ${pc.cyan("npx @farming-labs/docs@latest agent compact --check")}
+  ${pc.cyan('npx @farming-labs/docs@latest agent compact --review --reviewed-by "docs-team" --reason "Preserve operator guidance" /docs/configuration')}
 
 ${pc.dim("Per-page override:")}
   Add ${pc.cyan("agent.tokenBudget")} to a page frontmatter block to override the compact output target for that page.
@@ -1076,6 +1362,10 @@ ${pc.dim("Options:")}
   ${pc.cyan("--stale")}                  Re-compact only stale generated agent.md files
   ${pc.cyan("--include-missing")}        With ${pc.cyan("--stale")}, also create missing agent.md files for explicit pages or pages that define ${pc.cyan("agent.tokenBudget")}
   ${pc.cyan("--check")}                  Check generated agent.md freshness without an API key, network request, or file write
+  ${pc.cyan("--review")}                 Record hash-bound human review for explicit existing agent.md pages without rewriting them
+  ${pc.cyan("--reviewed-by <name>")}      Reviewer recorded with ${pc.cyan("--review")}
+  ${pc.cyan("--reason <text>")}           Review rationale recorded with ${pc.cyan("--review")}
+  ${pc.cyan("--review-manifest <path>")} Project-relative review manifest path
   ${pc.cyan("--config <path>")}          Use a custom docs config path instead of ${pc.dim("docs.config.ts[x]")}
   ${pc.cyan("--api-key <key>")}          Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}
   ${pc.cyan("--api-key-env <name>")}     Env var name for the Docs Cloud API key; prefer ${pc.dim("cloud.apiKey.env")}

--- a/packages/docs/src/cli/doctor.test.ts
+++ b/packages/docs/src/cli/doctor.test.ts
@@ -2454,6 +2454,21 @@ Updated body.
     expect(report.coverage.compaction.modifiedGeneratedPages).toBe(1);
     expect(report.coverage.compaction.unknownGeneratedPages).toBe(1);
     expect(report.coverage.compaction.tokenBudgetMissingPages).toBe(1);
+
+    await compactAgentDocs({
+      review: true,
+      reviewedBy: "docs-team",
+      reviewReason: "Preserve reviewed task-specific agent guidance.",
+      pages: ["page-actions", "handwritten"],
+    });
+    const reviewedReport = await inspectAgentReadiness();
+    const reviewedCompactCheck = reviewedReport.checks.find((check) => check.id === "compact");
+    expect(reviewedCompactCheck?.detail).toContain("2 reviewed");
+    expect(reviewedCompactCheck?.detail).toContain("0 invalid reviews");
+    expect(reviewedReport.coverage.compaction.reviewedGeneratedPages).toBe(2);
+    expect(reviewedReport.coverage.compaction.invalidReviewedPages).toBe(0);
+    expect(reviewedReport.coverage.compaction.modifiedGeneratedPages).toBe(0);
+    expect(reviewedReport.coverage.compaction.unknownGeneratedPages).toBe(0);
   });
 
   it("fixes stale generated agent docs and token-budget missing outputs", async () => {

--- a/packages/docs/src/cli/doctor.ts
+++ b/packages/docs/src/cli/doctor.ts
@@ -98,7 +98,12 @@ import {
   resolveDocsContentDir,
   resolveDocsProjectRoot,
 } from "./config.js";
-import { compactAgentDocs, inspectAgentCompactionState, scanDocsPageTargets } from "./agent.js";
+import {
+  compactAgentDocs,
+  inspectAgentCompactionState,
+  loadAgentCompactionReviews,
+  scanDocsPageTargets,
+} from "./agent.js";
 import type { AgentCompactOptions } from "./agent.js";
 import { resolveGoldenEvaluationInput } from "./golden-evaluations.js";
 import { detectFramework, type Framework } from "./utils.js";
@@ -162,6 +167,9 @@ export interface AgentDoctorCoverage {
 
 export interface AgentDoctorCompactionCoverage {
   freshGeneratedPages: number;
+  reviewedGeneratedPages: number;
+  invalidReviewedPages: number;
+  orphanedReviews: number;
   staleGeneratedPages: number;
   modifiedGeneratedPages: number;
   unknownGeneratedPages: number;
@@ -1103,6 +1111,9 @@ function buildCoverage(
     explicitCoverage,
     compaction: {
       freshGeneratedPages: 0,
+      reviewedGeneratedPages: 0,
+      invalidReviewedPages: 0,
+      orphanedReviews: 0,
       staleGeneratedPages: 0,
       modifiedGeneratedPages: 0,
       unknownGeneratedPages: 0,
@@ -1139,22 +1150,37 @@ function buildCompactionCoverage(
 
   const coverage: AgentDoctorCompactionCoverage = {
     freshGeneratedPages: 0,
+    reviewedGeneratedPages: 0,
+    invalidReviewedPages: 0,
+    orphanedReviews: 0,
     staleGeneratedPages: 0,
     modifiedGeneratedPages: 0,
     unknownGeneratedPages: 0,
     tokenBudgetMissingPages: 0,
     otherMissingPages: 0,
   };
+  const reviewRecords = loadAgentCompactionReviews(rootDir, defaults.reviewManifestPath);
+  const inspectionDefaults: AgentCompactOptions = { ...defaults, reviewRecords };
+  const targetRoutes = new Set(targets.map((target) => target.url));
+  coverage.orphanedReviews = reviewRecords.filter(
+    (review) => !targetRoutes.has(review.route),
+  ).length;
 
   for (const page of pages) {
     const target = targetsBySlug.get(page.slug);
     if (!target) continue;
 
-    const state = inspectAgentCompactionState(page, target, defaults);
+    const state = inspectAgentCompactionState(page, target, inspectionDefaults);
 
     switch (state.status) {
       case "fresh":
         coverage.freshGeneratedPages += 1;
+        break;
+      case "reviewed":
+        coverage.reviewedGeneratedPages += 1;
+        break;
+      case "review-invalid":
+        coverage.invalidReviewedPages += 1;
         break;
       case "stale":
         coverage.staleGeneratedPages += 1;
@@ -1181,12 +1207,24 @@ function compactionFreshnessScore(
   compactConfigured: boolean,
 ): { status: DoctorStatus; score: number; recommendation?: string } {
   const hasActionableIssues =
+    coverage.invalidReviewedPages > 0 ||
+    coverage.orphanedReviews > 0 ||
     coverage.staleGeneratedPages > 0 ||
     coverage.modifiedGeneratedPages > 0 ||
     coverage.tokenBudgetMissingPages > 0;
 
   if (hasActionableIssues) {
     const recommendations: string[] = [];
+    if (coverage.invalidReviewedPages > 0) {
+      recommendations.push(
+        "Inspect every changed source/settings/output hash, then rerun docs agent compact --review with an explicit reviewer and rationale only when the preserved agent.md remains correct.",
+      );
+    }
+    if (coverage.orphanedReviews > 0) {
+      recommendations.push(
+        "Remove or replace orphaned entries in the agent compaction review manifest.",
+      );
+    }
     if (coverage.staleGeneratedPages > 0) {
       recommendations.push(
         "Run docs agent compact --stale to refresh stale generated agent.md files.",
@@ -1217,7 +1255,7 @@ function compactionFreshnessScore(
     };
   }
 
-  if (coverage.freshGeneratedPages > 0) {
+  if (coverage.freshGeneratedPages > 0 || coverage.reviewedGeneratedPages > 0) {
     return {
       status: "pass",
       score: compactConfigured ? 5 : 4,
@@ -3033,6 +3071,9 @@ export async function inspectAgentReadiness(
         explicitCoverage: 0,
         compaction: {
           freshGeneratedPages: 0,
+          reviewedGeneratedPages: 0,
+          invalidReviewedPages: 0,
+          orphanedReviews: 0,
           staleGeneratedPages: 0,
           modifiedGeneratedPages: 0,
           unknownGeneratedPages: 0,
@@ -3830,7 +3871,7 @@ export async function inspectAgentReadiness(
       compactionResult.status,
       compactionResult.score,
       5,
-      `${compactionCoverage.freshGeneratedPages} fresh, ${compactionCoverage.staleGeneratedPages} stale, ${compactionCoverage.modifiedGeneratedPages} modified, ${compactionCoverage.unknownGeneratedPages} unknown, ${compactionCoverage.tokenBudgetMissingPages} token-budget missing, and ${compactionCoverage.otherMissingPages} other missing page${compactionCoverage.otherMissingPages === 1 ? "" : "s"} across compactable docs pages.` +
+      `${compactionCoverage.freshGeneratedPages} fresh, ${compactionCoverage.reviewedGeneratedPages} reviewed, ${compactionCoverage.invalidReviewedPages} invalid reviews, ${compactionCoverage.orphanedReviews} orphaned reviews, ${compactionCoverage.staleGeneratedPages} stale, ${compactionCoverage.modifiedGeneratedPages} modified, ${compactionCoverage.unknownGeneratedPages} unknown, ${compactionCoverage.tokenBudgetMissingPages} token-budget missing, and ${compactionCoverage.otherMissingPages} other missing page${compactionCoverage.otherMissingPages === 1 ? "" : "s"} across compactable docs pages.` +
         (compactConfigured
           ? " agent.compact defaults are configured."
           : " No agent.compact defaults were found in docs config."),
@@ -4258,7 +4299,7 @@ export function printAgentDoctorReport(report: AgentDoctorReport) {
     );
   }
   console.log(
-    `${pc.bold("Generated agent.md freshness:")} ${report.coverage.compaction.freshGeneratedPages} fresh ${pc.dim("•")} ${report.coverage.compaction.staleGeneratedPages} stale ${pc.dim("•")} ${report.coverage.compaction.modifiedGeneratedPages} modified ${pc.dim("•")} ${report.coverage.compaction.tokenBudgetMissingPages} token-budget missing`,
+    `${pc.bold("Generated agent.md freshness:")} ${report.coverage.compaction.freshGeneratedPages} fresh ${pc.dim("•")} ${report.coverage.compaction.reviewedGeneratedPages} reviewed ${pc.dim("•")} ${report.coverage.compaction.invalidReviewedPages} invalid reviews ${pc.dim("•")} ${report.coverage.compaction.staleGeneratedPages} stale ${pc.dim("•")} ${report.coverage.compaction.modifiedGeneratedPages} modified ${pc.dim("•")} ${report.coverage.compaction.tokenBudgetMissingPages} token-budget missing`,
   );
 
   if (report.fixes && report.fixes.length > 0) {
@@ -4420,13 +4461,18 @@ async function runAgentDoctorFixes(
     compaction.staleGeneratedPages > 0 || compaction.tokenBudgetMissingPages > 0;
 
   if (!shouldRunCompaction) {
-    if (compaction.modifiedGeneratedPages > 0 || compaction.unknownGeneratedPages > 0) {
+    if (
+      compaction.invalidReviewedPages > 0 ||
+      compaction.orphanedReviews > 0 ||
+      compaction.modifiedGeneratedPages > 0 ||
+      compaction.unknownGeneratedPages > 0
+    ) {
       fixes.push({
         id: "agent-compact",
         title: "agent compact",
         status: "skipped",
         detail:
-          "Only modified or unknown generated agent.md files need attention; doctor --fix leaves those for manual review.",
+          "Only invalid/orphaned reviews or modified/unknown agent.md files need attention; doctor --fix leaves those for manual review.",
       });
     }
 

--- a/packages/docs/src/cli/index.ts
+++ b/packages/docs/src/cli/index.ts
@@ -501,6 +501,7 @@ ${pc.dim("Options for agent compact:")}
   ${pc.cyan("agent compact --changed")}             Compact only docs pages changed in the current git working tree
   ${pc.cyan("agent compact --stale")}               Refresh only stale generated ${pc.dim("agent.md")} files
   ${pc.cyan("agent compact --check")}               Fail when generated ${pc.dim("agent.md")} files are stale or required files are missing
+  ${pc.cyan("agent compact --review <page...>")}    Record hash-bound human review without rewriting ${pc.dim("agent.md")}
   ${pc.cyan("--page <slug|path>")}                  Repeatable explicit page flag; positional page args work too
   ${pc.cyan("--include-missing")}                   With ${pc.cyan("--stale")}, also create explicit or token-budget pages missing ${pc.dim("agent.md")}
   ${pc.cyan("--api-key <key>")}                     Use an API key directly; prefer ${pc.dim("cloud.apiKey.env")}

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -3253,6 +3253,8 @@ export interface DocsAgentCompactConfig {
    * Preserve JSON objects during compression when supported by the provider.
    */
   protectJson?: boolean;
+  /** Project-relative JSON manifest for hash-bound reviewed compaction exceptions. */
+  reviewManifestPath?: string;
 }
 
 export interface DocsAgentGoldenTaskFilters {

--- a/skills/farming-labs/cli/references/agent-and-static-outputs.md
+++ b/skills/farming-labs/cli/references/agent-and-static-outputs.md
@@ -95,6 +95,8 @@ pnpm exec docs agent compact --all
 pnpm exec docs agent compact --changed
 pnpm exec docs agent compact --stale
 pnpm exec docs agent compact --stale --include-missing
+pnpm exec docs agent compact --review --reviewed-by "docs-team" --reason "Preserve reviewed operator guidance" /docs/configuration
+pnpm exec docs agent compact --check
 ```
 
 Behavior:
@@ -113,6 +115,15 @@ Behavior:
 - too-large inherited `minOutputTokens` is clamped down
 - hidden provenance lets doctor distinguish fresh, stale, modified, unknown, and missing-budget
   states
+- `--review` records source, settings, and output hashes in
+  `.farming-labs/agent-compaction-reviews.json` without rewriting `agent.md` or calling the
+  compressor
+- `--review` requires explicit pages, `--reviewed-by`, and `--reason`; use
+  `--review-manifest <path>` or `agent.compact.reviewManifestPath` for a custom project-relative
+  manifest
+- reviewed entries become invalid when the resolved page source, compaction settings, or reviewed
+  `agent.md` body changes; `--check` fails until the entry is inspected and deliberately reviewed
+  again
 
 Recommended config:
 
@@ -125,6 +136,7 @@ agent: {
     model: "docs-cloud-compress-v1",
     aggressiveness: 0.3,
     protectJson: true,
+    reviewManifestPath: ".farming-labs/agent-compaction-reviews.json",
   },
 }
 ```

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -45,6 +45,7 @@ Doctor checks:
 - golden retrieval, citation, version, answer, example, and budget tasks
 - Agent Skill frontmatter, budgets, shallow references, compatibility, and script guidance
 - generated `agent.md` freshness and compaction defaults
+- hash-bound reviewed `agent.md` exceptions, including invalid or orphaned review records
 - OKF trust-metadata enablement and pages beyond their resolved `stale_after` date
 
 Command health is static. It recognizes constrained package/CLI commands and safe probes but never

--- a/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
+++ b/skills/farming-labs/configuration/references/agent-skills-and-evaluations.md
@@ -206,6 +206,7 @@ agent: {
     model: "docs-cloud-compress-v1",
     aggressiveness: 0.3,
     protectJson: true,
+    reviewManifestPath: ".farming-labs/agent-compaction-reviews.json",
   },
 }
 ```
@@ -220,8 +221,14 @@ Supported defaults include `apiKeyEnv`, `baseUrl`, `model`, `aggressiveness`,
 - When the page budget is below `minOutputTokens`, the CLI clamps the minimum down.
 - `--changed` uses staged, unstaged, and untracked docs changes.
 - `--stale` refreshes generated files whose source or compaction settings changed.
+- `--review` records an auditable, hash-bound checkpoint for an intentional modified or
+  hand-authored `agent.md`; the default manifest is
+  `.farming-labs/agent-compaction-reviews.json`. A reviewed entry is invalidated by source,
+  settings, or output changes and then fails `--check` until a person inspects and reviews it
+  again.
 
 ```bash
 pnpm exec docs agent compact installation --dry-run
 pnpm exec docs agent compact --stale --include-missing
+pnpm exec docs agent compact --review --reviewed-by "docs-team" --reason "Preserve reviewed guidance" /docs/configuration
 ```

--- a/website/.farming-labs/agent-compaction-reviews.json
+++ b/website/.farming-labs/agent-compaction-reviews.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "reviews": [
+    {
+      "route": "/docs/configuration",
+      "sourceHash": "fnv1a64:67d7e2763afbf5a4",
+      "settingsHash": "fnv1a64:aa433a28ef4afd1f",
+      "outputHash": "fnv1a64:d404f870b0ddaafa",
+      "reviewedAt": "2026-08-14T15:49:25.027Z",
+      "reviewedBy": "farming-labs/docs maintainers",
+      "reason": "Preserve the detailed machine-oriented configuration contract."
+    },
+    {
+      "route": "/docs/customization/agent-primitive",
+      "sourceHash": "fnv1a64:c8aa1b291752bf79",
+      "settingsHash": "fnv1a64:3fa80ff29bd1598e",
+      "outputHash": "fnv1a64:d733ee51a757a5ec",
+      "reviewedAt": "2026-08-14T15:49:27.379Z",
+      "reviewedBy": "farming-labs/docs maintainers",
+      "reason": "Preserve the canonical audience projection, discovery, feedback, and Agent Skills operating guide."
+    },
+    {
+      "route": "/docs/customization/mcp",
+      "sourceHash": "fnv1a64:120a971d05404387",
+      "settingsHash": "fnv1a64:4d5874ba9e62babc",
+      "outputHash": "fnv1a64:0b4119aece602f67",
+      "reviewedAt": "2026-08-14T15:49:22.702Z",
+      "reviewedBy": "farming-labs/docs maintainers",
+      "reason": "Preserve reviewed operator-only authoring MCP and publishing safety guidance."
+    },
+    {
+      "route": "/docs/customization/sidebar",
+      "sourceHash": "fnv1a64:4cfd6a1ea869d828",
+      "settingsHash": "fnv1a64:063b4c9a14696a17",
+      "outputHash": "fnv1a64:b6bb2f7c8d8f3184",
+      "reviewedAt": "2026-08-14T15:49:29.748Z",
+      "reviewedBy": "farming-labs/docs maintainers",
+      "reason": "Preserve the intentionally scoped sidebar answer guide."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a versioned, machine-readable manifest for intentional human-reviewed `agent.md` content
- add `docs agent compact --review` with explicit reviewer and rationale metadata
- bind every review to source, settings, and output hashes so CI rejects drift and orphaned entries
- teach doctor and freshness checks to report reviewed and invalid review states
- record the four existing website exceptions through the new CLI workflow

## Validation

- `pnpm --filter @farming-labs/docs exec vitest run` (82 files, 1427 tests)
- `pnpm --filter @farming-labs/docs typecheck`
- `pnpm format:check`
- `pnpm lint` (0 errors; 9 pre-existing warnings)
- website `docs agent compact --check` (49 fresh, 4 reviewed, 0 invalid, 0 orphaned)
- website `docs doctor --agent --json` (compaction check passes)

## Notes

- This PR intentionally preserves the four reviewed hand-authored files; it does not regenerate them.
- The feedback-storage item is out of scope as requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hash-bound, human-reviewed state for agent.md compaction and enforces it in checks. Previously CI allowed hand-authored/modified pages via an exceptions note and only failed on stale or missing outputs; now reviews live in a versioned manifest and checks fail on drift or orphaned entries.

- Adds `--review`, `--reviewed-by`, `--reason`, and `--review-manifest` to `docs agent compact` in `@farming-labs/docs`; writes route-scoped entries with source/settings/output hashes, reviewer, timestamp, and rationale without rewriting `agent.md`. `--review` requires explicit pages plus both `--reviewed-by` and `--reason`.
- Introduces a strict, versioned manifest (v1) at `.farming-labs/agent-compaction-reviews.json` by default; must be project-relative, a regular file (no symlinks), and contain unique routes; configurable via `agent.compact.reviewManifestPath` or `--review-manifest`.
- Recognizes `reviewed` and `review-invalid` states in compaction and doctor; `--check` summaries include reviewed, invalid, and orphaned reviews, and fail on any invalid/orphaned/stale/required-missing pages.
- Updates `docs doctor` coverage, scoring, and recommendations; `doctor --fix` skips invalid/orphaned reviews and modified/unknown pages.
- CI watches `website/.farming-labs/agent-compaction-reviews.json`; migrates the four existing website exceptions to the new workflow.
- Required: For any intentionally modified or hand-authored `agent.md`, run `docs agent compact --review --reviewed-by "<name>" --reason "<why>" </route>` for each page. Re-review whenever the page source, compaction settings, or `agent.md` body changes.

<sup>Written for commit 4bf358c5bfaac2b614a31df487d3fb4c2ad9f12f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

