### PR TITLE
fix: stabilize deployed agent surface smoke checks

### DIFF
--- a/.github/workflows/agent-surface-smoke.yml
+++ b/.github/workflows/agent-surface-smoke.yml
@@ -158,7 +158,9 @@ jobs:
     timeout-minutes: 10
     env:
       DOCS_SMOKE_BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.environment_url || inputs.base_url || 'https://docs.farming-labs.dev' }}
+      DOCS_SMOKE_CONCURRENCY: "3"
       DOCS_SMOKE_EXPECT_SKILLS: ask-ai,cli,configuration,creating-themes,getting-started,page-actions
+      DOCS_SMOKE_TIMEOUT_MS: "30000"
       DOCS_SMOKE_VALIDATE_SKILL_FRONTMATTER: "1"
       DOCS_READINESS_WARNING_BASELINE: ${{ github.event_name == 'deployment_status' && '.github/agent-readiness-preview-warning-baseline.json' || '.github/agent-readiness-warning-baseline.json' }}
     steps:

--- a/scripts/smoke-agent-surfaces.mjs
+++ b/scripts/smoke-agent-surfaces.mjs
@@ -19,8 +19,9 @@ const LEGACY_SKILLS_INDEX_ROUTE = "/.well-known/skills/index.json";
 const AGENT_CARD_ROUTE = "/.well-known/agent-card.json";
 const MCP_ROUTES = ["/mcp", "/.well-known/mcp"];
 const MCP_PROTOCOL_VERSIONS = ["2025-11-25", "2026-07-28"];
-const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_CONCURRENCY = 3;
 const MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
 const TAR_BLOCK_BYTES = 512;
 const TAR_NAME_BYTES = 100;
@@ -1758,15 +1759,35 @@ function createRecorder(log) {
   };
 }
 
+async function runConcurrently(tasks, concurrency) {
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      await tasks[index]();
+    }
+  }
+
+  const workerCount = Math.min(concurrency, tasks.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}
+
 export async function runAgentSurfaceSmoke(options = {}) {
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
   const expectedSkillNames = new Set(options.expectedSkillNames ?? []);
   const maxResponseBytes = options.maxResponseBytes ?? MAX_RESPONSE_BYTES;
   assert(
     Number.isSafeInteger(maxResponseBytes) && maxResponseBytes > 0,
     "Response size limit must be a positive safe integer",
+  );
+  assert(
+    Number.isSafeInteger(concurrency) && concurrency > 0,
+    "Concurrency limit must be a positive safe integer",
   );
   const log = options.log ?? console.log;
   const request = createRequester({
@@ -1783,18 +1804,24 @@ export async function runAgentSurfaceSmoke(options = {}) {
   const manifest = await recorder.check("agent manifest /.well-known/agent.json", () =>
     validateManifestEndpoint(request, "/.well-known/agent.json"),
   );
-  await Promise.all([
-    recorder.check("agent manifest /.well-known/agent", () =>
-      validateManifestEndpoint(request, "/.well-known/agent"),
-    ),
-    recorder.check("agent manifest /api/docs/agent/spec", () =>
-      validateManifestEndpoint(request, "/api/docs/agent/spec"),
-    ),
-    recorder.check("Farming Labs agent manifest schema", () =>
-      validateAgentManifestSchema(request),
-    ),
-    recorder.check("RFC 9727 API catalog", () => validateApiCatalog(request)),
-  ]);
+  await runConcurrently(
+    [
+      () =>
+        recorder.check("agent manifest /.well-known/agent", () =>
+          validateManifestEndpoint(request, "/.well-known/agent"),
+        ),
+      () =>
+        recorder.check("agent manifest /api/docs/agent/spec", () =>
+          validateManifestEndpoint(request, "/api/docs/agent/spec"),
+        ),
+      () =>
+        recorder.check("Farming Labs agent manifest schema", () =>
+          validateAgentManifestSchema(request),
+        ),
+      () => recorder.check("RFC 9727 API catalog", () => validateApiCatalog(request)),
+    ],
+    concurrency,
+  );
 
   const modernIndex = await recorder.check("Agent Skills v0.2 index", async () => {
     const result = await readJson(request, AGENT_SKILLS_INDEX_ROUTE);
@@ -1815,12 +1842,14 @@ export async function runAgentSurfaceSmoke(options = {}) {
   );
 
   if (modernIndex) {
-    await Promise.all(
-      modernIndex.map((skill) =>
-        recorder.check(`Agent Skill artifact ${skill.name}`, () =>
-          validateModernSkillArtifact(request, baseUrl, skill),
-        ),
+    await runConcurrently(
+      modernIndex.map(
+        (skill) => () =>
+          recorder.check(`Agent Skill artifact ${skill.name}`, () =>
+            validateModernSkillArtifact(request, baseUrl, skill),
+          ),
       ),
+      concurrency,
     );
   }
 
@@ -1833,12 +1862,14 @@ export async function runAgentSurfaceSmoke(options = {}) {
     for (const file of manifestFiles) {
       expectedFileDigests.set(`${file.name}/${file.path}`, file.digest);
     }
-    await Promise.all(
-      manifestFiles.map((file) =>
-        recorder.check(`Agent Skill file ${file.name}/${file.path}`, () =>
-          validateManifestSkillFile(request, baseUrl, file),
-        ),
+    await runConcurrently(
+      manifestFiles.map(
+        (file) => () =>
+          recorder.check(`Agent Skill file ${file.name}/${file.path}`, () =>
+            validateManifestSkillFile(request, baseUrl, file),
+          ),
       ),
+      concurrency,
     );
   }
 
@@ -1854,12 +1885,14 @@ export async function runAgentSurfaceSmoke(options = {}) {
     return files;
   });
   if (legacyFiles) {
-    await Promise.all(
-      legacyFiles.map((file) =>
-        recorder.check(`legacy Agent Skill file ${file.name}/${file.path}`, () =>
-          validateLegacySkillFile(request, file, expectedFileDigests),
-        ),
+    await runConcurrently(
+      legacyFiles.map(
+        (file) => () =>
+          recorder.check(`legacy Agent Skill file ${file.name}/${file.path}`, () =>
+            validateLegacySkillFile(request, file, expectedFileDigests),
+          ),
       ),
+      concurrency,
     );
   }
 
@@ -1869,14 +1902,16 @@ export async function runAgentSurfaceSmoke(options = {}) {
     await request(AGENT_CARD_ROUTE, {}, [404]);
   });
 
-  await Promise.all(
+  await runConcurrently(
     MCP_ROUTES.flatMap((route) =>
-      MCP_PROTOCOL_VERSIONS.map((protocolVersion) =>
-        recorder.check(`MCP ${protocolVersion} ${route}`, () =>
-          validateMcp(request, route, protocolVersion),
-        ),
+      MCP_PROTOCOL_VERSIONS.map(
+        (protocolVersion) => () =>
+          recorder.check(`MCP ${protocolVersion} ${route}`, () =>
+            validateMcp(request, route, protocolVersion),
+          ),
       ),
     ),
+    concurrency,
   );
   if (manifest) {
     const canonicalMcp = readAdvertisedValue(manifest, ["mcp", "canonicalEndpoint"]);
@@ -1885,75 +1920,91 @@ export async function runAgentSurfaceSmoke(options = {}) {
         ? `MCP ${canonicalMcp}`
         : "advertised canonical MCP endpoint";
       await recorder.check(label, async () =>
-        Promise.all(
-          MCP_PROTOCOL_VERSIONS.map((protocolVersion) =>
-            validateMcp(
-              request,
-              resolveSameOriginTarget(baseUrl, canonicalMcp, "canonical MCP endpoint"),
-              protocolVersion,
-            ),
+        runConcurrently(
+          MCP_PROTOCOL_VERSIONS.map(
+            (protocolVersion) => () =>
+              validateMcp(
+                request,
+                resolveSameOriginTarget(baseUrl, canonicalMcp, "canonical MCP endpoint"),
+                protocolVersion,
+              ),
           ),
+          concurrency,
         ),
       );
     }
   }
 
-  await Promise.all([
-    recorder.check("well-known site skill", () =>
-      validateWellKnownText(request, "/.well-known/skill.md", "text/markdown", "name:"),
-    ),
-    recorder.check("well-known AGENTS.md", () =>
-      validateWellKnownText(request, "/.well-known/AGENTS.md", "text/markdown"),
-    ),
-    recorder.check("well-known AGENT.md", () =>
-      validateWellKnownText(request, "/.well-known/AGENT.md", "text/markdown"),
-    ),
-    recorder.check("well-known llms.txt", () =>
-      validateWellKnownText(request, "/.well-known/llms.txt", "text/plain"),
-    ),
-    recorder.check("well-known llms-full.txt", () =>
-      validateWellKnownText(request, "/.well-known/llms-full.txt", "text/plain"),
-    ),
-    recorder.check("well-known Markdown sitemap", () =>
-      validateWellKnownText(request, "/.well-known/sitemap.md", "text/markdown"),
-    ),
-  ]);
+  await runConcurrently(
+    [
+      () =>
+        recorder.check("well-known site skill", () =>
+          validateWellKnownText(request, "/.well-known/skill.md", "text/markdown", "name:"),
+        ),
+      () =>
+        recorder.check("well-known AGENTS.md", () =>
+          validateWellKnownText(request, "/.well-known/AGENTS.md", "text/markdown"),
+        ),
+      () =>
+        recorder.check("well-known AGENT.md", () =>
+          validateWellKnownText(request, "/.well-known/AGENT.md", "text/markdown"),
+        ),
+      () =>
+        recorder.check("well-known llms.txt", () =>
+          validateWellKnownText(request, "/.well-known/llms.txt", "text/plain"),
+        ),
+      () =>
+        recorder.check("well-known llms-full.txt", () =>
+          validateWellKnownText(request, "/.well-known/llms-full.txt", "text/plain"),
+        ),
+      () =>
+        recorder.check("well-known Markdown sitemap", () =>
+          validateWellKnownText(request, "/.well-known/sitemap.md", "text/markdown"),
+        ),
+    ],
+    concurrency,
+  );
 
   if (manifest) {
     const advertisedChecks = [
-      recorder.check("advertised config endpoint", () =>
-        validateAdvertisedJsonFormat(
-          request,
-          baseUrl,
-          manifest,
-          ["config", "endpoint"],
-          readAdvertisedValue(manifest, ["config", "format"]),
-          "config endpoint",
+      () =>
+        recorder.check("advertised config endpoint", () =>
+          validateAdvertisedJsonFormat(
+            request,
+            baseUrl,
+            manifest,
+            ["config", "endpoint"],
+            readAdvertisedValue(manifest, ["config", "format"]),
+            "config endpoint",
+          ),
         ),
-      ),
-      recorder.check("advertised diagnostics endpoint", () =>
-        validateAdvertisedJsonFormat(
-          request,
-          baseUrl,
-          manifest,
-          ["api", "diagnostics"],
-          "docs-diagnostics.v1",
-          "diagnostics endpoint",
+      () =>
+        recorder.check("advertised diagnostics endpoint", () =>
+          validateAdvertisedJsonFormat(
+            request,
+            baseUrl,
+            manifest,
+            ["api", "diagnostics"],
+            "docs-diagnostics.v1",
+            "diagnostics endpoint",
+          ),
         ),
-      ),
-      recorder.check("advertised Markdown negotiation", () =>
-        validateMarkdownNegotiation(request, baseUrl, manifest),
-      ),
-      recorder.check("advertised robots.txt", () =>
-        validateAdvertisedRobots(request, baseUrl, manifest),
-      ),
-      recorder.check("advertised XML sitemap", () =>
-        validateAdvertisedXmlSitemap(request, baseUrl, manifest),
-      ),
+      () =>
+        recorder.check("advertised Markdown negotiation", () =>
+          validateMarkdownNegotiation(request, baseUrl, manifest),
+        ),
+      () =>
+        recorder.check("advertised robots.txt", () =>
+          validateAdvertisedRobots(request, baseUrl, manifest),
+        ),
+      () =>
+        recorder.check("advertised XML sitemap", () =>
+          validateAdvertisedXmlSitemap(request, baseUrl, manifest),
+        ),
     ];
 
     if (asRecord(manifest.feedback)?.enabled === true) {
-      advertisedChecks.push(
+      advertisedChecks.push(() =>
         recorder.check("advertised feedback schema", () =>
           validateAdvertisedFeedbackSchema(request, baseUrl, manifest),
         ),
@@ -1961,32 +2012,34 @@ export async function runAgentSurfaceSmoke(options = {}) {
     }
     if (asRecord(manifest.search)?.enabled === true) {
       advertisedChecks.push(
-        recorder.check("advertised human search", () =>
-          validateAdvertisedSearch(
-            request,
-            baseUrl,
-            manifest,
-            ["search", "endpoint"],
-            "human search endpoint",
+        () =>
+          recorder.check("advertised human search", () =>
+            validateAdvertisedSearch(
+              request,
+              baseUrl,
+              manifest,
+              ["search", "endpoint"],
+              "human search endpoint",
+            ),
           ),
-        ),
-        recorder.check("advertised agent search", () =>
-          validateAdvertisedSearch(
-            request,
-            baseUrl,
-            manifest,
-            ["search", "agentEndpoint"],
-            "agent search endpoint",
+        () =>
+          recorder.check("advertised agent search", () =>
+            validateAdvertisedSearch(
+              request,
+              baseUrl,
+              manifest,
+              ["search", "agentEndpoint"],
+              "agent search endpoint",
+            ),
           ),
-        ),
       );
     }
     for (const spec of advertisedTextSurfaceSpecs(manifest)) {
-      advertisedChecks.push(
+      advertisedChecks.push(() =>
         recorder.check(spec.label, () => validateAdvertisedTextSurface(request, baseUrl, spec)),
       );
     }
-    await Promise.all(advertisedChecks);
+    await runConcurrently(advertisedChecks, concurrency);
   }
 
   if (recorder.failures.length > 0) {
@@ -2010,6 +2063,7 @@ async function main() {
       expectedSkillNames,
       timeoutMs: parsePositiveInteger(process.env.DOCS_SMOKE_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
       attempts: parsePositiveInteger(process.env.DOCS_SMOKE_ATTEMPTS, DEFAULT_ATTEMPTS),
+      concurrency: parsePositiveInteger(process.env.DOCS_SMOKE_CONCURRENCY, DEFAULT_CONCURRENCY),
     });
   } catch (error) {
     console.error(

--- a/scripts/smoke-agent-surfaces.test.mjs
+++ b/scripts/smoke-agent-surfaces.test.mjs
@@ -123,6 +123,7 @@ function cachedResponse(method, body, requestHeaders, options = {}) {
 function createFixtureFetch(options = {}) {
   const calls = [];
   const streamState = { aborted: false, cancelled: false, pulls: 0 };
+  const concurrencyState = { active: 0, max: 0 };
   const canonicalBaseUrl = options.canonicalBaseUrl ?? BASE_URL;
   const archiveBytes = options.invalidArchiveFrontmatter ? invalidPortableArchive : portableArchive;
   const archiveDigest = digest(archiveBytes);
@@ -598,17 +599,26 @@ Sitemap: ${BASE_URL}/sitemap.xml
   }
 
   async function fixtureFetch(input, init = {}) {
-    const requestedUrl = new URL(input);
-    const result = await fixtureResponse(input, init);
-    const finalUrl =
-      options.crossOriginRedirectPath === requestedUrl.pathname
-        ? new URL(requestedUrl.pathname, "https://redirect.example.net").href
-        : requestedUrl.href;
-    Object.defineProperty(result, "url", { configurable: true, value: finalUrl });
-    return result;
+    concurrencyState.active += 1;
+    concurrencyState.max = Math.max(concurrencyState.max, concurrencyState.active);
+    try {
+      if (options.responseDelayMs) {
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, options.responseDelayMs));
+      }
+      const requestedUrl = new URL(input);
+      const result = await fixtureResponse(input, init);
+      const finalUrl =
+        options.crossOriginRedirectPath === requestedUrl.pathname
+          ? new URL(requestedUrl.pathname, "https://redirect.example.net").href
+          : requestedUrl.href;
+      Object.defineProperty(result, "url", { configurable: true, value: finalUrl });
+      return result;
+    } finally {
+      concurrencyState.active -= 1;
+    }
   }
 
-  return { calls, fetch: fixtureFetch, streamState };
+  return { calls, concurrencyState, fetch: fixtureFetch, streamState };
 }
 
 async function expectAgentCardFailure(options, expectedMessage) {
@@ -681,6 +691,34 @@ test("smoke-checks deployed discovery, skills, MCP, and well-known aliases", asy
   assert(fixture.calls.some((call) => call.pathname === "/sitemap.xml"));
   assert(fixture.calls.some((call) => call.ifNoneMatch));
   assert(fixture.calls.every((call) => call.acceptEncoding === "identity"));
+});
+
+test("caps concurrent deployment requests", async () => {
+  const fixture = createFixtureFetch({ responseDelayMs: 2 });
+  const result = await runAgentSurfaceSmoke({
+    attempts: 1,
+    baseUrl: BASE_URL,
+    concurrency: 2,
+    expectedSkillNames: ["portable"],
+    fetchImpl: fixture.fetch,
+    log() {},
+  });
+
+  assert.equal(result.passed, true);
+  assert.equal(fixture.concurrencyState.max, 2);
+});
+
+test("rejects invalid concurrency limits", async () => {
+  await assert.rejects(
+    runAgentSurfaceSmoke({
+      attempts: 1,
+      baseUrl: BASE_URL,
+      concurrency: 0,
+      fetchImpl: createFixtureFetch().fetch,
+      log() {},
+    }),
+    /Concurrency limit must be a positive safe integer/u,
+  );
 });
 
 test("rejects stale typed API catalog Link metadata", async () => {


### PR DESCRIPTION
## Summary

- cap each smoke-test phase at three concurrent deployment checks
- allow 30 seconds for cold production requests while preserving the existing three attempts
- expose the concurrency setting through DOCS_SMOKE_CONCURRENCY and cover it with regression tests

## Tests

- pnpm test:smoke-agent-surfaces
- pnpm exec oxlint scripts/smoke-agent-surfaces.mjs scripts/smoke-agent-surfaces.test.mjs
- live production smoke: all 81 checks passed against https://docs.farming-labs.dev

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes deployed agent surface smoke checks by limiting concurrency and raising the request timeout. Previously all checks ran concurrently with a 15s timeout, which could overwhelm cold production instances and cause flaky failures. Now each phase runs at most three concurrent checks with a 30s timeout, and the concurrency setting is configurable via `DOCS_SMOKE_CONCUNCURRENCY`. Adds regression tests for the new concurrency cap.

<sup>Written for commit aa126bb03901a647c50866dbebb99f0f52378ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

