### PR TITLE
fix: prevent sidebar React key warnings

### DIFF
--- a/packages/fumadocs/src/docs-layout.test.ts
+++ b/packages/fumadocs/src/docs-layout.test.ts
@@ -281,6 +281,40 @@ agent:
     ).toBeUndefined();
   });
 
+  it("adds stable React keys to sidebar content", () => {
+    mkdirSync(join(tmpDir, "app", "docs", "guides"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "app", "docs", "guides", "page.mdx"),
+      "---\ntitle: Guides\nicon: guide\n---\n\n# Guides\n",
+      "utf-8",
+    );
+    const registeredIcon = React.createElement("span", null, "Guide");
+    const banner = React.createElement("div", null, "Release notes");
+    const footer = React.createElement("div", null, "Theme control");
+    const Layout = createDocsLayout({
+      entry: "docs",
+      icons: { guide: registeredIcon },
+      sidebar: { banner, footer },
+    });
+
+    const layout = Layout({ children: React.createElement("div", null, "child") });
+    const tree = findDocsLayoutTree(layout);
+    const children = tree?.children as Array<Record<string, unknown>> | undefined;
+    const guides = children?.find((entry) => entry.name === "Guides");
+    const icon = guides?.icon;
+    const sidebar = (
+      layout.props as { sidebar?: { banner?: React.ReactNode; footer?: React.ReactNode } }
+    ).sidebar;
+
+    expect(React.isValidElement(icon)).toBe(true);
+    expect((icon as React.ReactElement).key).toBe("guide");
+    expect((sidebar?.banner as React.ReactElement).key).toBe("docs-sidebar-banner");
+    expect((sidebar?.footer as React.ReactElement).key).toBe("docs-sidebar-footer");
+    expect(registeredIcon.key).toBeNull();
+    expect(banner.key).toBeNull();
+    expect(footer.key).toBeNull();
+  });
+
   it("supports boolean shorthand, custom providers, and above-title placement", () => {
     const Layout = createDocsLayout({
       entry: "docs",

--- a/packages/fumadocs/src/docs-layout.tsx
+++ b/packages/fumadocs/src/docs-layout.tsx
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
-import { Suspense, type ReactNode } from "react";
+import { cloneElement, isValidElement, Suspense, type ReactNode } from "react";
 import { serializeIcon } from "./serialize-icon.js";
 import {
   applySidebarFolderIndexBehavior,
@@ -83,13 +83,18 @@ function getNextAppDir(root: string): string {
   return "app";
 }
 
+function withStableReactKey(node: ReactNode, key: string): ReactNode {
+  return isValidElement(node) && node.key === null ? cloneElement(node, { key }) : node;
+}
+
 /** Resolve a frontmatter `icon` string to a ReactNode via the icon registry. */
 function resolveIcon(
   iconKey: string | undefined,
   registry: Record<string, unknown> | undefined,
 ): ReactNode | undefined {
   if (!iconKey || !registry) return undefined;
-  return (registry[iconKey] as ReactNode) ?? undefined;
+  const icon = (registry[iconKey] as ReactNode) ?? undefined;
+  return withStableReactKey(icon, iconKey);
 }
 
 /** Read frontmatter from a page.mdx file. */
@@ -1165,11 +1170,22 @@ export function createDocsLayout(config: DocsConfig, options?: { locale?: string
     const localizedTree = i18n ? localizeTreeUrls(tree, activeLocale) : tree;
 
     const finalSidebarProps = { ...sidebarProps } as Record<string, unknown>;
-    const sidebarFooter = sidebarProps.footer as ReactNode;
+    const sidebarFooter = withStableReactKey(
+      sidebarProps.footer as ReactNode,
+      "docs-sidebar-footer",
+    );
+    finalSidebarProps.banner = withStableReactKey(
+      sidebarProps.banner as ReactNode,
+      "docs-sidebar-banner",
+    );
+    finalSidebarProps.footer = sidebarFooter;
 
     if (i18n) {
       finalSidebarProps.footer = (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <div
+          key="docs-sidebar-footer"
+          style={{ display: "flex", flexDirection: "column", gap: 12 }}
+        >
           {sidebarFooter}
           <Suspense fallback={null}>
             <LocaleThemeControl


### PR DESCRIPTION
## Summary

- assign stable keys to registered page-tree icons before they reach the Fumadocs sidebar
- key custom sidebar banner and footer content while preserving user-provided keys
- cover icon, banner, and footer behavior with a layout regression test

## Tests

- pnpm --filter @farming-labs/theme test
- pnpm --filter @farming-labs/theme typecheck
- pnpm --filter @farming-labs/theme build
- desktop and mobile Playwright checks on /docs/migrations/mintlify: 200 responses, no overlays, no overflow, sidebar icons visible, zero React key warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents React key warnings in the Fumadocs sidebar by assigning stable keys to registered page-tree icons and custom banner/footer content.

- Keys are only applied when the element doesn't already have one, so user-provided keys are preserved.
- Adds a layout regression test covering icon, banner, and footer key behavior.

<sup>Written for commit 524c7b72903d13c5301747b29d9ed52918abf4b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

