### PR TITLE
chore: release v0.2.113

### DIFF
--- a/packages/astro-theme/package.json
+++ b/packages/astro-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro-theme",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Astro UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "astro",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/astro",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Astro adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "astro",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/docs",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Modern, flexible MDX-based docs framework — core types, config, and CLI",
   "keywords": [
     "docs",

--- a/packages/farmjs/package.json
+++ b/packages/farmjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/farmjs",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Farm.js adapter for @farming-labs/docs",
   "keywords": [
     "docs",

--- a/packages/fumadocs/package.json
+++ b/packages/fumadocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/theme",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Theme package for @farming-labs/docs — layout, provider, MDX components, and styles",
   "keywords": [
     "docs",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/next",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Next.js adapter for @farming-labs/docs — MDX config wrapper",
   "keywords": [
     "docs",

--- a/packages/nuxt-theme/package.json
+++ b/packages/nuxt-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt-theme",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Nuxt/Vue UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/nuxt",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Nuxt adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/svelte-theme/package.json
+++ b/packages/svelte-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte-theme",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Svelte UI components for @farming-labs/docs — layout, sidebar, TOC, search, and theme toggle",
   "keywords": [
     "docs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/svelte",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "SvelteKit adapter for @farming-labs/docs — content loading and navigation utilities",
   "keywords": [
     "docs",

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farming-labs/tanstack-start",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "TanStack Start adapter for @farming-labs/docs — content loading, search, and AI utilities",
   "keywords": [
     "docs",


### PR DESCRIPTION
## Summary

- bump all eleven published `@farming-labs` packages from `0.2.112` to `0.2.113`
- release the Farm.js theme hydration fix from #497
- ensure disabled theme toggles preserve their configured light or dark theme after hydration
- include the security-audit dependency updates merged with #497

## Verification

- `pnpm build`
- all eleven publishable package manifests resolve to `0.2.113`
- release diff contains only the eleven package version fields
- #497 passed lint/build, tests, security audit, package previews, reviewer, and cross-framework MCP conformance checks

## Rollout

- no migration is required
- consumers can upgrade to `^0.2.113`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all eleven published `@farming-labs` packages from `0.2.112` to `0.2.113`, releasing the Farm.js theme hydration fix and security-audit dependency updates from #497. The release diff contains only the package version fields.

**Rollout**
- No migration is required; consumers can upgrade to `^0.2.113`.

<sup>Written for commit 9be0d77672aea96a356249106e85e67f77da0326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

