### PR TITLE
chore: release v0.2.112

### DIFF
--- a/packages/astro-theme/package.json
+++ b/packages/astro-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro-theme",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Astro UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "astro",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Astro adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "astro",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/docs",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Modern, flexible MDX-based docs framework — core types, config, and CLI",
   "keywords": [
     "docs",

--- a/packages/farmjs/package.json
+++ b/packages/farmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/farmjs",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Farm.js adapter for @farming-labs/docs",
   "keywords": [
     "docs",

--- a/packages/fumadocs/package.json
+++ b/packages/fumadocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/theme",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Theme package for @farming-labs/docs — layout, provider, MDX components, and styles",
   "keywords": [
     "docs",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/next",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Next.js adapter for @farming-labs/docs — MDX config wrapper",
   "keywords": [
     "docs",

--- a/packages/nuxt-theme/package.json
+++ b/packages/nuxt-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt-theme",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Nuxt/Vue UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Nuxt adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/svelte-theme/package.json
+++ b/packages/svelte-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte-theme",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Svelte UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "SvelteKit adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/tanstack-start",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "TanStack Start adapter for @farming-labs/docs — content loading, search, and AI utilities",
   "keywords": [
     "docs",


### PR DESCRIPTION
## Summary

- bump all eleven published @farming-labs packages from 0.2.111 to 0.2.112
- release the migration sidebar brand icons and stable React key fix from #492 and #495
- release the production evaluation retry and deployed smoke stability fixes from #493 and #494

## Verification

- pnpm build
- all eleven publishable package manifests resolve to 0.2.112
- release diff contains only the eleven package version fields
- merged fix PR tests, typechecks, cross-framework MCP checks, Vercel previews, and deployment smoke checks passed

## Rollout

- no migration is required
- consumers can upgrade to ^0.2.112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all eleven published `@farming-labs` packages from 0.2.111 to 0.2.112 to ship the latest fixes.

**Includes**
- Migration sidebar brand icons and a stable React key fix.
- Production evaluation retry and deployed smoke stability fixes.

**Rollout**
- No migration required.
- Consumers can upgrade to `^0.2.112`.

<sup>Written for commit 4521274a7065169939fbc2438877124e6c6f3244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

