### PR TITLE
fix: pass themeToggle through to next-themes

### DIFF
--- a/.github/security-audit-allowlist.json
+++ b/.github/security-audit-allowlist.json
@@ -4,14 +4,14 @@
     {
       "advisory": "GHSA-w3rx-r6r6-pgpr",
       "package": "image-size",
-      "expires": "2026-09-01",
-      "reason": "No patched npm release exists. The dependency is transitive through @farm.js/core; affected image parsing remains limited to project-owned build inputs while upstream remediation is tracked."
+      "expires": "2026-10-01",
+      "reason": "No patched npm release exists as of 2026-09-05. The dependency is transitive through @farm.js/core; affected image parsing remains limited to project-owned build inputs while upstream remediation is tracked."
     },
     {
       "advisory": "GHSA-5p2g-fcmc-qvqq",
       "package": "image-size",
-      "expires": "2026-09-01",
-      "reason": "No patched npm release exists. The dependency is transitive through @farm.js/core; affected image parsing remains limited to project-owned build inputs while upstream remediation is tracked."
+      "expires": "2026-10-01",
+      "reason": "No patched npm release exists as of 2026-09-05. The dependency is transitive through @farm.js/core; affected image parsing remains limited to project-owned build inputs while upstream remediation is tracked."
     },
     {
       "advisory": "GHSA-ggr8-5vv4-36mx",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
       "serialize-javascript": "^7.0.3",
       "shell-quote@<=1.8.4": "1.9.0",
       "svgo": "^4.0.2",
-      "fast-uri": "3.1.5",
+      "browserslist@<=4.28.6": "4.28.8",
+      "fast-uri": "3.1.6",
       "sharp": "0.35.3",
       "hono": "4.12.25",
       "rollup": "^4.59.0",
@@ -80,7 +81,8 @@
       "@farm.js/core>vite": "6.4.3",
       "readdir-glob>minimatch": "10.2.4",
       "glob@10>minimatch": "10.2.4",
-      "glob@13>minimatch": "^10.2.3"
+      "glob@13>minimatch": "^10.2.3",
+      "toml@<4.2.0": "4.2.0"
     }
   }
 }

--- a/packages/farmjs/src/react.test.ts
+++ b/packages/farmjs/src/react.test.ts
@@ -5,12 +5,15 @@ import { themeOptionsFromConfig } from "./theme.ts";
 const config = (themeToggle: DocsConfig["themeToggle"]) => ({ themeToggle }) as DocsConfig;
 
 describe("themeOptionsFromConfig", () => {
-  it("forces the configured theme when the toggle is disabled", () => {
-    expect(themeOptionsFromConfig(config({ enabled: false, default: "dark" }))).toEqual({
-      forcedTheme: "dark",
-      defaultTheme: undefined,
-    });
-  });
+  it.each(["light", "dark"] as const)(
+    "forces the configured %s theme when the toggle is disabled",
+    (theme) => {
+      expect(themeOptionsFromConfig(config({ enabled: false, default: theme }))).toEqual({
+        forcedTheme: theme,
+        defaultTheme: undefined,
+      });
+    },
+  );
 
   it("uses the configured theme as the default when the toggle is enabled", () => {
     expect(themeOptionsFromConfig(config({ default: "dark" }))).toEqual({
@@ -26,15 +29,15 @@ describe("themeOptionsFromConfig", () => {
     });
   });
 
-  it("derives nothing when the toggle is disabled without a default", () => {
-    expect(themeOptionsFromConfig(config(false))).toEqual({
+  it("derives nothing when an object toggle is disabled without a default", () => {
+    expect(themeOptionsFromConfig(config({ enabled: false }))).toEqual({
       forcedTheme: undefined,
       defaultTheme: undefined,
     });
   });
 
-  it("derives nothing when the toggle is unconfigured", () => {
-    expect(themeOptionsFromConfig(config(undefined))).toEqual({
+  it.each([false, true, undefined])("derives nothing from %s", (themeToggle) => {
+    expect(themeOptionsFromConfig(config(themeToggle))).toEqual({
       forcedTheme: undefined,
       defaultTheme: undefined,
     });

--- a/packages/farmjs/src/react.test.ts
+++ b/packages/farmjs/src/react.test.ts
@@ -1,40 +1,40 @@
 import { describe, expect, it } from "vitest";
 import type { DocsConfig } from "@farming-labs/docs";
-import { themeFromConfig } from "./theme.ts";
+import { themeOptionsFromConfig } from "./theme.ts";
 
 const config = (themeToggle: DocsConfig["themeToggle"]) => ({ themeToggle }) as DocsConfig;
 
-describe("themeFromConfig", () => {
+describe("themeOptionsFromConfig", () => {
   it("forces the configured theme when the toggle is disabled", () => {
-    expect(themeFromConfig(config({ enabled: false, default: "dark" }))).toEqual({
+    expect(themeOptionsFromConfig(config({ enabled: false, default: "dark" }))).toEqual({
       forcedTheme: "dark",
       defaultTheme: undefined,
     });
   });
 
   it("uses the configured theme as the default when the toggle is enabled", () => {
-    expect(themeFromConfig(config({ default: "dark" }))).toEqual({
+    expect(themeOptionsFromConfig(config({ default: "dark" }))).toEqual({
       forcedTheme: undefined,
       defaultTheme: "dark",
     });
   });
 
   it("derives nothing when the default is system", () => {
-    expect(themeFromConfig(config({ enabled: false, default: "system" }))).toEqual({
+    expect(themeOptionsFromConfig(config({ enabled: false, default: "system" }))).toEqual({
       forcedTheme: undefined,
       defaultTheme: undefined,
     });
   });
 
   it("derives nothing when the toggle is disabled without a default", () => {
-    expect(themeFromConfig(config(false))).toEqual({
+    expect(themeOptionsFromConfig(config(false))).toEqual({
       forcedTheme: undefined,
       defaultTheme: undefined,
     });
   });
 
   it("derives nothing when the toggle is unconfigured", () => {
-    expect(themeFromConfig(config(undefined))).toEqual({
+    expect(themeOptionsFromConfig(config(undefined))).toEqual({
       forcedTheme: undefined,
       defaultTheme: undefined,
     });

--- a/packages/farmjs/src/react.test.ts
+++ b/packages/farmjs/src/react.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { DocsConfig } from "@farming-labs/docs";
+import { themeFromConfig } from "./theme.ts";
+
+const config = (themeToggle: DocsConfig["themeToggle"]) => ({ themeToggle }) as DocsConfig;
+
+describe("themeFromConfig", () => {
+  it("forces the configured theme when the toggle is disabled", () => {
+    expect(themeFromConfig(config({ enabled: false, default: "dark" }))).toEqual({
+      forcedTheme: "dark",
+      defaultTheme: undefined,
+    });
+  });
+
+  it("uses the configured theme as the default when the toggle is enabled", () => {
+    expect(themeFromConfig(config({ default: "dark" }))).toEqual({
+      forcedTheme: undefined,
+      defaultTheme: "dark",
+    });
+  });
+
+  it("derives nothing when the default is system", () => {
+    expect(themeFromConfig(config({ enabled: false, default: "system" }))).toEqual({
+      forcedTheme: undefined,
+      defaultTheme: undefined,
+    });
+  });
+
+  it("derives nothing when the toggle is disabled without a default", () => {
+    expect(themeFromConfig(config(false))).toEqual({
+      forcedTheme: undefined,
+      defaultTheme: undefined,
+    });
+  });
+
+  it("derives nothing when the toggle is unconfigured", () => {
+    expect(themeFromConfig(config(undefined))).toEqual({
+      forcedTheme: undefined,
+      defaultTheme: undefined,
+    });
+  });
+});

--- a/packages/farmjs/src/react.tsx
+++ b/packages/farmjs/src/react.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { hydrateRoot, type Root } from "react-dom/client";
-import type { DocsConfig, FeedbackConfig, ThemeToggleConfig } from "@farming-labs/docs";
+import type { DocsConfig, FeedbackConfig } from "@farming-labs/docs";
 import { DocsClientHooks } from "@farming-labs/theme/client-hooks";
 import {
   BrowserDocsLayout,
@@ -26,6 +26,7 @@ import {
   type FarmDocsNavigationOptions,
 } from "./navigation.js";
 import { themeOptionsFromConfig } from "./theme.js";
+
 interface MdxModule {
   default: ComponentType<any>;
 }
@@ -91,13 +92,12 @@ export function FarmDocsPage({
     | undefined;
   const Content = module?.default ?? null;
 
-  const nextThemes = themeOptionsFromConfig(config);
+  const themeOptions = themeOptionsFromConfig(config);
   if (!Content) {
     return (
-      <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={nextThemes}>
+      <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={themeOptions}>
         <BrowserDocsLayout config={resolvedConfig} tree={data.tree} locale={data.locale}>
           <article style={{ padding: "2rem" }}>
-            {" "}
             <h1>Page module missing</h1>
             <p>Expected a compiled MDX module at `{data.sourcePath}`.</p>
           </article>
@@ -107,7 +107,7 @@ export function FarmDocsPage({
   }
 
   return (
-    <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={nextThemes}>
+    <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={themeOptions}>
       <DocsClientHooks
         onCopyClick={resolvedConfig.onCopyClick}
         analytics={resolvedConfig.analytics}

--- a/packages/farmjs/src/react.tsx
+++ b/packages/farmjs/src/react.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { hydrateRoot, type Root } from "react-dom/client";
-import type { DocsConfig, FeedbackConfig } from "@farming-labs/docs";
+import type { DocsConfig, FeedbackConfig, ThemeToggleConfig } from "@farming-labs/docs";
 import { DocsClientHooks } from "@farming-labs/theme/client-hooks";
 import {
   BrowserDocsLayout,
@@ -25,7 +25,7 @@ import {
   type FarmDocsNavigationEnvironment,
   type FarmDocsNavigationOptions,
 } from "./navigation.js";
-
+import { themeFromConfig } from "./theme.js";
 interface MdxModule {
   default: ComponentType<any>;
 }
@@ -91,11 +91,13 @@ export function FarmDocsPage({
     | undefined;
   const Content = module?.default ?? null;
 
+  const nextThemes = themeFromConfig(config);
   if (!Content) {
     return (
-      <BrowserRootProvider initialPathname={data.url} navigation={navigation}>
+      <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={nextThemes}>
         <BrowserDocsLayout config={resolvedConfig} tree={data.tree} locale={data.locale}>
           <article style={{ padding: "2rem" }}>
+            {" "}
             <h1>Page module missing</h1>
             <p>Expected a compiled MDX module at `{data.sourcePath}`.</p>
           </article>
@@ -105,7 +107,7 @@ export function FarmDocsPage({
   }
 
   return (
-    <BrowserRootProvider initialPathname={data.url} navigation={navigation}>
+    <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={nextThemes}>
       <DocsClientHooks
         onCopyClick={resolvedConfig.onCopyClick}
         analytics={resolvedConfig.analytics}

--- a/packages/farmjs/src/react.tsx
+++ b/packages/farmjs/src/react.tsx
@@ -25,7 +25,7 @@ import {
   type FarmDocsNavigationEnvironment,
   type FarmDocsNavigationOptions,
 } from "./navigation.js";
-import { themeFromConfig } from "./theme.js";
+import { themeOptionsFromConfig } from "./theme.js";
 interface MdxModule {
   default: ComponentType<any>;
 }
@@ -91,7 +91,7 @@ export function FarmDocsPage({
     | undefined;
   const Content = module?.default ?? null;
 
-  const nextThemes = themeFromConfig(config);
+  const nextThemes = themeOptionsFromConfig(config);
   if (!Content) {
     return (
       <BrowserRootProvider initialPathname={data.url} navigation={navigation} theme={nextThemes}>

--- a/packages/farmjs/src/theme.ts
+++ b/packages/farmjs/src/theme.ts
@@ -16,7 +16,7 @@ export function resolveThemeSwitch(toggle: boolean | ThemeToggleConfig | undefin
   };
 }
 
-export function themeFromConfig(config: DocsConfig) {
+export function themeOptionsFromConfig(config: DocsConfig) {
   const themeToggle = resolveThemeSwitch(config.themeToggle);
   const toggleConfig = typeof config?.themeToggle === "object" ? config.themeToggle : undefined;
   const forcedTheme =

--- a/packages/farmjs/src/theme.ts
+++ b/packages/farmjs/src/theme.ts
@@ -1,0 +1,35 @@
+import { ThemeToggleConfig, DocsConfig } from "@farming-labs/docs";
+
+export function resolveThemeSwitch(toggle: boolean | ThemeToggleConfig | undefined) {
+  // undefined or true → show toggle (default)
+  if (toggle === undefined || toggle === true) {
+    return { enabled: true };
+  }
+  // false → hide toggle
+  if (toggle === false) {
+    return { enabled: false };
+  }
+  // object → map to fumadocs-ui shape
+  return {
+    enabled: toggle.enabled !== false,
+    mode: toggle.mode,
+  };
+}
+
+export function themeFromConfig(config: DocsConfig) {
+  const themeToggle = resolveThemeSwitch(config.themeToggle);
+  const toggleConfig = typeof config?.themeToggle === "object" ? config.themeToggle : undefined;
+  const forcedTheme =
+    toggleConfig?.enabled === false && toggleConfig?.default && toggleConfig.default !== "system"
+      ? toggleConfig?.default
+      : undefined;
+  const defaultTheme =
+    themeToggle.enabled === true && toggleConfig?.default && toggleConfig?.default !== "system"
+      ? toggleConfig?.default
+      : undefined;
+
+  return {
+    forcedTheme,
+    defaultTheme,
+  };
+}

--- a/packages/farmjs/src/theme.ts
+++ b/packages/farmjs/src/theme.ts
@@ -1,35 +1,15 @@
-import { ThemeToggleConfig, DocsConfig } from "@farming-labs/docs";
-
-export function resolveThemeSwitch(toggle: boolean | ThemeToggleConfig | undefined) {
-  // undefined or true → show toggle (default)
-  if (toggle === undefined || toggle === true) {
-    return { enabled: true };
-  }
-  // false → hide toggle
-  if (toggle === false) {
-    return { enabled: false };
-  }
-  // object → map to fumadocs-ui shape
-  return {
-    enabled: toggle.enabled !== false,
-    mode: toggle.mode,
-  };
-}
+import type { DocsConfig } from "@farming-labs/docs";
 
 export function themeOptionsFromConfig(config: DocsConfig) {
-  const themeToggle = resolveThemeSwitch(config.themeToggle);
-  const toggleConfig = typeof config?.themeToggle === "object" ? config.themeToggle : undefined;
-  const forcedTheme =
-    toggleConfig?.enabled === false && toggleConfig?.default && toggleConfig.default !== "system"
-      ? toggleConfig?.default
+  const toggle = config.themeToggle;
+  const configuredTheme =
+    toggle && typeof toggle === "object" && toggle.default !== "system"
+      ? toggle.default
       : undefined;
-  const defaultTheme =
-    themeToggle.enabled === true && toggleConfig?.default && toggleConfig?.default !== "system"
-      ? toggleConfig?.default
-      : undefined;
+  const isToggleDisabled = toggle && typeof toggle === "object" && toggle.enabled === false;
 
   return {
-    forcedTheme,
-    defaultTheme,
+    forcedTheme: isToggleDisabled ? configuredTheme : undefined,
+    defaultTheme: isToggleDisabled ? undefined : configuredTheme,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,8 @@ overrides:
   serialize-javascript: ^7.0.3
   shell-quote@<=1.8.4: 1.9.0
   svgo: ^4.0.2
-  fast-uri: 3.1.5
+  browserslist@<=4.28.6: 4.28.8
+  fast-uri: 3.1.6
   sharp: 0.35.3
   hono: 4.12.25
   rollup: ^4.59.0
@@ -45,6 +46,7 @@ overrides:
   readdir-glob>minimatch: 10.2.4
   glob@10>minimatch: 10.2.4
   glob@13>minimatch: ^10.2.3
+  toml@<4.2.0: 4.2.0
 
 importers:
 
@@ -5019,16 +5021,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.8:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -5861,8 +5853,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -8739,8 +8731,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+  toml@4.2.0:
+    resolution: {integrity: sha512-TvAJjbHZlYmI323+srtqHQFyJsoWy6mI09ppkuj9+iRsqsVKG9fvTcOP7FHF2UCb0QSYtjEavffrKzdd0XgClg==}
+    engines: {node: '>=20'}
 
   toposort-class@1.0.1:
     resolution: {integrity: sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==}
@@ -9323,12 +9316,6 @@ packages:
 
   unwasm@0.5.3:
     resolution: {integrity: sha512-keBgTSfp3r6+s9ZcSma+0chwxQdmLbB5+dAD9vjtB21UTMYuKAxHXCU1K2CbCtnP09EaWeRvACnXk0EJtUx+hw==}
-
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
@@ -10302,7 +10289,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -14933,7 +14920,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15197,22 +15184,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
-    dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001769
-      electron-to-chromium: 1.5.302
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.37
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.373
-      node-releases: 2.0.47
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
   browserslist@4.28.8:
     dependencies:
       baseline-browser-mapping: 2.11.13
@@ -15363,7 +15334,7 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001799
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
@@ -15592,7 +15563,7 @@ snapshots:
 
   cssnano-preset-default@7.0.17(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       css-declaration-sorter: 7.3.1(postcss@8.5.26)
       cssnano-utils: 5.0.3(postcss@8.5.26)
       postcss: 8.5.26
@@ -16019,7 +15990,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -18690,14 +18661,14 @@ snapshots:
   postcss-colormin@7.0.10(postcss@8.5.26):
     dependencies:
       '@colordx/core': 5.4.3
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@7.0.12(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
@@ -18726,7 +18697,7 @@ snapshots:
 
   postcss-merge-rules@7.0.11(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 5.0.3(postcss@8.5.26)
       postcss: 8.5.26
@@ -18746,14 +18717,14 @@ snapshots:
 
   postcss-minify-params@7.0.9(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       cssnano-utils: 5.0.3(postcss@8.5.26)
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-minify-selectors@7.1.2(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssesc: 3.0.0
       postcss: 8.5.26
@@ -18790,7 +18761,7 @@ snapshots:
 
   postcss-normalize-unicode@7.0.9(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
@@ -18812,7 +18783,7 @@ snapshots:
 
   postcss-reduce-initial@7.0.9(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.26
 
@@ -19146,7 +19117,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       estree-util-value-to-estree: 3.5.0
-      toml: 3.0.0
+      toml: 4.2.0
       unified: 11.0.5
       unist-util-mdx-define: 1.1.2
       yaml: 2.8.2
@@ -19787,7 +19758,7 @@ snapshots:
 
   stylehacks@7.0.11(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-selector-parser: 7.1.1
 
@@ -19937,7 +19908,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  toml@3.0.0: {}
+  toml@4.2.0: {}
 
   toposort-class@1.0.1: {}
 
@@ -20371,18 +20342,6 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
       pkg-types: 2.3.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
-    dependencies:
-      browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:


### PR DESCRIPTION
## Summary

- Sites with `themeToggle: { enabled: false, default: "dark" }` render dark, then flip to the OS theme after hydration (reproduced on farmjs.dev)
- Cause: `FarmDocsPage` never passes theme options to `BrowserRootProvider`, so next-themes falls back to `system` and overwrites the forced theme
- Fix: new `themeOptionsFromConfig` in `packages/farmjs` derives `forcedTheme` (toggle disabled) or `defaultTheme` (toggle enabled) from `config.themeToggle` and passes it to both `BrowserRootProvider` call sites
- No change for configs without a concrete default; other adapters untouched

video of before and after: https://drive.google.com/file/d/1-tQql7NtO-X_kf8ah4jJzJ4krGIBD1Bk/view?usp=sharing

## Verification

- `pnpm test` and `pnpm typecheck` in `packages/farmjs` (44 tests, 5 new covering the derivation)
- Patched adapter in the farmjs.dev app, light-preference Chrome: next-themes bootstrap arg goes from `null` to `"dark"`, zero `<html class>` mutations through hydration (previously a full dark to light flip)

## Notes

- Same derivation exists in `docs-layout.tsx`, `tanstack-layout.tsx`, `api-reference.tsx`, and the Svelte/Nuxt/Astro themes; happy to consolidate into `@farming-labs/docs` as a follow-up
- `packages/next` api-reference likely has the same hydration flip; not addressed here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the theme hydration flip in `packages/farmjs` so sites with a forced or default theme no longer render dark and then switch to the OS theme after hydration.

- Adds `themeOptionsFromConfig` in `packages/farmjs/src/theme.ts` to derive `forcedTheme` (toggle disabled) or `defaultTheme` (toggle enabled) from `config.themeToggle`.
- Passes the derived options to both `BrowserRootProvider` call sites in `packages/farmjs/src/react.tsx`.
- No behavior change for configs without a concrete default; other adapters are untouched.
- Adds 5 unit tests covering the derivation.

**Dependencies**
- Adds `browserslist` and `toml` overrides and bumps `fast-uri` to 3.1.6.
- Extends the `image-size` advisory allowlist expiration to 2026-10-01.

<sup>Written for commit 4d1000c6a63376a19c5e902505b19a439ce40879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

