### PR TITLE
fix: keep search dialog above page actions

### DIFF
--- a/packages/astro-theme/styles/omni.css
+++ b/packages/astro-theme/styles/omni.css
@@ -56,7 +56,7 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -65,7 +65,7 @@
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);

--- a/packages/fumadocs/src/omni-layering.test.ts
+++ b/packages/fumadocs/src/omni-layering.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const adapterStyles = ["fumadocs", "astro-theme", "nuxt-theme", "svelte-theme"].map((adapter) => ({
+  adapter,
+  css: readFileSync(
+    fileURLToPath(new URL(`../../${adapter}/styles/omni.css`, import.meta.url)),
+    "utf8",
+  ),
+}));
+
+describe("command palette layering", () => {
+  it.each(adapterStyles)(
+    "keeps the $adapter search dialog above elevated page chrome",
+    ({ css }) => {
+      expect(css).toMatch(/\.omni-overlay\s*\{[^}]*z-index:\s*9998;/s);
+      expect(css).toMatch(/\.omni-content\s*\{[^}]*z-index:\s*9999;/s);
+    },
+  );
+});

--- a/packages/fumadocs/styles/bundles/browser-framework.css
+++ b/packages/fumadocs/styles/bundles/browser-framework.css
@@ -5088,7 +5088,7 @@ body {
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -5097,7 +5097,7 @@ body {
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);

--- a/packages/fumadocs/styles/bundles/shared-framework.css
+++ b/packages/fumadocs/styles/bundles/shared-framework.css
@@ -5102,7 +5102,7 @@ code.shiki span {
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -5111,7 +5111,7 @@ code.shiki span {
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);

--- a/packages/fumadocs/styles/omni.css
+++ b/packages/fumadocs/styles/omni.css
@@ -56,7 +56,7 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -65,7 +65,7 @@
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);

--- a/packages/nuxt-theme/styles/omni.css
+++ b/packages/nuxt-theme/styles/omni.css
@@ -56,7 +56,7 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -65,7 +65,7 @@
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);

--- a/packages/svelte-theme/styles/omni.css
+++ b/packages/svelte-theme/styles/omni.css
@@ -56,7 +56,7 @@
 .omni-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
+  z-index: 9998;
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(2px);
   animation: omni-fade-in 150ms ease-out;
@@ -65,7 +65,7 @@
 .omni-content {
   --omni-content-top: clamp(5rem, 16vh, 7rem);
   position: fixed;
-  z-index: 51;
+  z-index: 9999;
   top: var(--omni-content-top);
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
## Summary
- move the command search overlay and dialog onto the framework modal layer
- keep React/Farm, Astro, Nuxt, and Svelte theme styles aligned
- add a cross-adapter regression test for search dialog layering

## Verification
- `pnpm --filter @farming-labs/theme test -- omni-layering.test.ts` (215 tests)
- `pnpm --filter @farming-labs/docs build`
- `pnpm --filter @farming-labs/theme typecheck`
- `pnpm --filter @farming-labs/theme build`
- browser verification with the command palette open; overlay `9998`, dialog `9999`, no console errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the command search dialog's z-index so it no longer renders below elevated page actions across all framework adapters.

- Updates the overlay and dialog z-index from `50`/`51` to `9998`/`9999` in the Astro, Nuxt, Svelte, and React/Farm theme styles.
- Adds a cross-adapter regression test that verifies the `omni.css` files keep these z-index values aligned.

<sup>Written for commit 1cc7186d30ec7e8de55d564fabbbb3aec33fe8ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/docs/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

