### PR TITLE
fix: make agent compaction freshness mtime-independent

### DIFF
--- a/packages/docs/src/cli/agent.test.ts
+++ b/packages/docs/src/cli/agent.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createServer } from "node:http";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AddressInfo } from "node:net";
@@ -1229,6 +1229,64 @@ Updated body.
     await expect(compactAgentDocs({ check: true })).rejects.toThrow(
       "Agent compaction freshness check failed: 0 fresh, 0 reviewed, 0 invalid reviews, 0 orphaned reviews, 1 stale",
     );
+  });
+
+  it("keeps generated content fresh when only the page file mtime changes", async () => {
+    writeFileSync(
+      path.join(tmpDir, "docs.config.ts"),
+      `export default { entry: "docs" };`,
+      "utf-8",
+    );
+    mkdirSync(path.join(tmpDir, "app", "docs", "installation"), { recursive: true });
+    const pagePath = path.join(tmpDir, "app", "docs", "installation", "page.mdx");
+    writeFileSync(
+      pagePath,
+      `---
+title: "Installation"
+description: "Install the framework"
+agent:
+  tokenBudget: 500
+---
+
+# Installation
+
+Body.
+`,
+      "utf-8",
+    );
+
+    const server = createServer(async (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          output: "Initial compacted",
+          original_input_tokens: 100,
+          output_tokens: 25,
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      process.chdir(tmpDir);
+      await compactAgentDocs({
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${port}`,
+        pages: ["installation"],
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    // A fresh checkout resets every file's mtime; that alone must not flag drift.
+    const shifted = new Date(Date.now() + 400 * 24 * 60 * 60 * 1000);
+    utimesSync(pagePath, shifted, shifted);
+
+    delete process.env.DOCS_CLOUD_API_KEY;
+    await expect(compactAgentDocs({ check: true })).resolves.toBeUndefined();
   });
 
   it("records reviewed agent.md hashes and fails when reviewed content or source drifts", async () => {

--- a/packages/docs/src/cli/agent.ts
+++ b/packages/docs/src/cli/agent.ts
@@ -686,11 +686,15 @@ function buildPageOptions(
 }
 
 function buildResolvedPageSourceDocument(page: DocsMcpPage): string {
+  // Filesystem mtimes differ across checkouts, so the mtime-derived lastModified
+  // fallback must not leak into compaction source hashes; only explicit
+  // frontmatter lastmod may contribute a last_updated line.
   return stripGeneratedPageAgentContractMarkdown(
     renderDocsMarkdownDocument({
       ...page,
       agentContent: undefined,
       agentRawContent: undefined,
+      lastModified: undefined,
     }),
   );
 }

--- a/website/.farming-labs/agent-compaction-reviews.json
+++ b/website/.farming-labs/agent-compaction-reviews.json
@@ -2,40 +2,67 @@
   "version": 1,
   "reviews": [
     {
+      "route": "/docs/cli",
+      "sourceHash": "fnv1a64:ff98ba0ac661af3e",
+      "settingsHash": "fnv1a64:e50e89e221226fc3",
+      "outputHash": "fnv1a64:c95a0dd048e26147",
+      "reviewedAt": "2026-08-20T10:21:22.767Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Preserve the curated compacted output that passes the golden-task quality gates: #485/#487 added agent-compact review-workflow coverage to these source pages, and a cloud re-compaction regressed golden tasks from 22/22 to 9/22, so the curated agent.md is kept until the new coverage is folded in by a reviewed curation pass."
+    },
+    {
       "route": "/docs/configuration",
-      "sourceHash": "fnv1a64:67d7e2763afbf5a4",
+      "sourceHash": "fnv1a64:036bc04f1a1943f6",
       "settingsHash": "fnv1a64:aa433a28ef4afd1f",
       "outputHash": "fnv1a64:d404f870b0ddaafa",
-      "reviewedAt": "2026-08-14T15:49:25.027Z",
-      "reviewedBy": "farming-labs/docs maintainers",
-      "reason": "Preserve the detailed machine-oriented configuration contract."
+      "reviewedAt": "2026-08-20T10:21:05.808Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Re-reviewed after #485 documented agent.compact.reviewManifestPath in the source page: the preserved machine-oriented configuration contract covers agent.compact at the defaults level, so its guidance remains correct without enumerating the new option. Hash also shifted because compaction source hashing no longer embeds mtime-derived last_updated dates."
     },
     {
       "route": "/docs/customization/agent-primitive",
-      "sourceHash": "fnv1a64:c8aa1b291752bf79",
+      "sourceHash": "fnv1a64:28b9ad19a979f2f4",
       "settingsHash": "fnv1a64:3fa80ff29bd1598e",
       "outputHash": "fnv1a64:d733ee51a757a5ec",
-      "reviewedAt": "2026-08-14T15:49:27.379Z",
-      "reviewedBy": "farming-labs/docs maintainers",
-      "reason": "Preserve the canonical audience projection, discovery, feedback, and Agent Skills operating guide."
+      "reviewedAt": "2026-08-20T10:21:13.546Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Re-recorded after compaction source hashing stopped embedding mtime-derived last_updated dates; page sources are unchanged since the 2026-08-14 review, and the intentionally preserved agent.md content (audience projection and Agent Skills guide, operator-only authoring MCP safety guidance, scoped sidebar answer guide) still matches its source."
     },
     {
       "route": "/docs/customization/mcp",
-      "sourceHash": "fnv1a64:120a971d05404387",
+      "sourceHash": "fnv1a64:724e794e76a6d24e",
       "settingsHash": "fnv1a64:4d5874ba9e62babc",
       "outputHash": "fnv1a64:0b4119aece602f67",
-      "reviewedAt": "2026-08-14T15:49:22.702Z",
-      "reviewedBy": "farming-labs/docs maintainers",
-      "reason": "Preserve reviewed operator-only authoring MCP and publishing safety guidance."
+      "reviewedAt": "2026-08-20T10:21:13.548Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Re-recorded after compaction source hashing stopped embedding mtime-derived last_updated dates; page sources are unchanged since the 2026-08-14 review, and the intentionally preserved agent.md content (audience projection and Agent Skills guide, operator-only authoring MCP safety guidance, scoped sidebar answer guide) still matches its source."
     },
     {
       "route": "/docs/customization/sidebar",
-      "sourceHash": "fnv1a64:4cfd6a1ea869d828",
+      "sourceHash": "fnv1a64:34bc2c22bac145f1",
       "settingsHash": "fnv1a64:063b4c9a14696a17",
       "outputHash": "fnv1a64:b6bb2f7c8d8f3184",
-      "reviewedAt": "2026-08-14T15:49:29.748Z",
-      "reviewedBy": "farming-labs/docs maintainers",
-      "reason": "Preserve the intentionally scoped sidebar answer guide."
+      "reviewedAt": "2026-08-20T10:21:13.549Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Re-recorded after compaction source hashing stopped embedding mtime-derived last_updated dates; page sources are unchanged since the 2026-08-14 review, and the intentionally preserved agent.md content (audience projection and Agent Skills guide, operator-only authoring MCP safety guidance, scoped sidebar answer guide) still matches its source."
+    },
+    {
+      "route": "/docs/reference",
+      "sourceHash": "fnv1a64:083bdfc462e36413",
+      "settingsHash": "fnv1a64:aa433a28ef4afd1f",
+      "outputHash": "fnv1a64:173fd105503fea58",
+      "reviewedAt": "2026-08-20T10:21:22.777Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Preserve the curated compacted output that passes the golden-task quality gates: #485/#487 added agent-compact review-workflow coverage to these source pages, and a cloud re-compaction regressed golden tasks from 22/22 to 9/22, so the curated agent.md is kept until the new coverage is folded in by a reviewed curation pass."
+    },
+    {
+      "route": "/docs/token-efficiency",
+      "sourceHash": "fnv1a64:723305a70b3f23f3",
+      "settingsHash": "fnv1a64:72be2461542d7a95",
+      "outputHash": "fnv1a64:d63cfdc9326dd1b7",
+      "reviewedAt": "2026-08-20T10:21:22.778Z",
+      "reviewedBy": "Kinfe123",
+      "reason": "Preserve the curated compacted output that passes the golden-task quality gates: #485/#487 added agent-compact review-workflow coverage to these source pages, and a cloud re-compaction regressed golden tasks from 22/22 to 9/22, so the curated agent.md is kept until the new coverage is folded in by a reviewed curation pass."
     }
   ]
 }

--- a/website/app/docs/agent.md
+++ b/website/app/docs/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:59c67ee6d2cf86cb
+sourceHash=fnv1a64:f31c3c54e92a6a1e
 settingsHash=fnv1a64:0a67cd1f3384201a
 outputHash=fnv1a64:5a773c15e735f864
-generatedAt=2026-08-14T12:45:38.380Z
+generatedAt=2026-08-20T10:20:45.454Z
 -->
 # Introduction
 

--- a/website/app/docs/cli/agent.md
+++ b/website/app/docs/cli/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:8474cf95b5a961dd
+sourceHash=fnv1a64:ff98ba0ac661af3e
 settingsHash=fnv1a64:e50e89e221226fc3
 outputHash=fnv1a64:c95a0dd048e26147
-generatedAt=2026-08-14T12:45:38.405Z
+generatedAt=2026-08-20T10:20:45.204Z
 -->
 URL: /docs/cli
 LLM index: /llms.txt

--- a/website/app/docs/cloud/agent.md
+++ b/website/app/docs/cloud/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:18c7a33ffe5d8ac7
+sourceHash=fnv1a64:ea4599fe0d071f98
 settingsHash=fnv1a64:54aabfe997b31e1c
 outputHash=fnv1a64:3bbb07e4687e854e
-generatedAt=2026-08-14T12:45:38.425Z
+generatedAt=2026-08-20T10:20:45.233Z
 -->
 # Docs Cloud
 

--- a/website/app/docs/cloud/analytics/agent.md
+++ b/website/app/docs/cloud/analytics/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:6f70f7ff5dd7cacb
+sourceHash=fnv1a64:7034d577d38a7462
 settingsHash=fnv1a64:72be2461542d7a95
 outputHash=fnv1a64:71082a9b0c66a490
-generatedAt=2026-08-14T12:45:38.442Z
+generatedAt=2026-08-20T10:20:45.215Z
 -->
 # Analytics
 

--- a/website/app/docs/cloud/deploy/agent.md
+++ b/website/app/docs/cloud/deploy/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:71b392aaea120dba
+sourceHash=fnv1a64:21f42c17384037d9
 settingsHash=fnv1a64:063b4c9a14696a17
 outputHash=fnv1a64:c156b3ca29676945
-generatedAt=2026-08-14T12:45:38.462Z
+generatedAt=2026-08-20T10:20:45.224Z
 -->
 # Deploy
 

--- a/website/app/docs/contributing/agent.md
+++ b/website/app/docs/contributing/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:9d52eda6dbea2d4d
+sourceHash=fnv1a64:b5dc93bd0362d4de
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:0ba4aa7e16e15e72
-generatedAt=2026-08-14T12:45:38.478Z
+generatedAt=2026-08-20T10:20:45.259Z
 -->
 # Contributing
 

--- a/website/app/docs/customization/agent.md
+++ b/website/app/docs/customization/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:96996c56771b9d6e
+sourceHash=fnv1a64:e24affa1d337935b
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:14aaecb13600c381
-generatedAt=2026-08-14T12:45:38.496Z
+generatedAt=2026-08-20T10:20:45.362Z
 -->
 # Customization
 

--- a/website/app/docs/customization/ai-chat/agent.md
+++ b/website/app/docs/customization/ai-chat/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:2f11c9729fea733b
+sourceHash=fnv1a64:90a70f0c0a38a3ce
 settingsHash=fnv1a64:7a85fb928fd52635
 outputHash=fnv1a64:ded084b41bf41852
-generatedAt=2026-08-14T12:45:38.514Z
+generatedAt=2026-08-20T10:20:45.282Z
 -->
 # Ask AI
 

--- a/website/app/docs/customization/analytics/agent.md
+++ b/website/app/docs/customization/analytics/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:7bbdd54dbf142528
+sourceHash=fnv1a64:1d7dae95f1156a3b
 settingsHash=fnv1a64:72be2461542d7a95
 outputHash=fnv1a64:8dfc9629f7835ae0
-generatedAt=2026-08-14T12:45:38.531Z
+generatedAt=2026-08-20T10:20:45.290Z
 -->
 # Analytics
 

--- a/website/app/docs/customization/colors/agent.md
+++ b/website/app/docs/customization/colors/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:c961ad4ca8c68060
+sourceHash=fnv1a64:868072b335139257
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:3ef315ed2e252ae5
-generatedAt=2026-08-14T12:45:38.549Z
+generatedAt=2026-08-20T10:20:45.296Z
 -->
 # Colors
 

--- a/website/app/docs/customization/components/agent.md
+++ b/website/app/docs/customization/components/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:a6c99c7c5dd5505d
+sourceHash=fnv1a64:5c3143c5a326a02e
 settingsHash=fnv1a64:063b4c9a14696a17
 outputHash=fnv1a64:359366d4cee9d620
-generatedAt=2026-08-14T12:45:38.567Z
+generatedAt=2026-08-20T10:20:45.310Z
 -->
 # Components
 

--- a/website/app/docs/customization/llms-txt/agent.md
+++ b/website/app/docs/customization/llms-txt/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:16f85bc74cf45618
+sourceHash=fnv1a64:575801915b4e04d5
 settingsHash=fnv1a64:3fa80ff29bd1598e
 outputHash=fnv1a64:34ab5873e4b3807d
-generatedAt=2026-08-14T12:45:38.585Z
+generatedAt=2026-08-20T10:20:45.323Z
 -->
 # llms.txt
 

--- a/website/app/docs/customization/observability/agent.md
+++ b/website/app/docs/customization/observability/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:69c2b01877d26ee6
+sourceHash=fnv1a64:9d3948c775786cbd
 settingsHash=fnv1a64:72be2461542d7a95
 outputHash=fnv1a64:5a926dd8952106a9
-generatedAt=2026-08-14T12:45:38.600Z
+generatedAt=2026-08-20T10:20:45.332Z
 -->
 # Observability
 

--- a/website/app/docs/customization/og-images/agent.md
+++ b/website/app/docs/customization/og-images/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:a1b9c8598c9c6647
+sourceHash=fnv1a64:6fa5aff3470aecd8
 settingsHash=fnv1a64:1b5212557ba75927
 outputHash=fnv1a64:7df800a8c45ebe93
-generatedAt=2026-08-14T12:45:38.615Z
+generatedAt=2026-08-20T10:20:45.344Z
 -->
 # OG Images
 

--- a/website/app/docs/customization/page-actions/agent.md
+++ b/website/app/docs/customization/page-actions/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:f232a73ce7fd95a0
+sourceHash=fnv1a64:f58201f70663f345
 settingsHash=fnv1a64:72be2461542d7a95
 outputHash=fnv1a64:64fef2cb27439f75
-generatedAt=2026-08-14T12:45:38.632Z
+generatedAt=2026-08-20T10:20:45.354Z
 -->
 # Page Actions
 

--- a/website/app/docs/customization/sitemaps/agent.md
+++ b/website/app/docs/customization/sitemaps/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:3cd93ebac6b64e23
+sourceHash=fnv1a64:c75827353d89371c
 settingsHash=fnv1a64:0a67cd1f3384201a
 outputHash=fnv1a64:3255515be7b4e3ee
-generatedAt=2026-08-14T12:45:38.649Z
+generatedAt=2026-08-20T10:20:45.376Z
 -->
 # Sitemaps
 

--- a/website/app/docs/customization/telemetry/agent.md
+++ b/website/app/docs/customization/telemetry/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:b3153c6a1e416385
+sourceHash=fnv1a64:27054689be801ecc
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:aad652137c192ee9
-generatedAt=2026-08-14T12:45:38.665Z
+generatedAt=2026-08-20T10:20:45.382Z
 -->
 # Telemetry
 

--- a/website/app/docs/customization/typography/agent.md
+++ b/website/app/docs/customization/typography/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:69c5a7b4e0778750
+sourceHash=fnv1a64:d09604014837a203
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:65b300952ebb86ca
-generatedAt=2026-08-14T12:45:38.681Z
+generatedAt=2026-08-20T10:20:45.388Z
 -->
 # Typography
 

--- a/website/app/docs/guides/adapter-agent-conformance/agent.md
+++ b/website/app/docs/guides/adapter-agent-conformance/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:30143e9f8fe81760
+sourceHash=fnv1a64:452409f4999cf5d1
 settingsHash=fnv1a64:1b5212557ba75927
 outputHash=fnv1a64:a83cd1b06f2d79ce
-generatedAt=2026-08-14T12:45:38.700Z
+generatedAt=2026-08-20T10:20:45.398Z
 -->
 # Adapter Agent Conformance
 URL: /docs/guides/adapter-agent-conformance

--- a/website/app/docs/guides/agent-friendly-docs/agent.md
+++ b/website/app/docs/guides/agent-friendly-docs/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:4d12e10b1ac9e077
+sourceHash=fnv1a64:d065d00a89874ed0
 settingsHash=fnv1a64:4d5874ba9e62babc
 outputHash=fnv1a64:61659a4471a71139
-generatedAt=2026-08-14T12:45:38.718Z
+generatedAt=2026-08-20T10:20:45.416Z
 -->
 # How to Write Agent-Friendly Docs
 

--- a/website/app/docs/guides/agent.md
+++ b/website/app/docs/guides/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:1dfb9b75edeeb648
+sourceHash=fnv1a64:e51c1292ad1939d7
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:436ed7d4465ca450
-generatedAt=2026-08-14T12:45:38.733Z
+generatedAt=2026-08-20T10:20:45.423Z
 -->
 # Guides
 

--- a/website/app/docs/guides/docs-json/agent.md
+++ b/website/app/docs/guides/docs-json/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:ab69aa297661d3d3
+sourceHash=fnv1a64:e4672a145ab7496a
 settingsHash=fnv1a64:1b5212557ba75927
 outputHash=fnv1a64:1e47ea690d0acfae
-generatedAt=2026-08-14T12:45:38.750Z
+generatedAt=2026-08-20T10:20:45.420Z
 -->
 # docs.json
 

--- a/website/app/docs/installation/agent.md
+++ b/website/app/docs/installation/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:85177fbaa1b81ffe
+sourceHash=fnv1a64:fa9ae05c7f2c8a21
 settingsHash=fnv1a64:7a85fb928fd52635
 outputHash=fnv1a64:71ccadee7aea1a56
-generatedAt=2026-08-14T12:45:38.767Z
+generatedAt=2026-08-20T10:20:45.429Z
 -->
 # Installation
 

--- a/website/app/docs/migrations/agent.md
+++ b/website/app/docs/migrations/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:d65cb9b52018b5c1
+sourceHash=fnv1a64:b088d797f0937bf6
 settingsHash=fnv1a64:e50e89e221226fc3
 outputHash=fnv1a64:16b6b9153ee159ac
-generatedAt=2026-08-14T12:45:38.782Z
+generatedAt=2026-08-20T10:20:45.447Z
 -->
 # Migrations
 

--- a/website/app/docs/migrations/docusaurus/agent.md
+++ b/website/app/docs/migrations/docusaurus/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:cb1a64a72b2b5b3a
+sourceHash=fnv1a64:7473ae5d8120fdfd
 settingsHash=fnv1a64:dbac89e9f25094c8
 outputHash=fnv1a64:abf1331eb2fcdb2d
-generatedAt=2026-08-14T12:45:38.798Z
+generatedAt=2026-08-20T10:20:45.432Z
 -->
 # From Docusaurus
 

--- a/website/app/docs/migrations/fumadocs/agent.md
+++ b/website/app/docs/migrations/fumadocs/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:5c085ce3b80716d0
+sourceHash=fnv1a64:ba443015bda70c53
 settingsHash=fnv1a64:ab89fb28872d1850
 outputHash=fnv1a64:ceb94ed92d52e0d2
-generatedAt=2026-08-14T12:45:38.814Z
+generatedAt=2026-08-20T10:20:45.435Z
 -->
 # From Fumadocs
 

--- a/website/app/docs/migrations/gitbook/agent.md
+++ b/website/app/docs/migrations/gitbook/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:b8008eca9537395e
+sourceHash=fnv1a64:61844429143e125d
 settingsHash=fnv1a64:cd874ef828c34e2e
 outputHash=fnv1a64:1d89b214573ca5cb
-generatedAt=2026-08-14T12:45:38.831Z
+generatedAt=2026-08-20T10:20:45.437Z
 -->
 # From GitBook
 

--- a/website/app/docs/migrations/mintlify/agent.md
+++ b/website/app/docs/migrations/mintlify/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:d754ee9cd3292bb8
+sourceHash=fnv1a64:d6c92a8a6a7e2fa5
 settingsHash=fnv1a64:f146078e2605e9a5
 outputHash=fnv1a64:0c1d2236f001482f
-generatedAt=2026-08-14T12:45:38.847Z
+generatedAt=2026-08-20T10:20:45.440Z
 -->
 # From Mintlify
 

--- a/website/app/docs/migrations/mkdocs/agent.md
+++ b/website/app/docs/migrations/mkdocs/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:a88e536390348978
+sourceHash=fnv1a64:fdd94c82eb0cdb59
 settingsHash=fnv1a64:4b53757ce3e12a9b
 outputHash=fnv1a64:bf8874a303153bea
-generatedAt=2026-08-14T12:45:38.863Z
+generatedAt=2026-08-20T10:20:45.442Z
 -->
 # From Material for MkDocs
 

--- a/website/app/docs/migrations/nextra/agent.md
+++ b/website/app/docs/migrations/nextra/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:81bdb3af1e955ea8
+sourceHash=fnv1a64:2ac86bd1ef7c6b27
 settingsHash=fnv1a64:156231f9a09bd12a
 outputHash=fnv1a64:37de327de919bc44
-generatedAt=2026-08-14T12:45:38.879Z
+generatedAt=2026-08-20T10:20:45.445Z
 -->
 # From Nextra
 

--- a/website/app/docs/migrations/starlight/agent.md
+++ b/website/app/docs/migrations/starlight/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:1a9be43e00ba06ca
+sourceHash=fnv1a64:a910a0ceb75b0ed1
 settingsHash=fnv1a64:f146078e2605e9a5
 outputHash=fnv1a64:09583f805cb9d574
-generatedAt=2026-08-14T12:45:38.894Z
+generatedAt=2026-08-20T10:20:45.448Z
 -->
 # From Starlight
 

--- a/website/app/docs/migrations/vitepress/agent.md
+++ b/website/app/docs/migrations/vitepress/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:40480511b9483fbf
+sourceHash=fnv1a64:1eb3fc02f91739e4
 settingsHash=fnv1a64:cd874ef828c34e2e
 outputHash=fnv1a64:45e7a29e8e2d6424
-generatedAt=2026-08-14T12:45:38.909Z
+generatedAt=2026-08-20T10:20:45.450Z
 -->
 # From VitePress
 

--- a/website/app/docs/reference/agent.md
+++ b/website/app/docs/reference/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:7b1e836b3fdb970d
+sourceHash=fnv1a64:083bdfc462e36413
 settingsHash=fnv1a64:aa433a28ef4afd1f
 outputHash=fnv1a64:173fd105503fea58
-generatedAt=2026-08-14T12:45:38.933Z
+generatedAt=2026-08-20T10:20:45.743Z
 -->
 # API Reference
 URL: /docs/reference

--- a/website/app/docs/themes/agent.md
+++ b/website/app/docs/themes/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:0df67fe4d790f27e
+sourceHash=fnv1a64:4f98b04c6461ce6d
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:75c3aeaa240cd419
-generatedAt=2026-08-14T12:45:38.950Z
+generatedAt=2026-08-20T10:20:45.768Z
 -->
 # Themes
 URL: /docs/themes

--- a/website/app/docs/themes/colorful/agent.md
+++ b/website/app/docs/themes/colorful/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:606c53b9fb2a32e2
+sourceHash=fnv1a64:771733902b7228d1
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:0d7370d212e309e5
-generatedAt=2026-08-14T12:45:38.974Z
+generatedAt=2026-08-20T10:20:45.744Z
 -->
 # Colorful
 

--- a/website/app/docs/themes/command-grid/agent.md
+++ b/website/app/docs/themes/command-grid/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:2fa85c7d0af1647a
+sourceHash=fnv1a64:b53016c05f2ce795
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:fd28ea196ce8fcc0
-generatedAt=2026-08-14T12:45:39.004Z
+generatedAt=2026-08-20T10:20:45.746Z
 -->
 # Command Grid
 

--- a/website/app/docs/themes/concrete/agent.md
+++ b/website/app/docs/themes/concrete/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:d08b0f9d5f512b0c
+sourceHash=fnv1a64:f557580ee7f34db1
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:0ec98bd556d4357d
-generatedAt=2026-08-14T12:45:39.039Z
+generatedAt=2026-08-20T10:20:45.748Z
 -->
 # Concrete
 

--- a/website/app/docs/themes/creating-themes/agent.md
+++ b/website/app/docs/themes/creating-themes/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:c8e8eed91a75f7a3
+sourceHash=fnv1a64:7d3ea2e43cae0eb0
 settingsHash=fnv1a64:7a85fb928fd52635
 outputHash=fnv1a64:e4b62340e869277c
-generatedAt=2026-08-14T12:45:39.076Z
+generatedAt=2026-08-20T10:20:45.754Z
 -->
 # Creating Your Own Theme
 

--- a/website/app/docs/themes/darkbold/agent.md
+++ b/website/app/docs/themes/darkbold/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:1cf49d919b1b69af
+sourceHash=fnv1a64:eb28de07cc138d5a
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:10efb89ec97603ba
-generatedAt=2026-08-14T12:45:39.099Z
+generatedAt=2026-08-20T10:20:45.758Z
 -->
 # DarkBold
 

--- a/website/app/docs/themes/darksharp/agent.md
+++ b/website/app/docs/themes/darksharp/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:4a8ce4febf960206
+sourceHash=fnv1a64:430fa8fa630bea97
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:db2d07bbd99ba64e
-generatedAt=2026-08-14T12:45:39.117Z
+generatedAt=2026-08-20T10:20:45.759Z
 -->
 # Darksharp
 

--- a/website/app/docs/themes/default/agent.md
+++ b/website/app/docs/themes/default/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:9705d5bc86aaee85
+sourceHash=fnv1a64:38fc99035018bcec
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:96e8ebfae0f20da1
-generatedAt=2026-08-14T12:45:39.137Z
+generatedAt=2026-08-20T10:20:45.761Z
 -->
 # Default
 

--- a/website/app/docs/themes/greentree/agent.md
+++ b/website/app/docs/themes/greentree/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:018b273ee81c6a2b
+sourceHash=fnv1a64:af3df0c736fda380
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:8ac9a34d7b0c2434
-generatedAt=2026-08-14T12:45:39.157Z
+generatedAt=2026-08-20T10:20:45.763Z
 -->
 # GreenTree
 

--- a/website/app/docs/themes/hardline/agent.md
+++ b/website/app/docs/themes/hardline/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:b3ce971f1e640c96
+sourceHash=fnv1a64:13194b4e4a39f347
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:cc0e1afd72d1fd95
-generatedAt=2026-08-14T12:45:39.176Z
+generatedAt=2026-08-20T10:20:45.764Z
 -->
 # Hardline
 

--- a/website/app/docs/themes/ledger/agent.md
+++ b/website/app/docs/themes/ledger/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:beba09c58afaecfc
+sourceHash=fnv1a64:eb1bb0dc77715047
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:ce62f61e9051808e
-generatedAt=2026-08-14T12:45:39.203Z
+generatedAt=2026-08-20T10:20:45.766Z
 -->
 # Ledger
 

--- a/website/app/docs/themes/pixel-border/agent.md
+++ b/website/app/docs/themes/pixel-border/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:f777b1eacb30bd21
+sourceHash=fnv1a64:d83cd5953ab45dba
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:fb4a7dc49297d5e8
-generatedAt=2026-08-14T12:45:39.224Z
+generatedAt=2026-08-20T10:20:45.770Z
 -->
 # Pixel Border
 

--- a/website/app/docs/themes/shadcn/agent.md
+++ b/website/app/docs/themes/shadcn/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:49626196cddb16c7
+sourceHash=fnv1a64:526ea9f2e422fbee
 settingsHash=fnv1a64:ea29d93dde491bab
 outputHash=fnv1a64:44f89535b30a6f07
-generatedAt=2026-08-14T12:45:39.242Z
+generatedAt=2026-08-20T10:20:45.774Z
 -->
 ---
 title: "Shadcn"

--- a/website/app/docs/themes/shiny/agent.md
+++ b/website/app/docs/themes/shiny/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:f1961d315bcd1197
+sourceHash=fnv1a64:85813aa2618e1e42
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:974a02e90d406493
-generatedAt=2026-08-14T12:45:39.261Z
+generatedAt=2026-08-20T10:20:45.776Z
 -->
 # Shiny
 

--- a/website/app/docs/themes/threadline/agent.md
+++ b/website/app/docs/themes/threadline/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:59cda7e7d54ea0dd
+sourceHash=fnv1a64:e04737affe319498
 settingsHash=fnv1a64:b2106dff2d4f1f98
 outputHash=fnv1a64:7622f8a43295cd5e
-generatedAt=2026-08-14T12:45:39.294Z
+generatedAt=2026-08-20T10:20:45.778Z
 -->
 # Threadline
 

--- a/website/app/docs/token-efficiency/agent.md
+++ b/website/app/docs/token-efficiency/agent.md
@@ -1,10 +1,10 @@
 <!-- @farming-labs/docs:generated
 version=1
 sourceKind=resolved-page
-sourceHash=fnv1a64:bee96ff137ec7085
+sourceHash=fnv1a64:723305a70b3f23f3
 settingsHash=fnv1a64:72be2461542d7a95
 outputHash=fnv1a64:d63cfdc9326dd1b7
-generatedAt=2026-08-14T12:45:39.313Z
+generatedAt=2026-08-20T10:20:45.785Z
 -->
 # Token Efficiency
 


### PR DESCRIPTION
## Problem

The `freshness` (agent-freshness.yml) and `local-readiness` (agent-surface-smoke.yml) checks have been red on `main` since Aug 17.

Root cause: the compaction source document embedded a `last_updated` date derived from **file mtime** whenever a page had no explicit `lastmod` frontmatter — and no docs page sets one. Since every fresh checkout (including `actions/checkout`) stamps mtimes with the checkout time, `agent compact --check` could only pass on the same calendar day the content was generated. It passed Aug 14–16 by coincidence and broke on the first push after the Aug 14 provenance refresh (#485), flagging all 49 generated pages as stale and all 4 review-manifest entries as invalid, even though only the pages touched by #485/#487 had actually changed.

## Fix

- **Drop the mtime-derived `lastModified` fallback from the compaction source document** (`buildResolvedPageSourceDocument`); only explicit frontmatter `lastmod` contributes a `last_updated` line, so source hashes are stable across checkouts. Regression test included (shifts page mtimes by 400 days and asserts freshness is unaffected).
- **Re-stamp provenance `sourceHash` on all 49 generated `agent.md` pages** — content unchanged, only the two header lines per file. A full cloud re-compaction was measured to regress golden-task quality from 22/22 (99.5/100) to 9/22, so the curated output is kept, matching the approach of the #479 refresh.
- **Re-record the 4 drifted review-manifest entries** with explicit reviewer + rationale (`/docs/configuration` genuinely changed in #485; the three customization pages drifted only via the hashing fix), and **add reviewed entries for `/docs/cli`, `/docs/reference`, `/docs/token-efficiency`**, whose sources gained #485/#487 review-workflow coverage that the preserved compacted output does not yet fold in. The next edit to those pages will correctly demand a re-review.

## Verification

- `agent compact --check`: exits 0 — 46 fresh, 7 reviewed, 0 invalid/orphaned/stale/modified — and still passes after touching every `page.mdx` mtime (the failure mode that broke CI).
- `local-readiness` steps run locally: `doctor --agent --ci --fail-on fail` exits 0 (golden tasks 22/22 at 99.5/100, task completeness 30/30) and `check-agent-readiness-report.mjs` passes with 0 unexpected warnings.
- `vitest`: `cli/agent.test.ts` 29/29 (incl. new regression test), `agent-provenance.test.ts`, `cli/doctor.test.ts` 66/66.

## Follow-up

Fold #485's review-workflow coverage into the curated `agent.md` for `/docs/cli`, `/docs/reference`, and `/docs/token-efficiency`, then re-review those entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes agent compaction freshness independent of file mtimes so CI stays green. Previously the compaction source document injected a last_updated from file mtime when lastmod was missing; now only explicit frontmatter lastmod contributes, stabilizing source hashes across checkouts.

- Review focus
  - Removes the mtime-derived fallback in buildResolvedPageSourceDocument; adds a regression test that shifts a page’s mtime and keeps freshness unchanged.
  - Restamps provenance sourceHash on 49 generated agent.md files; content is unchanged aside from header lines. Re-compaction was measured to degrade golden-task quality, so curated outputs are preserved.
  - Updates the review manifest: re-records 4 drifted entries and adds reviewed entries for /docs/cli, /docs/reference, and /docs/token-efficiency to preserve curated outputs until new review-workflow coverage is folded in.

- Rollout and verification
  - No migration required.
  - `agent compact --check` now passes across days and after mtime changes; local readiness checks and tests pass, including the new regression test.

<sup>Written for commit 044c704b724f3cf1b154e412ed37ca5ece2b5304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

