### PR TITLE
fix: prevent docs navigation style flash

### DIFF
--- a/packages/fumadocs/src/browser.tsx
+++ b/packages/fumadocs/src/browser.tsx
@@ -12,6 +12,7 @@ import {
   type ComponentPropsWithoutRef,
   type MouseEvent as ReactMouseEvent,
 } from "react";
+import { subscribeToWindowLocation } from "./client-location.js";
 import { TanstackDocsLayout, type TanstackDocsLayoutProps } from "./tanstack-layout.js";
 
 export type BrowserDocsLayoutProps = Omit<TanstackDocsLayoutProps, "browserRuntime">;
@@ -22,12 +23,6 @@ export function BrowserDocsLayout(props: BrowserDocsLayoutProps) {
 }
 
 type FumadocsProviderProps = ComponentPropsWithoutRef<typeof FumadocsRootProvider>;
-
-declare global {
-  interface Window {
-    __fdBrowserHistoryPatched?: boolean;
-  }
-}
 
 export interface BrowserRootProviderProps extends FumadocsProviderProps {
   /** Path rendered by the server, used to keep hydration deterministic. */
@@ -51,33 +46,6 @@ const defaultBrowserNavigation: BrowserNavigationAdapter = {
 };
 
 const BrowserNavigationContext = createContext<BrowserNavigationAdapter>(defaultBrowserNavigation);
-
-function patchHistoryEvents() {
-  if (typeof window === "undefined" || window.__fdBrowserHistoryPatched) return;
-
-  for (const method of ["pushState", "replaceState"] as const) {
-    const original = window.history[method];
-    window.history[method] = function patchedHistoryMethod(...args) {
-      const result = original.apply(this, args);
-      window.dispatchEvent(new Event("fd-location-change"));
-      return result;
-    };
-  }
-
-  window.__fdBrowserHistoryPatched = true;
-}
-
-function subscribeToLocation(onStoreChange: () => void) {
-  if (typeof window === "undefined") return () => {};
-  patchHistoryEvents();
-
-  window.addEventListener("popstate", onStoreChange);
-  window.addEventListener("fd-location-change", onStoreChange);
-  return () => {
-    window.removeEventListener("popstate", onStoreChange);
-    window.removeEventListener("fd-location-change", onStoreChange);
-  };
-}
 
 function getBrowserPathname() {
   return typeof window === "undefined" ? "/" : window.location.pathname;
@@ -145,7 +113,7 @@ export function BrowserRootProvider({
   ...props
 }: BrowserRootProviderProps) {
   const useBrowserPathname = () =>
-    useSyncExternalStore(subscribeToLocation, getBrowserPathname, () => initialPathname);
+    useSyncExternalStore(subscribeToWindowLocation, getBrowserPathname, () => initialPathname);
 
   return (
     <BrowserNavigationContext.Provider value={navigation}>

--- a/packages/fumadocs/src/client-location.test.ts
+++ b/packages/fumadocs/src/client-location.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { subscribeToWindowLocation } from "./client-location.js";
+
+type TestWindow = EventTarget & {
+  __fdHistoryPatched?: boolean;
+  history: {
+    pushState(data: unknown, unused: string, url?: string | URL | null): void;
+    replaceState(data: unknown, unused: string, url?: string | URL | null): void;
+  };
+};
+
+const originalWindow = globalThis.window;
+
+function createTestWindow(): TestWindow {
+  return Object.assign(new EventTarget(), {
+    history: {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("subscribeToWindowLocation", () => {
+  it("notifies after the current React commit and coalesces history changes", async () => {
+    const testWindow = createTestWindow();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: testWindow,
+    });
+    const onStoreChange = vi.fn();
+    const unsubscribe = subscribeToWindowLocation(onStoreChange);
+
+    testWindow.history.pushState(null, "", "/docs/one");
+    testWindow.history.replaceState(null, "", "/docs/two");
+
+    expect(onStoreChange).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(onStoreChange).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("cancels a queued notification when the subscriber unmounts", async () => {
+    const testWindow = createTestWindow();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: testWindow,
+    });
+    const onStoreChange = vi.fn();
+    const unsubscribe = subscribeToWindowLocation(onStoreChange);
+
+    testWindow.history.pushState(null, "", "/docs/one");
+    unsubscribe();
+    await Promise.resolve();
+
+    expect(onStoreChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fumadocs/src/client-location.ts
+++ b/packages/fumadocs/src/client-location.ts
@@ -25,18 +25,31 @@ function patchHistoryEvents() {
   window.__fdHistoryPatched = true;
 }
 
-function subscribe(onStoreChange: () => void) {
+export function subscribeToWindowLocation(onStoreChange: () => void) {
   if (typeof window === "undefined") return () => {};
 
   patchHistoryEvents();
 
-  const notify = () => onStoreChange();
+  let active = true;
+  let notificationQueued = false;
+  const notify = () => {
+    if (notificationQueued) return;
+    notificationQueued = true;
+
+    // Routers can update history during React's commit phase. Notify subscribers
+    // once that commit completes while still updating before the browser paints.
+    queueMicrotask(() => {
+      notificationQueued = false;
+      if (active) onStoreChange();
+    });
+  };
 
   window.addEventListener("popstate", notify);
   window.addEventListener("hashchange", notify);
   window.addEventListener("fd-location-change", notify);
 
   return () => {
+    active = false;
     window.removeEventListener("popstate", notify);
     window.removeEventListener("hashchange", notify);
     window.removeEventListener("fd-location-change", notify);
@@ -54,10 +67,10 @@ function getPathnameSnapshot() {
 }
 
 export function useWindowSearchParams(): URLSearchParams {
-  const search = useSyncExternalStore(subscribe, getSearchSnapshot, () => "");
+  const search = useSyncExternalStore(subscribeToWindowLocation, getSearchSnapshot, () => "");
   return new URLSearchParams(search);
 }
 
 export function useWindowPathname(): string {
-  return useSyncExternalStore(subscribe, getPathnameSnapshot, () => "");
+  return useSyncExternalStore(subscribeToWindowLocation, getPathnameSnapshot, () => "");
 }

--- a/packages/fumadocs/src/docs-page-client.tsx
+++ b/packages/fumadocs/src/docs-page-client.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { DocsBody, DocsPage, EditOnGitHub } from "fumadocs-ui/layouts/docs/page";
-import { Children, Fragment, useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  Children,
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 import { usePathname, useRouter } from "fumadocs-core/framework";
 import type {
@@ -627,24 +635,20 @@ export function DocsPageClient({
   const effectiveTocEnabled = isChangelogRoute ? false : tocEnabled;
   const effectiveBreadcrumbEnabled = isChangelogRoute ? false : breadcrumbEnabled;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!effectiveTocEnabled) return;
 
-    const timer = requestAnimationFrame(() => {
-      const container = document.getElementById("nd-page");
-      if (!container) return;
+    const container = document.getElementById("nd-page");
+    if (!container) return;
 
-      const headings = container.querySelectorAll("h2[id], h3[id], h4[id]");
-      const items: TOCItem[] = Array.from(headings).map((el) => ({
-        title: el.textContent?.replace(/^#\s*/, "") || "",
-        url: `#${el.id}`,
-        depth: parseInt(el.tagName[1], 10),
-      }));
+    const headings = container.querySelectorAll("h2[id], h3[id], h4[id]");
+    const items: TOCItem[] = Array.from(headings).map((el) => ({
+      title: el.textContent?.replace(/^#\s*/, "") || "",
+      url: `#${el.id}`,
+      depth: parseInt(el.tagName[1], 10),
+    }));
 
-      setToc(items);
-    });
-
-    return () => cancelAnimationFrame(timer);
+    setToc(items);
   }, [children, effectiveTocEnabled, pathname]);
 
   useEffect(() => {
@@ -731,7 +735,7 @@ export function DocsPageClient({
         )
       : undefined);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!showActionsInToc) {
       setTocActionsPortalHost(null);
       return;
@@ -782,7 +786,7 @@ export function DocsPageClient({
     };
   }, [pathname, showActionsInToc, toc.length]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!showActionsInToc) {
       setTitleControlsPortalHost(null);
       return;
@@ -890,7 +894,7 @@ export function DocsPageClient({
   const decoratedChildren = children;
   const needsTitleDecorationsPortal = !pageTitle && (!!titleDescription || !!belowTitleBlock);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!needsTitleDecorationsPortal) {
       setTitlePortalHost(null);
       return;

--- a/packages/nuxt-theme/src/components/DocsPage.vue
+++ b/packages/nuxt-theme/src/components/DocsPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import Breadcrumb from "./Breadcrumb.vue";
 import TableOfContents from "./TableOfContents.vue";


### PR DESCRIPTION
## Summary

- defer and coalesce shared location-store notifications until React commits finish
- mount navigation-dependent TOC and title controls before the browser paints
- fix the missing Vue `computed` import uncovered while checking Nuxt navigation

## Verification

- `pnpm --filter @farming-labs/theme test` (210 tests)
- `pnpm --filter @farming-labs/theme typecheck`
- `pnpm --filter @farming-labs/theme build`
- `pnpm --filter @farming-labs/farmjs test` (39 tests)
- adapter typechecks for Next.js, Farm.js, TanStack Start, SvelteKit, Astro, and Nuxt
- browser navigation checks for Next.js, TanStack Start, SvelteKit, Astro, and Nuxt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a flash of incorrect styles during docs navigation by deferring location updates until after React commits and mounting navigation‑dependent UI before the browser paints. Previously, history changes notified subscribers immediately and TOC/title controls mounted post‑paint; now notifications are coalesced in a microtask and TOC/actions/title decorations mount in layout effects.

- Review notes
  - Centralizes window location subscription as `subscribeToWindowLocation`, patching `pushState`/`replaceState`, coalescing `popstate`/`hashchange`/custom events into a single microtask notification, and canceling when unsubscribed; unit tests added.
  - Switches several effects in `DocsPageClient` to `useLayoutEffect` so TOC computation and portals for actions/title controls mount before paint.
  - `BrowserRootProvider` now uses the shared subscription to avoid duplicate history patching.
  - Fixes a missing Vue `computed` import in the Nuxt docs page.
  - No consumer migration required; behavior change is the removal of the style flash during navigation.

<sup>Written for commit befa1b168c7f36732ac3e034e2227d278b558382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

