### PR TITLE
ci: add agent readiness monitoring

### DIFF
--- a/.github/agent-readiness-preview-warning-baseline.json
+++ b/.github/agent-readiness-preview-warning-baseline.json
@@ -2,21 +2,6 @@
   "version": 1,
   "allowedWarnings": [
     {
-      "id": "compact",
-      "reason": "Reviewed compaction state for the four intentional hand-authored files is tracked by the compaction review change.",
-      "required": true
-    },
-    {
-      "id": "golden-task-coverage",
-      "reason": "Executable-example applicability is tracked by the evaluation coverage change.",
-      "required": true
-    },
-    {
-      "id": "hosted-llms",
-      "reason": "Cold preview llms-full responses can exceed the pre-reliability-fix hosted timeout.",
-      "required": false
-    },
-    {
       "id": "hosted-markdown-canonical",
       "reason": "The public docs-cloud preview currently omits a canonical Link header on nested markdown pages.",
       "required": true

--- a/.github/agent-readiness-preview-warning-baseline.json
+++ b/.github/agent-readiness-preview-warning-baseline.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "allowedWarnings": [
+    {
+      "id": "compact",
+      "reason": "Reviewed compaction state for the four intentional hand-authored files is tracked by the compaction review change.",
+      "required": true
+    },
+    {
+      "id": "golden-task-coverage",
+      "reason": "Executable-example applicability is tracked by the evaluation coverage change.",
+      "required": true
+    },
+    {
+      "id": "hosted-llms",
+      "reason": "Cold preview llms-full responses can exceed the pre-reliability-fix hosted timeout.",
+      "required": false
+    },
+    {
+      "id": "hosted-markdown-canonical",
+      "reason": "The public docs-cloud preview currently omits a canonical Link header on nested markdown pages.",
+      "required": true
+    }
+  ]
+}

--- a/.github/agent-readiness-warning-baseline.json
+++ b/.github/agent-readiness-warning-baseline.json
@@ -1,15 +1,4 @@
 {
   "version": 1,
-  "allowedWarnings": [
-    {
-      "id": "compact",
-      "reason": "Reviewed compaction state for the four intentional hand-authored files is tracked by the compaction review change.",
-      "required": true
-    },
-    {
-      "id": "golden-task-coverage",
-      "reason": "Executable-example applicability is tracked by the evaluation coverage change.",
-      "required": true
-    }
-  ]
+  "allowedWarnings": []
 }

--- a/.github/agent-readiness-warning-baseline.json
+++ b/.github/agent-readiness-warning-baseline.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "allowedWarnings": [
+    {
+      "id": "compact",
+      "reason": "Reviewed compaction state for the four intentional hand-authored files is tracked by the compaction review change.",
+      "required": true
+    },
+    {
+      "id": "golden-task-coverage",
+      "reason": "Executable-example applicability is tracked by the evaluation coverage change.",
+      "required": true
+    }
+  ]
+}

--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -187,7 +187,8 @@ jobs:
         run: |
           mkdir -p .farming-labs/readiness
           for attempt in 1 2 3; do
-            if node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json; then
+            if node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json &&
+              node ../scripts/check-agent-readiness-report.mjs .farming-labs/readiness/hosted.json "../${DOCS_READINESS_WARNING_BASELINE}"; then
               break
             fi
             if [ "${attempt}" -eq 3 ]; then

--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - ".github/agent-readiness-warning-baseline.json"
+      - ".github/agent-readiness-preview-warning-baseline.json"
       - ".github/workflows/agent-surface-smoke.yml"
       - "packages/docs/src/**"
       - "scripts/check-agent-readiness-report.mjs"
@@ -18,6 +19,7 @@ on:
     branches: [main]
     paths:
       - ".github/agent-readiness-warning-baseline.json"
+      - ".github/agent-readiness-preview-warning-baseline.json"
       - ".github/workflows/agent-surface-smoke.yml"
       - "packages/docs/src/**"
       - "scripts/check-agent-readiness-report.mjs"
@@ -158,6 +160,7 @@ jobs:
       DOCS_SMOKE_BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.environment_url || inputs.base_url || 'https://docs.farming-labs.dev' }}
       DOCS_SMOKE_EXPECT_SKILLS: ask-ai,cli,configuration,creating-themes,getting-started,page-actions
       DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER: "1"
+      DOCS_READINESS_WARNING_BASELINE: ${{ github.event_name == 'deployment_status' && '.github/agent-readiness-preview-warning-baseline.json' || '.github/agent-readiness-warning-baseline.json' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -186,7 +189,7 @@ jobs:
           node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json
 
       - name: Enforce readiness warning baseline
-        run: node scripts/check-agent-readiness-report.mjs website/.farming-labs/readiness/hosted.json .github/agent-readiness-warning-baseline.json
+        run: node scripts/check-agent-readiness-report.mjs website/.farming-labs/readiness/hosted.json "${DOCS_READINESS_WARNING_BASELINE}"
 
       - name: Smoke-test deployed agent surfaces
         run: |

--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -1,6 +1,32 @@
 name: Agent surface smoke
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/agent-readiness-warning-baseline.json"
+      - ".github/workflows/agent-surface-smoke.yml"
+      - "packages/docs/src/**"
+      - "scripts/check-agent-readiness-report.mjs"
+      - "scripts/check-agent-readiness-report.test.mjs"
+      - "scripts/smoke-agent-surfaces.mjs"
+      - "scripts/smoke-agent-surfaces.test.mjs"
+      - "skills/farming-labs/**"
+      - "website/app/docs/**"
+      - "website/docs.config.tsx"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/agent-readiness-warning-baseline.json"
+      - ".github/workflows/agent-surface-smoke.yml"
+      - "packages/docs/src/**"
+      - "scripts/check-agent-readiness-report.mjs"
+      - "scripts/check-agent-readiness-report.test.mjs"
+      - "scripts/smoke-agent-surfaces.mjs"
+      - "scripts/smoke-agent-surfaces.test.mjs"
+      - "skills/farming-labs/**"
+      - "website/app/docs/**"
+      - "website/docs.config.tsx"
   deployment_status:
   schedule:
     - cron: "17 6 * * *"
@@ -16,12 +42,114 @@ permissions:
   contents: read
 
 jobs:
+  local-readiness:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DOCS_AGENT_EVALUATION_SURFACE: mcp-context
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.9.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build config dependencies
+        run: |
+          pnpm --filter @farming-labs/docs build
+          pnpm --filter @farming-labs/theme build
+
+      - name: Test readiness policy
+        run: node --test scripts/check-agent-readiness-report.test.mjs
+
+      - name: Generate local agent-readiness report
+        working-directory: website
+        run: |
+          mkdir -p .farming-labs/readiness
+          node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --json-output .farming-labs/readiness/local.json
+
+      - name: Enforce readiness warning baseline
+        run: node scripts/check-agent-readiness-report.mjs website/.farming-labs/readiness/local.json .github/agent-readiness-warning-baseline.json
+
+      - name: Upload local readiness report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-readiness-local
+          path: website/.farming-labs/readiness/local.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  production-evaluations:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        surface: [configured-search, ask-ai-context]
+    env:
+      DOCS_AGENT_EVALUATION_SURFACE: ${{ matrix.surface }}
+      DOCS_AGENT_EVALUATION_TASKS: author-structured-agent-contract
+      DOCS_SEARCH_PROVIDER: mcp
+      NEXT_PUBLIC_BASE_URL: ${{ inputs.base_url || 'https://docs.farming-labs.dev' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.9.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build config dependencies
+        run: |
+          pnpm --filter @farming-labs/docs build
+          pnpm --filter @farming-labs/theme build
+
+      - name: Generate production ${{ matrix.surface }} report
+        working-directory: website
+        run: |
+          mkdir -p .farming-labs/readiness
+          node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --json-output ".farming-labs/readiness/${DOCS_AGENT_EVALUATION_SURFACE}.json"
+
+      - name: Enforce readiness warning baseline
+        run: node scripts/check-agent-readiness-report.mjs "website/.farming-labs/readiness/${DOCS_AGENT_EVALUATION_SURFACE}.json" .github/agent-readiness-warning-baseline.json
+
+      - name: Upload production evaluation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-readiness-${{ matrix.surface }}
+          path: website/.farming-labs/readiness/${{ matrix.surface }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
   smoke:
     # Every docs-website deployment is protected by Vercel SSO. Deployment events
     # therefore exercise only the public docs-cloud project, while scheduled and
     # manual runs continue to verify the production origin.
     if: >-
-      github.event_name != 'deployment_status' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
       endsWith(github.event.deployment.environment, ' – farming-labs-docs-docs-cloud'))
     runs-on: ubuntu-latest
@@ -44,10 +172,35 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build the Agent Skills validator
-        run: pnpm --filter @farming-labs/docs build
+        run: |
+          pnpm --filter @farming-labs/docs build
+          pnpm --filter @farming-labs/theme build
 
       - name: Test the smoke validator
         run: node --test scripts/smoke-agent-surfaces.test.mjs
 
+      - name: Generate hosted agent-readiness report
+        working-directory: website
+        run: |
+          mkdir -p .farming-labs/readiness
+          node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json
+
+      - name: Enforce readiness warning baseline
+        run: node scripts/check-agent-readiness-report.mjs website/.farming-labs/readiness/hosted.json .github/agent-readiness-warning-baseline.json
+
       - name: Smoke-test deployed agent surfaces
-        run: node scripts/smoke-agent-surfaces.mjs
+        run: |
+          mkdir -p .farming-labs/readiness
+          set -o pipefail
+          node scripts/smoke-agent-surfaces.mjs 2>&1 | tee .farming-labs/readiness/surface-smoke.log
+
+      - name: Upload hosted readiness reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-readiness-hosted
+          path: |
+            website/.farming-labs/readiness/hosted.json
+            .farming-labs/readiness/surface-smoke.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -186,7 +186,16 @@ jobs:
         working-directory: website
         run: |
           mkdir -p .farming-labs/readiness
-          node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json
+          for attempt in 1 2 3; do
+            if node ../packages/docs/dist/cli/index.mjs doctor --agent --ci --fail-on fail --config docs.config.tsx --url "${DOCS_SMOKE_BASE_URL}" --json-output .farming-labs/readiness/hosted.json; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              exit 1
+            fi
+            echo "Hosted readiness attempt ${attempt} failed; retrying after the preview warms up."
+            sleep $((attempt * 5))
+          done
 
       - name: Enforce readiness warning baseline
         run: node scripts/check-agent-readiness-report.mjs website/.farming-labs/readiness/hosted.json "${DOCS_READINESS_WARNING_BASELINE}"

--- a/packages/docs/src/agent-surface-drift.test.ts
+++ b/packages/docs/src/agent-surface-drift.test.ts
@@ -474,6 +474,7 @@ describe("agent surface drift", () => {
       "agent.evaluations.tasks[].expect.safety.promptInjection.markers",
       "agent.evaluations.tasks[].expect.safety.freshness.sourceDigests.*",
       "agent.evaluations.tasks[].expect.safety.queryVariants[].kind",
+      "agent.evaluations.tasks[].expect.coverage.executableExamples",
       "agent.evaluations.tasks[].expect.examples[].verification",
     ]) {
       expect(getDocsConfigSchema({ option }).resultCount, option).toBe(1);
@@ -500,6 +501,7 @@ describe("agent surface drift", () => {
       "agent.evaluations.tasks[0].expect.safety.promptInjection.markers[0]",
       "agent.evaluations.tasks[0].expect.safety.freshness.sourceDigests./docs/install",
       "agent.evaluations.tasks[0].expect.safety.queryVariants[0].kind",
+      "agent.evaluations.tasks[0].expect.coverage.executableExamples",
       "agent.evaluations.tasks[0].expect.examples[0].verification",
     ];
     options.schemaOptions = getDocsConfigSchema().options;

--- a/packages/docs/src/mcp.test.ts
+++ b/packages/docs/src/mcp.test.ts
@@ -2465,6 +2465,20 @@ describe("MCP context and schema APIs", () => {
       expect(findSchemaOption(schema.options, path), path).toBeDefined();
     }
   });
+
+  it("publishes golden-task coverage applicability schema", () => {
+    const schema = getDocsConfigSchema();
+    expect(
+      findSchemaOption(
+        schema.options,
+        "agent.evaluations.tasks[].expect.coverage.executableExamples",
+      ),
+    ).toMatchObject({
+      type: '"applicable" | "not-applicable"',
+      default: "applicable",
+      values: ["applicable", "not-applicable"],
+    });
+  });
 });
 
 describe("createFilesystemDocsMcpSource", () => {

--- a/packages/docs/src/mcp.ts
+++ b/packages/docs/src/mcp.ts
@@ -1854,6 +1854,24 @@ const DOCS_CONFIG_SCHEMA_OPTIONS_TEMPLATE: DocsMcpConfigSchemaOption[] = [
                     ],
                   },
                   {
+                    path: "agent.evaluations.tasks[].expect.coverage",
+                    name: "coverage",
+                    type: "DocsAgentGoldenCoverageExpectation",
+                    description:
+                      "Applicability declarations for optional confidence-coverage dimensions.",
+                    children: [
+                      {
+                        path: "agent.evaluations.tasks[].expect.coverage.executableExamples",
+                        name: "executableExamples",
+                        type: '"applicable" | "not-applicable"',
+                        default: "applicable",
+                        values: ["applicable", "not-applicable"],
+                        description:
+                          "Whether runtime example execution meaningfully validates this task.",
+                      },
+                    ],
+                  },
+                  {
                     path: "agent.evaluations.tasks[].expect.examples",
                     name: "examples",
                     type: "DocsAgentGoldenExpectedExample[]",

--- a/scripts/check-agent-readiness-report.mjs
+++ b/scripts/check-agent-readiness-report.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function asRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Could not read ${label} ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function readBaseline(value) {
+  const baseline = asRecord(value);
+  if (!baseline || baseline.version !== 1 || !Array.isArray(baseline.allowedWarnings)) {
+    throw new Error("Agent readiness warning baseline must use version 1 and allowedWarnings[].");
+  }
+
+  const entries = baseline.allowedWarnings.map((value, index) => {
+    const entry = asRecord(value);
+    if (
+      !entry ||
+      typeof entry.id !== "string" ||
+      !entry.id.trim() ||
+      typeof entry.reason !== "string" ||
+      !entry.reason.trim() ||
+      (entry.required !== undefined && typeof entry.required !== "boolean")
+    ) {
+      throw new Error(`Agent readiness warning baseline entry ${index} is invalid.`);
+    }
+    return {
+      id: entry.id.trim(),
+      reason: entry.reason.trim(),
+      required: entry.required === true,
+    };
+  });
+
+  if (new Set(entries.map((entry) => entry.id)).size !== entries.length) {
+    throw new Error("Agent readiness warning baseline contains duplicate check IDs.");
+  }
+  return entries;
+}
+
+export function validateAgentReadinessReport(reportValue, baselineValue) {
+  const report = asRecord(reportValue);
+  if (!report || report.mode !== "agent" || !Array.isArray(report.checks)) {
+    throw new Error('Agent readiness report must use mode "agent" and contain checks[].');
+  }
+  if (report.checks.length === 0) {
+    throw new Error("Agent readiness report must contain at least one check.");
+  }
+  const checks = report.checks.map((value, index) => {
+    const check = asRecord(value);
+    if (
+      !check ||
+      typeof check.id !== "string" ||
+      !check.id.trim() ||
+      !["pass", "warn", "fail"].includes(check.status)
+    ) {
+      throw new Error(`Agent readiness report check ${index} is invalid.`);
+    }
+    return { id: check.id.trim(), status: check.status };
+  });
+  if (new Set(checks.map((check) => check.id)).size !== checks.length) {
+    throw new Error("Agent readiness report contains duplicate check IDs.");
+  }
+  const baseline = readBaseline(baselineValue);
+  const allowed = new Map(baseline.map((entry) => [entry.id, entry]));
+  const failures = checks.filter((check) => check.status === "fail").map((check) => check.id);
+  const warnings = checks.filter((check) => check.status === "warn").map((check) => check.id);
+  const unexpectedWarnings = warnings.filter((id) => !allowed.has(id));
+  const staleRequiredWarnings = baseline
+    .filter((entry) => entry.required && !warnings.includes(entry.id))
+    .map((entry) => entry.id);
+
+  const issues = [];
+  if (failures.length > 0) issues.push(`failing checks: ${failures.join(", ")}`);
+  if (unexpectedWarnings.length > 0) {
+    issues.push(`unexpected warnings: ${unexpectedWarnings.join(", ")}`);
+  }
+  if (staleRequiredWarnings.length > 0) {
+    issues.push(
+      `resolved baseline warnings still marked required: ${staleRequiredWarnings.join(", ")}`,
+    );
+  }
+  if (issues.length > 0) {
+    throw new Error(`Agent readiness policy failed (${issues.join("; ")}).`);
+  }
+
+  return {
+    checks: checks.length,
+    warnings,
+    allowedWarnings: warnings.filter((id) => allowed.has(id)),
+    passed: true,
+  };
+}
+
+function main() {
+  const reportPath = process.argv[2];
+  const baselinePath = process.argv[3];
+  if (!reportPath || !baselinePath) {
+    throw new Error(
+      "Usage: node scripts/check-agent-readiness-report.mjs <doctor.json> <warning-baseline.json>",
+    );
+  }
+  const result = validateAgentReadinessReport(
+    readJson(reportPath, "doctor report"),
+    readJson(baselinePath, "warning baseline"),
+  );
+  console.log(
+    `Agent readiness policy passed: ${result.checks} checks, ${result.warnings.length} allowed warning${result.warnings.length === 1 ? "" : "s"}.`,
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isDirectExecution) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-agent-readiness-report.test.mjs
+++ b/scripts/check-agent-readiness-report.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateAgentReadinessReport } from "./check-agent-readiness-report.mjs";
+
+const baseline = {
+  version: 1,
+  allowedWarnings: [{ id: "known-warning", reason: "Tracked remediation.", required: true }],
+};
+
+test("accepts the exact warning baseline", () => {
+  assert.deepEqual(
+    validateAgentReadinessReport(
+      {
+        mode: "agent",
+        checks: [
+          { id: "healthy", status: "pass" },
+          { id: "known-warning", status: "warn" },
+        ],
+      },
+      baseline,
+    ),
+    {
+      checks: 2,
+      warnings: ["known-warning"],
+      allowedWarnings: ["known-warning"],
+      passed: true,
+    },
+  );
+});
+
+test("rejects failures and unexpected warnings", () => {
+  assert.throws(
+    () =>
+      validateAgentReadinessReport(
+        {
+          mode: "agent",
+          checks: [
+            { id: "hard-failure", status: "fail" },
+            { id: "new-warning", status: "warn" },
+            { id: "known-warning", status: "warn" },
+          ],
+        },
+        baseline,
+      ),
+    /failing checks: hard-failure; unexpected warnings: new-warning/u,
+  );
+});
+
+test("rejects a required warning after it is resolved", () => {
+  assert.throws(
+    () =>
+      validateAgentReadinessReport(
+        { mode: "agent", checks: [{ id: "known-warning", status: "pass" }] },
+        baseline,
+      ),
+    /resolved baseline warnings still marked required: known-warning/u,
+  );
+});
+
+test("allows a non-required historical warning to disappear", () => {
+  assert.equal(
+    validateAgentReadinessReport(
+      { mode: "agent", checks: [{ id: "healthy", status: "pass" }] },
+      {
+        version: 1,
+        allowedWarnings: [
+          { id: "historical-warning", reason: "Kept for context.", required: false },
+        ],
+      },
+    ).passed,
+    true,
+  );
+});
+
+test("rejects a non-agent report and duplicate check IDs", () => {
+  assert.throws(
+    () => validateAgentReadinessReport({ mode: "site", checks: [] }, baseline),
+    /must use mode "agent"/u,
+  );
+  assert.throws(
+    () =>
+      validateAgentReadinessReport(
+        {
+          mode: "agent",
+          checks: [
+            { id: "same", status: "pass" },
+            { id: "same", status: "warn" },
+          ],
+        },
+        baseline,
+      ),
+    /duplicate check IDs/u,
+  );
+});

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -8,6 +8,7 @@ endpoint conformance.
 - [Commands](#commands)
 - [Agent audit coverage](#agent-audit-coverage)
 - [Hosted probes](#hosted-probes)
+- [CI and production monitoring](#ci-and-production-monitoring)
 - [Interpreting results](#interpreting-results)
 - [Verification and recovery](#verification-and-recovery)
 
@@ -75,6 +76,19 @@ core docs tools. Hosted evidence adds checks without changing the normalized 100
 
 Hosted JSON IDs include `hosted-agent-discovery`, `hosted-llms`, `hosted-sitemap`,
 `hosted-robots`, `hosted-skill`, `hosted-markdown`, and `hosted-mcp`.
+
+## CI and production monitoring
+
+For pull requests, run doctor once with the local `mcp-context` surface, persist the report with
+`--json-output`, and upload that file even when the job fails. Use a checked warning baseline when
+known warnings are being repaired: reject unexpected warnings, and make each temporary warning
+required so CI tells maintainers when the baseline is stale and can be removed.
+
+For scheduled production checks, exercise both `configured-search` and `ask-ai-context` against the
+deployed origin in separate jobs. Keep the general hosted doctor probe and the deeper discovery,
+Agent Skills, search, Markdown, cache, and MCP smoke test as independent evidence, and retain their
+JSON/log artifacts for incident review. Deployment-triggered checks should run only against public
+origins, never authenticated preview URLs without an explicit credential design.
 
 ## Interpreting results
 

--- a/skills/farming-labs/cli/references/doctor-audits.md
+++ b/skills/farming-labs/cli/references/doctor-audits.md
@@ -84,6 +84,10 @@ For pull requests, run doctor once with the local `mcp-context` surface, persist
 known warnings are being repaired: reject unexpected warnings, and make each temporary warning
 required so CI tells maintainers when the baseline is stale and can be removed.
 
+Keep preview-only warnings in a separate baseline. A preview exception must never weaken the
+scheduled production policy, and transient allowances should remain optional so a healthy retry is
+not treated as a stale-baseline failure.
+
 For scheduled production checks, exercise both `configured-search` and `ask-ai-context` against the
 deployed origin in separate jobs. Keep the general hosted doctor probe and the deeper discovery,
 Agent Skills, search, Markdown, cache, and MCP smoke test as independent evidence, and retain their

--- a/website/docs.config.tsx
+++ b/website/docs.config.tsx
@@ -1,5 +1,6 @@
 import {
   defineDocs,
+  type DocsAgentEvaluationSurface,
   type DocsAgentEvaluationAnswerRunner,
   type DocsAgentGoldenTask,
 } from "@farming-labs/docs";
@@ -57,6 +58,36 @@ const docsSearchProvider =
   process.env.DOCS_SEARCH_PROVIDER ?? (algoliaAppId && algoliaSearchApiKey ? "algolia" : "mcp");
 const docsSiteOrigin = process.env.NEXT_PUBLIC_BASE_URL ?? "https://docs.farming-labs.dev";
 
+function resolveAgentEvaluationSurface(): DocsAgentEvaluationSurface {
+  const value = process.env.DOCS_AGENT_EVALUATION_SURFACE;
+  if (!value) return "mcp-context";
+  if (value === "mcp-context" || value === "configured-search" || value === "ask-ai-context") {
+    return value;
+  }
+  throw new Error(`Unsupported DOCS_AGENT_EVALUATION_SURFACE: ${value}`);
+}
+
+const agentEvaluationSurface = resolveAgentEvaluationSurface();
+
+function selectAgentEvaluationTasks(tasks: DocsAgentGoldenTask[]): DocsAgentGoldenTask[] {
+  const configured = process.env.DOCS_AGENT_EVALUATION_TASKS;
+  if (!configured) return tasks;
+  const requested = new Set(
+    configured
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  const selected = tasks.filter((task) => requested.has(task.id));
+  const missing = [...requested].filter((id) => !selected.some((task) => task.id === id));
+  if (selected.length === 0 || missing.length > 0) {
+    throw new Error(
+      `DOCS_AGENT_EVALUATION_TASKS contains unknown task IDs: ${missing.join(", ") || configured}`,
+    );
+  }
+  return selected;
+}
+
 const searchConfig =
   docsSearchProvider === "algolia" && algoliaAppId && algoliaSearchApiKey
     ? {
@@ -97,7 +128,8 @@ function withAgentEvaluationCoverage(tasks: DocsAgentGoldenTask[]): DocsAgentGol
     ),
   );
 
-  return tasks.map((task) => ({
+  const selectedTasks = selectAgentEvaluationTasks(tasks);
+  return selectedTasks.map((task) => ({
     ...task,
     expect: {
       ...task.expect,
@@ -358,7 +390,7 @@ export default defineDocs({
       protectJson: true,
     },
     evaluations: {
-      surface: "mcp-context",
+      surface: agentEvaluationSurface,
       allowNetwork: true,
       tokenBudget: 5_000,
       topK: 3,


### PR DESCRIPTION
## Summary

- run the complete local agent doctor on relevant pull requests and upload its JSON report
- schedule focused live `configured-search` and `ask-ai-context` canaries through the production MCP search path
- add hosted doctor evidence and retained smoke logs to the existing 81-check deployment monitor
- enforce an exact, tested warning baseline that rejects failures, unexpected warnings, duplicate checks, and stale required exceptions
- make the website evaluation surface and canary task selection explicit through validated environment variables

## Validation

- website TypeScript check
- readiness policy and surface smoke tests (29 passed, 1 existing conditional skip)
- `pnpm format:check`
- `pnpm lint` (0 errors; 9 pre-existing warnings)
- local doctor report: 22/22 tasks passed; exact two-warning baseline accepted
- live `configured-search` canary: 1/1 passed through production MCP
- live `ask-ai-context` canary: 1/1 passed through production MCP
- hosted doctor: all 13 hosted checks passed
- deployed surface smoke: 81/81 checks passed

## Merge-order note

The temporary required warnings (`golden-task-coverage` and `compact`) correspond to PRs #481 and #482. After those merge, this branch should be updated from `main` and the now-stale baseline entries removed before this PR merges.

The feedback-storage item is intentionally out of scope as requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent readiness monitoring to CI and scheduled runs and enforces a versioned warning baseline. Previously we only ran surface smoke; now PRs/pushes run a local doctor, scheduled runs probe production via MCP, and all runs apply a strict baseline with preview-only exceptions.

- Adds `scripts/check-agent-readiness-report.mjs` with tests; fails on failures, unexpected warnings, duplicate IDs, and stale required warnings.
- CI: adds `local-readiness` (PR/push), `production-evaluations` (scheduled `configured-search` and `ask-ai-context` via MCP), and enhances `smoke` with hosted doctor and retained logs; retries hosted probe up to 3 times for cold previews.
- Uploads readiness JSON and smoke logs as artifacts for local, hosted, and each production surface.
- Scopes preview-only warnings to `.github/agent-readiness-preview-warning-baseline.json`; production uses `.github/agent-readiness-warning-baseline.json` (empty). Preview baseline allows only `hosted-markdown-canonical` (required).
- Makes evaluation surface and task selection explicit and validated via `DOCS_AGENT_EVALUATION_SURFACE` and `DOCS_AGENT_EVALUATION_TASKS`; unknown tasks fail.
- Publishes and tests `agent.evaluations.tasks[].expect.coverage.executableExamples` in the config schema.

<sup>Written for commit da474ab18ea7832346f00a5a4a1edafccafc8598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

