### PR TITLE
chore: release v0.2.111

### DIFF
--- a/packages/astro-theme/package.json
+++ b/packages/astro-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro-theme",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Astro UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "astro",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Astro adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "astro",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/docs",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Modern, flexible MDX-based docs framework — core types, config, and CLI",
   "keywords": [
     "docs",

--- a/packages/farmjs/package.json
+++ b/packages/farmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/farmjs",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Farm.js adapter for @farming-labs/docs",
   "keywords": [
     "docs",

--- a/packages/fumadocs/package.json
+++ b/packages/fumadocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/theme",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Theme package for @farming-labs/docs — layout, provider, MDX components, and styles",
   "keywords": [
     "docs",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/next",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Next.js adapter for @farming-labs/docs — MDX config wrapper",
   "keywords": [
     "docs",

--- a/packages/nuxt-theme/package.json
+++ b/packages/nuxt-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt-theme",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Nuxt/Vue UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Nuxt adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/svelte-theme/package.json
+++ b/packages/svelte-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte-theme",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "Svelte UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "SvelteKit adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/tanstack-start",
-  "version": "0.2.110",
+  "version": "0.2.111",
   "description": "TanStack Start adapter for @farming-labs/docs — content loading, search, and AI utilities",
   "keywords": [
     "docs",


### PR DESCRIPTION
## Summary

- bump all eleven published @farming-labs packages from 0.2.110 to 0.2.111
- release the Farm browser-style compatibility fix from #490
- include the patched tar 7.5.22 security override merged with #490

## Verification

- full workspace build passed during the version bump
- theme: 210 tests, typecheck, and build passed
- Farm adapter: 39 tests, typecheck, and build passed
- security audit passed with no unapproved high or critical vulnerabilities
- PR #490 checks and Vercel previews were green before merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v0.2.111 across all published `@farming-labs` packages. Previously, the Farm adapter had a browser-style compatibility issue; this release ships the fix and pins `tar@7.5.22` for security without other behavior changes.

**What’s included**
- Version bump to 0.2.111 for: `@farming-labs/astro-theme`, `@farming-labs/astro`, `@farming-labs/docs`, `@farming-labs/farmjs`, `@farming-labs/theme`, `@farming-labs/next`, `@farming-labs/nuxt-theme`, `@farming-labs/nuxt`, `@farming-labs/svelte-theme`, `@farming-labs/svelte`, `@farming-labs/tanstack-start`.
- Ships the Farm browser-style compatibility fix.
- Forces `tar@7.5.22` via security override.

**Rollout**
- No migration required; consumers can upgrade to `^0.2.111`.
- CI passed: full workspace build, adapter/theme tests, and security audit clean.

<sup>Written for commit 16c18753a8f8c0287423ed4c7d31c38afa36c889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

