### PR TITLE
fix: create require lazily so server bundles load when import.meta.url is undefined

### DIFF
--- a/packages/docs/src/prompt-utils.ts
+++ b/packages/docs/src/prompt-utils.ts
@@ -1,8 +1,6 @@
 import { createRequire } from "node:module";
 import type { OpenDocsProvider, OpenDocsTarget } from "./types.js";
 
-const require = createRequire(import.meta.url);
-
 export type PromptAction = "copy" | "open";
 
 export interface SerializedOpenDocsProvider {
@@ -98,6 +96,10 @@ export function serializeDocsIcon(icon: unknown): string | undefined {
   if (typeof icon === "string") return icon;
 
   try {
+    // createRequire must stay inside the try: import.meta.url is undefined in
+    // some server runtimes (e.g. Cloudflare workerd), and calling it at module
+    // scope would throw at import time and break the whole server bundle.
+    const require = createRequire(import.meta.url);
     const { renderToStaticMarkup } = require("react-dom/server") as {
       renderToStaticMarkup: (element: unknown) => string;
     };

--- a/packages/fumadocs/src/serialize-icon.ts
+++ b/packages/fumadocs/src/serialize-icon.ts
@@ -5,13 +5,15 @@
 import { createRequire } from "node:module";
 import type { ReactElement } from "react";
 
-const require = createRequire(import.meta.url);
-
 export function serializeIcon(icon: unknown): string | undefined {
   if (!icon) return undefined;
   if (typeof icon === "string") return icon;
 
   try {
+    // createRequire must stay inside the try: import.meta.url is undefined in
+    // some server runtimes (e.g. Cloudflare workerd), and calling it at module
+    // scope would throw at import time and break the whole server bundle.
+    const require = createRequire(import.meta.url);
     const { renderToStaticMarkup } = require("react-dom/server") as {
       renderToStaticMarkup: (el: ReactElement) => string;
     };


### PR DESCRIPTION
## Problem

A user reported this crash from their server bundle:

```
TypeError: The argument 'path' must be a file URL object, a file URL string, or an absolute path string. Received 'undefined'
    at createRequire (node:module:34:15)
    at docs.server-*.js:54495:1
```

Both `packages/docs/src/prompt-utils.ts` and `packages/fumadocs/src/serialize-icon.ts` called `createRequire(import.meta.url)` at **module scope**. On runtimes where `import.meta.url` is `undefined` — Cloudflare workerd, or ESM re-bundled to CJS by a downstream bundler — this throws at import time and takes down the entire server bundle, even though the `require` is only needed to lazily load `react-dom/server` for ReactNode icon serialization.

## Fix

Move the `createRequire` call inside the existing `try/catch` in the one function that uses it. On Node the behavior is identical (module resolution is still cached). On runtimes without `import.meta.url`, ReactNode icons now serialize to `undefined` (the already-established fallback) instead of crashing the bundle; string icons are unaffected.

## Verification

- Reproduced the exact reported `TypeError` by bundling the **old** code ESM→CJS with esbuild (`import.meta.url` becomes `undefined`, same condition as workerd) — crashes at module load for both files.
- Same harness on the **fixed** code: module loads, string icons round-trip, ReactNode icons return `undefined`.
- `prompt-utils` tests: 14/14 pass; full `@farming-labs/fumadocs` suite: 208/208 pass.
- `tsc --noEmit` clean on both packages; inspected built `dist` output to confirm no module-scope `createRequire(...)` call remains.

## Notes

This unblocks loading the server bundle on Cloudflare, but full SSR support there (search/AI/MCP routes, `fs`-reading server components) remains a separate effort — static export (`staticExport: true` + `output: "export"`) is still the supported Cloudflare path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create `require` lazily in icon serializers so server bundles load when `import.meta.url` is undefined. Previously `createRequire(import.meta.url)` ran at module scope and crashed on import; now it runs inside the serializer’s try/catch, preserving Node behavior and degrading ReactNode icons to `undefined` instead of crashing; string icons are unchanged.

**Review notes**
- Moves `createRequire` into `serializeDocsIcon` (`packages/docs/src/prompt-utils.ts`) and `serializeIcon` (`packages/fumadocs/src/serialize-icon.ts`); removes module-scope calls.
- On runtimes without `import.meta.url` (e.g., Cloudflare workerd or ESM→CJS), ReactNode icons return `undefined`; on Node, behavior is unchanged and resolution remains cached.
- Tests pass; built output contains no module-scope `createRequire(...)`.

<sup>Written for commit 309f8f089ef432730d36cb82cdf28afe1f7f1cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

