### PR TITLE
fix: stabilize production agent evaluations

### DIFF
--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -1769,6 +1769,7 @@ Use the scoped integration.
   });
 
   it("fails configured provider errors instead of falling back to simple search", async () => {
+    let calls = 0;
     const report = await runDocsGoldenTasks(
       pages,
       [
@@ -1786,6 +1787,7 @@ Use the scoped integration.
           adapter: {
             name: "broken-search",
             async search() {
+              calls += 1;
               throw new Error("fixture provider unavailable");
             },
           },
@@ -1793,9 +1795,55 @@ Use the scoped integration.
       },
     );
 
+    expect(calls).toBe(1);
     expect(report.status).toBe("failed");
     expect(report.tasks[0]).toMatchObject({ provider: "unavailable", sources: [] });
     expect(report.tasks[0].issues.join(" ")).toContain("fixture provider unavailable");
+  });
+
+  it("retries transient configured provider failures", async () => {
+    let calls = 0;
+    const report = await runDocsGoldenTasks(
+      pages,
+      [
+        {
+          id: "transient-search",
+          query: "legacy middleware authentication",
+          surface: "configured-search",
+          topK: 1,
+          expect: { relevantSources: ["/docs/auth-v15"] },
+        },
+      ],
+      {
+        allowNetwork: true,
+        searchTimeoutMs: 10,
+        search: {
+          provider: "custom",
+          adapter: {
+            name: "transient-search",
+            async search() {
+              calls += 1;
+              if (calls === 1) throw new TypeError("fetch failed");
+              if (calls === 2) {
+                throw new Error("MCP search request failed (503 Service Unavailable)");
+              }
+              return [
+                {
+                  id: "remote-v15",
+                  url: "/docs/auth-v15",
+                  content: "Remote legacy authentication result",
+                  type: "page" as const,
+                },
+              ];
+            },
+          },
+        },
+      },
+    );
+
+    expect(calls).toBe(3);
+    expect(report.status).toBe("passed");
+    expect(report.tasks[0]).toMatchObject({ provider: "custom", passed: true });
   });
 
   it("fails closed on malformed runtime search provider values", async () => {
@@ -1854,7 +1902,7 @@ Use the scoped integration.
   });
 
   it("times out configured providers and aborts their adapter context", async () => {
-    let observedSignal: AbortSignal | undefined;
+    const observedSignals: AbortSignal[] = [];
     const report = await runDocsGoldenTasks(
       pages,
       [{ ...passingTask, surface: "configured-search" }],
@@ -1866,7 +1914,7 @@ Use the scoped integration.
           adapter: {
             name: "stalled",
             search(_query, context) {
-              observedSignal = context.signal;
+              if (context.signal) observedSignals.push(context.signal);
               return new Promise(() => undefined);
             },
           },
@@ -1874,7 +1922,8 @@ Use the scoped integration.
       },
     );
 
-    expect(observedSignal?.aborted).toBe(true);
+    expect(observedSignals).toHaveLength(3);
+    expect(observedSignals.every((signal) => signal.aborted)).toBe(true);
     expect(report.status).toBe("failed");
     expect(report.tasks[0].issues.join(" ")).toContain("timed out after 10ms");
   });

--- a/packages/docs/src/agent-evals.test.ts
+++ b/packages/docs/src/agent-evals.test.ts
@@ -1825,7 +1825,7 @@ Use the scoped integration.
               calls += 1;
               if (calls === 1) throw new TypeError("fetch failed");
               if (calls === 2) {
-                throw new Error("MCP search request failed (503 Service Unavailable)");
+                throw new Error("MCP search request failed with HTTP 503 Service Unavailable");
               }
               return [
                 {
@@ -1844,6 +1844,114 @@ Use the scoped integration.
     expect(calls).toBe(3);
     expect(report.status).toBe("passed");
     expect(report.tasks[0]).toMatchObject({ provider: "custom", passed: true });
+  });
+
+  it("retries malformed transient MCP responses using their HTTP status", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const initialize = () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            protocolVersion: "2025-11-25",
+            capabilities: {},
+            serverInfo: { name: "fixture", version: "1.0.0" },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const initialized = () => new Response(null, { status: 202 });
+    const searchResponse = () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  results: [
+                    {
+                      slug: "auth-v15",
+                      url: "/docs/auth-v15",
+                      title: "Authentication for Next.js 15",
+                      excerpt: "legacy middleware authentication",
+                    },
+                  ],
+                }),
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    try {
+      fetchMock
+        .mockResolvedValueOnce(initialize())
+        .mockResolvedValueOnce(initialized())
+        .mockResolvedValueOnce(
+          new Response("{", {
+            status: 503,
+            statusText: "Service Unavailable",
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(initialize())
+        .mockResolvedValueOnce(initialized())
+        .mockResolvedValueOnce(searchResponse());
+
+      const report = await runDocsGoldenTasks(
+        pages,
+        [
+          {
+            id: "transient-mcp-search",
+            query: "legacy middleware authentication",
+            surface: "configured-search",
+            topK: 1,
+            expect: { relevantSources: ["/docs/auth-v15"] },
+          },
+        ],
+        {
+          allowNetwork: true,
+          searchTimeoutMs: 100,
+          search: { provider: "mcp", endpoint: "https://search.example/mcp" },
+        },
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(report.status).toBe("passed");
+      expect(report.tasks[0]).toMatchObject({ provider: "mcp", passed: true });
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("does not retry non-HTTP provider errors that only contain status-like numbers", async () => {
+    let calls = 0;
+    const report = await runDocsGoldenTasks(
+      pages,
+      [{ ...passingTask, surface: "configured-search" }],
+      {
+        allowNetwork: true,
+        search: {
+          provider: "custom",
+          adapter: {
+            name: "invalid-config",
+            async search() {
+              calls += 1;
+              throw new Error("Expected 503 indexed documents in the validation fixture.");
+            },
+          },
+        },
+      },
+    );
+
+    expect(calls).toBe(1);
+    expect(report.status).toBe("failed");
+    expect(report.tasks[0].issues.join(" ")).toContain("Expected 503 indexed documents");
   });
 
   it("fails closed on malformed runtime search provider values", async () => {

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -60,6 +60,7 @@ import type {
 
 const DEFAULT_TOP_K = 5;
 const DEFAULT_TOKEN_BUDGET = 4_000;
+const DEFAULT_SEARCH_RETRIES = 2;
 const CONTEXT_SEPARATOR = "\n\n---\n\n";
 const STATIC_CODE_PLAN_CONFIG = resolveDocsCodeBlocksValidateConfig(true);
 const STATIC_JITI = createJiti(import.meta.url, { fsCache: false, moduleCache: false });
@@ -366,7 +367,7 @@ export interface RunDocsGoldenTasksOptions {
   rootDir?: string;
   /** Permit external configured search or HTTP answer calls. @default false */
   allowNetwork?: boolean;
-  /** Per-task configured-search/Ask-AI retrieval timeout in milliseconds. @default 30000 */
+  /** Per-attempt configured-search/Ask-AI retrieval timeout in milliseconds. @default 30000 */
   searchTimeoutMs?: number;
   /** Project code-block validation config used only by explicit execute expectations. */
   codeBlocksValidate?: boolean | DocsCodeBlocksValidateConfig;
@@ -1458,6 +1459,72 @@ function assertEvaluationSearchAllowed(
   }
 }
 
+class EvaluationSearchTimeoutError extends Error {
+  constructor(provider: string, timeoutMs: number) {
+    super(`The ${provider} search provider timed out after ${timeoutMs}ms.`);
+    this.name = "EvaluationSearchTimeoutError";
+  }
+}
+
+function isRetryableEvaluationSearchError(error: unknown): boolean {
+  if (error instanceof EvaluationSearchTimeoutError) return true;
+  if (
+    error instanceof TypeError &&
+    /\b(?:fetch|network|socket|connection)\b/iu.test(error.message)
+  ) {
+    return true;
+  }
+  if (!isRecord(error)) return false;
+
+  const status = typeof error.status === "number" ? error.status : undefined;
+  if (
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    (status !== undefined && status >= 500 && status <= 599)
+  ) {
+    return true;
+  }
+
+  const code = typeof error.code === "string" ? error.code : "";
+  if (/^(?:ECONNABORTED|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT)$/u.test(code)) {
+    return true;
+  }
+
+  const message = typeof error.message === "string" ? error.message : "";
+  if (/\b(?:408|425|429|5\d\d)\b/u.test(message)) return true;
+  return error.cause !== error && isRetryableEvaluationSearchError(error.cause);
+}
+
+async function runEvaluationSearchAttempt<T>(options: {
+  provider: string;
+  timeoutMs: number;
+  run: (signal: AbortSignal) => Promise<T>;
+}): Promise<T> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: EvaluationSearchTimeoutError | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      timeoutError = new EvaluationSearchTimeoutError(options.provider, options.timeoutMs);
+      controller.abort();
+      reject(timeoutError);
+    }, options.timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => options.run(controller.signal)),
+      timedOut,
+    ]).catch((error: unknown) => {
+      if (timeoutError) throw timeoutError;
+      throw error;
+    });
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 async function runEvaluationSearchWithTimeout<T>(options: {
   provider: string;
   timeoutMs?: number;
@@ -1472,29 +1539,16 @@ async function runEvaluationSearchWithTimeout<T>(options: {
     throw new Error("The agent evaluation searchTimeoutMs must be a positive finite number.");
   }
   const timeoutMs = normalizePositiveInteger(options.timeoutMs, 30_000, 300_000);
-  const controller = new AbortController();
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: Error | undefined;
-  const timedOut = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      timeoutError = new Error(
-        `The ${options.provider} search provider timed out after ${timeoutMs}ms.`,
-      );
-      controller.abort();
-      reject(timeoutError);
-    }, timeoutMs);
-  });
-
-  try {
-    return await Promise.race([
-      Promise.resolve().then(() => options.run(controller.signal)),
-      timedOut,
-    ]).catch((error: unknown) => {
-      if (timeoutError) throw timeoutError;
-      throw error;
-    });
-  } finally {
-    if (timeout) clearTimeout(timeout);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await runEvaluationSearchAttempt({ ...options, timeoutMs });
+    } catch (error) {
+      if (attempt >= DEFAULT_SEARCH_RETRIES || !isRetryableEvaluationSearchError(error)) {
+        throw error;
+      }
+      const retryDelayMs = Math.min(1_000, Math.max(1, Math.floor(timeoutMs / 100)) * 2 ** attempt);
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
   }
 }
 

--- a/packages/docs/src/agent-evals.ts
+++ b/packages/docs/src/agent-evals.ts
@@ -1492,7 +1492,13 @@ function isRetryableEvaluationSearchError(error: unknown): boolean {
   }
 
   const message = typeof error.message === "string" ? error.message : "";
-  if (/\b(?:408|425|429|5\d\d)\b/u.test(message)) return true;
+  if (
+    /\b(?:HTTP(?: status)?|status(?: code)?|response code)\s*[:=]?\s*(?:408|425|429|5\d\d)\b/iu.test(
+      message,
+    )
+  ) {
+    return true;
+  }
   return error.cause !== error && isRetryableEvaluationSearchError(error.cause);
 }
 

--- a/packages/docs/src/search.ts
+++ b/packages/docs/src/search.ts
@@ -3059,9 +3059,19 @@ async function readMcpResponsePayload(response: Response) {
   return normalizeMcpSsePayload(text);
 }
 
+class DocsSearchHttpError extends Error {
+  readonly status: number;
+
+  constructor(response: Response, message: string) {
+    super(`${message} (${response.status} ${response.statusText})`);
+    this.name = "DocsSearchHttpError";
+    this.status = response.status;
+  }
+}
+
 function ensureOk(response: Response, message: string) {
   if (response.ok) return;
-  throw new Error(`${message} (${response.status} ${response.statusText})`);
+  throw new DocsSearchHttpError(response, message);
 }
 
 function ensureJsonRpcOk(payload: unknown, message: string) {
@@ -3866,8 +3876,8 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
       signal: context.signal,
     });
 
-    const initializePayload = await readMcpResponsePayload(initializeResponse);
     ensureOk(initializeResponse, "MCP search initialization failed");
+    const initializePayload = await readMcpResponsePayload(initializeResponse);
     ensureJsonRpcOk(initializePayload, "MCP search initialization failed");
 
     const sessionId = initializeResponse.headers.get("mcp-session-id") ?? undefined;
@@ -3938,8 +3948,8 @@ export function createMcpSearchAdapter(config: McpDocsSearchConfig): DocsSearchA
           signal: context.signal,
         });
 
-        const payload = await readMcpResponsePayload(searchResponse);
         ensureOk(searchResponse, "MCP search request failed");
+        const payload = await readMcpResponsePayload(searchResponse);
         ensureJsonRpcOk(payload, "MCP search request failed");
 
         const parsed = readMcpSearchToolPayload(payload) as McpSearchToolData;

--- a/website/.farming-labs/agent-compaction-reviews.json
+++ b/website/.farming-labs/agent-compaction-reviews.json
@@ -3,21 +3,21 @@
   "reviews": [
     {
       "route": "/docs/cli",
-      "sourceHash": "fnv1a64:ff98ba0ac661af3e",
+      "sourceHash": "fnv1a64:c6b16ea956736363",
       "settingsHash": "fnv1a64:e50e89e221226fc3",
       "outputHash": "fnv1a64:c95a0dd048e26147",
-      "reviewedAt": "2026-08-20T10:21:22.767Z",
+      "reviewedAt": "2026-09-04T09:42:24.212Z",
       "reviewedBy": "Kinfe123",
-      "reason": "Preserve the curated compacted output that passes the golden-task quality gates: #485/#487 added agent-compact review-workflow coverage to these source pages, and a cloud re-compaction regressed golden tasks from 22/22 to 9/22, so the curated agent.md is kept until the new coverage is folded in by a reviewed curation pass."
+      "reason": "Reviewed the evaluation retry documentation: the CLI and reference summaries remain accurate, and the configuration summary now reflects per-attempt timeouts plus two transient retries."
     },
     {
       "route": "/docs/configuration",
-      "sourceHash": "fnv1a64:036bc04f1a1943f6",
+      "sourceHash": "fnv1a64:deb172b215e402b7",
       "settingsHash": "fnv1a64:aa433a28ef4afd1f",
-      "outputHash": "fnv1a64:d404f870b0ddaafa",
-      "reviewedAt": "2026-08-20T10:21:05.808Z",
+      "outputHash": "fnv1a64:d02d5fedea16c02f",
+      "reviewedAt": "2026-09-04T09:42:24.218Z",
       "reviewedBy": "Kinfe123",
-      "reason": "Re-reviewed after #485 documented agent.compact.reviewManifestPath in the source page: the preserved machine-oriented configuration contract covers agent.compact at the defaults level, so its guidance remains correct without enumerating the new option. Hash also shifted because compaction source hashing no longer embeds mtime-derived last_updated dates."
+      "reason": "Reviewed the evaluation retry documentation: the CLI and reference summaries remain accurate, and the configuration summary now reflects per-attempt timeouts plus two transient retries."
     },
     {
       "route": "/docs/customization/agent-primitive",
@@ -48,12 +48,12 @@
     },
     {
       "route": "/docs/reference",
-      "sourceHash": "fnv1a64:083bdfc462e36413",
+      "sourceHash": "fnv1a64:e90f1c62e51677bc",
       "settingsHash": "fnv1a64:aa433a28ef4afd1f",
       "outputHash": "fnv1a64:173fd105503fea58",
-      "reviewedAt": "2026-08-20T10:21:22.777Z",
+      "reviewedAt": "2026-09-04T09:42:24.227Z",
       "reviewedBy": "Kinfe123",
-      "reason": "Preserve the curated compacted output that passes the golden-task quality gates: #485/#487 added agent-compact review-workflow coverage to these source pages, and a cloud re-compaction regressed golden tasks from 22/22 to 9/22, so the curated agent.md is kept until the new coverage is folded in by a reviewed curation pass."
+      "reason": "Reviewed the evaluation retry documentation: the CLI and reference summaries remain accurate, and the configuration summary now reflects per-attempt timeouts plus two transient retries."
     },
     {
       "route": "/docs/token-efficiency",

--- a/website/app/docs/cli/page.mdx
+++ b/website/app/docs/cli/page.mdx
@@ -748,7 +748,8 @@ default. Opt-in `configured-search` and `ask-ai-context` surfaces fail closed wh
 provider fails. Framework-managed external search, HTTP answer requests, and runtime example
 execution require `allowNetwork: true`; callbacks are explicit user code, and runtime examples
 execute only when both the task and `codeBlocks.validate` request it. Configured retrieval uses the
-per-task `searchTimeoutMs` limit, which defaults to 30 seconds.
+per-attempt `searchTimeoutMs` limit, which defaults to 30 seconds, and retries transient failures
+twice with bounded backoff.
 
 The doctor separates **golden-task quality** (pass/fail rate across configured expectations) from **evaluation coverage** (which evaluation dimensions are exercised). The three coverage dimensions — safety, answer quality, and executable examples — each report `unmeasured` until at least one configured task explicitly exercises them, and `partially-measured` when only a subset of tasks do. A new `golden-task-coverage` check reports `warn` when any dimension is unmeasured or partially measured. Because incomplete coverage blocks the top grade, a site with unmeasured dimensions scores as **Agent-ready** at most, even when quality is perfect — **Agent-optimized** requires full evaluation coverage.
 Common forms:

--- a/website/app/docs/configuration/agent.md
+++ b/website/app/docs/configuration/agent.md
@@ -64,9 +64,9 @@ Use this machine-oriented page when the user needs implementation guidance for `
   and `ask-ai-context` measures the production Ask AI retrieval/context assembly path.
 - Non-simple search providers and the built-in HTTP answer provider require
   `agent.evaluations.allowNetwork: true`. Provider failures fail the task instead of falling back to
-  local search. Configured retrieval also fails at `searchTimeoutMs`, which defaults to 30 seconds
-  per task. Optional HTTP authentication belongs in `answer.headers`; header values are never
-  included in reports.
+  local search. `searchTimeoutMs` defaults to 30 seconds per retrieval attempt; transient timeouts,
+  fetch failures, rate limits, and server errors are retried twice with bounded backoff. Optional
+  HTTP authentication belongs in `answer.headers`; header values are never included in reports.
 - An answer provider is opt-in. Use `{ provider: "callback", run }` for explicit user code or
   `{ provider: "http", endpoint, headers?, timeoutMs? }` for the managed HTTP contract. Add
   `expect.answer` only when answer text and answer citations should be scored; context citations are

--- a/website/app/docs/configuration/page.mdx
+++ b/website/app/docs/configuration/page.mdx
@@ -1681,8 +1681,9 @@ Choose the surface globally with `agent.evaluations.surface` or override it on o
 Non-simple configured search providers require `allowNetwork: true`. Provider errors fail the task
 instead of silently substituting local search, so the report always identifies the surface and
 provider it actually measured. `searchTimeoutMs` bounds each configured-search or Ask AI retrieval
-and defaults to 30 seconds; the timeout aborts framework-managed requests and is also exposed to
-custom adapters as `context.signal`. The evaluator records actual UTF-8 usage for every surface. MCP and
+attempt and defaults to 30 seconds. Transient timeouts, fetch failures, rate limits, and server
+errors are retried twice with bounded backoff; other provider errors fail immediately. Each timeout
+aborts framework-managed requests and is also exposed to custom adapters as `context.signal`. The evaluator records actual UTF-8 usage for every surface. MCP and
 configured-search contexts enforce the byte ceiling directly; Ask AI uses its production character
 limit and fails the budget check if the resulting UTF-8 payload exceeds the configured ceiling.
 

--- a/website/app/docs/reference/page.mdx
+++ b/website/app/docs/reference/page.mdx
@@ -1075,7 +1075,7 @@ transports do not implement A2A.
 | `topK` | `number` | `5` | Default ranked retrieval depth |
 | `surface` | `"mcp-context" \| "configured-search" \| "ask-ai-context"` | `"mcp-context"` | Retrieval/context surface measured by the suite |
 | `allowNetwork` | `boolean` | `false` | Allow framework-managed external search, HTTP answers, and runtime example execution |
-| `searchTimeoutMs` | `number` | `30000` | Per-task timeout for configured-search and Ask AI retrieval |
+| `searchTimeoutMs` | `number` | `30000` | Per-attempt timeout for configured-search and Ask AI retrieval; transient failures are retried twice |
 | `answer` | `DocsAgentEvaluationAnswerProvider` | — | Opt-in callback or HTTP provider for actual-answer evaluation |
 | `tasks` | `DocsAgentGoldenTask[]` | `[]` | Representative tasks; an empty list is reported as unmeasured |
 


### PR DESCRIPTION
## Summary

- retry configured-search and Ask AI retrieval after transient timeouts, fetch failures, rate limits, and server errors
- abort every timed-out attempt and retain immediate failures for non-transient provider errors
- document the per-attempt timeout and bounded retry behavior

## Tests

- pnpm --filter @farming-labs/docs test
- pnpm --filter @farming-labs/docs typecheck
- pnpm exec oxlint packages/docs/src/agent-evals.ts packages/docs/src/agent-evals.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes production agent evaluations by retrying transient retrieval failures in configured-search and Ask AI instead of failing the task on the first attempt.

- Retries timeouts, fetch failures, rate limits, and server errors up to two times with bounded backoff; other provider errors still fail immediately.
- Classifies transient MCP failures by HTTP status even when the payload is malformed, and ignores status-like numbers in plain error messages.
- Aborts every timed-out attempt and exposes the abort signal to custom adapters via `context.signal`.
- Documents the per-attempt `searchTimeoutMs` limit and retry behavior in the CLI, configuration, and reference docs.

<sup>Written for commit 04f2b98f96adc98d85764e8d3f5ec83441675e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

